### PR TITLE
Receive test management settings from CIVis settings request

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -158,7 +158,7 @@ public class CiVisibilitySystem {
                 services, repoServices, coverageServices, executionSettings);
       } else {
         sessionFactory =
-            headlessTestFrameworkEssionFactory(
+            headlessTestFrameworkSessionFactory(
                 services, repoServices, coverageServices, executionSettings);
       }
     }
@@ -259,7 +259,7 @@ public class CiVisibilitySystem {
     };
   }
 
-  private static TestFrameworkSession.Factory headlessTestFrameworkEssionFactory(
+  private static TestFrameworkSession.Factory headlessTestFrameworkSessionFactory(
       CiVisibilityServices services,
       CiVisibilityRepoServices repoServices,
       CiVisibilityCoverageServices.Child coverageServices,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
@@ -9,7 +9,15 @@ public class CiVisibilitySettings {
 
   public static final CiVisibilitySettings DEFAULT =
       new CiVisibilitySettings(
-          false, false, false, false, false, false, false, EarlyFlakeDetectionSettings.DEFAULT);
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          EarlyFlakeDetectionSettings.DEFAULT,
+          TestManagementSettings.DEFAULT);
 
   private final boolean itrEnabled;
   private final boolean codeCoverage;
@@ -19,6 +27,7 @@ public class CiVisibilitySettings {
   private final boolean impactedTestsDetectionEnabled;
   private final boolean knownTestsEnabled;
   private final EarlyFlakeDetectionSettings earlyFlakeDetectionSettings;
+  private final TestManagementSettings testManagementSettings;
 
   CiVisibilitySettings(
       boolean itrEnabled,
@@ -28,7 +37,8 @@ public class CiVisibilitySettings {
       boolean flakyTestRetriesEnabled,
       boolean impactedTestsDetectionEnabled,
       boolean knownTestsEnabled,
-      EarlyFlakeDetectionSettings earlyFlakeDetectionSettings) {
+      EarlyFlakeDetectionSettings earlyFlakeDetectionSettings,
+      TestManagementSettings testManagementSettings) {
     this.itrEnabled = itrEnabled;
     this.codeCoverage = codeCoverage;
     this.testsSkipping = testsSkipping;
@@ -37,6 +47,7 @@ public class CiVisibilitySettings {
     this.impactedTestsDetectionEnabled = impactedTestsDetectionEnabled;
     this.knownTestsEnabled = knownTestsEnabled;
     this.earlyFlakeDetectionSettings = earlyFlakeDetectionSettings;
+    this.testManagementSettings = testManagementSettings;
   }
 
   public boolean isItrEnabled() {
@@ -71,6 +82,10 @@ public class CiVisibilitySettings {
     return earlyFlakeDetectionSettings;
   }
 
+  public TestManagementSettings getTestManagementSettings() {
+    return testManagementSettings;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -87,7 +102,8 @@ public class CiVisibilitySettings {
         && flakyTestRetriesEnabled == that.flakyTestRetriesEnabled
         && impactedTestsDetectionEnabled == that.impactedTestsDetectionEnabled
         && knownTestsEnabled == that.knownTestsEnabled
-        && Objects.equals(earlyFlakeDetectionSettings, that.earlyFlakeDetectionSettings);
+        && Objects.equals(earlyFlakeDetectionSettings, that.earlyFlakeDetectionSettings)
+        && Objects.equals(testManagementSettings, that.testManagementSettings);
   }
 
   @Override
@@ -100,7 +116,8 @@ public class CiVisibilitySettings {
         flakyTestRetriesEnabled,
         impactedTestsDetectionEnabled,
         knownTestsEnabled,
-        earlyFlakeDetectionSettings);
+        earlyFlakeDetectionSettings,
+        testManagementSettings);
   }
 
   public interface Factory {
@@ -126,7 +143,9 @@ public class CiVisibilitySettings {
           getBoolean(json, "impacted_tests_enabled", false),
           getBoolean(json, "known_tests_enabled", false),
           EarlyFlakeDetectionSettingsJsonAdapter.INSTANCE.fromJson(
-              (Map<String, Object>) json.get("early_flake_detection")));
+              (Map<String, Object>) json.get("early_flake_detection")),
+          TestManagementSettingsJsonAdapter.INSTANCE.fromJson(
+              (Map<String, Object>) json.get("test_management")));
     }
 
     private static boolean getBoolean(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -21,6 +21,7 @@ import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.KnownTestsEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
+import datadog.trace.api.civisibility.telemetry.tag.TestManagementEnabled;
 import datadog.trace.civisibility.communication.TelemetryListener;
 import datadog.trace.util.RandomUtils;
 import java.io.File;
@@ -146,6 +147,7 @@ public class ConfigurationApiImpl implements ConfigurationApi {
         settings.isFlakyTestRetriesEnabled() ? FlakyTestRetriesEnabled.TRUE : null,
         settings.isKnownTestsEnabled() ? KnownTestsEnabled.TRUE : null,
         settings.isImpactedTestsDetectionEnabled() ? ImpactedTestsDetectionEnabled.TRUE : null,
+        settings.getTestManagementSettings().isEnabled() ? TestManagementEnabled.TRUE : null,
         settings.isGitUploadRequired() ? RequireGit.TRUE : null);
 
     return settings;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettings.java
@@ -25,6 +25,7 @@ public class ExecutionSettings {
           false,
           false,
           EarlyFlakeDetectionSettings.DEFAULT,
+          TestManagementSettings.DEFAULT,
           null,
           Collections.emptyMap(),
           Collections.emptyMap(),
@@ -39,6 +40,7 @@ public class ExecutionSettings {
   private final boolean flakyTestRetriesEnabled;
   private final boolean impactedTestsDetectionEnabled;
   @Nonnull private final EarlyFlakeDetectionSettings earlyFlakeDetectionSettings;
+  @Nonnull private final TestManagementSettings testManagementSettings;
   @Nullable private final String itrCorrelationId;
   @Nonnull private final Map<TestIdentifier, TestMetadata> skippableTests;
   @Nonnull private final Map<String, BitSet> skippableTestsCoverage;
@@ -54,6 +56,7 @@ public class ExecutionSettings {
       boolean flakyTestRetriesEnabled,
       boolean impactedTestsDetectionEnabled,
       @Nonnull EarlyFlakeDetectionSettings earlyFlakeDetectionSettings,
+      @Nonnull TestManagementSettings testManagementSettings,
       @Nullable String itrCorrelationId,
       @Nonnull Map<TestIdentifier, TestMetadata> skippableTests,
       @Nonnull Map<String, BitSet> skippableTestsCoverage,
@@ -67,6 +70,7 @@ public class ExecutionSettings {
     this.flakyTestRetriesEnabled = flakyTestRetriesEnabled;
     this.impactedTestsDetectionEnabled = impactedTestsDetectionEnabled;
     this.earlyFlakeDetectionSettings = earlyFlakeDetectionSettings;
+    this.testManagementSettings = testManagementSettings;
     this.itrCorrelationId = itrCorrelationId;
     this.skippableTests = skippableTests;
     this.skippableTestsCoverage = skippableTestsCoverage;
@@ -103,6 +107,11 @@ public class ExecutionSettings {
   @Nonnull
   public EarlyFlakeDetectionSettings getEarlyFlakeDetectionSettings() {
     return earlyFlakeDetectionSettings;
+  }
+
+  @Nonnull
+  public TestManagementSettings getTestManagementSettings() {
+    return testManagementSettings;
   }
 
   @Nullable
@@ -162,6 +171,7 @@ public class ExecutionSettings {
         && codeCoverageEnabled == that.codeCoverageEnabled
         && testSkippingEnabled == that.testSkippingEnabled
         && Objects.equals(earlyFlakeDetectionSettings, that.earlyFlakeDetectionSettings)
+        && Objects.equals(testManagementSettings, that.testManagementSettings)
         && Objects.equals(itrCorrelationId, that.itrCorrelationId)
         && Objects.equals(skippableTests, that.skippableTests)
         && Objects.equals(skippableTestsCoverage, that.skippableTestsCoverage)
@@ -178,6 +188,7 @@ public class ExecutionSettings {
         codeCoverageEnabled,
         testSkippingEnabled,
         earlyFlakeDetectionSettings,
+        testManagementSettings,
         itrCorrelationId,
         skippableTests,
         skippableTestsCoverage,
@@ -211,6 +222,8 @@ public class ExecutionSettings {
 
       EarlyFlakeDetectionSettingsSerializer.serialize(s, settings.earlyFlakeDetectionSettings);
 
+      TestManagementSettingsSerializer.serialize(s, settings.testManagementSettings);
+
       s.write(settings.itrCorrelationId);
       s.write(
           settings.skippableTests,
@@ -238,6 +251,9 @@ public class ExecutionSettings {
       EarlyFlakeDetectionSettings earlyFlakeDetectionSettings =
           EarlyFlakeDetectionSettingsSerializer.deserialize(buffer);
 
+      TestManagementSettings testManagementSettings =
+          TestManagementSettingsSerializer.deserialize(buffer);
+
       String itrCorrelationId = Serializer.readString(buffer);
 
       Map<TestIdentifier, TestMetadata> skippableTests =
@@ -262,6 +278,7 @@ public class ExecutionSettings {
           flakyTestRetriesEnabled,
           impactedTestsDetectionEnabled,
           earlyFlakeDetectionSettings,
+          testManagementSettings,
           itrCorrelationId,
           skippableTests,
           skippableTestsCoverage,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
@@ -289,7 +289,9 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
   }
 
   private void overrideIntegerSetting(
-      Function<Config, Integer> valueGetter, Function<Integer, Boolean> overrideCheck, Consumer<Integer> overrideAction) {
+      Function<Config, Integer> valueGetter,
+      Function<Integer, Boolean> overrideCheck,
+      Consumer<Integer> overrideAction) {
     Integer value = valueGetter.apply(config);
     if (value != null && overrideCheck.apply(value)) {
       overrideAction.accept(value);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
@@ -4,8 +4,7 @@ import java.util.Objects;
 
 public class TestManagementSettings {
 
-  public static final TestManagementSettings DEFAULT =
-      new TestManagementSettings(false, -1);
+  public static final TestManagementSettings DEFAULT = new TestManagementSettings(false, -1);
 
   private final boolean enabled;
   private int attemptToFixRetries;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
@@ -1,0 +1,47 @@
+package datadog.trace.civisibility.config;
+
+import java.util.Objects;
+
+public class TestManagementSettings {
+
+  public static final TestManagementSettings DEFAULT =
+      new TestManagementSettings(false, -1);
+
+  private final boolean enabled;
+  private int attemptToFixRetries;
+
+  public TestManagementSettings(boolean enabled, int attemptToFixRetries) {
+    this.enabled = enabled;
+    this.attemptToFixRetries = attemptToFixRetries;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public int getAttemptToFixRetries() {
+    return attemptToFixRetries;
+  }
+
+  public void setAttemptToFixRetries(int value) {
+    attemptToFixRetries = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TestManagementSettings that = (TestManagementSettings) o;
+    return enabled == that.enabled && attemptToFixRetries == that.attemptToFixRetries;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, attemptToFixRetries);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
@@ -7,7 +7,7 @@ public class TestManagementSettings {
   public static final TestManagementSettings DEFAULT = new TestManagementSettings(false, -1);
 
   private final boolean enabled;
-  private int attemptToFixRetries;
+  private final int attemptToFixRetries;
 
   public TestManagementSettings(boolean enabled, int attemptToFixRetries) {
     this.enabled = enabled;
@@ -20,10 +20,6 @@ public class TestManagementSettings {
 
   public int getAttemptToFixRetries() {
     return attemptToFixRetries;
-  }
-
-  public void setAttemptToFixRetries(int value) {
-    attemptToFixRetries = value;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsJsonAdapter.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsJsonAdapter.java
@@ -1,0 +1,24 @@
+package datadog.trace.civisibility.config;
+
+import com.squareup.moshi.FromJson;
+
+import java.util.Map;
+
+public class TestManagementSettingsJsonAdapter {
+  public static final TestManagementSettingsJsonAdapter INSTANCE = new TestManagementSettingsJsonAdapter();
+
+  @FromJson
+  public TestManagementSettings fromJson(Map<String, Object> json) {
+    if (json == null) {
+      return TestManagementSettings.DEFAULT;
+    }
+
+    Boolean enabled = (Boolean) json.get("enabled");
+    Double attemptToFixRetries = (Double) json.get("attempt_to_fix_retries");
+
+    return new TestManagementSettings(
+        enabled != null ? enabled : false,
+        attemptToFixRetries != null ? attemptToFixRetries.intValue() : -1
+    );
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsJsonAdapter.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsJsonAdapter.java
@@ -1,11 +1,11 @@
 package datadog.trace.civisibility.config;
 
 import com.squareup.moshi.FromJson;
-
 import java.util.Map;
 
 public class TestManagementSettingsJsonAdapter {
-  public static final TestManagementSettingsJsonAdapter INSTANCE = new TestManagementSettingsJsonAdapter();
+  public static final TestManagementSettingsJsonAdapter INSTANCE =
+      new TestManagementSettingsJsonAdapter();
 
   @FromJson
   public TestManagementSettings fromJson(Map<String, Object> json) {
@@ -18,7 +18,6 @@ public class TestManagementSettingsJsonAdapter {
 
     return new TestManagementSettings(
         enabled != null ? enabled : false,
-        attemptToFixRetries != null ? attemptToFixRetries.intValue() : -1
-    );
+        attemptToFixRetries != null ? attemptToFixRetries.intValue() : -1);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsSerializer.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsSerializer.java
@@ -1,0 +1,26 @@
+package datadog.trace.civisibility.config;
+
+import datadog.trace.civisibility.ipc.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+
+public class TestManagementSettingsSerializer {
+  public static void serialize(Serializer serializer, TestManagementSettings settings) {
+    if (!settings.isEnabled()) {
+      serializer.write((byte) 0);
+      return;
+    }
+    serializer.write((byte) 1);
+    serializer.write(settings.getAttemptToFixRetries());
+  }
+
+  public static TestManagementSettings deserialize(ByteBuffer buf) {
+    boolean enabled = Serializer.readByte(buf) != 0;
+    if (!enabled) {
+      return TestManagementSettings.DEFAULT;
+    }
+
+    int attemptToFixRetries = Serializer.readInt(buf);
+    return new TestManagementSettings(enabled, attemptToFixRetries);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsSerializer.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettingsSerializer.java
@@ -1,7 +1,6 @@
 package datadog.trace.civisibility.config;
 
 import datadog.trace.civisibility.ipc.serialization.Serializer;
-
 import java.nio.ByteBuffer;
 
 public class TestManagementSettingsSerializer {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -195,6 +195,8 @@ public class BuildSystemSessionImpl<T extends CoverageCalculator> extends Abstra
       SpanUtils.propagateTag(span, moduleSpan, Tags.TEST_ITR_TESTS_SKIPPING_TYPE);
       SpanUtils.propagateTag(span, moduleSpan, Tags.TEST_ITR_TESTS_SKIPPING_COUNT, Long::sum);
       SpanUtils.propagateTag(span, moduleSpan, DDTags.CI_ITR_TESTS_SKIPPED, Boolean::logicalOr);
+
+      SpanUtils.propagateTag(span, moduleSpan, Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -196,7 +196,8 @@ public class BuildSystemSessionImpl<T extends CoverageCalculator> extends Abstra
       SpanUtils.propagateTag(span, moduleSpan, Tags.TEST_ITR_TESTS_SKIPPING_COUNT, Long::sum);
       SpanUtils.propagateTag(span, moduleSpan, DDTags.CI_ITR_TESTS_SKIPPED, Boolean::logicalOr);
 
-      SpanUtils.propagateTag(span, moduleSpan, Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr);
+      SpanUtils.propagateTag(
+          span, moduleSpan, Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
@@ -15,6 +15,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.config.EarlyFlakeDetectionSettings;
 import datadog.trace.civisibility.config.ExecutionSettings;
+import datadog.trace.civisibility.config.TestManagementSettings;
 import datadog.trace.civisibility.coverage.percentage.child.ChildProcessCoverageReporter;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.InstrumentationType;
@@ -148,6 +149,8 @@ public class ProxyTestModule implements TestFrameworkModule {
       boolean earlyFlakeDetectionEnabled = earlyFlakeDetectionSettings.isEnabled();
       boolean earlyFlakeDetectionFaulty =
           earlyFlakeDetectionEnabled && executionStrategy.isEFDLimitReached();
+      TestManagementSettings testManagementSettings = executionSettings.getTestManagementSettings();
+      boolean testManagementEnabled = testManagementSettings.isEnabled();
       long testsSkippedTotal = executionResults.getTestsSkippedByItr();
 
       signalClient.send(
@@ -158,6 +161,7 @@ public class ProxyTestModule implements TestFrameworkModule {
               testSkippingEnabled,
               earlyFlakeDetectionEnabled,
               earlyFlakeDetectionFaulty,
+              testManagementEnabled,
               testsSkippedTotal,
               new TreeSet<>(testFrameworks)));
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -16,6 +16,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.config.EarlyFlakeDetectionSettings;
 import datadog.trace.civisibility.config.ExecutionSettings;
+import datadog.trace.civisibility.config.TestManagementSettings;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestModule;
 import datadog.trace.civisibility.domain.InstrumentationType;
@@ -130,6 +131,11 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       if (executionStrategy.isEFDLimitReached()) {
         setTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON, CIConstants.EFD_ABORT_REASON_FAULTY);
       }
+    }
+
+    TestManagementSettings testManagementSettings = executionSettings.getTestManagementSettings();
+    if (testManagementSettings.isEnabled()) {
+      setTag(Tags.TEST_TEST_MANAGEMENT_ENABLED, true);
     }
 
     super.end(endTime);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -90,7 +90,8 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         Tags.TEST_ITR_TESTS_SKIPPING_COUNT,
         Tags.TEST_EARLY_FLAKE_ENABLED,
         Tags.TEST_EARLY_FLAKE_ABORT_REASON,
-        DDTags.CI_ITR_TESTS_SKIPPED);
+        DDTags.CI_ITR_TESTS_SKIPPED,
+        Tags.TEST_TEST_MANAGEMENT_ENABLED);
   }
 
   @Override
@@ -104,10 +105,6 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
 
   @Override
   public void end(@Nullable Long endTime) {
-    if (executionStrategy.getExecutionSettings().getTestManagementSettings().isEnabled()) {
-      span.setTag(Tags.TEST_TEST_MANAGEMENT_ENABLED, true);
-    }
-
     super.end(endTime);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -101,4 +101,13 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
     }
     return Collections.emptySet();
   }
+
+  @Override
+  public void end(@Nullable Long endTime) {
+    if (executionStrategy.getExecutionSettings().getTestManagementSettings().isEnabled()) {
+      span.setTag(Tags.TEST_TEST_MANAGEMENT_ENABLED, true);
+    }
+
+    super.end(endTime);
+  }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -12,11 +12,13 @@ public class ModuleExecutionResult extends ModuleSignal {
   private static final int TEST_SKIPPING_ENABLED_FLAG = 2;
   private static final int EARLY_FLAKE_DETECTION_ENABLED_FLAG = 4;
   private static final int EARLY_FLAKE_DETECTION_FAULTY_FLAG = 8;
+  private static final int TEST_MANAGEMENT_ENABLED_FLAG = 16;
 
   private final boolean coverageEnabled;
   private final boolean testSkippingEnabled;
   private final boolean earlyFlakeDetectionEnabled;
   private final boolean earlyFlakeDetectionFaulty;
+  private final boolean testManagementEnabled;
   private final long testsSkippedTotal;
   private final Collection<TestFramework> testFrameworks;
 
@@ -27,6 +29,7 @@ public class ModuleExecutionResult extends ModuleSignal {
       boolean testSkippingEnabled,
       boolean earlyFlakeDetectionEnabled,
       boolean earlyFlakeDetectionFaulty,
+      boolean testManagementEnabled,
       long testsSkippedTotal,
       Collection<TestFramework> testFrameworks) {
     super(sessionId, moduleId);
@@ -34,6 +37,7 @@ public class ModuleExecutionResult extends ModuleSignal {
     this.testSkippingEnabled = testSkippingEnabled;
     this.earlyFlakeDetectionEnabled = earlyFlakeDetectionEnabled;
     this.earlyFlakeDetectionFaulty = earlyFlakeDetectionFaulty;
+    this.testManagementEnabled = testManagementEnabled;
     this.testsSkippedTotal = testsSkippedTotal;
     this.testFrameworks = testFrameworks;
   }
@@ -52,6 +56,10 @@ public class ModuleExecutionResult extends ModuleSignal {
 
   public boolean isEarlyFlakeDetectionFaulty() {
     return earlyFlakeDetectionFaulty;
+  }
+
+  public boolean isTestManagementEnabled() {
+    return testManagementEnabled;
   }
 
   public long getTestsSkippedTotal() {
@@ -131,6 +139,9 @@ public class ModuleExecutionResult extends ModuleSignal {
     if (earlyFlakeDetectionFaulty) {
       flags |= EARLY_FLAKE_DETECTION_FAULTY_FLAG;
     }
+    if (testManagementEnabled) {
+      flags |= TEST_MANAGEMENT_ENABLED_FLAG;
+    }
     s.write(flags);
 
     s.write(testsSkippedTotal);
@@ -148,6 +159,7 @@ public class ModuleExecutionResult extends ModuleSignal {
     boolean testSkippingEnabled = (flags & TEST_SKIPPING_ENABLED_FLAG) != 0;
     boolean earlyFlakeDetectionEnabled = (flags & EARLY_FLAKE_DETECTION_ENABLED_FLAG) != 0;
     boolean earlyFlakeDetectionFaulty = (flags & EARLY_FLAKE_DETECTION_FAULTY_FLAG) != 0;
+    boolean testManagementEnabled = (flags & TEST_MANAGEMENT_ENABLED_FLAG) != 0;
 
     long testsSkippedTotal = Serializer.readLong(buffer);
     Collection<TestFramework> testFrameworks =
@@ -160,6 +172,7 @@ public class ModuleExecutionResult extends ModuleSignal {
         testSkippingEnabled,
         earlyFlakeDetectionEnabled,
         earlyFlakeDetectionFaulty,
+        testManagementEnabled,
         testsSkippedTotal,
         testFrameworks);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -105,7 +105,7 @@ public class ExecutionStrategy {
           config.getCiVisibilityFlakyRetryCount(), isQuarantined(test), autoRetriesUsed);
     }
 
-    if (isQuarantined(test)) {
+    if (executionSettings.getTestManagementSettings().isEnabled() && isQuarantined(test)) {
       return new RunOnceIgnoreOutcome();
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -8,6 +8,7 @@ import datadog.trace.api.civisibility.execution.TestExecutionPolicy;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.civisibility.config.EarlyFlakeDetectionSettings;
 import datadog.trace.civisibility.config.ExecutionSettings;
+import datadog.trace.civisibility.config.TestManagementSettings;
 import datadog.trace.civisibility.execution.Regular;
 import datadog.trace.civisibility.execution.RetryUntilSuccessful;
 import datadog.trace.civisibility.execution.RunNTimes;
@@ -62,6 +63,10 @@ public class ExecutionStrategy {
   }
 
   public boolean isQuarantined(TestIdentifier test) {
+    TestManagementSettings testManagementSettings = executionSettings.getTestManagementSettings();
+    if (!testManagementSettings.isEnabled()) {
+      return false;
+    }
     Collection<TestIdentifier> quarantinedTests = executionSettings.getQuarantinedTests();
     return quarantinedTests.contains(test.withoutParameters());
   }
@@ -105,7 +110,7 @@ public class ExecutionStrategy {
           config.getCiVisibilityFlakyRetryCount(), isQuarantined(test), autoRetriesUsed);
     }
 
-    if (executionSettings.getTestManagementSettings().isEnabled() && isQuarantined(test)) {
+    if (isQuarantined(test)) {
       return new RunOnceIgnoreOutcome();
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -54,13 +54,13 @@ class ConfigurationApiImplTest extends Specification {
 
     where:
     agentless | compression | expectedSettings
-    false     | false       | new CiVisibilitySettings(false, false, false, false, false, false, false, EarlyFlakeDetectionSettings.DEFAULT)
-    false     | true        | new CiVisibilitySettings(true, true, true, true, true, true, true, EarlyFlakeDetectionSettings.DEFAULT)
-    true      | false       | new CiVisibilitySettings(false, true, false, true, false, true, false, new EarlyFlakeDetectionSettings(true, [new EarlyFlakeDetectionSettings.ExecutionsByDuration(1000, 3)], 10))
+    false     | false       | new CiVisibilitySettings(false, false, false, false, false, false, false, EarlyFlakeDetectionSettings.DEFAULT, TestManagementSettings.DEFAULT)
+    false     | true        | new CiVisibilitySettings(true, true, true, true, true, true, true, EarlyFlakeDetectionSettings.DEFAULT, TestManagementSettings.DEFAULT)
+    true      | false       | new CiVisibilitySettings(false, true, false, true, false, true, false, new EarlyFlakeDetectionSettings(true, [new EarlyFlakeDetectionSettings.ExecutionsByDuration(1000, 3)], 10), new TestManagementSettings(true, 10))
     true      | true        | new CiVisibilitySettings(false, false, true, true, false, false, true, new EarlyFlakeDetectionSettings(true, [
       new EarlyFlakeDetectionSettings.ExecutionsByDuration(5000, 3),
       new EarlyFlakeDetectionSettings.ExecutionsByDuration(120000, 2)
-    ], 10))
+    ], 10), new TestManagementSettings(true, 20))
   }
 
   def "test skippable tests request"() {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ExecutionSettingsTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ExecutionSettingsTest.groovy
@@ -26,6 +26,7 @@ class ExecutionSettingsTest extends Specification {
       false,
       false,
       EarlyFlakeDetectionSettings.DEFAULT,
+      TestManagementSettings.DEFAULT,
       null,
       [:],
       [:],
@@ -41,6 +42,7 @@ class ExecutionSettingsTest extends Specification {
       true,
       true,
       new EarlyFlakeDetectionSettings(true, [], 10),
+      new TestManagementSettings(true, 20),
       "",
       [(new TestIdentifier("bc", "def", "g")): new TestMetadata(true), (new TestIdentifier("de", "f", null)): new TestMetadata(false)],
       [:],
@@ -57,6 +59,7 @@ class ExecutionSettingsTest extends Specification {
       false,
       true,
       new EarlyFlakeDetectionSettings(true, [new EarlyFlakeDetectionSettings.ExecutionsByDuration(10, 20)], 10),
+      new TestManagementSettings(true, 20),
       "itrCorrelationId",
       [:],
       ["cov"    : BitSet.valueOf(new byte[]{
@@ -77,6 +80,7 @@ class ExecutionSettingsTest extends Specification {
       true,
       true,
       new EarlyFlakeDetectionSettings(true, [new EarlyFlakeDetectionSettings.ExecutionsByDuration(10, 20), new EarlyFlakeDetectionSettings.ExecutionsByDuration(30, 40)], 10),
+        new TestManagementSettings(true, 20),
       "itrCorrelationId",
       [(new TestIdentifier("bc", "def", null)): new TestMetadata(true), (new TestIdentifier("de", "f", null)): new TestMetadata(true)],
       ["cov"    : BitSet.valueOf(new byte[]{

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ExecutionSettingsTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ExecutionSettingsTest.groovy
@@ -80,7 +80,7 @@ class ExecutionSettingsTest extends Specification {
       true,
       true,
       new EarlyFlakeDetectionSettings(true, [new EarlyFlakeDetectionSettings.ExecutionsByDuration(10, 20), new EarlyFlakeDetectionSettings.ExecutionsByDuration(30, 40)], 10),
-        new TestManagementSettings(true, 20),
+      new TestManagementSettings(true, 20),
       "itrCorrelationId",
       [(new TestIdentifier("bc", "def", null)): new TestMetadata(true), (new TestIdentifier("de", "f", null)): new TestMetadata(true)],
       ["cov"    : BitSet.valueOf(new byte[]{

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TestManagementSettingsSerializerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TestManagementSettingsSerializerTest.groovy
@@ -16,9 +16,6 @@ class TestManagementSettingsSerializerTest extends Specification {
     deserialized == settings
 
     where:
-    settings << [
-      TestManagementSettings.DEFAULT,
-      new TestManagementSettings(true, 10),
-    ]
+    settings << [TestManagementSettings.DEFAULT, new TestManagementSettings(true, 10),]
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TestManagementSettingsSerializerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TestManagementSettingsSerializerTest.groovy
@@ -1,0 +1,24 @@
+package datadog.trace.civisibility.config
+
+import datadog.trace.civisibility.ipc.serialization.Serializer
+import spock.lang.Specification
+
+class TestManagementSettingsSerializerTest extends Specification {
+  def "test TestManagementSettings serialization: #iterationIndex"() {
+    when:
+    Serializer s = new Serializer()
+    TestManagementSettingsSerializer.serialize(s, settings)
+
+    def buffer = s.flush()
+    def deserialized = TestManagementSettingsSerializer.deserialize(buffer)
+
+    then:
+    deserialized == settings
+
+    where:
+    settings << [
+      TestManagementSettings.DEFAULT,
+      new TestManagementSettings(true, 10),
+    ]
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
@@ -21,23 +21,27 @@ class HeadlessTestSessionTest extends SpanWriterTest {
   def "test tags are populated correctly in span"() {
     setup:
     def session = givenAHeadlessTestSession()
+    def module = session.testModuleStart("module-name", null)
 
     when:
+    module.end(null)
     session.end(null)
 
     then:
     ListWriterAssert.assertTraces(TEST_WRITER, 1, false, {
-      trace(1) {
+      trace(2) {
         span(0) {
           spanType DDSpanTypes.TEST_SESSION_END
           tags(false) {
             "$Tags.TEST_TEST_MANAGEMENT_ENABLED" true
           }
         }
+        span (1) {
+          spanType DDSpanTypes.TEST_MODULE_END
+        }
       }
     })
   }
-
 
   private HeadlessTestSession givenAHeadlessTestSession() {
     def executionSettings = Stub(ExecutionSettings)

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
@@ -18,45 +18,45 @@ import datadog.trace.civisibility.test.ExecutionStrategy
 
 class HeadlessTestSessionTest extends SpanWriterTest {
 
-    def "test tags are populated correctly in span"() {
-        setup:
-        def session = givenAHeadlessTestSession()
+  def "test tags are populated correctly in span"() {
+    setup:
+    def session = givenAHeadlessTestSession()
 
-        when:
-        session.end(null)
+    when:
+    session.end(null)
 
-        then:
-        ListWriterAssert.assertTraces(TEST_WRITER, 1, false, {
-            trace(1) {
-                span(0) {
-                    spanType DDSpanTypes.TEST_SESSION_END
-                    tags(false) {
-                        "$Tags.TEST_TEST_MANAGEMENT_ENABLED" true
-                    }
-                }
-            }
-        })
-    }
+    then:
+    ListWriterAssert.assertTraces(TEST_WRITER, 1, false, {
+      trace(1) {
+        span(0) {
+          spanType DDSpanTypes.TEST_SESSION_END
+          tags(false) {
+            "$Tags.TEST_TEST_MANAGEMENT_ENABLED" true
+          }
+        }
+      }
+    })
+  }
 
 
-    private HeadlessTestSession givenAHeadlessTestSession() {
-        def executionSettings = Stub(ExecutionSettings)
-        executionSettings.getTestManagementSettings() >> new TestManagementSettings(true, 10)
+  private HeadlessTestSession givenAHeadlessTestSession() {
+    def executionSettings = Stub(ExecutionSettings)
+    executionSettings.getTestManagementSettings() >> new TestManagementSettings(true, 10)
 
-        def executionStrategy = new ExecutionStrategy(Stub(Config), executionSettings, Stub(SourcePathResolver), Stub(LinesResolver))
+    def executionStrategy = new ExecutionStrategy(Stub(Config), executionSettings, Stub(SourcePathResolver), Stub(LinesResolver))
 
-        new HeadlessTestSession(
-                "project-name",
-                null,
-                Provider.UNSUPPORTED,
-                Stub(Config),
-                Stub(CiVisibilityMetricCollector),
-                Stub(TestDecorator),
-                Stub(SourcePathResolver),
-                Stub(Codeowners),
-                Stub(LinesResolver),
-                Stub(CoverageStore.Factory),
-                executionStrategy
-        )
-    }
+    new HeadlessTestSession(
+      "project-name",
+      null,
+      Provider.UNSUPPORTED,
+      Stub(Config),
+      Stub(CiVisibilityMetricCollector),
+      Stub(TestDecorator),
+      Stub(SourcePathResolver),
+      Stub(Codeowners),
+      Stub(LinesResolver),
+      Stub(CoverageStore.Factory),
+      executionStrategy
+      )
+  }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
@@ -1,0 +1,62 @@
+package datadog.trace.civisibility.domain.headless
+
+import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.api.Config
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.civisibility.coverage.CoverageStore
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
+import datadog.trace.api.civisibility.telemetry.tag.Provider
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.civisibility.codeowners.Codeowners
+import datadog.trace.civisibility.config.ExecutionSettings
+import datadog.trace.civisibility.config.TestManagementSettings
+import datadog.trace.civisibility.decorator.TestDecorator
+import datadog.trace.civisibility.domain.SpanWriterTest
+import datadog.trace.civisibility.source.LinesResolver
+import datadog.trace.civisibility.source.SourcePathResolver
+import datadog.trace.civisibility.test.ExecutionStrategy
+
+class HeadlessTestSessionTest extends SpanWriterTest {
+
+    def "test tags are populated correctly in span"() {
+        setup:
+        def session = givenAHeadlessTestSession()
+
+        when:
+        session.end(null)
+
+        then:
+        ListWriterAssert.assertTraces(TEST_WRITER, 1, false, {
+            trace(1) {
+                span(0) {
+                    spanType DDSpanTypes.TEST_SESSION_END
+                    tags(false) {
+                        "$Tags.TEST_TEST_MANAGEMENT_ENABLED" true
+                    }
+                }
+            }
+        })
+    }
+
+
+    private HeadlessTestSession givenAHeadlessTestSession() {
+        def executionSettings = Stub(ExecutionSettings)
+        executionSettings.getTestManagementSettings() >> new TestManagementSettings(true, 10)
+
+        def executionStrategy = new ExecutionStrategy(Stub(Config), executionSettings, Stub(SourcePathResolver), Stub(LinesResolver))
+
+        new HeadlessTestSession(
+                "project-name",
+                null,
+                Provider.UNSUPPORTED,
+                Stub(Config),
+                Stub(CiVisibilityMetricCollector),
+                Stub(TestDecorator),
+                Stub(SourcePathResolver),
+                Stub(Codeowners),
+                Stub(LinesResolver),
+                Stub(CoverageStore.Factory),
+                executionStrategy
+        )
+    }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -16,11 +16,11 @@ class ModuleExecutionResultTest extends Specification {
 
     where:
     signal << [
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, false, false, false, 0, Collections.emptyList()),
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, true, false, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2"))),
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, true, true, false, 2, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework("junit", "5.9.2"))),
-      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, false, false, false, true, 3, Arrays.asList(new TestFramework("junit", null), new TestFramework("junit", "5.9.2"))),
-      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, true, true, true, true, Integer.MAX_VALUE, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework(null, "5.9.2")))
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, false, false, false, false, 0, Collections.emptyList()),
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, true, false, true, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2"))),
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, true, true, false, false, 2, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework("junit", "5.9.2"))),
+      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, false, false, false, true, true, 3, Arrays.asList(new TestFramework("junit", null), new TestFramework("junit", "5.9.2"))),
+      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, true, true, true, true, true, Integer.MAX_VALUE, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework(null, "5.9.2")))
     ]
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -12,7 +12,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -41,8 +41,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
-    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, true, true, false, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, true, true, false, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -70,8 +70,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, true, false, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
-    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, false, true, false, true, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, true, false, true, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, false, true, false, true, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -118,7 +118,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2"))))
+      client.send(new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2"))))
     }
 
     then:
@@ -130,7 +130,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
 
     def errorResponse = new ErrorResponse("An error occurred while processing the signal")

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/config/settings-response.ftl
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/config/settings-response.ftl
@@ -18,6 +18,10 @@
           </#list>
         },
         "faulty_session_threshold": ${settings.earlyFlakeDetectionSettings.faultySessionThreshold}
+      },
+      "test_management": {
+        "enabled": ${settings.testManagementSettings.enabled?c},
+        "attempt_to_fix_retries": ${settings.testManagementSettings.attemptToFixRetries}
       }
     }
   }

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
@@ -80,7 +80,7 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
   private static volatile boolean flakyRetryEnabled = false
   private static volatile boolean earlyFlakinessDetectionEnabled = false
   private static volatile boolean impactedTestsDetectionEnabled = false
-  private static volatile boolean quarantineEnabled = false
+  private static volatile boolean testManagementEnabled = false
 
   public static final int SLOW_TEST_THRESHOLD_MILLIS = 1000
   public static final int VERY_SLOW_TEST_THRESHOLD_MILLIS = 2000
@@ -117,6 +117,10 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
         ], 0)
         : EarlyFlakeDetectionSettings.DEFAULT
 
+        def testManagementSettings = testManagementEnabled
+        ? new TestManagementSettings(true, 20)
+        : TestManagementSettings.DEFAULT
+
         Map<TestIdentifier, TestMetadata> skippableTestsWithMetadata = new HashMap<>()
         for (TestIdentifier skippableTest : skippableTests) {
           skippableTestsWithMetadata.put(skippableTest, new TestMetadata(false))
@@ -129,6 +133,7 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
         flakyRetryEnabled,
         impactedTestsDetectionEnabled,
         earlyFlakinessDetectionSettings,
+        testManagementSettings,
         itrEnabled ? "itrCorrelationId" : null,
         skippableTestsWithMetadata,
         [:],
@@ -259,10 +264,10 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
     knownTests.clear()
     diff = LineDiff.EMPTY
     itrEnabled = false
-    quarantineEnabled = false
     flakyRetryEnabled = false
     earlyFlakinessDetectionEnabled = false
     impactedTestsDetectionEnabled = false
+    testManagementEnabled = false
 
     TEST_WRITER.setFilter(spanFilter)
   }
@@ -288,10 +293,6 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
     this.diff = diff
   }
 
-  def givenQuarantineEnabled(boolean quarantineEnabled) {
-    this.quarantineEnabled = quarantineEnabled
-  }
-
   def givenFlakyRetryEnabled(boolean flakyRetryEnabled) {
     this.flakyRetryEnabled = flakyRetryEnabled
   }
@@ -302,6 +303,10 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
 
   def givenImpactedTestsDetectionEnabled(boolean impactedTestsDetectionEnabled) {
     this.impactedTestsDetectionEnabled = impactedTestsDetectionEnabled
+  }
+
+  def givenTestManagementEnabled(boolean testManagementEnabled) {
+    this.testManagementEnabled = testManagementEnabled
   }
 
   def givenTestsOrder(String testsOrder) {
@@ -321,6 +326,8 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
     injectSysConfig(CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED, "true")
     injectSysConfig(CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_ENABLED, "true")
     injectSysConfig(CiVisibilityConfig.CIVISIBILITY_EARLY_FLAKE_DETECTION_LOWER_LIMIT, "1")
+    injectSysConfig(CiVisibilityConfig.TEST_MANAGEMENT_ENABLED, "true")
+    injectSysConfig(CiVisibilityConfig.TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES, "20")
   }
 
   def cleanupSpec() {

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
@@ -90,7 +90,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runFeatures(features, true)
@@ -105,7 +105,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -126,7 +126,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -293,6 +293,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -326,6 +326,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -233,6 +233,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -199,6 +199,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -131,6 +131,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -97,6 +97,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed/events.ftl
@@ -129,6 +129,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-quarantined-failed/events.ftl
@@ -96,6 +96,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after-class/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after-class/events.ftl
@@ -1,224 +1,224 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedAfterClass",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 1,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfterClass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
-      "span.kind" : "test_suite_end",
-      "error.message" : ${content_meta_error_message},
-      "test.suite" : "org.example.TestFailedAfterClass",
-      "error.stack" : ${content_meta_error_stack},
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedAfterClass",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterClass.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestFailedAfterClass",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterClass.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterClass.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestFailedAfterClass",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterClass.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "AfterClass",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterClass"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after-param/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after-param/events.ftl
@@ -1,289 +1,289 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedAfterParam",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestFailedAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedAfterParam",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedAfterParam",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterParam.parameterized_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "parameterized_test_succeed",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[0]\"}}",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "parameterized_test_succeed()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestFailedAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
-    "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "parameterized_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "parameterized_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfterParam",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[0]\"}}",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedAfterParam.parameterized_test_succeed",
-    "start" : ${content_start_5},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_5},
     "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "parameterized_test_succeed",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[1]\"}}",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "parameterized_test_succeed()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestFailedAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
-    "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "parameterized_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "parameterized_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfterParam",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[1]\"}}",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterParam.parameterized_test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "test.callback" : "BeforeParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
     "name" : "setup",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "setup",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_5},
-      "test.callback" : "BeforeParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_5},
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
+    "name" : "setup",
     "parent_id" : ${content_test_suite_id},
+    "resource" : "setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_8},
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_8},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_6},
-      "error.stack" : ${content_meta_error_stack},
-      "test.callback" : "AfterParam",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_6},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "tearDown",
-    "start" : ${content_start_9},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_9},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_7},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "AfterParam",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_6},
+    "start" : ${content_start_9},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-after/events.ftl
@@ -1,249 +1,249 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedAfter",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfter",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedAfter",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedAfter",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfter.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfter",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfter.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 1,
+      "test.module" : "junit-4.13",
+      "test.name" : "another_test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "another_test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfter",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfter.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 1,
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfter",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id_2},
+      "test.module" : "junit-4.13",
+      "test.name" : "test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfter",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfter.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_3},
-      "test.callback" : "After",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "After"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_span_id_2},
     "resource" : "tearDown",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_4},
-      "test.callback" : "After",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "After"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_span_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before-class/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before-class/events.ftl
@@ -1,130 +1,130 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedBeforeClass",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 1,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBeforeClass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
-      "span.kind" : "test_suite_end",
-      "error.message" : ${content_meta_error_message},
-      "test.suite" : "org.example.TestFailedBeforeClass",
-      "error.stack" : ${content_meta_error_stack},
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedBeforeClass",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "BeforeClass",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeClass"
+    },
+    "metrics" : { },
+    "name" : "setup",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "setup",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before-param/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before-param/events.ftl
@@ -1,193 +1,193 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "skip",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "skip",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedBeforeParam",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "skip",
+      "test.suite" : "org.example.TestFailedBeforeParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "skip",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedBeforeParam",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedBeforeParam",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "error.stack" : ${content_meta_error_stack},
-      "test.callback" : "BeforeParam",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
     "name" : "setup",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "setup",
-    "start" : ${content_start_5},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_5},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_5},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "BeforeParam",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
+    "name" : "setup",
     "parent_id" : ${content_test_suite_id},
+    "resource" : "setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_6},
-      "test.callback" : "AfterParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "tearDown",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_7},
-      "test.callback" : "AfterParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-failed-before/events.ftl
@@ -1,249 +1,249 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedBefore",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBefore",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedBefore",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedBefore",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedBefore.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedBefore",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedBefore.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 1,
+      "test.module" : "junit-4.13",
+      "test.name" : "another_test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "another_test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBefore",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedBefore.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 1,
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedBefore",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id_2},
+      "test.module" : "junit-4.13",
+      "test.name" : "test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBefore",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedBefore.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_3},
-      "test.callback" : "Before",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "Before"
+    },
+    "metrics" : { },
     "name" : "setup",
+    "parent_id" : ${content_span_id_2},
     "resource" : "setup",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_4},
-      "test.callback" : "Before",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "Before"
+    },
+    "metrics" : { },
+    "name" : "setup",
+    "parent_id" : ${content_span_id},
+    "resource" : "setup",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-after/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-after/events.ftl
@@ -1,277 +1,277 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestSucceedBeforeAfter",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeAfter",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestSucceedBeforeAfter",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestSucceedBeforeAfter",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeAfter.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeAfter",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeAfter.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeAfter.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeAfter",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id_2},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeAfter.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "Before",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "Before"
+    },
+    "metrics" : { },
     "name" : "setup",
+    "parent_id" : ${content_span_id_2},
     "resource" : "setup",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "Before",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_5},
-    "parent_id" : ${content_span_id_2},
+      "test.callback" : "Before"
+    },
+    "metrics" : { },
+    "name" : "setup",
+    "parent_id" : ${content_span_id},
+    "resource" : "setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_8},
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_8},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "After",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_6},
-    "parent_id" : ${content_span_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "After"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_span_id_2},
     "resource" : "tearDown",
-    "start" : ${content_start_9},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_9},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "After",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "After"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_span_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_6},
+    "start" : ${content_start_9},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-class-after-class/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-class-after-class/events.ftl
@@ -1,239 +1,239 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestSucceedBeforeClassAfterClass",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeClassAfterClass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestSucceedBeforeClassAfterClass",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestSucceedBeforeClassAfterClass",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeClassAfterClass.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeClassAfterClass",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeClassAfterClass.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeClassAfterClass.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-4.13",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeClassAfterClass",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeClassAfterClass.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "test.callback" : "BeforeClass",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_4},
+      "test.callback" : "BeforeClass"
+    },
+    "metrics" : { },
+    "name" : "setup",
     "parent_id" : ${content_test_suite_id},
+    "resource" : "setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_7},
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_5},
-      "test.callback" : "AfterClass",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "AfterClass"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-param-after-param/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/resources/test-succeed-before-param-after-param/events.ftl
@@ -1,283 +1,283 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-4.13",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-4.13",
+      "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-4.13",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-4.13",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestSucceedBeforeParamAfterParam",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestSucceedBeforeParamAfterParam",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeParamAfterParam.parameterized_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "parameterized_test_succeed",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[0]\"}}",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "parameterized_test_succeed()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
-    "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "parameterized_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "parameterized_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[0]\"}}",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedBeforeParamAfterParam.parameterized_test_succeed",
-    "start" : ${content_start_5},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_5},
     "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-4.13",
+      "test.name" : "parameterized_test_succeed",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[1]\"}}",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "parameterized_test_succeed()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
-    "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "parameterized_test_succeed()V",
-      "test.module" : "junit-4.13",
-      "test.status" : "pass",
-      "language" : "jvm",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "parameterized_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestSucceedBeforeParamAfterParam",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[1]\"}}",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit4"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeParamAfterParam.parameterized_test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setup",
-    "resource" : "setup",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "test.callback" : "BeforeParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
     "name" : "setup",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "setup",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_5},
-      "test.callback" : "BeforeParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_5},
+      "test.callback" : "BeforeParam"
+    },
+    "metrics" : { },
+    "name" : "setup",
     "parent_id" : ${content_test_suite_id},
+    "resource" : "setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_8},
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_8},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_6},
-      "test.callback" : "AfterParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_6},
-    "parent_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
     "resource" : "tearDown",
-    "start" : ${content_start_9},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_9},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_7},
-      "test.callback" : "AfterParam",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "AfterParam"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_6},
+    "start" : ${content_start_9},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/groovy/MUnitTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/groovy/MUnitTest.groovy
@@ -80,7 +80,7 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)
@@ -93,7 +93,7 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -110,7 +110,7 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "munit",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "munit-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "munit-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "munit",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "munit-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "munit",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "munit",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/resources/test-quarantined-failed/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "munit-junit-4",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -127,7 +127,7 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)
@@ -141,7 +141,7 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -158,7 +158,7 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-4.10",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-4.10",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-4.10",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-4.10",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-4.10",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/resources/test-quarantined-failed/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit4",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
@@ -100,7 +100,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runFeatures(features, false, true)
@@ -115,7 +115,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -136,7 +136,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -326,6 +326,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -293,6 +293,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -199,6 +199,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -233,6 +233,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -131,6 +131,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -97,6 +97,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed/events.ftl
@@ -129,6 +129,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "cucumber-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-quarantined-failed/events.ftl
@@ -96,6 +96,7 @@
       "test.framework" : "cucumber",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-before-all-after-all/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-before-all-after-all/events.ftl
@@ -1,241 +1,241 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestSucceedBeforeAllAfterAll",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeAllAfterAll",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestSucceedBeforeAllAfterAll",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestSucceedBeforeAllAfterAll",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeAllAfterAll.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeAllAfterAll",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeAllAfterAll.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeAllAfterAll.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeAllAfterAll",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeAllAfterAll.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setUp",
-    "resource" : "setUp",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "test.callback" : "BeforeAll",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_4},
+      "test.callback" : "BeforeAll"
+    },
+    "metrics" : { },
+    "name" : "setUp",
     "parent_id" : ${content_test_suite_id},
+    "resource" : "setUp",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_7},
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_5},
-      "test.callback" : "AfterAll",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "AfterAll"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-before-each-after-each/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-before-each-after-each/events.ftl
@@ -1,279 +1,279 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestSucceedBeforeEachAfterEach",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedBeforeEachAfterEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "pass",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestSucceedBeforeEachAfterEach",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestSucceedBeforeEachAfterEach",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeEachAfterEach.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeEachAfterEach",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestSucceedBeforeEachAfterEach.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeEachAfterEach.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestSucceedBeforeEachAfterEach",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedBeforeEachAfterEach.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setUp",
-    "resource" : "setUp",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "BeforeEach",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id_2},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "BeforeEach"
+    },
+    "metrics" : { },
     "name" : "setUp",
+    "parent_id" : ${content_span_id},
     "resource" : "setUp",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "BeforeEach",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_5},
-    "parent_id" : ${content_span_id},
+      "test.callback" : "BeforeEach"
+    },
+    "metrics" : { },
+    "name" : "setUp",
+    "parent_id" : ${content_span_id_2},
+    "resource" : "setUp",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_8},
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_8},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "AfterEach",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_6},
-    "parent_id" : ${content_span_id_2},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "test.callback" : "AfterEach"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_span_id},
     "resource" : "tearDown",
-    "start" : ${content_start_9},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_9},
     "error" : 0,
-    "metrics" : { },
     "meta" : {
-      "test.callback" : "AfterEach",
+      "env" : "none",
       "library_version" : ${content_meta_library_version},
-      "env" : "none"
-    }
-  }
+      "test.callback" : "AfterEach"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_span_id_2},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_6},
+    "start" : ${content_start_9},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-after-all/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-after-all/events.ftl
@@ -1,226 +1,226 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedAfterAll",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 1,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfterAll",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
-      "span.kind" : "test_suite_end",
-      "error.message" : ${content_meta_error_message},
-      "test.suite" : "org.example.TestFailedAfterAll",
-      "error.stack" : ${content_meta_error_stack},
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedAfterAll",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterAll.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 0,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "another_test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestFailedAfterAll",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterAll.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 0,
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterAll.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 0,
     "meta" : {
+      "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "test_succeed",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-5.8",
       "test.status" : "pass",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
       "test.suite" : "org.example.TestFailedAfterAll",
-      "runtime-id" : ${content_meta_runtime_id},
       "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "_dd.profiling.ctx" : "test",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_test_suite_id},
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterAll.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "AfterAll",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterAll"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-after-each/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-after-each/events.ftl
@@ -1,251 +1,251 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedAfterEach",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfterEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedAfterEach",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedAfterEach",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterEach.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfterEach",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedAfterEach.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 1,
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "another_test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "another_test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfterEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterEach.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 1,
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedAfterEach",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedAfterEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedAfterEach.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "tearDown",
-    "resource" : "tearDown",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_3},
-      "test.callback" : "AfterEach",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id_2},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterEach"
+    },
+    "metrics" : { },
     "name" : "tearDown",
+    "parent_id" : ${content_span_id},
     "resource" : "tearDown",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_4},
-      "test.callback" : "AfterEach",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "AfterEach"
+    },
+    "metrics" : { },
+    "name" : "tearDown",
+    "parent_id" : ${content_span_id_2},
+    "resource" : "tearDown",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-before-all/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-before-all/events.ftl
@@ -1,130 +1,130 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedBeforeAll",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 1,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBeforeAll",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
-      "span.kind" : "test_suite_end",
-      "error.message" : ${content_meta_error_message},
-      "test.suite" : "org.example.TestFailedBeforeAll",
-      "error.stack" : ${content_meta_error_stack},
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_test_session_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedBeforeAll",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setUp",
-    "resource" : "setUp",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "error.stack" : ${content_meta_error_stack_2},
-      "test.callback" : "BeforeAll",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeAll"
+    },
+    "metrics" : { },
+    "name" : "setUp",
+    "parent_id" : ${content_test_suite_id},
+    "resource" : "setUp",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-before-each/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/resources/test-failed-before-each/events.ftl
@@ -1,251 +1,251 @@
 [ {
-  "type" : "test_session_end",
-  "version" : 1,
   "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_session",
-    "resource" : "junit-5.8",
-    "start" : ${content_start},
     "duration" : ${content_duration},
     "error" : 0,
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0
-    },
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
-      "test.type" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "language" : "jvm",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
       "_dd.profiling.ctx" : "test",
-      "span.kind" : "test_session_end",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
       "test.command" : "junit-5.8",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_module_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_module",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "junit.test_session",
     "resource" : "junit-5.8",
-    "start" : ${content_start_2},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_2},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "test.type" : "test",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_module_end",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test_suite_end",
-  "version" : 1,
-  "content" : {
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_module",
+    "resource" : "junit-5.8",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test_suite",
-    "resource" : "org.example.TestFailedBeforeEach",
-    "start" : ${content_start_3},
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_3},
     "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_suite_end",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5.8",
+      "test.source.file" : "dummy_source_path",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBeforeEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "test.type" : "test",
-      "test.source.file" : "dummy_source_path",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "component" : "junit",
-      "span.kind" : "test_suite_end",
-      "test.suite" : "org.example.TestFailedBeforeEach",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
+    "name" : "junit.test_suite",
+    "resource" : "org.example.TestFailedBeforeEach",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedBeforeEach.another_test_succeed",
-    "start" : ${content_start_4},
+    "start" : ${content_start_3},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id}
+  },
+  "type" : "test_suite_end",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_4},
     "error" : 1,
-    "metrics" : {
-      "process_id" : ${content_metrics_process_id},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "another_test_succeed()V",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "another_test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedBeforeEach",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "test",
-  "version" : 2,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_2},
-    "parent_id" : ${content_parent_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_module_id" : ${content_test_module_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "junit.test",
-    "resource" : "org.example.TestFailedBeforeEach.test_succeed",
-    "start" : ${content_start_5},
-    "duration" : ${content_duration_5},
-    "error" : 1,
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "another_test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "another_test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBeforeEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
     "metrics" : {
-      "process_id" : ${content_metrics_process_id},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "process_id" : ${content_metrics_process_id},
       "test.source.end" : 18,
       "test.source.start" : 12
     },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedBeforeEach.another_test_succeed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id},
+    "start" : ${content_start_4},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_5},
+    "error" : 1,
     "meta" : {
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test_succeed()V",
-      "test.module" : "junit-5.8",
-      "test.status" : "fail",
-      "language" : "jvm",
-      "test.is_new" : "true",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "library_version" : ${content_meta_library_version},
-      "test.name" : "test_succeed",
-      "span.kind" : "test",
-      "test.suite" : "org.example.TestFailedBeforeEach",
-      "runtime-id" : ${content_meta_runtime_id},
-      "test.type" : "test",
-      "test_session.name" : "session-name",
-      "env" : "none",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "component" : "junit",
-      "error.type" : "java.lang.RuntimeException",
       "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "junit",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
       "error.message" : ${content_meta_error_message},
       "error.stack" : ${content_meta_error_stack_2},
+      "error.type" : "java.lang.RuntimeException",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.framework" : "junit5"
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id},
-    "span_id" : ${content_span_id_3},
-    "parent_id" : ${content_span_id},
+      "test.is_new" : "true",
+      "test.module" : "junit-5.8",
+      "test.name" : "test_succeed",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test_succeed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedBeforeEach",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "junit.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedBeforeEach.test_succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "name" : "setUp",
-    "resource" : "setUp",
-    "start" : ${content_start_6},
+    "span_id" : ${content_span_id_2},
+    "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
     "duration" : ${content_duration_6},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_3},
-      "test.callback" : "BeforeEach",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
-}, {
-  "type" : "span",
-  "version" : 1,
-  "content" : {
-    "trace_id" : ${content_trace_id_2},
-    "span_id" : ${content_span_id_4},
-    "parent_id" : ${content_span_id_2},
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeEach"
+    },
+    "metrics" : { },
     "name" : "setUp",
+    "parent_id" : ${content_span_id},
     "resource" : "setUp",
-    "start" : ${content_start_7},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_trace_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
     "duration" : ${content_duration_7},
     "error" : 1,
-    "metrics" : { },
     "meta" : {
-      "error.stack" : ${content_meta_error_stack_4},
-      "test.callback" : "BeforeEach",
-      "library_version" : ${content_meta_library_version},
-      "error.type" : "java.lang.RuntimeException",
       "env" : "none",
-      "error.message" : ${content_meta_error_message}
-    }
-  }
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "java.lang.RuntimeException",
+      "library_version" : ${content_meta_library_version},
+      "test.callback" : "BeforeEach"
+    },
+    "metrics" : { },
+    "name" : "setUp",
+    "parent_id" : ${content_span_id_2},
+    "resource" : "setUp",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "span",
+  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.api.DisableTestTrace
-import datadog.trace.api.civisibility.CIConstants
 import datadog.trace.api.civisibility.config.TestIdentifier
 import datadog.trace.civisibility.CiVisibilityInstrumentationTest
 import datadog.trace.civisibility.diff.FileDiff
@@ -133,7 +132,7 @@ class SpockTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)
@@ -147,7 +146,7 @@ class SpockTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -164,7 +163,7 @@ class SpockTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -317,6 +317,7 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -350,6 +350,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "spock-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -215,6 +215,7 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -249,6 +249,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "spock-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -105,6 +105,7 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -139,6 +139,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "spock-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -153,6 +153,7 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -186,6 +186,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "spock-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed/events.ftl
@@ -137,6 +137,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "spock-junit-5",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/resources/test-quarantined-failed/events.ftl
@@ -104,6 +104,7 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -165,7 +165,7 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)
@@ -179,7 +179,7 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -196,7 +196,7 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-5.3",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-5.3",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -18,6 +18,7 @@
       "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -52,6 +52,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-5.3",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-5.3",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed/events.ftl
@@ -50,6 +50,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "junit-5.3",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/test-quarantined-failed/events.ftl
@@ -17,6 +17,7 @@
       "test.framework" : "junit5",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
+++ b/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
@@ -96,7 +96,7 @@ class KarateTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)

--- a/dd-java-agent/instrumentation/karate/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/karate/src/test/resources/test-quarantined-failed/events.ftl
@@ -185,6 +185,7 @@
       "test.framework" : "karate",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/karate/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/karate/src/test/resources/test-quarantined-failed/events.ftl
@@ -218,6 +218,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "karate",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/groovy/ScalatestTest.groovy
+++ b/dd-java-agent/instrumentation/scalatest/src/test/groovy/ScalatestTest.groovy
@@ -102,7 +102,7 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, true)
@@ -115,7 +115,7 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined auto-retries #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -132,7 +132,7 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test quarantined early flakiness detection #testcaseName"() {
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -335,6 +335,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "scalatest",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -302,6 +302,7 @@
       "test.framework" : "scalatest",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -240,6 +240,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "scalatest",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -206,6 +206,7 @@
       "test.framework" : "scalatest",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -136,6 +136,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "scalatest",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -102,6 +102,7 @@
       "test.framework" : "scalatest",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed/events.ftl
@@ -134,6 +134,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "scalatest",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/scalatest/src/test/resources/test-quarantined-failed/events.ftl
@@ -101,6 +101,7 @@
       "test.framework" : "scalatest",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -157,7 +157,7 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
   def "test quarantined #testcaseName"() {
     Assumptions.assumeTrue(isExceptionSuppressionSupported())
 
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     runTests(tests, null, true)
@@ -173,7 +173,7 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
   def "test quarantined auto-retries #testcaseName"() {
     Assumptions.assumeTrue(isExceptionSuppressionSupported())
 
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenFlakyRetryEnabled(true)
@@ -192,7 +192,7 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
   def "test quarantined early flakiness detection #testcaseName"() {
     Assumptions.assumeTrue(isExceptionSuppressionSupported())
 
-    givenQuarantineEnabled(true)
+    givenTestManagementEnabled(true)
     givenQuarantinedTests(quarantined)
 
     givenEarlyFlakinessDetectionEnabled(true)

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-7/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-7/events.ftl
@@ -137,6 +137,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "testng-7",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-7/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-7/events.ftl
@@ -104,6 +104,7 @@
       "test.framework" : "testng",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-atr-7/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-atr-7/events.ftl
@@ -317,6 +317,7 @@
       "test.framework" : "testng",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-atr-7/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-atr-7/events.ftl
@@ -350,6 +350,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "testng-7",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -249,6 +249,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "testng-7",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -215,6 +215,7 @@
       "test.framework" : "testng",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -139,6 +139,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "testng-7",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -105,6 +105,7 @@
       "test.framework" : "testng",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -186,6 +186,7 @@
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.module" : "testng-7",
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -153,6 +153,7 @@
       "test.framework" : "testng",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.status" : "fail",
+      "test.test_management.enabled" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -163,6 +163,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_CIVISIBILITY_SIGNAL_SERVER_PORT = 0;
   static final List<String> DEFAULT_CIVISIBILITY_RESOURCE_FOLDER_NAMES =
       asList("/resources/", "/java/", "/groovy/", "/kotlin/", "/scala/");
+  public static final int DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES = -1;
 
   static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
   static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -163,7 +163,6 @@ public final class ConfigDefaults {
   static final int DEFAULT_CIVISIBILITY_SIGNAL_SERVER_PORT = 0;
   static final List<String> DEFAULT_CIVISIBILITY_RESOURCE_FOLDER_NAMES =
       asList("/resources/", "/java/", "/groovy/", "/kotlin/", "/scala/");
-  public static final int DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES = -1;
 
   static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
   static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -77,6 +77,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_REMOTE_ENV_VARS_PROVIDER_KEY =
       "civisibility.remote.env.vars.provider.key";
   public static final String CIVISIBILITY_TEST_ORDER = "civisibility.test.order";
+  public static final String TEST_MANAGEMENT_ENABLED = "test.management.enabled";
+  public static final String TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES = "test.management.attempt.to.fix.retries";
 
   /* COVERAGE SETTINGS */
   public static final String CIVISIBILITY_CODE_COVERAGE_ENABLED =

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -78,7 +78,8 @@ public final class CiVisibilityConfig {
       "civisibility.remote.env.vars.provider.key";
   public static final String CIVISIBILITY_TEST_ORDER = "civisibility.test.order";
   public static final String TEST_MANAGEMENT_ENABLED = "test.management.enabled";
-  public static final String TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES = "test.management.attempt.to.fix.retries";
+  public static final String TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES =
+      "test.management.attempt.to.fix.retries";
 
   /* COVERAGE SETTINGS */
   public static final String CIVISIBILITY_CODE_COVERAGE_ENABLED =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -114,12 +114,14 @@ public class Config {
   private final String runtimeVersion;
 
   private final String applicationKey;
+
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting. If CI Visibility is used with agentless mode, api key is used when
    * sending data (including traces) to backend
    */
   private final String apiKey;
+
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
@@ -374,7 +376,7 @@ public class Config {
   private final String ciVisibilityRemoteEnvVarsProviderKey;
   private final String ciVisibilityTestOrder;
   private final boolean ciVisibilityTestManagementEnabled;
-  private final int ciVisibilityTestManagementAttemptToFixRetries;
+  private final Integer ciVisibilityTestManagementAttemptToFixRetries;
 
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
@@ -1526,8 +1528,7 @@ public class Config {
     ciVisibilityTestOrder = configProvider.getString(CIVISIBILITY_TEST_ORDER);
     ciVisibilityTestManagementEnabled = configProvider.getBoolean(TEST_MANAGEMENT_ENABLED, true);
     ciVisibilityTestManagementAttemptToFixRetries =
-        configProvider.getInteger(
-            TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES, DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
+        configProvider.getInteger(TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
 
     remoteConfigEnabled =
         configProvider.getBoolean(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -373,6 +373,8 @@ public class Config {
   private final String ciVisibilityRemoteEnvVarsProviderUrl;
   private final String ciVisibilityRemoteEnvVarsProviderKey;
   private final String ciVisibilityTestOrder;
+  private final boolean ciVisibilityTestManagementEnabled;
+  private final int ciVisibilityTestManagementAttemptToFixRetries;
 
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
@@ -1522,6 +1524,8 @@ public class Config {
     ciVisibilityRemoteEnvVarsProviderKey =
         configProvider.getString(CIVISIBILITY_REMOTE_ENV_VARS_PROVIDER_KEY);
     ciVisibilityTestOrder = configProvider.getString(CIVISIBILITY_TEST_ORDER);
+    ciVisibilityTestManagementEnabled = configProvider.getBoolean(TEST_MANAGEMENT_ENABLED, true);
+    ciVisibilityTestManagementAttemptToFixRetries = configProvider.getInteger(TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES, DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
 
     remoteConfigEnabled =
         configProvider.getBoolean(
@@ -2977,6 +2981,14 @@ public class Config {
 
   public String getCiVisibilityTestOrder() {
     return ciVisibilityTestOrder;
+  }
+
+  public boolean isCiVisibilityTestManagementEnabled() {
+    return ciVisibilityTestManagementEnabled;
+  }
+
+  public int getCiVisibilityTestManagementAttemptToFixRetries() {
+    return ciVisibilityTestManagementAttemptToFixRetries;
   }
 
   public String getAppSecRulesFile() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2990,7 +2990,7 @@ public class Config {
     return ciVisibilityTestManagementEnabled;
   }
 
-  public int getCiVisibilityTestManagementAttemptToFixRetries() {
+  public Integer getCiVisibilityTestManagementAttemptToFixRetries() {
     return ciVisibilityTestManagementAttemptToFixRetries;
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1525,7 +1525,9 @@ public class Config {
         configProvider.getString(CIVISIBILITY_REMOTE_ENV_VARS_PROVIDER_KEY);
     ciVisibilityTestOrder = configProvider.getString(CIVISIBILITY_TEST_ORDER);
     ciVisibilityTestManagementEnabled = configProvider.getBoolean(TEST_MANAGEMENT_ENABLED, true);
-    ciVisibilityTestManagementAttemptToFixRetries = configProvider.getInteger(TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES, DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
+    ciVisibilityTestManagementAttemptToFixRetries =
+        configProvider.getInteger(
+            TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES, DEFAULT_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
 
     remoteConfigEnabled =
         configProvider.getBoolean(

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -34,7 +34,6 @@ import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.StatusCode;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.api.civisibility.telemetry.tag.TestManagementEnabled;
-
 import java.util.Arrays;
 
 public enum CiVisibilityCountMetric {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -33,6 +33,8 @@ import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
 import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.StatusCode;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
+import datadog.trace.api.civisibility.telemetry.tag.TestManagementEnabled;
+
 import java.util.Arrays;
 
 public enum CiVisibilityCountMetric {
@@ -120,6 +122,7 @@ public enum CiVisibilityCountMetric {
       FlakyTestRetriesEnabled.class,
       ImpactedTestsDetectionEnabled.class,
       KnownTestsEnabled.class,
+      TestManagementEnabled.class,
       RequireGit.class),
   /** The number of requests sent to the itr skippable tests endpoint */
   ITR_SKIPPABLE_TESTS_REQUEST("itr_skippable_tests.request", RequestCompressed.class),

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/TestManagementEnabled.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/TestManagementEnabled.java
@@ -1,0 +1,12 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+public enum TestManagementEnabled implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "test_management_enabled:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -98,6 +98,7 @@ public class Tags {
   public static final String TEST_IS_MODIFIED = "test.is_modified";
   public static final String TEST_HAS_FAILED_ALL_RETRIES = "test.has_failed_all_retries";
   public static final String TEST_MANAGEMENT_IS_QUARANTINED = "test.management.is_quarantined";
+  public static final String TEST_TEST_MANAGEMENT_ENABLED = "test.test_management.enabled";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";


### PR DESCRIPTION
# What Does This Do

- Updates CIVis settings request to receive the `test_management` settings field
- Updates CIVis telemetry accordingly
- Sets `test.test_management.enabled` tag on `test_session_end` events when feature is enabled

# Motivation

First step in the implementation of Flaky Test Management.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1530]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1483]: https://datadoghq.atlassian.net/browse/SDTEST-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDTEST-1530]: https://datadoghq.atlassian.net/browse/SDTEST-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ