### PR TITLE
Update muzzle to record that the Ignite 2.0 instrumentation is not compatible with Ignite 3.0

### DIFF
--- a/dd-java-agent/instrumentation/ignite-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ignite-2.0/build.gradle
@@ -7,7 +7,7 @@ muzzle {
   pass {
     group = 'org.apache.ignite'
     module = 'ignite-core'
-    versions = "[2.0.0,)"
+    versions = "[2.0.0,3)"
   }
 }
 


### PR DESCRIPTION
.