### PR TITLE
Update CODEOWNERS parser to not log errors on comments with leading whitespace

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
@@ -47,9 +47,14 @@ public class EntryBuilder {
 
   public @Nullable Entry parse() {
     try {
-      if (c.length == 0 // empty line
-          || c[0] == '#' // comment
-          || c[0] == '[') { // section header
+      // skip trailing whitespace
+      while (offset < c.length && Character.isWhitespace(c[offset])) {
+        offset++;
+      }
+
+      if (offset == c.length // empty line
+          || c[offset] == '#' // comment
+          || c[offset] == '[') { // section header
         return null;
       }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/codeowners/EntryBuilderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/codeowners/EntryBuilderTest.groovy
@@ -154,14 +154,25 @@ class EntryBuilderTest extends Specification {
     return result.toString()
   }
 
-  def "test invalid range parsing"() {
+  def "test invalid entry parsing: #entry"() {
     setup:
     def matcherFactory = new CharacterMatcher.Factory()
 
     when:
-    def entry = new EntryBuilder(matcherFactory, "token[z-a] owner").parse()
+    def parsedEntry = new EntryBuilder(matcherFactory, entry).parse()
 
     then:
-    entry == null
+    parsedEntry == null
+
+    where:
+    entry << [
+      "token[z-a] owner",
+      "# comment",
+      " # comment with a leading space",
+      "[section header]",
+      " [section header with a leading space]",
+      "",
+      " ",
+    ]
   }
 }


### PR DESCRIPTION
# What Does This Do

Updates CODEOWNERS parsing logic: when there is a comment with a leading whitespace, there will be no error logged.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
