### PR TITLE
Submit Gradle Dependencies

### DIFF
--- a/.github/workflows/submit-dependencies.yaml
+++ b/.github/workflows/submit-dependencies.yaml
@@ -1,0 +1,30 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: ['master']
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    name: Submit Gradle Dependencies
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: 'recursive'
+    - name: Java environment setup
+      shell: bash
+      run: |
+        echo "JAVA_HOME=$JAVA_HOME_8_X64" >> $GITHUB_ENV
+        echo "JAVA_8_HOME=$JAVA_HOME_8_X64" >> $GITHUB_ENV
+        echo "JAVA_11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
+        echo "JAVA_17_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        echo "JAVA_21_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+      env:
+        DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^((?!dd-smoke-tests|buildSrc|test).)*$"


### PR DESCRIPTION
# What Does This Do
[SINT-2813] Gradle dependencies aren't submitted to Github's dependency graph by default, so this PR configures a Github Action to do so. It excludes test and build targets, but let me know if the list of those targets needs to be expanded

[SINT-2813]: https://datadoghq.atlassian.net/browse/SINT-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ