### PR TITLE
Add support for endpoint discovery in spring mvc

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 1ef00a34ad1f83ae999887e510ef1ea1c27b151b
+default_system_tests_commit: &default_system_tests_commit 9be8b2793d687c7d9b39f3265fef27b5ec91910c
 
 parameters:
   nightly:

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/build.gradle
@@ -34,6 +34,20 @@ muzzle {
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
     extraDependency "org.springframework:spring-webmvc:3.1.0.RELEASE"
   }
+
+  pass {
+    name = 'spring-mvc-pre-5.3'
+    group = 'org.springframework'
+    module = 'spring-webmvc'
+    versions = "[3.1.0.RELEASE,5.3)"
+    skipVersions += [
+      '1.2.1',
+      '1.2.2',
+      '1.2.3',
+      '1.2.4'] // broken releases... missing dependencies
+    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
+    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
@@ -42,6 +42,11 @@ public class AppSecDispatcherServletInstrumentation extends InstrumenterModule.A
   }
 
   @Override
+  public String muzzleDirective() {
+    return "spring-mvc-pre-5.3";
+  }
+
+  @Override
   public String[] helperClassNames() {
     return new String[] {packageName + ".RequestMappingInfoIterator"};
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
@@ -57,22 +57,25 @@ public class AppSecDispatcherServletInstrumentation extends InstrumenterModule.A
         AppSecDispatcherServletInstrumentation.class.getName() + "$AppSecHandlerMappingAdvice");
   }
 
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled() && Config.get().isApiSecurityEndpointCollectionEnabled();
+  }
+
   public static class AppSecHandlerMappingAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterRefresh(@Advice.Argument(0) final ApplicationContext springCtx) {
-      if (Config.get().isApiSecurityEndpointCollectionEnabled()) {
-        final RequestMappingHandlerMapping handler =
-            springCtx.getBean(RequestMappingHandlerMapping.class);
-        if (handler == null) {
-          return;
-        }
-        final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
-        if (mappings == null || mappings.isEmpty()) {
-          return;
-        }
-        EndpointCollector.get().supplier(new RequestMappingInfoIterator(mappings));
+      final RequestMappingHandlerMapping handler =
+          springCtx.getBean(RequestMappingHandlerMapping.class);
+      if (handler == null) {
+        return;
       }
+      final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
+      if (mappings == null || mappings.isEmpty()) {
+        return;
+      }
+      EndpointCollector.get().supplier(new RequestMappingInfoIterator(mappings));
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
@@ -1,0 +1,78 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.Config;
+import datadog.trace.api.telemetry.EndpointCollector;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@AutoService(InstrumenterModule.class)
+public class AppSecDispatcherServletInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public AppSecDispatcherServletInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.web.servlet.DispatcherServlet";
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return not(
+        hasClassNamed(
+            "org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition"));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".RequestMappingInfoIterator"};
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(isProtected())
+            .and(named("onRefresh"))
+            .and(takesArgument(0, named("org.springframework.context.ApplicationContext")))
+            .and(takesArguments(1)),
+        AppSecDispatcherServletInstrumentation.class.getName() + "$AppSecHandlerMappingAdvice");
+  }
+
+  public static class AppSecHandlerMappingAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void afterRefresh(@Advice.Argument(0) final ApplicationContext springCtx) {
+      if (Config.get().isApiSecurityEndpointCollectionEnabled()) {
+        final RequestMappingHandlerMapping handler =
+            springCtx.getBean(RequestMappingHandlerMapping.class);
+        if (handler == null) {
+          return;
+        }
+        final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
+        if (mappings == null || mappings.isEmpty()) {
+          return;
+        }
+        EndpointCollector.get().supplier(new RequestMappingInfoIterator(mappings));
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoIterator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoIterator.java
@@ -20,6 +20,7 @@ public class RequestMappingInfoIterator implements Iterator<Endpoint> {
   private final Map<RequestMappingInfo, HandlerMethod> mappings;
   private final Queue<Endpoint> queue = new LinkedList<>();
   private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator;
+  private boolean first = true;
 
   public RequestMappingInfoIterator(final Map<RequestMappingInfo, HandlerMethod> mappings) {
     this.mappings = mappings;
@@ -64,7 +65,7 @@ public class RequestMappingInfoIterator implements Iterator<Endpoint> {
     for (final String path : nextInfo.getPatternsCondition().getPatterns()) {
       final List<String> methods = Method.parseMethods(nextInfo.getMethodsCondition().getMethods());
       for (final String method : methods) {
-        final Endpoint endpoint =
+        Endpoint endpoint =
             new Endpoint()
                 .type(Endpoint.Type.REST)
                 .operation(Endpoint.Operation.HTTP_REQUEST)
@@ -76,6 +77,10 @@ public class RequestMappingInfoIterator implements Iterator<Endpoint> {
           final Map<String, String> metadata = new HashMap<>();
           metadata.put("handler", nextHandler.toString());
           endpoint.metadata(metadata);
+        }
+        if (first) {
+          endpoint.first(true);
+          first = false;
         }
         queue.add(endpoint);
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoIterator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoIterator.java
@@ -1,0 +1,95 @@
+package datadog.trace.instrumentation.springweb;
+
+import datadog.trace.api.telemetry.Endpoint;
+import datadog.trace.api.telemetry.Endpoint.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.condition.MediaTypeExpression;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+
+public class RequestMappingInfoIterator implements Iterator<Endpoint> {
+
+  private final Map<RequestMappingInfo, HandlerMethod> mappings;
+  private final Queue<Endpoint> queue = new LinkedList<>();
+  private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator;
+
+  public RequestMappingInfoIterator(final Map<RequestMappingInfo, HandlerMethod> mappings) {
+    this.mappings = mappings;
+  }
+
+  private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator() {
+    if (iterator == null) {
+      iterator = mappings.entrySet().iterator();
+    }
+    return iterator;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !queue.isEmpty() || iterator().hasNext();
+  }
+
+  @Override
+  public Endpoint next() {
+    if (queue.isEmpty()) {
+      fetchNext();
+    }
+    final Endpoint endpoint = queue.poll();
+    if (endpoint == null) {
+      throw new NoSuchElementException();
+    }
+    return endpoint;
+  }
+
+  private void fetchNext() {
+    final Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> delegate = iterator();
+    if (!delegate.hasNext()) {
+      return;
+    }
+    final Map.Entry<RequestMappingInfo, HandlerMethod> nextEntry = delegate.next();
+    final RequestMappingInfo nextInfo = nextEntry.getKey();
+    final HandlerMethod nextHandler = nextEntry.getValue();
+    final List<String> requestBody =
+        parseMediaTypes(nextInfo.getConsumesCondition().getExpressions());
+    final List<String> responseBody =
+        parseMediaTypes(nextInfo.getProducesCondition().getExpressions());
+    for (final String path : nextInfo.getPatternsCondition().getPatterns()) {
+      final List<String> methods = Method.parseMethods(nextInfo.getMethodsCondition().getMethods());
+      for (final String method : methods) {
+        final Endpoint endpoint =
+            new Endpoint()
+                .type(Endpoint.Type.REST)
+                .operation(Endpoint.Operation.HTTP_REQUEST)
+                .path(path)
+                .method(method)
+                .requestBodyType(requestBody)
+                .responseBodyType(responseBody);
+        if (nextHandler != null) {
+          final Map<String, String> metadata = new HashMap<>();
+          metadata.put("handler", nextHandler.toString());
+          endpoint.metadata(metadata);
+        }
+        queue.add(endpoint);
+      }
+    }
+  }
+
+  private List<String> parseMediaTypes(final Set<MediaTypeExpression> expressions) {
+    if (expressions == null || expressions.isEmpty()) {
+      return null;
+    }
+    final List<String> result = new ArrayList<>(expressions.size());
+    for (final MediaTypeExpression expression : expressions) {
+      result.add(expression.toString());
+    }
+    return result;
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -9,6 +9,7 @@ import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.api.telemetry.Endpoint
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
@@ -19,6 +20,7 @@ import okhttp3.Response
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.context.embedded.EmbeddedWebApplicationContext
 import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.http.MediaType
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter
 import org.springframework.web.servlet.view.RedirectView
 import test.SetupSpecHelper
@@ -127,6 +129,22 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   @Override
   boolean testUserBlocking() {
     true
+  }
+
+  @Override
+  boolean testEndpointDiscovery() {
+    true
+  }
+
+  @Override
+  void assertEndpointDiscovery(final List<?> endpoints) {
+    final discovered = endpoints.collectEntries { [(it.method): it] }  as Map<String, Endpoint>
+    assert discovered.keySet().containsAll([Endpoint.Method.POST, Endpoint.Method.PATCH, Endpoint.Method.PUT])
+    discovered.values().each {
+      assert it.requestBodyType.containsAll([MediaType.APPLICATION_JSON_VALUE])
+      assert it.responseBodyType.containsAll([MediaType.TEXT_PLAIN_VALUE])
+      assert it.metadata['handler'] == 'public org.springframework.http.ResponseEntity test.boot.TestController.discovery()'
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/TestController.groovy
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ENDPOINT_DISCOVERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
@@ -155,6 +156,16 @@ class TestController {
   ResponseEntity exception() {
     HttpServerTest.controller(EXCEPTION) {
       throw new Exception(EXCEPTION.body)
+    }
+  }
+
+  @RequestMapping(value = "/discovery",
+  method = [RequestMethod.POST, RequestMethod.PATCH, RequestMethod.PUT],
+  consumes = MediaType.APPLICATION_JSON_VALUE,
+  produces = MediaType.TEXT_PLAIN_VALUE)
+  ResponseEntity discovery() {
+    HttpServerTest.controller(ENDPOINT_DISCOVERY) {
+      new ResponseEntity(ENDPOINT_DISCOVERY.body, HttpStatus.valueOf(ENDPOINT_DISCOVERY.status))
     }
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
@@ -1,0 +1,78 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.Config;
+import datadog.trace.api.telemetry.EndpointCollector;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@AutoService(InstrumenterModule.class)
+public class AppSecDispatcherServletWithPathPatternsInstrumentation
+    extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public AppSecDispatcherServletWithPathPatternsInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.web.servlet.DispatcherServlet";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".RequestMappingInfoWithPathPatternsIterator"};
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassNamed(
+        "org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition");
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(isProtected())
+            .and(named("onRefresh"))
+            .and(takesArgument(0, named("org.springframework.context.ApplicationContext")))
+            .and(takesArguments(1)),
+        AppSecDispatcherServletWithPathPatternsInstrumentation.class.getName()
+            + "$AppSecHandlerMappingAdvice");
+  }
+
+  public static class AppSecHandlerMappingAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void afterRefresh(@Advice.Argument(0) final ApplicationContext springCtx) {
+      if (Config.get().isApiSecurityEndpointCollectionEnabled()) {
+        final RequestMappingHandlerMapping handler =
+            springCtx.getBean(RequestMappingHandlerMapping.class);
+        if (handler == null) {
+          return;
+        }
+        final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
+        if (mappings == null || mappings.isEmpty()) {
+          return;
+        }
+        EndpointCollector.get().supplier(new RequestMappingInfoWithPathPatternsIterator(mappings));
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
@@ -57,22 +57,25 @@ public class AppSecDispatcherServletWithPathPatternsInstrumentation
             + "$AppSecHandlerMappingAdvice");
   }
 
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled() && Config.get().isApiSecurityEndpointCollectionEnabled();
+  }
+
   public static class AppSecHandlerMappingAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterRefresh(@Advice.Argument(0) final ApplicationContext springCtx) {
-      if (Config.get().isApiSecurityEndpointCollectionEnabled()) {
-        final RequestMappingHandlerMapping handler =
-            springCtx.getBean(RequestMappingHandlerMapping.class);
-        if (handler == null) {
-          return;
-        }
-        final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
-        if (mappings == null || mappings.isEmpty()) {
-          return;
-        }
-        EndpointCollector.get().supplier(new RequestMappingInfoWithPathPatternsIterator(mappings));
+      final RequestMappingHandlerMapping handler =
+          springCtx.getBean(RequestMappingHandlerMapping.class);
+      if (handler == null) {
+        return;
       }
+      final Map<RequestMappingInfo, HandlerMethod> mappings = handler.getHandlerMethods();
+      if (mappings == null || mappings.isEmpty()) {
+        return;
+      }
+      EndpointCollector.get().supplier(new RequestMappingInfoWithPathPatternsIterator(mappings));
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoWithPathPatternsIterator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoWithPathPatternsIterator.java
@@ -1,0 +1,112 @@
+package datadog.trace.instrumentation.springweb;
+
+import datadog.trace.api.telemetry.Endpoint;
+import datadog.trace.api.telemetry.Endpoint.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.condition.MediaTypeExpression;
+import org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+
+public class RequestMappingInfoWithPathPatternsIterator implements Iterator<Endpoint> {
+
+  private final Map<RequestMappingInfo, HandlerMethod> mappings;
+  private final Queue<Endpoint> queue = new LinkedList<>();
+  private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator;
+
+  public RequestMappingInfoWithPathPatternsIterator(
+      final Map<RequestMappingInfo, HandlerMethod> mappings) {
+    this.mappings = mappings;
+  }
+
+  private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator() {
+    if (iterator == null) {
+      iterator = mappings.entrySet().iterator();
+    }
+    return iterator;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !queue.isEmpty() || iterator().hasNext();
+  }
+
+  @Override
+  public Endpoint next() {
+    if (queue.isEmpty()) {
+      fetchNext();
+    }
+    final Endpoint endpoint = queue.poll();
+    if (endpoint == null) {
+      throw new NoSuchElementException();
+    }
+    return endpoint;
+  }
+
+  private void fetchNext() {
+    final Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> delegate = iterator();
+    if (!delegate.hasNext()) {
+      return;
+    }
+    final Map.Entry<RequestMappingInfo, HandlerMethod> nextEntry = delegate.next();
+    final RequestMappingInfo nextInfo = nextEntry.getKey();
+    final HandlerMethod nextHandler = nextEntry.getValue();
+    final List<String> requestBody =
+        parseMediaTypes(nextInfo.getConsumesCondition().getExpressions());
+    final List<String> responseBody =
+        parseMediaTypes(nextInfo.getProducesCondition().getExpressions());
+    for (final String path : getPatterns(nextInfo)) {
+      final List<String> methods = Method.parseMethods(nextInfo.getMethodsCondition().getMethods());
+      for (final String method : methods) {
+        final Endpoint endpoint =
+            new Endpoint()
+                .type(Endpoint.Type.REST)
+                .operation(Endpoint.Operation.HTTP_REQUEST)
+                .path(path)
+                .method(method)
+                .requestBodyType(requestBody)
+                .responseBodyType(responseBody);
+        if (nextHandler != null) {
+          final Map<String, String> metadata = new HashMap<>();
+          metadata.put("handler", nextHandler.toString());
+          endpoint.metadata(metadata);
+        }
+        queue.add(endpoint);
+      }
+    }
+  }
+
+  private Set<String> getPatterns(final RequestMappingInfo info) {
+    final Set<String> result = new HashSet<>();
+    final PatternsRequestCondition patternsCondition = info.getPatternsCondition();
+    if (patternsCondition != null) {
+      result.addAll(patternsCondition.getPatterns());
+    }
+    final PathPatternsRequestCondition pathPatternsCondition = info.getPathPatternsCondition();
+    if (pathPatternsCondition != null) {
+      result.addAll(pathPatternsCondition.getPatternValues());
+    }
+    return result;
+  }
+
+  private List<String> parseMediaTypes(final Set<MediaTypeExpression> expressions) {
+    if (expressions == null || expressions.isEmpty()) {
+      return null;
+    }
+    final List<String> result = new ArrayList<>(expressions.size());
+    for (final MediaTypeExpression expression : expressions) {
+      result.add(expression.toString());
+    }
+    return result;
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoWithPathPatternsIterator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/RequestMappingInfoWithPathPatternsIterator.java
@@ -23,6 +23,7 @@ public class RequestMappingInfoWithPathPatternsIterator implements Iterator<Endp
   private final Map<RequestMappingInfo, HandlerMethod> mappings;
   private final Queue<Endpoint> queue = new LinkedList<>();
   private Iterator<Map.Entry<RequestMappingInfo, HandlerMethod>> iterator;
+  private boolean first = true;
 
   public RequestMappingInfoWithPathPatternsIterator(
       final Map<RequestMappingInfo, HandlerMethod> mappings) {
@@ -80,6 +81,10 @@ public class RequestMappingInfoWithPathPatternsIterator implements Iterator<Endp
           final Map<String, String> metadata = new HashMap<>();
           metadata.put("handler", nextHandler.toString());
           endpoint.metadata(metadata);
+        }
+        if (first) {
+          endpoint.first(true);
+          first = false;
         }
         queue.add(endpoint);
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/test/boot/EndpointCollectorSpringBootTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/test/boot/EndpointCollectorSpringBootTest.groovy
@@ -1,0 +1,54 @@
+package test.boot
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.telemetry.Endpoint
+import datadog.trace.api.telemetry.EndpointCollector
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ENDPOINT_DISCOVERY
+
+@SpringBootTest(classes = DiscoveryController)
+@EnableWebMvc
+@AutoConfigureMockMvc
+class EndpointCollectorSpringBootTest extends AgentTestRunner {
+
+  @Controller
+  static class DiscoveryController {
+
+    @RequestMapping(value = "/discovery",
+    method = [RequestMethod.POST, RequestMethod.PATCH, RequestMethod.PUT],
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.TEXT_PLAIN_VALUE)
+    ResponseEntity discovery() {
+      HttpServerTest.controller(ENDPOINT_DISCOVERY) {
+        new ResponseEntity(ENDPOINT_DISCOVERY.body, HttpStatus.valueOf(ENDPOINT_DISCOVERY.status))
+      }
+    }
+  }
+
+  void 'test endpoint discovery'() {
+    when:
+    final endpoints = EndpointCollector.get().drain().toList().findAll { it.path == ENDPOINT_DISCOVERY.path }
+
+    then:
+    final discovery = endpoints.collectEntries { [(it.method): it] } as Map<String, Endpoint>
+    discovery.keySet().containsAll([Endpoint.Method.POST, Endpoint.Method.PATCH, Endpoint.Method.PUT])
+    discovery.values().each {
+      assert it.path == ENDPOINT_DISCOVERY.path
+      assert it.type == Endpoint.Type.REST
+      assert it.operation == Endpoint.Operation.HTTP_REQUEST
+      assert it.requestBodyType.containsAll([MediaType.APPLICATION_JSON_VALUE])
+      assert it.responseBodyType.containsAll([MediaType.TEXT_PLAIN_VALUE])
+      assert it.metadata['handler'] == 'test.boot.EndpointCollectorSpringBootTest$DiscoveryController#discovery()'
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/test/boot/EndpointCollectorSpringBootTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/test/boot/EndpointCollectorSpringBootTest.groovy
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.servlet.config.annotation.EnableWebMvc
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ENDPOINT_DISCOVERY
+import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENDPOINT_COLLECTION_ENABLED
 
 @SpringBootTest(classes = DiscoveryController)
 @EnableWebMvc
@@ -33,6 +34,11 @@ class EndpointCollectorSpringBootTest extends AgentTestRunner {
         new ResponseEntity(ENDPOINT_DISCOVERY.body, HttpStatus.valueOf(ENDPOINT_DISCOVERY.status))
       }
     }
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig(API_SECURITY_ENDPOINT_COLLECTION_ENABLED, "true")
   }
 
   void 'test endpoint discovery'() {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/TestController.groovy
@@ -137,6 +137,16 @@ class TestController {
     }
   }
 
+  @RequestMapping(value = "/discovery",
+  method = [RequestMethod.POST, RequestMethod.PATCH, RequestMethod.PUT],
+  consumes = MediaType.APPLICATION_JSON_VALUE,
+  produces = MediaType.TEXT_PLAIN_VALUE)
+  ResponseEntity discovery() {
+    HttpServerTest.controller(ENDPOINT_DISCOVERY) {
+      new ResponseEntity(ENDPOINT_DISCOVERY.body, HttpStatus.valueOf(ENDPOINT_DISCOVERY.status))
+    }
+  }
+
   @ExceptionHandler
   ResponseEntity handleException(Throwable throwable) {
     new ResponseEntity(throwable.message, HttpStatus.INTERNAL_SERVER_ERROR)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -84,6 +84,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_B
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.WEBSOCKET
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENDPOINT_COLLECTION_ENABLED
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_QUERY_STRING
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING
@@ -163,6 +164,8 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     injectSysConfig(REQUEST_HEADER_TAGS, 'x-datadog-test-request-header:request_header_tag')
     // We don't inject a matching response header tag here since it would be always on and show up in all the tests
     injectSysConfig(TRACE_WEBSOCKET_MESSAGES_ENABLED, "true")
+    // allow endpoint discover for the tests
+    injectSysConfig(API_SECURITY_ENDPOINT_COLLECTION_ENABLED, "true")
   }
 
   // used in blocking tests to check if the handler was skipped

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -462,7 +462,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     SECURE_SUCCESS("secure/success", 200, null),
 
     SESSION_ID("session", 200, null),
-    WEBSOCKET("websocket", 101, null)
+    WEBSOCKET("websocket", 101, null),
 
     ENDPOINT_DISCOVERY('discovery', 200, 'OK')
 
@@ -2117,11 +2117,16 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     final discovered = endpoints.findAll { it.path == ServerEndpoint.ENDPOINT_DISCOVERY.path }
 
     then:
+    !endpoints.isEmpty()
+    endpoints.eachWithIndex { Endpoint entry, int i ->
+      assert entry.first == (i == 0)
+    }
+
     !discovered.isEmpty()
-    discovered.each {
-      assert it.path == ServerEndpoint.ENDPOINT_DISCOVERY.path
-      assert it.type == Endpoint.Type.REST
-      assert it.operation == Endpoint.Operation.HTTP_REQUEST
+    discovered.eachWithIndex { endpoint, index ->
+      assert endpoint.path == ServerEndpoint.ENDPOINT_DISCOVERY.path
+      assert endpoint.type == Endpoint.Type.REST
+      assert endpoint.operation == Endpoint.Operation.HTTP_REQUEST
     }
     assertEndpointDiscovery(discovered)
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -115,7 +115,8 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_SAMPLE_DELAY = 30.0f;
-  static final boolean DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED = true;
+  // TODO: change to true once the RFC is approved
+  static final boolean DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED = false;
   static final int DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT = 300;
   static final boolean DEFAULT_APPSEC_RASP_ENABLED = true;
   static final boolean DEFAULT_APPSEC_STACK_TRACE_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -115,6 +115,8 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_SAMPLE_DELAY = 30.0f;
+  static final boolean DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED = true;
+  static final int DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT = 300;
   static final boolean DEFAULT_APPSEC_RASP_ENABLED = true;
   static final boolean DEFAULT_APPSEC_STACK_TRACE_ENABLED = true;
   static final int DEFAULT_APPSEC_MAX_STACK_TRACES = 2;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -27,6 +27,11 @@ public final class AppSecConfig {
   public static final String API_SECURITY_ENABLED_EXPERIMENTAL =
       "experimental.api-security.enabled";
   public static final String API_SECURITY_SAMPLE_DELAY = "api-security.sample.delay";
+  public static final String API_SECURITY_REQUEST_SAMPLE_RATE = "api-security.request.sample.rate";
+  public static final String API_SECURITY_ENDPOINT_COLLECTION_ENABLED =
+      "api-security.endpoint.collection.enabled";
+  public static final String API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT =
+      "api-security.endpoint.collection.message.limit";
 
   public static final String APPSEC_SCA_ENABLED = "appsec.sca.enabled";
   public static final String APPSEC_RASP_ENABLED = "appsec.rasp.enabled";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -27,7 +27,6 @@ public final class AppSecConfig {
   public static final String API_SECURITY_ENABLED_EXPERIMENTAL =
       "experimental.api-security.enabled";
   public static final String API_SECURITY_SAMPLE_DELAY = "api-security.sample.delay";
-  public static final String API_SECURITY_REQUEST_SAMPLE_RATE = "api-security.request.sample.rate";
   public static final String API_SECURITY_ENDPOINT_COLLECTION_ENABLED =
       "api-security.endpoint.collection.enabled";
   public static final String API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT =

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -197,6 +197,8 @@ excludedClassesCoverage += [
   // POJO
   'datadog.trace.api.iast.util.Cookie',
   'datadog.trace.api.iast.util.Cookie.Builder',
+  'datadog.trace.api.telemetry.Endpoint',
+  'datadog.trace.api.telemetry.Endpoint.Method',
   'datadog.trace.api.telemetry.LogCollector.RawLogMessage',
   "datadog.trace.api.telemetry.MetricCollector.DistributionSeriesPoint",
   "datadog.trace.api.telemetry.MetricCollector",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -293,6 +293,8 @@ public class Config {
   private final int appSecMaxStackTraceDepth;
   private final boolean apiSecurityEnabled;
   private final float apiSecuritySampleDelay;
+  private final boolean apiSecurityEndpointCollectionEnabled;
+  private final int apiSecurityEndpointCollectionMessageLimit;
 
   private final IastDetectionMode iastDetectionMode;
   private final int iastMaxConcurrentRequests;
@@ -1387,6 +1389,15 @@ public class Config {
             API_SECURITY_ENABLED, DEFAULT_API_SECURITY_ENABLED, API_SECURITY_ENABLED_EXPERIMENTAL);
     apiSecuritySampleDelay =
         configProvider.getFloat(API_SECURITY_SAMPLE_DELAY, DEFAULT_API_SECURITY_SAMPLE_DELAY);
+    apiSecurityEndpointCollectionEnabled =
+        configProvider.getBoolean(
+            API_SECURITY_ENDPOINT_COLLECTION_ENABLED,
+            getAppSecActivation() != ProductActivation.FULLY_DISABLED
+                && DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED);
+    apiSecurityEndpointCollectionMessageLimit =
+        configProvider.getInteger(
+            API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT,
+            DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT);
 
     iastDebugEnabled = configProvider.getBoolean(IAST_DEBUG_ENABLED, DEFAULT_IAST_DEBUG_ENABLED);
 
@@ -2764,6 +2775,14 @@ public class Config {
 
   public float getApiSecuritySampleDelay() {
     return apiSecuritySampleDelay;
+  }
+
+  public int getApiSecurityEndpointCollectionMessageLimit() {
+    return apiSecurityEndpointCollectionMessageLimit;
+  }
+
+  public boolean isApiSecurityEndpointCollectionEnabled() {
+    return apiSecurityEndpointCollectionEnabled;
   }
 
   public ProductActivation getIastActivation() {
@@ -4798,6 +4817,10 @@ public class Config {
         + appSecHttpBlockedTemplateJson
         + ", apiSecurityEnabled="
         + apiSecurityEnabled
+        + ", apiSecurityEndpointCollectionEnabled="
+        + apiSecurityEndpointCollectionEnabled
+        + ", apiSecurityEndpointCollectionMessageLimit="
+        + apiSecurityEndpointCollectionMessageLimit
         + ", cwsEnabled="
         + cwsEnabled
         + ", cwsTlsRefresh="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1392,8 +1392,7 @@ public class Config {
     apiSecurityEndpointCollectionEnabled =
         configProvider.getBoolean(
             API_SECURITY_ENDPOINT_COLLECTION_ENABLED,
-            getAppSecActivation() != ProductActivation.FULLY_DISABLED
-                && DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED);
+            DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED);
     apiSecurityEndpointCollectionMessageLimit =
         configProvider.getInteger(
             API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT,

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class Endpoint {
+  private boolean fist;
   private String type;
   private String method;
   private String path;
@@ -20,6 +21,15 @@ public class Endpoint {
   private List<Integer> responseCode;
   private List<String> authentication;
   private Map<String, String> metadata;
+
+  public boolean isFirst() {
+    return fist;
+  }
+
+  public Endpoint first(boolean first) {
+    this.fist = first;
+    return this;
+  }
 
   public String getType() {
     return type;

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
@@ -149,17 +149,4 @@ public class Endpoint {
       return result;
     }
   }
-
-  public interface Authentication {
-    String JWT = "JWT";
-    String BASIC = "basic";
-    String OAUTH = "oauth";
-    String OIDC = "OIDC";
-    String API_KEY = "api_key";
-    String SESSION = "session";
-    String M_TLS = "mTLS";
-    String SAML = "SAML";
-    String FORM = "Form";
-    String OTHER = "other";
-  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/Endpoint.java
@@ -1,0 +1,155 @@
+package datadog.trace.api.telemetry;
+
+import static java.util.Collections.singletonList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Endpoint {
+  private String type;
+  private String method;
+  private String path;
+  private String operation;
+  private List<String> requestBodyType;
+  private List<String> responseBodyType;
+  private List<Integer> responseCode;
+  private List<String> authentication;
+  private Map<String, String> metadata;
+
+  public String getType() {
+    return type;
+  }
+
+  public Endpoint type(final String type) {
+    this.type = type;
+    return this;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public Endpoint method(final String method) {
+    this.method = method;
+    return this;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public Endpoint path(final String path) {
+    this.path = path;
+    return this;
+  }
+
+  public String getOperation() {
+    return operation;
+  }
+
+  public Endpoint operation(final String operation) {
+    this.operation = operation;
+    return this;
+  }
+
+  public List<String> getRequestBodyType() {
+    return requestBodyType;
+  }
+
+  public Endpoint requestBodyType(final List<String> requestBodyType) {
+    this.requestBodyType = requestBodyType;
+    return this;
+  }
+
+  public List<String> getResponseBodyType() {
+    return responseBodyType;
+  }
+
+  public Endpoint responseBodyType(final List<String> responseBodyType) {
+    this.responseBodyType = responseBodyType;
+    return this;
+  }
+
+  public List<Integer> getResponseCode() {
+    return responseCode;
+  }
+
+  public Endpoint responseCode(final List<Integer> responseCode) {
+    this.responseCode = responseCode;
+    return this;
+  }
+
+  public List<String> getAuthentication() {
+    return authentication;
+  }
+
+  public Endpoint authentication(final List<String> authentication) {
+    this.authentication = authentication;
+    return this;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+  public Endpoint metadata(final Map<String, String> metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public interface Operation {
+    String HTTP_REQUEST = "http.request";
+  }
+
+  public interface Type {
+    String REST = "REST";
+  }
+
+  public interface Method {
+    String CONNECT = "CONNECT";
+    String HEAD = "HEAD";
+    String GET = "GET";
+    String POST = "POST";
+    String PUT = "PUT";
+    String PATCH = "PATCH";
+    String OPTIONS = "OPTIONS";
+    String DELETE = "DELETE";
+    String TRACE = "TRACE";
+    String ALL = "*";
+
+    Set<String> METHODS =
+        new HashSet<>(Arrays.asList(CONNECT, HEAD, GET, POST, PUT, PATCH, OPTIONS, DELETE, TRACE));
+
+    static <E extends Enum<E>, C extends Collection<E>> List<String> parseMethods(final C methods) {
+      if (methods == null || methods.isEmpty()) {
+        return singletonList(ALL);
+      }
+      final List<String> result = new ArrayList<>(methods.size());
+      for (E value : methods) {
+        final String methodName = value.name().toUpperCase();
+        if (METHODS.contains(value.name())) {
+          result.add(methodName);
+        }
+      }
+      return result;
+    }
+  }
+
+  public interface Authentication {
+    String JWT = "JWT";
+    String BASIC = "basic";
+    String OAUTH = "oauth";
+    String OIDC = "OIDC";
+    String API_KEY = "api_key";
+    String SESSION = "session";
+    String M_TLS = "mTLS";
+    String SAML = "SAML";
+    String FORM = "Form";
+    String OTHER = "other";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/EndpointCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/EndpointCollector.java
@@ -1,0 +1,26 @@
+package datadog.trace.api.telemetry;
+
+import static java.util.Collections.emptyIterator;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class EndpointCollector {
+
+  private static final EndpointCollector INSTANCE = new EndpointCollector();
+
+  public static EndpointCollector get() {
+    return INSTANCE;
+  }
+
+  private final AtomicReference<Iterator<Endpoint>> provider =
+      new AtomicReference<>(emptyIterator());
+
+  public Iterator<Endpoint> drain() {
+    return provider.getAndSet(emptyIterator());
+  }
+
+  public void supplier(final Iterator<Endpoint> supplier) {
+    provider.set(supplier);
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/EndpointCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/EndpointCollectorTest.groovy
@@ -1,0 +1,37 @@
+package datadog.trace.api.telemetry
+
+import datadog.trace.test.util.DDSpecification
+
+class EndpointCollectorTest extends DDSpecification {
+
+  void 'no metrics - drain empty list'() {
+    when:
+    final list = EndpointCollector.get().drain()
+
+    then:
+    !list.hasNext()
+  }
+
+  void 'set iterator'() {
+    setup:
+    final expected = (0..10).collect { index ->
+      new Endpoint()
+        .first(index == 0)
+        .type(Endpoint.Type.REST)
+        .operation(Endpoint.Operation.HTTP_REQUEST)
+        .path("/$index")
+        .requestBodyType(['application/json'])
+        .responseBodyType(['plain/text'])
+        .responseCode([200])
+        .authentication(['JWT'])
+        .method(Endpoint.Method.METHODS[index % Endpoint.Method.METHODS.size()])
+    }
+    EndpointCollector.get().supplier(expected.iterator())
+
+    when:
+    final received = EndpointCollector.get().drain().toList()
+
+    then:
+    received == expected
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -6,6 +6,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 import datadog.trace.api.ConfigSetting;
+import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange;
 import java.util.ArrayList;
 
@@ -29,6 +30,8 @@ public final class BufferedEvents implements EventSource, EventSink {
   private int logMessageIndex;
   private ArrayList<ProductChange> productChangeEvents;
   private int productChangeIndex;
+  private ArrayList<Endpoint> endpointEvents;
+  private int endpointIndex;
 
   public void addConfigChangeEvent(ConfigSetting event) {
     if (configChangeEvents == null) {
@@ -83,6 +86,14 @@ public final class BufferedEvents implements EventSource, EventSink {
       productChangeEvents = new ArrayList<>(INITIAL_CAPACITY);
     }
     productChangeEvents.add(event);
+  }
+
+  @Override
+  public void addEndpointEvent(final Endpoint event) {
+    if (endpointEvents == null) {
+      endpointEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    endpointEvents.add(event);
   }
 
   @Override
@@ -154,5 +165,15 @@ public final class BufferedEvents implements EventSource, EventSink {
   @Override
   public ProductChange nextProductChangeEvent() {
     return productChangeEvents.get(productChangeIndex++);
+  }
+
+  @Override
+  public boolean hasEndpoint() {
+    return endpointEvents != null && endpointIndex < endpointEvents.size();
+  }
+
+  @Override
+  public Endpoint nextEndpoint() {
+    return endpointEvents.get(endpointIndex++);
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/EventSink.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSink.java
@@ -6,6 +6,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 import datadog.trace.api.ConfigSetting;
+import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange;
 
 /**
@@ -27,6 +28,8 @@ interface EventSink {
   void addLogMessageEvent(LogMessage event);
 
   void addProductChangeEvent(ProductChange event);
+
+  void addEndpointEvent(Endpoint event);
 
   EventSink NOOP = new Noop();
 
@@ -53,5 +56,8 @@ interface EventSink {
 
     @Override
     public void addProductChangeEvent(ProductChange event) {}
+
+    @Override
+    public void addEndpointEvent(Endpoint event) {}
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -6,6 +6,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 import datadog.trace.api.ConfigSetting;
+import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange;
 import java.util.Queue;
 
@@ -43,6 +44,10 @@ interface EventSource {
 
   ProductChange nextProductChangeEvent();
 
+  boolean hasEndpoint();
+
+  Endpoint nextEndpoint();
+
   default boolean isEmpty() {
     return !hasConfigChangeEvent()
         && !hasIntegrationEvent()
@@ -50,7 +55,8 @@ interface EventSource {
         && !hasMetricEvent()
         && !hasDistributionSeriesEvent()
         && !hasLogMessageEvent()
-        && !hasProductChangeEvent();
+        && !hasProductChangeEvent()
+        && !hasEndpoint();
   }
 
   final class Queued implements EventSource {
@@ -61,6 +67,7 @@ interface EventSource {
     private final Queue<DistributionSeries> distributionSeriesQueue;
     private final Queue<LogMessage> logMessageQueue;
     private final Queue<ProductChange> productChanges;
+    private final Queue<Endpoint> endpoints;
 
     Queued(
         Queue<ConfigSetting> configChangeQueue,
@@ -69,7 +76,8 @@ interface EventSource {
         Queue<Metric> metricQueue,
         Queue<DistributionSeries> distributionSeriesQueue,
         Queue<LogMessage> logMessageQueue,
-        Queue<ProductChange> productChanges) {
+        Queue<ProductChange> productChanges,
+        Queue<Endpoint> endpoints) {
       this.configChangeQueue = configChangeQueue;
       this.integrationQueue = integrationQueue;
       this.dependencyQueue = dependencyQueue;
@@ -77,6 +85,7 @@ interface EventSource {
       this.distributionSeriesQueue = distributionSeriesQueue;
       this.logMessageQueue = logMessageQueue;
       this.productChanges = productChanges;
+      this.endpoints = endpoints;
     }
 
     @Override
@@ -147,6 +156,16 @@ interface EventSource {
     @Override
     public ProductChange nextProductChangeEvent() {
       return productChanges.poll();
+    }
+
+    @Override
+    public boolean hasEndpoint() {
+      return !endpoints.isEmpty();
+    }
+
+    @Override
+    public Endpoint nextEndpoint() {
+      return endpoints.poll();
     }
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/ExtendedHeartbeatData.java
+++ b/telemetry/src/main/java/datadog/telemetry/ExtendedHeartbeatData.java
@@ -6,6 +6,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 import datadog.trace.api.ConfigSetting;
+import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange;
 import java.util.ArrayList;
 
@@ -119,6 +120,16 @@ public class ExtendedHeartbeatData {
 
     @Override
     public ProductChange nextProductChangeEvent() {
+      return null;
+    }
+
+    @Override
+    public boolean hasEndpoint() {
+      return false;
+    }
+
+    @Override
+    public Endpoint nextEndpoint() {
       return null;
     }
   }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
@@ -234,12 +234,19 @@ public class TelemetryRequest {
     try {
       log.debug("Writing endpoints");
       requestBody.beginEndpoints();
-      while (eventSource.hasEndpoint() && isWithinSizeLimits()) {
-        Endpoint event = eventSource.nextEndpoint();
+      boolean first = false;
+      while (eventSource.hasEndpoint()) {
+        final Endpoint event = eventSource.nextEndpoint();
+        if (event.isFirst()) {
+          first = true;
+        }
         requestBody.writeEndpoint(event);
         eventSink.addEndpointEvent(event);
+        if (!isWithinSizeLimits()) {
+          break;
+        }
       }
-      requestBody.endEndpoints();
+      requestBody.endEndpoints(first);
     } catch (IOException e) {
       throw new TelemetryRequestBody.SerializationException("asm-endpoints", e);
     }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
@@ -235,8 +235,10 @@ public class TelemetryRequest {
       log.debug("Writing endpoints");
       requestBody.beginEndpoints();
       boolean first = false;
-      while (eventSource.hasEndpoint()) {
+      int remaining = Config.get().getApiSecurityEndpointCollectionMessageLimit();
+      while (eventSource.hasEndpoint() && remaining > 0) {
         final Endpoint event = eventSource.nextEndpoint();
+        remaining--;
         if (event.isFirst()) {
           first = true;
         }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -12,6 +12,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.ConfigSetting;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Platform;
+import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange.ProductType;
 import java.io.IOException;
 import java.util.EnumMap;
@@ -301,6 +302,41 @@ public class TelemetryRequestBody extends RequestBody {
 
   public void endProducts() throws IOException {
     endMessageIfBatch(RequestType.APP_PRODUCT_CHANGE);
+  }
+
+  public void beginEndpoints() throws IOException {
+    beginMessageIfBatch(RequestType.ASM_ENDPOINTS);
+    bodyWriter.name("endpoints");
+    bodyWriter.beginArray();
+  }
+
+  public void writeEndpoint(final Endpoint endpoint) throws IOException {
+    bodyWriter.beginObject();
+    bodyWriter.name("type").value(endpoint.getType());
+    bodyWriter.name("method").value(endpoint.getMethod());
+    bodyWriter.name("path").value(endpoint.getPath());
+    bodyWriter.name("operation-name").value(endpoint.getOperation());
+    if (endpoint.getRequestBodyType() != null) {
+      bodyWriter.name("request-body-type").jsonValue(endpoint.getRequestBodyType());
+    }
+    if (endpoint.getResponseBodyType() != null) {
+      bodyWriter.name("response-body-type").jsonValue(endpoint.getResponseBodyType());
+    }
+    if (endpoint.getResponseCode() != null) {
+      bodyWriter.name("response-code").jsonValue(endpoint.getResponseCode());
+    }
+    if (endpoint.getAuthentication() != null) {
+      bodyWriter.name("authentication").jsonValue(endpoint.getAuthentication());
+    }
+    if (endpoint.getMetadata() != null) {
+      bodyWriter.name("metadata").jsonValue(endpoint.getMetadata());
+    }
+    bodyWriter.endObject();
+  }
+
+  public void endEndpoints() throws IOException {
+    bodyWriter.endArray();
+    endMessageIfBatch(RequestType.ASM_ENDPOINTS);
   }
 
   public void writeInstallSignature(String installId, String installType, String installTime)

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -305,7 +305,7 @@ public class TelemetryRequestBody extends RequestBody {
   }
 
   public void beginEndpoints() throws IOException {
-    beginMessageIfBatch(RequestType.ASM_ENDPOINTS);
+    beginMessageIfBatch(RequestType.APP_ENDPOINTS);
     bodyWriter.name("endpoints");
     bodyWriter.beginArray();
   }
@@ -334,9 +334,10 @@ public class TelemetryRequestBody extends RequestBody {
     bodyWriter.endObject();
   }
 
-  public void endEndpoints() throws IOException {
+  public void endEndpoints(final boolean first) throws IOException {
     bodyWriter.endArray();
-    endMessageIfBatch(RequestType.ASM_ENDPOINTS);
+    bodyWriter.name("is_first").value(first);
+    endMessageIfBatch(RequestType.APP_ENDPOINTS);
   }
 
   public void writeInstallSignature(String installId, String installType, String installTime)

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -6,6 +6,7 @@ import datadog.communication.http.HttpRetryPolicy;
 import datadog.telemetry.TelemetryRunnable.TelemetryPeriodicAction;
 import datadog.telemetry.dependency.DependencyPeriodicAction;
 import datadog.telemetry.dependency.DependencyService;
+import datadog.telemetry.endpoint.EndpointPeriodicAction;
 import datadog.telemetry.integration.IntegrationPeriodicAction;
 import datadog.telemetry.log.LogPeriodicAction;
 import datadog.telemetry.metric.CiVisibilityMetricPeriodicAction;
@@ -67,6 +68,9 @@ public class TelemetrySystem {
       log.debug("Telemetry log collection enabled");
     }
     actions.add(new ProductChangeAction());
+    if (Config.get().isApiSecurityEndpointCollectionEnabled()) {
+      actions.add(new EndpointPeriodicAction());
+    }
 
     TelemetryRunnable telemetryRunnable = new TelemetryRunnable(telemetryService, actions);
     return AgentThreadFactory.newAgentThread(

--- a/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
@@ -12,7 +12,8 @@ public enum RequestType {
   GENERATE_METRICS("generate-metrics"),
   LOGS("logs"),
   DISTRIBUTIONS("distributions"),
-  MESSAGE_BATCH("message-batch");
+  MESSAGE_BATCH("message-batch"),
+  ASM_ENDPOINTS("asm-endpoints");
 
   private final String value;
 

--- a/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
@@ -13,7 +13,7 @@ public enum RequestType {
   LOGS("logs"),
   DISTRIBUTIONS("distributions"),
   MESSAGE_BATCH("message-batch"),
-  ASM_ENDPOINTS("asm-endpoints");
+  APP_ENDPOINTS("app-endpoints");
 
   private final String value;
 

--- a/telemetry/src/main/java/datadog/telemetry/endpoint/EndpointPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/endpoint/EndpointPeriodicAction.java
@@ -8,9 +8,19 @@ import java.util.Iterator;
 
 public class EndpointPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAction {
 
+  private final EndpointCollector collector;
+
+  public EndpointPeriodicAction() {
+    this(EndpointCollector.get());
+  }
+
+  public EndpointPeriodicAction(EndpointCollector collector) {
+    this.collector = collector;
+  }
+
   @Override
   public void doIteration(final TelemetryService service) {
-    for (final Iterator<Endpoint> it = EndpointCollector.get().drain(); it.hasNext(); ) {
+    for (final Iterator<Endpoint> it = collector.drain(); it.hasNext(); ) {
       if (!service.addEndpoint(it.next())) {
         break;
       }

--- a/telemetry/src/main/java/datadog/telemetry/endpoint/EndpointPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/endpoint/EndpointPeriodicAction.java
@@ -1,0 +1,19 @@
+package datadog.telemetry.endpoint;
+
+import datadog.telemetry.TelemetryRunnable;
+import datadog.telemetry.TelemetryService;
+import datadog.trace.api.telemetry.Endpoint;
+import datadog.trace.api.telemetry.EndpointCollector;
+import java.util.Iterator;
+
+public class EndpointPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAction {
+
+  @Override
+  public void doIteration(final TelemetryService service) {
+    for (final Iterator<Endpoint> it = EndpointCollector.get().drain(); it.hasNext(); ) {
+      if (!service.addEndpoint(it.next())) {
+        break;
+      }
+    }
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
@@ -7,6 +7,7 @@ import datadog.telemetry.api.Metric
 import datadog.telemetry.dependency.Dependency
 import datadog.trace.api.ConfigOrigin
 import datadog.trace.api.ConfigSetting
+import datadog.trace.api.telemetry.Endpoint
 import datadog.trace.test.util.DDSpecification
 
 class BufferedEventsSpecification extends DDSpecification {
@@ -22,6 +23,7 @@ class BufferedEventsSpecification extends DDSpecification {
     !events.hasIntegrationEvent()
     !events.hasLogMessageEvent()
     !events.hasMetricEvent()
+    !events.hasEndpoint()
   }
 
   def 'return added events'() {
@@ -32,6 +34,7 @@ class BufferedEventsSpecification extends DDSpecification {
     def integration = new Integration("integration-name", true)
     def logMessage = new LogMessage()
     def metric = new Metric()
+    def endpoint = new Endpoint()
 
     when:
     events.addConfigChangeEvent(configSetting)
@@ -92,6 +95,16 @@ class BufferedEventsSpecification extends DDSpecification {
     events.nextMetricEvent() == metric
     !events.hasMetricEvent()
     events.isEmpty()
+
+    when:
+    events.addEndpointEvent(endpoint)
+
+    then:
+    !events.isEmpty()
+    events.hasEndpoint()
+    events.nextEndpoint() == endpoint
+    !events.hasEndpoint()
+    events.isEmpty()
   }
 
   def 'noop sink'() {
@@ -104,5 +117,6 @@ class BufferedEventsSpecification extends DDSpecification {
     sink.addDistributionSeriesEvent(null)
     sink.addDependencyEvent(null)
     sink.addConfigChangeEvent(null)
+    sink.addEndpointEvent(null)
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
@@ -7,6 +7,7 @@ import datadog.telemetry.api.Metric
 import datadog.telemetry.dependency.Dependency
 import datadog.trace.api.ConfigOrigin
 import datadog.trace.api.ConfigSetting
+import datadog.trace.api.telemetry.Endpoint
 import datadog.trace.api.telemetry.ProductChange
 import datadog.trace.test.util.DDSpecification
 
@@ -23,7 +24,8 @@ class EventSourceTest extends DDSpecification{
       metricQueue            : new LinkedBlockingQueue<Metric>(),
       distributionSeriesQueue: new LinkedBlockingQueue<DistributionSeries>(),
       logMessageQueue        : new LinkedBlockingQueue<LogMessage>(),
-      productChanges         : new LinkedBlockingQueue<ProductChange>()
+      productChanges         : new LinkedBlockingQueue<ProductChange>(),
+      endpointQueue          : new LinkedBlockingQueue<Endpoint>()
     ]
 
     def eventSource = new EventSource.Queued(
@@ -33,7 +35,8 @@ class EventSourceTest extends DDSpecification{
       eventQueues.metricQueue,
       eventQueues.distributionSeriesQueue,
       eventQueues.logMessageQueue,
-      eventQueues.productChanges
+      eventQueues.productChanges,
+      eventQueues.endpointQueue
       )
 
     expect:
@@ -60,5 +63,6 @@ class EventSourceTest extends DDSpecification{
     "Distribution Series" | "distributionSeriesQueue" | new DistributionSeries()
     "Log Message"         | "logMessageQueue"         | new LogMessage()
     "Product Change"      | "productChanges"          | new ProductChange()
+    "Endpoint"            | "endpointQueue"           | new Endpoint()
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -8,6 +8,7 @@ import datadog.telemetry.api.LogMessage
 import datadog.telemetry.api.Metric
 import datadog.telemetry.api.RequestType
 import datadog.trace.api.ConfigSetting
+import datadog.trace.api.telemetry.Endpoint
 import datadog.trace.api.telemetry.ProductChange
 import groovy.json.JsonSlurper
 import okhttp3.Request
@@ -265,6 +266,36 @@ class TestTelemetryRouter extends TelemetryRouter {
         (name) : [enabled: product.isEnabled()]
       ]
       assert this.payload['products'] == expected
+      return this
+    }
+
+    PayloadAssertions endpoint(final Endpoint... endpoints) {
+      def expected = []
+      endpoints.each {
+        final item = [
+          'type'          : it.type,
+          'method'        : it.method,
+          'path'          : it.path,
+          'operation-name': it.operation
+        ] as Map<String, Object>
+        if (it.requestBodyType) {
+          item['request-body-type'] = it.requestBodyType
+        }
+        if (it.responseBodyType) {
+          item['response-body-type'] = it.responseBodyType
+        }
+        if (it.authentication) {
+          item['authentication'] = it.authentication
+        }
+        if (it.responseCode) {
+          item['response-code'] = it.responseCode
+        }
+        if (it.metadata) {
+          item['metadata'] = it.metadata
+        }
+        expected.add(item)
+      }
+      assert this.payload['endpoints'] == expected
       return this
     }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/endpoint/EndpointPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/endpoint/EndpointPeriodicActionTest.groovy
@@ -1,0 +1,25 @@
+package datadog.telemetry.endpoint
+
+import datadog.telemetry.TelemetryService
+import datadog.trace.api.telemetry.Endpoint
+import datadog.trace.api.telemetry.EndpointCollector
+import spock.lang.Specification
+
+class EndpointPeriodicActionTest extends Specification {
+
+  void 'test that common metrics are joined before being sent to telemetry #iterationIndex'() {
+    given:
+    final endpoint = new Endpoint().first(true).type('REST').method("GET").operation('http.request').path("/test")
+    final service = Mock(TelemetryService)
+    final endpointCollector = Mock(EndpointCollector)
+    final action = new EndpointPeriodicAction(endpointCollector)
+
+    when:
+    action.doIteration(service)
+
+    then:
+    1 * endpointCollector.drain() >> [endpoint].iterator()
+    1 * service.addEndpoint(endpoint)
+    0 * _
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/endpoint/EndpointPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/endpoint/EndpointPeriodicActionTest.groovy
@@ -7,19 +7,48 @@ import spock.lang.Specification
 
 class EndpointPeriodicActionTest extends Specification {
 
-  void 'test that common metrics are joined before being sent to telemetry #iterationIndex'() {
+  void 'test that endpoints are captured by the periodic action'() {
     given:
     final endpoint = new Endpoint().first(true).type('REST').method("GET").operation('http.request').path("/test")
     final service = Mock(TelemetryService)
-    final endpointCollector = Mock(EndpointCollector)
+    final endpointCollector = new EndpointCollector()
+    endpointCollector.supplier([endpoint].iterator())
     final action = new EndpointPeriodicAction(endpointCollector)
 
     when:
     action.doIteration(service)
 
     then:
-    1 * endpointCollector.drain() >> [endpoint].iterator()
     1 * service.addEndpoint(endpoint)
+    0 * _
+  }
+
+  void 'test that endpoints are not lost if the service is at capacity'() {
+    given:
+    final endpoints = [
+      new Endpoint().first(true).type('REST').method("GET").operation('http.request').path("/test1"),
+      new Endpoint().type('REST').method("GET").operation('http.request').path("/test2"),
+      new Endpoint().type('REST').method("GET").operation('http.request').path("/test3"),
+    ]
+    final service = Mock(TelemetryService)
+    final endpointCollector = new EndpointCollector()
+    endpointCollector.supplier(endpoints.iterator())
+    final action = new EndpointPeriodicAction(endpointCollector)
+
+    when:
+    action.doIteration(service)
+
+    then:
+    1 * service.addEndpoint(endpoints[0]) >> true
+    1 * service.addEndpoint(endpoints[1]) >> false
+    0 * _
+
+    when:
+    action.doIteration(service)
+
+    then:
+    1 * service.addEndpoint(endpoints[1]) >> true
+    1 * service.addEndpoint(endpoints[2]) >> true
     0 * _
   }
 }


### PR DESCRIPTION
# What Does This Do
This update involves parsing all the endpoints defined by Spring MVC using `org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping`. The parsed endpoint data is then transmitted to the backend via telemetry to build an API catalog for the service, eliminating the need for any previous traffic. 

The PR introduces a new configuration variable `DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED` (`false` by default) to enable/disable this new feature.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56437]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56437]: https://datadoghq.atlassian.net/browse/APPSEC-56437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ