### PR TITLE
Update metrics: appsec.waf.requests

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 315bc8a32cc888834726397f088336ba8038277f
+default_system_tests_commit: &default_system_tests_commit d4974a9d88a10a70a8688afd08697affb5e82261
 
 parameters:
   nightly:

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -68,6 +68,7 @@ ext {
   excludedClassesCoverage = [
     'com.datadog.appsec.config.MergedAsmData.InvalidAsmDataException',
     'com.datadog.appsec.powerwaf.LibSqreenInitialization',
+    'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFDataCallback',
     'com.datadog.appsec.report.*',
     'com.datadog.appsec.config.AppSecConfigServiceImpl.SubscribeFleetServiceRunnable.1',
     'com.datadog.appsec.util.StandardizedLogging',
@@ -87,7 +88,6 @@ ext {
     'com.datadog.appsec.config.CurrentAppSecConfig',
     // equals() / hashCode() are not well covered
     'com.datadog.appsec.config.AppSecConfig.Helper',
-    'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFDataCallback',
     'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFEventsCallback',
     // assert never fails
     'com.datadog.appsec.util.StandardizedLogging',

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '11.2.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '12.0.0'
   implementation libs.moshi
 
   testImplementation libs.bytebuddy

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -29,6 +29,7 @@ import datadog.trace.api.ProductActivation;
 import datadog.trace.api.ProductTraceSource;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.telemetry.LogCollector;
+import datadog.trace.api.telemetry.TruncatedType;
 import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -460,6 +461,27 @@ public class PowerWAFModule implements AppSecModule {
         if (log.isDebugEnabled()) {
           long elapsed = System.currentTimeMillis() - start;
           StandardizedLogging.finishedExecutionWAF(log, elapsed);
+        }
+        if (!gwCtx.isRasp) {
+          PowerwafMetrics wafMetrics = reqCtx.getWafMetrics();
+          if (wafMetrics != null) {
+            final long stringTooLong = wafMetrics.getWafInputsTruncatedStringTooLongCount();
+            final long listMapTooLarge = wafMetrics.getWafInputsTruncatedListMapTooLargeCount();
+            final long objectTooDeep = wafMetrics.getWafInputsTruncatedObjectTooDeepCount();
+
+            if (stringTooLong > 0) {
+              WafMetricCollector.get()
+                  .wafInputTruncated(TruncatedType.STRING_TOO_LONG, stringTooLong);
+            }
+            if (listMapTooLarge > 0) {
+              WafMetricCollector.get()
+                  .wafInputTruncated(TruncatedType.LIST_MAP_TOO_LARGE, listMapTooLarge);
+            }
+            if (objectTooDeep > 0) {
+              WafMetricCollector.get()
+                  .wafInputTruncated(TruncatedType.OBJECT_TOO_DEEP, objectTooDeep);
+            }
+          }
         }
       }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -542,7 +542,7 @@ public class PowerWAFModule implements AppSecModule {
               // when the request ends
               log.debug("There is no active span available");
             }
-          reqCtx.reportEvents(events);
+            reqCtx.reportEvents(events);
           } else {
             log.debug("Rate limited WAF events");
             WafMetricCollector.get().wafRequestRateLimited();

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -496,6 +496,7 @@ public class PowerWAFModule implements AppSecModule {
             }
           } else {
             log.info("Ignoring action with type {}", actionInfo.type);
+            WafMetricCollector.get().wafRequestBlockFailure();
           }
         }
         Collection<AppSecEvent> events = buildEvents(resultWithData);
@@ -557,6 +558,7 @@ public class PowerWAFModule implements AppSecModule {
         return new Flow.Action.RequestBlockingAction(statusCode, blockingContentType);
       } catch (RuntimeException cce) {
         log.warn("Invalid blocking action data", cce);
+        WafMetricCollector.get().wafRequestBlockFailure();
         return null;
       }
     }
@@ -582,6 +584,7 @@ public class PowerWAFModule implements AppSecModule {
         return Flow.Action.RequestBlockingAction.forRedirect(statusCode, location);
       } catch (RuntimeException cce) {
         log.warn("Invalid blocking action data", cce);
+        WafMetricCollector.get().wafRequestBlockFailure();
         return null;
       }
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -29,8 +29,8 @@ import datadog.trace.api.ProductActivation;
 import datadog.trace.api.ProductTraceSource;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.telemetry.LogCollector;
-import datadog.trace.api.telemetry.TruncatedType;
 import datadog.trace.api.telemetry.WafMetricCollector;
+import datadog.trace.api.telemetry.WafTruncatedType;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -471,15 +471,15 @@ public class PowerWAFModule implements AppSecModule {
 
             if (stringTooLong > 0) {
               WafMetricCollector.get()
-                  .wafInputTruncated(TruncatedType.STRING_TOO_LONG, stringTooLong);
+                  .wafInputTruncated(WafTruncatedType.STRING_TOO_LONG, stringTooLong);
             }
             if (listMapTooLarge > 0) {
               WafMetricCollector.get()
-                  .wafInputTruncated(TruncatedType.LIST_MAP_TOO_LARGE, listMapTooLarge);
+                  .wafInputTruncated(WafTruncatedType.LIST_MAP_TOO_LARGE, listMapTooLarge);
             }
             if (objectTooDeep > 0) {
               WafMetricCollector.get()
-                  .wafInputTruncated(TruncatedType.OBJECT_TOO_DEEP, objectTooDeep);
+                  .wafInputTruncated(WafTruncatedType.OBJECT_TOO_DEEP, objectTooDeep);
             }
           }
         }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -445,6 +445,7 @@ public class PowerWAFModule implements AppSecModule {
         if (!reqCtx.isAdditiveClosed()) {
           log.error("Error calling WAF", e);
         }
+        WafMetricCollector.get().wafRequestError();
         return;
       } catch (AbstractPowerwafException e) {
         if (gwCtx.isRasp) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -465,9 +465,9 @@ public class PowerWAFModule implements AppSecModule {
         if (!gwCtx.isRasp) {
           PowerwafMetrics wafMetrics = reqCtx.getWafMetrics();
           if (wafMetrics != null) {
-            final long stringTooLong = wafMetrics.getWafInputsTruncatedStringTooLongCount();
-            final long listMapTooLarge = wafMetrics.getWafInputsTruncatedListMapTooLargeCount();
-            final long objectTooDeep = wafMetrics.getWafInputsTruncatedObjectTooDeepCount();
+            final long stringTooLong = wafMetrics.getTruncatedStringTooLongCount();
+            final long listMapTooLarge = wafMetrics.getTruncatedListMapTooLargeCount();
+            final long objectTooDeep = wafMetrics.getTruncatedObjectTooDeepCount();
 
             if (stringTooLong > 0) {
               WafMetricCollector.get()

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -538,7 +538,7 @@ public class PowerWAFModule implements AppSecModule {
                   .getLocalRootSpan()
                   .setTag(Tags.PROPAGATED_TRACE_SOURCE, ProductTraceSource.ASM);
             } else {
-              // If active span is not available the ASK_KEEP tag will be set in the GatewayBridge
+              // If active span is not available the ASM_KEEP tag will be set in the GatewayBridge
               // when the request ends
               log.debug("There is no active span available");
             }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -37,6 +37,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicLong
 
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP
@@ -221,7 +222,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -256,7 +257,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     2 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -299,7 +300,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -324,7 +325,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -382,7 +383,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -401,7 +402,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     0 * _
@@ -463,7 +464,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
     1 * ctx.setBlocked()
@@ -484,7 +485,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     0 * _
@@ -546,10 +547,9 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    3 * tracer.activeSpan()
-    // we get two events: one for origin rule, and one for the custom one
-    1 * ctx.reportEvents(hasSize(2))
-    1 * ctx.getWafMetrics()
+    2 * tracer.activeSpan()
+    1 * ctx.reportEvents(hasSize(1))
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.setBlocked()
@@ -629,7 +629,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> { it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
@@ -653,7 +653,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       metrics = pwCtx.createMetrics()
       pwafAdditive
     }
-    1 * ctx.getWafMetrics() >> metrics
+    2 * ctx.getWafMetrics() >> metrics
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
@@ -719,7 +719,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       metrics = pwCtx.createMetrics()
       pwafAdditive
     }
-    1 * ctx.getWafMetrics() >> metrics
+    2 * ctx.getWafMetrics() >> metrics
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
@@ -746,7 +746,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, false, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    1 * ctx.getWafMetrics() >> null
+    2 * ctx.getWafMetrics() >> null
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
@@ -777,7 +777,14 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive
     }
     1 * ctx.closeAdditive()
-    2 * ctx.getWafMetrics() >> { metrics.with { totalDdwafRunTimeNs = 1000; totalRunTimeNs = 2000; it} }
+    3 * ctx.getWafMetrics() >> {
+      metrics.with {
+        totalDdwafRunTimeNs = new AtomicLong(1000)
+        totalRunTimeNs = new AtomicLong(2000)
+        wafInputsTruncatedStringTooLongCount = new AtomicLong(0)
+        wafInputsTruncatedListMapTooLargeCount = new AtomicLong(0)
+        wafInputsTruncatedObjectTooDeepCount = new AtomicLong(0)
+        it } }
 
     1 * segment.setTagTop('_dd.appsec.waf.duration', 1)
     1 * segment.setTagTop('_dd.appsec.waf.duration_ext', 2)
@@ -800,7 +807,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       metrics = pwCtx.createMetrics()
       pwafAdditive
     }
-    1 * ctx.getWafMetrics() >> metrics
+    2 * ctx.getWafMetrics() >> metrics
     1 * ctx.reportEvents(*_)
     1 * ctx.setBlocked()
     1 * ctx.isThrottled(null)
@@ -999,7 +1006,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.isAdditiveClosed()
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.increaseWafTimeouts()
     1 * wafMetricCollector.get().wafRequestTimeout()
     0 * _
@@ -1083,7 +1090,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.isAdditiveClosed()
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isThrottled(null)
     1 * ctx.closeAdditive()
     2 * tracer.activeSpan()
@@ -1126,7 +1133,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
@@ -1183,7 +1190,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
     _ * ctx.increaseWafTimeouts()
@@ -1207,7 +1214,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then: 'no match; data was cleared (though rule is no longer disabled)'
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     1 * wafMetricCollector.wafUpdates(_, true)
@@ -1234,7 +1241,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
@@ -1261,7 +1268,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * wafMetricCollector.wafUpdates(_, true)
     1 * reconf.reloadSubscriptions()
     1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     _ * ctx.increaseWafTimeouts()
@@ -1293,7 +1300,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
     // no attack
     1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseWafTimeouts()
@@ -1319,7 +1326,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     // no attack
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseWafTimeouts()
@@ -1345,7 +1352,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     // attack found
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * flow.isBlocking()
     1 * flow.setAction({ it.blocking })
     2 * tracer.activeSpan()
@@ -1374,7 +1381,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     // no attack
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     _ * ctx.increaseWafTimeouts()
@@ -1491,7 +1498,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>) >> {
       it[0].iterator().next().ruleMatches[0].parameters[0].value == '/cybercop'
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
     1 * ctx.isAdditiveClosed() >> false
@@ -1509,7 +1516,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>) >> {
       it[0].iterator().next().ruleMatches[0].parameters[0].value == 'user-to-block-1'
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.isThrottled(null)
@@ -1588,7 +1595,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isThrottled(null)
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.closeAdditive()
@@ -1627,7 +1634,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
-    1 * ctx.getWafMetrics()
+    2 * ctx.getWafMetrics()
     1 * ctx.isThrottled(null)
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.closeAdditive()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -781,9 +781,9 @@ class PowerWAFModuleSpecification extends DDSpecification {
       metrics.with {
         totalDdwafRunTimeNs = new AtomicLong(1000)
         totalRunTimeNs = new AtomicLong(2000)
-        wafInputsTruncatedStringTooLongCount = new AtomicLong(0)
-        wafInputsTruncatedListMapTooLargeCount = new AtomicLong(0)
-        wafInputsTruncatedObjectTooDeepCount = new AtomicLong(0)
+        truncatedStringTooLongCount = new AtomicLong(0)
+        truncatedListMapTooLargeCount = new AtomicLong(0)
+        truncatedObjectTooDeepCount = new AtomicLong(0)
         it } }
 
     1 * segment.setTagTop('_dd.appsec.waf.duration', 1)

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFStatsReporterSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFStatsReporterSpecification.groovy
@@ -6,6 +6,7 @@ import datadog.trace.test.util.DDSpecification
 import io.sqreen.powerwaf.PowerwafMetrics
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 class PowerWAFStatsReporterSpecification extends DDSpecification {
   PowerWAFStatsReporter reporter = new PowerWAFStatsReporter()
@@ -14,8 +15,8 @@ class PowerWAFStatsReporterSpecification extends DDSpecification {
   void 'reporter reports waf timings and version'() {
     setup:
     PowerwafMetrics metrics = new PowerwafMetrics()
-    metrics.totalRunTimeNs = 2_000
-    metrics.totalDdwafRunTimeNs = 1_000
+    metrics.totalRunTimeNs = new AtomicLong(2_000)
+    metrics.totalDdwafRunTimeNs = new AtomicLong(1_000)
     TraceSegment segment = Mock()
     reporter.rulesVersion = '1.2.3'
     def wafTimeouts = 1
@@ -37,12 +38,12 @@ class PowerWAFStatsReporterSpecification extends DDSpecification {
   void 'reporter reports rasp timings and version'() {
     setup:
     PowerwafMetrics metrics = new PowerwafMetrics()
-    metrics.totalRunTimeNs = 2_000
-    metrics.totalDdwafRunTimeNs = 1_000
+    metrics.totalRunTimeNs = new AtomicLong(2_000)
+    metrics.totalDdwafRunTimeNs = new AtomicLong(1_000)
 
     PowerwafMetrics raspMetrics = new PowerwafMetrics()
-    raspMetrics.totalRunTimeNs = 4_000
-    raspMetrics.totalDdwafRunTimeNs = 3_000
+    raspMetrics.totalRunTimeNs = new AtomicLong(4_000)
+    raspMetrics.totalDdwafRunTimeNs = new AtomicLong(3_000)
     TraceSegment segment = Mock()
     reporter.rulesVersion = '1.2.3'
     def raspTimeouts = 1

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
@@ -1,0 +1,17 @@
+package datadog.trace.api.telemetry;
+
+public enum TruncatedType {
+  STRING_TOO_LONG(1),
+  LIST_MAP_TOO_LARGE(2),
+  OBJECT_TOO_DEEP(4);
+
+  private final int value;
+
+  TruncatedType(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return this.value;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -41,6 +41,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   private static final AtomicRequestCounter wafErrorRequestCounter = new AtomicRequestCounter();
   private static final AtomicRequestCounter wafRateLimitedRequestCounter =
       new AtomicRequestCounter();
+  private static final AtomicRequestCounter wafBlockFailureRequestCounter =
+      new AtomicRequestCounter();
   private static final AtomicLongArray raspRuleEvalCounter =
       new AtomicLongArray(RuleType.getNumValues());
   private static final AtomicLongArray raspRuleMatchCounter =
@@ -119,6 +121,10 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
     wafRateLimitedRequestCounter.increment();
   }
 
+  public void wafRequestBlockFailure() {
+    wafBlockFailureRequestCounter.increment();
+  }
+
   public void raspRuleEval(final RuleType ruleType) {
     raspRuleEvalCounter.incrementAndGet(ruleType.ordinal());
   }
@@ -163,6 +169,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   @Override
   public void prepareMetrics() {
     final boolean isRateLimited = wafRateLimitedRequestCounter.getAndReset() > 0;
+    final boolean isBlockFailure = wafBlockFailureRequestCounter.getAndReset() > 0;
 
     // Requests
     if (wafRequestCounter.get() > 0) {
@@ -175,6 +182,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               false,
               false,
               false,
+              isBlockFailure,
               isRateLimited))) {
         return;
       }
@@ -191,6 +199,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               false,
               false,
               false,
+              isBlockFailure,
               isRateLimited))) {
         return;
       }
@@ -207,6 +216,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               true,
               false,
               false,
+              isBlockFailure,
               isRateLimited))) {
         return;
       }
@@ -223,6 +233,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               false,
               false,
               true,
+              isBlockFailure,
               isRateLimited))) {
         return;
       }
@@ -239,6 +250,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               false,
               true,
               false,
+              isBlockFailure,
               isRateLimited))) {
         return;
       }
@@ -387,6 +399,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
         final boolean blocked,
         final boolean wafError,
         final boolean wafTimeout,
+        final boolean blockFailure,
         final boolean rateLimited) {
       super(
           "waf.requests",
@@ -397,6 +410,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
           "request_blocked:" + blocked,
           "waf_error:" + wafError,
           "waf_timeout:" + wafTimeout,
+          "block_failure:" + blockFailure,
           "rate_limited:" + rateLimited);
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -44,7 +44,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   private static final AtomicRequestCounter wafBlockFailureRequestCounter =
       new AtomicRequestCounter();
   private static final AtomicLongArray wafInputTruncatedCounter =
-      new AtomicLongArray(TruncatedType.values().length);
+      new AtomicLongArray(WafTruncatedType.values().length);
   private static final AtomicLongArray raspRuleEvalCounter =
       new AtomicLongArray(RuleType.getNumValues());
   private static final AtomicLongArray raspRuleMatchCounter =
@@ -127,8 +127,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
     wafBlockFailureRequestCounter.increment();
   }
 
-  public void wafInputTruncated(final TruncatedType truncatedType, long increment) {
-    wafInputTruncatedCounter.addAndGet(truncatedType.ordinal(), increment);
+  public void wafInputTruncated(final WafTruncatedType wafTruncatedType, long increment) {
+    wafInputTruncatedCounter.addAndGet(wafTruncatedType.ordinal(), increment);
   }
 
   public void raspRuleEval(final RuleType ruleType) {
@@ -177,8 +177,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
     final boolean isRateLimited = wafRateLimitedRequestCounter.getAndReset() > 0;
     final boolean isBlockFailure = wafBlockFailureRequestCounter.getAndReset() > 0;
     boolean isWafInputTruncated = false;
-    for (TruncatedType truncatedType : TruncatedType.values()) {
-      isWafInputTruncated = wafInputTruncatedCounter.getAndSet(truncatedType.ordinal(), 0) > 0;
+    for (WafTruncatedType wafTruncatedType : WafTruncatedType.values()) {
+      isWafInputTruncated = wafInputTruncatedCounter.getAndSet(wafTruncatedType.ordinal(), 0) > 0;
       if (isWafInputTruncated) {
         break;
       }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafTruncatedType.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafTruncatedType.java
@@ -1,13 +1,13 @@
 package datadog.trace.api.telemetry;
 
-public enum TruncatedType {
+public enum WafTruncatedType {
   STRING_TOO_LONG(1),
   LIST_MAP_TOO_LARGE(2),
   OBJECT_TOO_DEEP(4);
 
   private final int value;
 
-  TruncatedType(int value) {
+  WafTruncatedType(int value) {
     this.value = value;
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -33,6 +33,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
+    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)
@@ -82,7 +83,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:false',
       'waf_timeout:false',
       'block_failure:true',
-      'rate_limited:true'
+      'rate_limited:true',
+      'input_truncated:true',
     ].toSet()
 
     def requestTriggeredMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[4]
@@ -97,7 +99,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:false',
       'waf_timeout:false',
       'block_failure:true',
-      'rate_limited:true'
+      'rate_limited:true',
+      'input_truncated:true',
     ].toSet()
 
 
@@ -114,7 +117,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:false',
       'waf_timeout:false',
       'block_failure:true',
-      'rate_limited:true'
+      'rate_limited:true',
+      'input_truncated:true',
     ].toSet()
 
     def requestTimeoutMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[6]
@@ -130,7 +134,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:false',
       'waf_timeout:true',
       'block_failure:true',
-      'rate_limited:true'
+      'rate_limited:true',
+      'input_truncated:true',
     ].toSet()
 
     def requestWafErrorMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[7]
@@ -146,7 +151,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:true',
       'waf_timeout:false',
       'block_failure:true',
-      'rate_limited:true'
+      'rate_limited:true',
+      'input_truncated:true',
     ].toSet()
 
     def raspRuleEvalSqli = (WafMetricCollector.RaspRuleEval)metrics[8]

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -31,6 +31,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().wafRequestBlocked()
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
+    WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)
@@ -78,7 +79,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_triggered:false',
       'request_blocked:false',
       'waf_error:false',
-      'waf_timeout:false'
+      'waf_timeout:false',
+      'rate_limited:true'
     ].toSet()
 
     def requestTriggeredMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[4]
@@ -91,7 +93,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_triggered:true',
       'request_blocked:false',
       'waf_error:false',
-      'waf_timeout:false'
+      'waf_timeout:false',
+      'rate_limited:true'
     ].toSet()
 
 
@@ -106,7 +109,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_triggered:true',
       'request_blocked:true',
       'waf_error:false',
-      'waf_timeout:false'
+      'waf_timeout:false',
+      'rate_limited:true'
     ].toSet()
 
     def requestTimeoutMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[6]
@@ -120,7 +124,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_triggered:false',
       'request_blocked:false',
       'waf_error:false',
-      'waf_timeout:true'
+      'waf_timeout:true',
+      'rate_limited:true'
     ].toSet()
 
     def requestWafErrorMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[7]
@@ -134,7 +139,8 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_triggered:false',
       'request_blocked:false',
       'waf_error:true',
-      'waf_timeout:false'
+      'waf_timeout:false',
+      'rate_limited:true'
     ].toSet()
 
     def raspRuleEvalSqli = (WafMetricCollector.RaspRuleEval)metrics[8]

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -176,7 +176,7 @@ class WafMetricCollectorTest extends DDSpecification {
     raspTimeout.metricName == 'rasp.timeout'
     raspTimeout.tags.toSet() == ['rule_type:sql_injection', 'waf_version:waf_ver1'].toSet()
 
-    def raspInvalidCode = (WafMetricCollector.RaspError)metrics[10]
+    def raspInvalidCode = (WafMetricCollector.RaspError)metrics[11]
     raspInvalidCode.type == 'count'
     raspInvalidCode.value == 1
     raspInvalidCode.namespace == 'appsec'
@@ -189,7 +189,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:' + DD_WAF_RUN_INTERNAL_ERROR
     ].toSet()
 
-    def wafInvalidCode = (WafMetricCollector.WafError)metrics[11]
+    def wafInvalidCode = (WafMetricCollector.WafError)metrics[12]
     wafInvalidCode.type == 'count'
     wafInvalidCode.value == 1
     wafInvalidCode.namespace == 'appsec'
@@ -202,7 +202,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:' +DD_WAF_RUN_INTERNAL_ERROR
     ].toSet()
 
-    def raspInvalidObjectCode = (WafMetricCollector.RaspError)metrics[12]
+    def raspInvalidObjectCode = (WafMetricCollector.RaspError)metrics[13]
     raspInvalidObjectCode.type == 'count'
     raspInvalidObjectCode.value == 1
     raspInvalidObjectCode.namespace == 'appsec'
@@ -214,7 +214,7 @@ class WafMetricCollectorTest extends DDSpecification {
     ]
     .toSet()
 
-    def wafInvalidObjectCode = (WafMetricCollector.WafError)metrics[13]
+    def wafInvalidObjectCode = (WafMetricCollector.WafError)metrics[14]
     wafInvalidObjectCode.type == 'count'
     wafInvalidObjectCode.value == 1
     wafInvalidObjectCode.namespace == 'appsec'

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -30,6 +30,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().wafRequestTriggered()
     WafMetricCollector.get().wafRequestBlocked()
     WafMetricCollector.get().wafRequestTimeout()
+    WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)
@@ -76,6 +77,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'event_rules_version:rules.3',
       'rule_triggered:false',
       'request_blocked:false',
+      'waf_error:false',
       'waf_timeout:false'
     ].toSet()
 
@@ -88,6 +90,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'event_rules_version:rules.3',
       'rule_triggered:true',
       'request_blocked:false',
+      'waf_error:false',
       'waf_timeout:false'
     ].toSet()
 
@@ -102,6 +105,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'event_rules_version:rules.3',
       'rule_triggered:true',
       'request_blocked:true',
+      'waf_error:false',
       'waf_timeout:false'
     ].toSet()
 
@@ -115,24 +119,39 @@ class WafMetricCollectorTest extends DDSpecification {
       'event_rules_version:rules.3',
       'rule_triggered:false',
       'request_blocked:false',
+      'waf_error:false',
       'waf_timeout:true'
     ].toSet()
 
-    def raspRuleEvalSqli = (WafMetricCollector.RaspRuleEval)metrics[7]
+    def requestWafErrorMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[7]
+    requestWafErrorMetric.namespace == 'appsec'
+    requestWafErrorMetric.metricName == 'waf.requests'
+    requestWafErrorMetric.type == 'count'
+    requestWafErrorMetric.value == 1
+    requestWafErrorMetric.tags.toSet() == [
+      'waf_version:waf_ver1',
+      'event_rules_version:rules.3',
+      'rule_triggered:false',
+      'request_blocked:false',
+      'waf_error:true',
+      'waf_timeout:false'
+    ].toSet()
+
+    def raspRuleEvalSqli = (WafMetricCollector.RaspRuleEval)metrics[8]
     raspRuleEvalSqli.type == 'count'
     raspRuleEvalSqli.value == 3
     raspRuleEvalSqli.namespace == 'appsec'
     raspRuleEvalSqli.metricName == 'rasp.rule.eval'
     raspRuleEvalSqli.tags.toSet() == ['rule_type:sql_injection', 'waf_version:waf_ver1'].toSet()
 
-    def raspRuleMatch = (WafMetricCollector.RaspRuleMatch)metrics[8]
+    def raspRuleMatch = (WafMetricCollector.RaspRuleMatch)metrics[9]
     raspRuleMatch.type == 'count'
     raspRuleMatch.value == 1
     raspRuleMatch.namespace == 'appsec'
     raspRuleMatch.metricName == 'rasp.rule.match'
     raspRuleMatch.tags.toSet() == ['rule_type:sql_injection', 'waf_version:waf_ver1'].toSet()
 
-    def raspTimeout = (WafMetricCollector.RaspTimeout)metrics[9]
+    def raspTimeout = (WafMetricCollector.RaspTimeout)metrics[10]
     raspTimeout.type == 'count'
     raspTimeout.value == 1
     raspTimeout.namespace == 'appsec'

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -32,6 +32,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
+    WafMetricCollector.get().wafRequestBlockFailure()
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)
@@ -80,6 +81,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'request_blocked:false',
       'waf_error:false',
       'waf_timeout:false',
+      'block_failure:true',
       'rate_limited:true'
     ].toSet()
 
@@ -94,6 +96,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'request_blocked:false',
       'waf_error:false',
       'waf_timeout:false',
+      'block_failure:true',
       'rate_limited:true'
     ].toSet()
 
@@ -110,6 +113,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'request_blocked:true',
       'waf_error:false',
       'waf_timeout:false',
+      'block_failure:true',
       'rate_limited:true'
     ].toSet()
 
@@ -125,6 +129,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'request_blocked:false',
       'waf_error:false',
       'waf_timeout:true',
+      'block_failure:true',
       'rate_limited:true'
     ].toSet()
 
@@ -140,6 +145,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'request_blocked:false',
       'waf_error:true',
       'waf_timeout:false',
+      'block_failure:true',
       'rate_limited:true'
     ].toSet()
 

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -33,7 +33,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
-    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
+    WafMetricCollector.get().wafInputTruncated(WafTruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -50,6 +50,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequest()
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
+    WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -68,7 +69,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -81,7 +83,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:true',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -94,7 +97,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:true',
           'request_blocked:true',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -107,7 +111,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:true'
+          'waf_timeout:true',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -120,7 +125,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:true',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     0 * _._
@@ -132,6 +138,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestBlocked()
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
+    WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -150,7 +157,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -163,7 +171,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:true',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -176,7 +185,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:true',
           'request_blocked:true',
           'waf_error:false',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -189,7 +199,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:false',
-          'waf_timeout:true'
+          'waf_timeout:true',
+          'rate_limited:true'
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -202,7 +213,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'rule_triggered:false',
           'request_blocked:false',
           'waf_error:true',
-          'waf_timeout:false'
+          'waf_timeout:false',
+          'rate_limited:true'
         ]
     } )
     0 * _._

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -2,7 +2,7 @@ package datadog.telemetry.metric
 
 import datadog.telemetry.TelemetryService
 import datadog.telemetry.api.Metric
-import datadog.trace.api.telemetry.TruncatedType
+import datadog.trace.api.telemetry.WafTruncatedType
 import datadog.trace.api.telemetry.WafMetricCollector
 import datadog.trace.test.util.DDSpecification
 
@@ -53,7 +53,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
-    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
+    WafMetricCollector.get().wafInputTruncated(WafTruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -153,7 +153,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
-    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
+    WafMetricCollector.get().wafInputTruncated(WafTruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -49,6 +49,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestBlocked()
     WafMetricCollector.get().wafRequest()
     WafMetricCollector.get().wafRequestTimeout()
+    WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -66,6 +67,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_1',
           'rule_triggered:false',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -78,6 +80,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_1',
           'rule_triggered:true',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -90,6 +93,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_1',
           'rule_triggered:true',
           'request_blocked:true',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -102,7 +106,21 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_1',
           'rule_triggered:false',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:true'
+        ]
+    } )
+    1 * telemetryService.addMetric( { Metric metric ->
+      metric.namespace == 'appsec' &&
+        metric.metric == 'waf.requests' &&
+        metric.points[0][1] == 1 &&
+        metric.tags == [
+          'waf_version:0.0.0',
+          'event_rules_version:rules_ver_1',
+          'rule_triggered:false',
+          'request_blocked:false',
+          'waf_error:true',
+          'waf_timeout:false'
         ]
     } )
     0 * _._
@@ -113,6 +131,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestTriggered()
     WafMetricCollector.get().wafRequestBlocked()
     WafMetricCollector.get().wafRequestTimeout()
+    WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -130,6 +149,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_2',
           'rule_triggered:false',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -142,6 +162,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_2',
           'rule_triggered:true',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -154,6 +175,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_2',
           'rule_triggered:true',
           'request_blocked:true',
+          'waf_error:false',
           'waf_timeout:false'
         ]
     } )
@@ -166,7 +188,21 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'event_rules_version:rules_ver_2',
           'rule_triggered:false',
           'request_blocked:false',
+          'waf_error:false',
           'waf_timeout:true'
+        ]
+    } )
+    1 * telemetryService.addMetric( { Metric metric ->
+      metric.namespace == 'appsec' &&
+        metric.metric == 'waf.requests' &&
+        metric.points[0][1] == 1 &&
+        metric.tags == [
+          'waf_version:0.0.0',
+          'event_rules_version:rules_ver_2',
+          'rule_triggered:false',
+          'request_blocked:false',
+          'waf_error:true',
+          'waf_timeout:false'
         ]
     } )
     0 * _._

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -51,6 +51,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
+    WafMetricCollector.get().wafRequestBlockFailure()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -70,6 +71,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -84,6 +86,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -98,6 +101,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:true',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -112,6 +116,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:true',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -126,6 +131,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:true',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -139,6 +145,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestTimeout()
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
+    WafMetricCollector.get().wafRequestBlockFailure()
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -158,6 +165,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -172,6 +180,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -186,6 +195,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:true',
           'waf_error:false',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -200,6 +210,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:false',
           'waf_timeout:true',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )
@@ -214,6 +225,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'request_blocked:false',
           'waf_error:true',
           'waf_timeout:false',
+          'block_failure:true',
           'rate_limited:true'
         ]
     } )

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -2,6 +2,7 @@ package datadog.telemetry.metric
 
 import datadog.telemetry.TelemetryService
 import datadog.telemetry.api.Metric
+import datadog.trace.api.telemetry.TruncatedType
 import datadog.trace.api.telemetry.WafMetricCollector
 import datadog.trace.test.util.DDSpecification
 
@@ -52,6 +53,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
+    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -72,7 +74,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -87,7 +90,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -102,7 +106,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -117,7 +122,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:true',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -132,7 +138,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:true',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     0 * _._
@@ -146,6 +153,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     WafMetricCollector.get().wafRequestError()
     WafMetricCollector.get().wafRequestRateLimited()
     WafMetricCollector.get().wafRequestBlockFailure()
+    WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, 5)
     WafMetricCollector.get().prepareMetrics()
     periodicAction.doIteration(telemetryService)
 
@@ -166,7 +174,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -181,7 +190,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -196,7 +206,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -211,7 +222,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:false',
           'waf_timeout:true',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     1 * telemetryService.addMetric( { Metric metric ->
@@ -226,7 +238,8 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
           'waf_error:true',
           'waf_timeout:false',
           'block_failure:true',
-          'rate_limited:true'
+          'rate_limited:true',
+          'input_truncated:true',
         ]
     } )
     0 * _._


### PR DESCRIPTION
# What Does This Do
This adds a new value to some metrics which is necessary for the consolidation of ASM Span Tags, Metrics, and Logs across all supported languages. The newly value will be implemented in the following metrics:
- **appsec.waf.requests**:
  - _waf_error_: If WAF has failed (except timeout)
  - _block_failure_: If the block has failed
  - _rate_limited_: Wheter the trace has been rate limited
  - _input_truncated_: Wheter the data provided to the libddwaf has been truncated

# Motivation
Our goal is to implement all the missing ASM Span Tags, Metrics, and Logs.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56676]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56676]: https://datadoghq.atlassian.net/browse/APPSEC-56676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ