### PR TITLE
Update appsec metrics with event_rules_version tag

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -329,7 +329,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
                 "waf_version:" + wafVersion,
-                "event_rules_version" + rulesVersion
+                "event_rules_version:" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }
@@ -345,7 +345,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
                 "waf_version:" + wafVersion,
-                "event_rules_version" + rulesVersion
+                "event_rules_version:" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }
@@ -361,7 +361,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
                 "waf_version:" + wafVersion,
-                "event_rules_version" + rulesVersion
+                "event_rules_version:" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -328,7 +328,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               ? new String[] {
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
-                "waf_version:" + wafVersion
+                "waf_version:" + wafVersion,
+                "event_rules_version" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }
@@ -343,7 +344,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               ? new String[] {
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
-                "waf_version:" + wafVersion
+                "waf_version:" + wafVersion,
+                "event_rules_version" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }
@@ -358,7 +360,8 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
               ? new String[] {
                 "rule_type:" + ruleType.type,
                 "rule_variant:" + ruleType.variant,
-                "waf_version:" + wafVersion
+                "waf_version:" + wafVersion,
+                "event_rules_version" + rulesVersion
               }
               : new String[] {"rule_type:" + ruleType.type, "waf_version:" + wafVersion});
     }

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -314,21 +314,36 @@ class WafMetricCollectorTest extends DDSpecification {
     raspRuleEval.value == 3
     raspRuleEval.namespace == 'appsec'
     raspRuleEval.metricName == 'rasp.rule.eval'
-    raspRuleEval.tags.toSet() == ['rule_type:command_injection', 'rule_variant:'+ruleType.variant, 'waf_version:waf_ver1'].toSet()
+    raspRuleEval.tags.toSet() == [
+      'rule_type:command_injection',
+      'rule_variant:'+ruleType.variant,
+      'waf_version:waf_ver1',
+      'event_rules_versionrules.1'
+    ].toSet()
 
     def raspRuleMatch = (WafMetricCollector.RaspRuleMatch)metrics[2]
     raspRuleMatch.type == 'count'
     raspRuleMatch.value == 1
     raspRuleMatch.namespace == 'appsec'
     raspRuleMatch.metricName == 'rasp.rule.match'
-    raspRuleMatch.tags.toSet() == ['rule_type:command_injection', 'rule_variant:'+ruleType.variant, 'waf_version:waf_ver1'].toSet()
+    raspRuleMatch.tags.toSet() == [
+      'rule_type:command_injection',
+      'rule_variant:'+ruleType.variant,
+      'waf_version:waf_ver1',
+      'event_rules_versionrules.1'
+    ].toSet()
 
     def raspTimeout = (WafMetricCollector.RaspTimeout)metrics[3]
     raspTimeout.type == 'count'
     raspTimeout.value == 1
     raspTimeout.namespace == 'appsec'
     raspTimeout.metricName == 'rasp.timeout'
-    raspTimeout.tags.toSet() == ['rule_type:command_injection', 'rule_variant:'+ruleType.variant, 'waf_version:waf_ver1'].toSet()
+    raspTimeout.tags.toSet() == [
+      'rule_type:command_injection',
+      'rule_variant:'+ruleType.variant,
+      'waf_version:waf_ver1',
+      'event_rules_versionrules.1'
+    ].toSet()
 
     where:
     ruleType << [RuleType.COMMAND_INJECTION, RuleType.SHELL_INJECTION]

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -318,7 +318,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_type:command_injection',
       'rule_variant:'+ruleType.variant,
       'waf_version:waf_ver1',
-      'event_rules_versionrules.1'
+      'event_rules_version:rules.1'
     ].toSet()
 
     def raspRuleMatch = (WafMetricCollector.RaspRuleMatch)metrics[2]
@@ -330,7 +330,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_type:command_injection',
       'rule_variant:'+ruleType.variant,
       'waf_version:waf_ver1',
-      'event_rules_versionrules.1'
+      'event_rules_version:rules.1'
     ].toSet()
 
     def raspTimeout = (WafMetricCollector.RaspTimeout)metrics[3]
@@ -342,7 +342,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_type:command_injection',
       'rule_variant:'+ruleType.variant,
       'waf_version:waf_ver1',
-      'event_rules_versionrules.1'
+      'event_rules_version:rules.1'
     ].toSet()
 
     where:


### PR DESCRIPTION
# What Does This Do
Updates metrics: appsec.rasp.rule.eval, appsec.rasp.rule.match and appsec.rasp.timeout (adds event_rules_version tag)

# Motivation
Part of a project to expand metrics information

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56677]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56677]: https://datadoghq.atlassian.net/browse/APPSEC-56677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ