### PR TITLE
[K9VULN-3470] ci(static-analyzer): remove deprecated env fields

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -29,8 +29,6 @@ jobs:
           dd_app_key: ${{ secrets.DATADOG_APP_KEY_STAGING }}
           dd_api_key: ${{ secrets.DATADOG_API_KEY_STAGING }}
           dd_site: "datad0g.com"
-          dd_service: "dd-trace-java"
-          dd_env: "ci"
           cpu_count: 2
           enable_performance_statistics: false
 


### PR DESCRIPTION
# What Does This Do

This removes deprecated fields in the [datadog-static-analyzer-github-action](https://github.com/DataDog/datadog-static-analyzer-github-action) (see this [section](https://github.com/DataDog/datadog-static-analyzer-github-action#deprecated-inputs))

# Motivation

A colleague (@PerfectSlayer) pointed out the warning in the CI job ([slack link](https://dd.slack.com/archives/C04BFTWHNNL/p1738932825093229?thread_ts=1738932796.783539&cid=C04BFTWHNNL))

# Additional Notes

# Contributor Checklist

Jira ticket: [K9VULN-3470]


[K9VULN-3470]: https://datadoghq.atlassian.net/browse/K9VULN-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ