### PR TITLE
Migrate context injection calls to context-first APIs

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -767,7 +767,7 @@ jobs:
 
   muzzle:
     <<: *defaults
-    resource_class: medium
+    resource_class: medium+
     parallelism: 4
     steps:
       - setup_code
@@ -798,7 +798,7 @@ jobs:
           name: Verify Muzzle
           command: >-
             SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx3G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
             ./gradlew `circleci tests split --split-by=timings workspace/build/muzzleTasks | xargs`
             << pipeline.parameters.gradle_flags >>
             --max-workers=4

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HeadersInjectAdapter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HeadersInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.bootstrap.instrumentation.httpurlconnection;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.net.HttpURLConnection;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class HeadersInjectAdapter implements AgentPropagation.Setter<HttpURLConnection> {
 
   public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/ContextPayload.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/ContextPayload.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.rmi;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.context.propagation.Propagators.defaultPropagator;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -9,6 +9,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class ContextPayload {
 
   public static ContextPayload from(final AgentSpan span) {
     final ContextPayload payload = new ContextPayload();
-    propagate().inject(span, payload, SETTER);
+    defaultPropagator().inject(span, payload, SETTER);
     return payload;
   }
 
@@ -54,6 +55,7 @@ public class ContextPayload {
     out.writeObject(context);
   }
 
+  @ParametersAreNonnullByDefault
   public static class InjectAdapter implements AgentPropagation.Setter<ContextPayload> {
     @Override
     public void set(final ContextPayload carrier, final String key, final String value) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
@@ -1,6 +1,6 @@
 package datadog.trace.civisibility.domain.buildsystem;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.context.propagation.Propagators.defaultPropagator;
 
 import datadog.communication.ddagent.TracerVersion;
 import datadog.trace.api.Config;
@@ -33,10 +33,15 @@ import datadog.trace.civisibility.utils.SpanUtils;
 import datadog.trace.util.Strings;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSystemModule {
 
@@ -105,6 +110,7 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
     setTag(Tags.TEST_COMMAND, startCommand);
   }
 
+  @ParametersAreNonnullByDefault
   private static final class ChildProcessPropertiesPropagationSetter
       implements AgentPropagation.Setter<Map<String, String>> {
     static final AgentPropagation.Setter<Map<String, String>> INSTANCE =
@@ -221,7 +227,7 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
     }
 
     // propagate module span context to child processes
-    propagate()
+    defaultPropagator()
         .inject(span, propagatedSystemProperties, ChildProcessPropertiesPropagationSetter.INSTANCE);
 
     return propagatedSystemProperties;

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
@@ -1,5 +1,6 @@
 package datadog.opentelemetry.shim.context.propagation;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.opentelemetry.shim.trace.OtelSpanContext.fromRemote;
 import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 
@@ -7,6 +8,7 @@ import datadog.opentelemetry.shim.context.OtelContext;
 import datadog.opentelemetry.shim.trace.OtelExtractedContext;
 import datadog.opentelemetry.shim.trace.OtelSpan;
 import datadog.trace.api.TracePropagationStyle;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext.Extracted;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -36,11 +38,7 @@ public class AgentTextMapPropagator implements TextMapPropagator {
     if (carrier == null) {
       return;
     }
-    Span span = Span.fromContext(context);
-    if (span.getSpanContext().isValid()) {
-      AgentSpanContext agentSpanContext = OtelExtractedContext.extract(context);
-      AgentTracer.propagate().inject(agentSpanContext, carrier, setter::set);
-    }
+    defaultPropagator().inject(convertContext(context), carrier, setter::set);
   }
 
   @Override
@@ -66,6 +64,14 @@ public class AgentTextMapPropagator implements TextMapPropagator {
     }
   }
 
+  private static datadog.context.Context convertContext(Context context) {
+    // TODO Extract baggage too
+    // TODO Create fast path from OtelSpan --> AgentSpan delegate --> with() to inflate as full
+    // context if baggage
+    AgentSpanContext extract = OtelExtractedContext.extract(context);
+    return AgentSpan.fromSpanContext(extract);
+  }
+
   /**
    * Extracts tracestate if {@code tracestate} header is present and extracted context comes from
    * {@link TracePropagationStyle#TRACECONTEXT}
@@ -73,8 +79,8 @@ public class AgentTextMapPropagator implements TextMapPropagator {
    * @param extracted The extracted context.
    * @param carrier The context carrier.
    * @param getter The context getter.
-   * @return The extracted tracestate, or an empty tracestate otherwise.
    * @param <C> The carrier type.
+   * @return The extracted tracestate, or an empty tracestate otherwise.
    */
   private static <C> TraceState extractTraceState(
       Extracted extracted, C carrier, TextMapGetter<C> getter) {

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -172,7 +172,7 @@ public class OtelSpan implements Span, WithAgentSpan {
 
   @Override
   public AgentSpan asAgentSpan() {
-    return delegate;
+    return this.delegate;
   }
 
   private static class NoopSpan implements Span {

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientHelpers.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientHelpers.java
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.HttpResponse;
 import akka.http.scaladsl.model.headers.CustomHeader;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import javax.annotation.ParametersAreNonnullByDefault;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
@@ -35,7 +36,7 @@ public final class AkkaHttpClientHelpers {
   public static class AkkaHttpHeaders implements AgentPropagation.Setter<HttpRequest> {
     private HttpRequest request;
     // Did this request have a span when the AkkaHttpHeaders object was created?
-    private boolean hadSpan;
+    private final boolean hadSpan;
 
     public AkkaHttpHeaders(final HttpRequest request) {
       hadSpan = request != null && request.getHeader(HasSpanHeader.class).isPresent();
@@ -51,6 +52,7 @@ public final class AkkaHttpClientHelpers {
       return hadSpan;
     }
 
+    @ParametersAreNonnullByDefault
     @Override
     public void set(final HttpRequest carrier, final String key, final String value) {
       // Coerce a Scala trait Self type into the correct type

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.akkahttp;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -78,7 +79,7 @@ public final class AkkaHttpSingleRequestInstrumentation extends InstrumenterModu
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        propagate().inject(span, request, headers);
+        defaultPropagator().inject(span, request, headers);
         propagate()
             .injectPathwayContext(
                 span, request, headers, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.akkahttp106;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -28,7 +29,7 @@ public class SingleRequestAdvice {
     AkkaHttpClientDecorator.DECORATE.onRequest(span, request);
 
     if (request != null) {
-      propagate().inject(span, request, headers);
+      defaultPropagator().inject(span, request, headers);
       propagate()
           .injectPathwayContext(
               span, request, headers, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
@@ -34,7 +35,7 @@ public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
     final HttpRequest request = delegate.generateRequest();
     DECORATE.onRequest(span, new HostAndRequestAsHttpUriRequest(delegate.getTarget(), request));
 
-    propagate().inject(span, request, SETTER);
+    defaultPropagator().inject(span, request, SETTER);
     propagate()
         .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.http.HttpRequest;
 
+@ParametersAreNonnullByDefault
 public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -45,7 +46,7 @@ public class HelperMethods {
 
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.apachehttpclient;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.http.client.methods.HttpUriRequest;
 
+@ParametersAreNonnullByDefault
 public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpUriRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
@@ -27,7 +28,7 @@ public class DelegatingRequestChannel implements RequestChannel {
       throws HttpException, IOException {
     DECORATE.onRequest(span, request);
 
-    propagate().inject(span, request, SETTER);
+    defaultPropagator().inject(span, request, SETTER);
     propagate()
         .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     delegate.sendRequest(request, entityDetails, context);

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -45,7 +46,7 @@ public class HelperMethods {
     final boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HttpHeadersInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.hc.core5.http.HttpRequest;
 
+@ParametersAreNonnullByDefault
 public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.armeria.grpc.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
@@ -120,7 +121,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
       if (null != responseListener && null != headers) {
         span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
         if (null != span) {
-          propagate().inject(span, headers, SETTER);
+          defaultPropagator().inject(span, headers, SETTER);
           propagate().injectPathwayContext(span, headers, SETTER, CLIENT_PATHWAY_EDGE_TAGS);
           return activateSpan(span);
         }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcInjectAdapter.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.armeria.grpc.client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.grpc.Metadata;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public final class GrpcInjectAdapter implements AgentPropagation.Setter<Metadata> {
 
   public static final GrpcInjectAdapter SETTER = new GrpcInjectAdapter();

--- a/dd-java-agent/instrumentation/aws-java-eventbridge-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/eventbridge/EventBridgeInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-eventbridge-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/eventbridge/EventBridgeInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v2.eventbridge;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.BUS_TAG;
@@ -86,7 +87,7 @@ public class EventBridgeInterceptor implements ExecutionInterceptor {
     jsonBuilder.append('{');
 
     // Inject trace context
-    propagate().inject(span, jsonBuilder, SETTER);
+    defaultPropagator().inject(span, jsonBuilder, SETTER);
 
     if (traceConfig().isDataStreamsEnabled()) {
       propagate().injectPathwayContext(span, jsonBuilder, SETTER, getTags(eventBusName));

--- a/dd-java-agent/instrumentation/aws-java-eventbridge-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/eventbridge/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/aws-java-eventbridge-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/eventbridge/TextMapInjectAdapter.java
@@ -1,7 +1,9 @@
 package datadog.trace.instrumentation.aws.v2.eventbridge;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class TextMapInjectAdapter implements AgentPropagation.Setter<StringBuilder> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -333,6 +333,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     return response.getHttpResponse().getStatusCode();
   }
 
+  @ParametersAreNonnullByDefault
   @Override
   public void set(Request<?> carrier, String key, String value) {
     carrier.addHeader(key, value);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response>
     implements AgentPropagation.Setter<Request<?>> {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.aws.v0;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
@@ -16,8 +16,8 @@ import com.amazonaws.Request;
 import com.amazonaws.Response;
 import com.amazonaws.handlers.HandlerContextKey;
 import com.amazonaws.handlers.RequestHandler2;
+import datadog.context.propagation.Propagators;
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentDataStreamsMonitoring;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -69,7 +69,7 @@ public class TracingRequestHandler extends RequestHandler2 {
       request.addHandlerContext(SPAN_CONTEXT_KEY, span);
       if (Config.get().isAwsPropagationEnabled()) {
         try {
-          propagate().inject(span, request, DECORATE, TracePropagationStyle.XRAY);
+          Propagators.forConcern(XRAY_TRACING_CONCERN).inject(span, request, DECORATE);
         } catch (Throwable e) {
           log.warn("Unable to inject trace header", e);
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
@@ -443,6 +444,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     return response.statusCode();
   }
 
+  @ParametersAreNonnullByDefault
   @Override
   public void set(SdkHttpRequest.Builder carrier, String key, String value) {
     carrier.putHeader(key, value);

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -1,14 +1,14 @@
 package datadog.trace.instrumentation.aws.v2;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
+import datadog.context.propagation.Propagators;
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstanceStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -71,7 +71,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
         final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
         if (span != null) {
           SdkHttpRequest.Builder requestBuilder = context.httpRequest().toBuilder();
-          propagate().inject(span, requestBuilder, DECORATE, TracePropagationStyle.XRAY);
+          Propagators.forConcern(XRAY_TRACING_CONCERN).inject(span, requestBuilder, DECORATE);
           return requestBuilder.build();
         }
       } catch (Throwable e) {

--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -37,7 +37,12 @@ public class SnsInterceptor extends RequestHandler2 {
     final AgentSpan span = newSpan(request);
     StringBuilder jsonBuilder = new StringBuilder();
     jsonBuilder.append('{');
-    propagate().inject(span, jsonBuilder, SETTER, TracePropagationStyle.DATADOG);
+    propagate()
+        .inject(
+            span,
+            jsonBuilder,
+            SETTER,
+            TracePropagationStyle.DATADOG); // TODO Is forcing Datadog encoding on purpose?
     if (traceConfig().isDataStreamsEnabled()) {
       propagate().injectPathwayContext(span, jsonBuilder, SETTER, getTags(snsTopicName));
     }

--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v1.sns;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
@@ -14,7 +15,6 @@ import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishBatchRequest;
 import com.amazonaws.services.sns.model.PublishBatchRequestEntry;
 import com.amazonaws.services.sns.model.PublishRequest;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -37,12 +37,7 @@ public class SnsInterceptor extends RequestHandler2 {
     final AgentSpan span = newSpan(request);
     StringBuilder jsonBuilder = new StringBuilder();
     jsonBuilder.append('{');
-    propagate()
-        .inject(
-            span,
-            jsonBuilder,
-            SETTER,
-            TracePropagationStyle.DATADOG); // TODO Is forcing Datadog encoding on purpose?
+    defaultPropagator().inject(span, jsonBuilder, SETTER);
     if (traceConfig().isDataStreamsEnabled()) {
       propagate().injectPathwayContext(span, jsonBuilder, SETTER, getTags(snsTopicName));
     }

--- a/dd-java-agent/instrumentation/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v2.sns;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
@@ -37,7 +38,7 @@ public class SnsInterceptor implements ExecutionInterceptor {
     final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
     StringBuilder jsonBuilder = new StringBuilder();
     jsonBuilder.append('{');
-    propagate().inject(span, jsonBuilder, SETTER);
+    defaultPropagator().inject(span, jsonBuilder, SETTER);
     if (traceConfig().isDataStreamsEnabled()) {
       propagate().injectPathwayContext(span, jsonBuilder, SETTER, getTags(snsTopicName));
     }

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.axis2;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_ASYNC_SPAN_KEY;
 import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_TRANSPORT;
@@ -77,7 +77,7 @@ public final class AxisTransportInstrumentation extends InstrumenterModule.Traci
           message.setProperty("TRANSPORT_HEADERS", headers);
         }
         try {
-          propagate().inject(span, headers, SETTER);
+          defaultPropagator().inject(span, headers, SETTER);
         } catch (Throwable ignore) {
         }
 

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/TextMapInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.axis2;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.util.Map;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class TextMapInjectAdapter implements AgentPropagation.Setter<Map<String, Object>> {
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.commonshttpclient;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -68,7 +69,7 @@ public class CommonsHttpClientInstrumentation extends InstrumenterModule.Tracing
 
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, httpMethod);
-        propagate().inject(span, httpMethod, SETTER);
+        defaultPropagator().inject(span, httpMethod, SETTER);
         propagate()
             .injectPathwayContext(
                 span, httpMethod, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/HttpHeadersInjectAdapter.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.commonshttpclient;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpMethod;
 
+@ParametersAreNonnullByDefault
 public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpMethod> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.googlehttpclient;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapter.SETTER;
 
@@ -37,7 +38,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   public AgentSpan prepareSpan(AgentSpan span, HttpRequest request) {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    propagate().inject(span, request, SETTER);
+    defaultPropagator().inject(span, request, SETTER);
     propagate()
         .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     return span;

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.googlehttpclient;
 
 import com.google.api.client.http.HttpRequest;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class HeadersInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
 
   public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.googlepubsub;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -80,7 +81,7 @@ public final class PublisherInstrumentation extends InstrumenterModule.Tracing
       sortedTags.put(TYPE_TAG, "google-pubsub");
 
       PubsubMessage.Builder builder = msg.toBuilder();
-      propagate().inject(span, builder, SETTER);
+      defaultPropagator().inject(span, builder, SETTER);
       propagate().injectPathwayContext(span, builder, SETTER, sortedTags);
       msg = builder.build();
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.googlepubsub;
 
 import com.google.pubsub.v1.PubsubMessage;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class TextMapInjectAdapter implements AgentPropagation.Setter<PubsubMessage.Builder> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.grizzly.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -68,7 +69,7 @@ public final class AsyncHttpClientInstrumentation extends InstrumenterModule.Tra
       AgentSpan span = startSpan(HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/InjectAdapter.java
@@ -2,9 +2,10 @@ package datadog.trace.instrumentation.grizzly.client;
 
 import com.ning.http.client.Request;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class InjectAdapter implements AgentPropagation.Setter<Request> {
-
   public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.grpc.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -92,7 +93,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
         @Advice.Local("$$ddSpan") AgentSpan span) {
       span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
       if (null != span) {
-        propagate().inject(span, headers, SETTER);
+        defaultPropagator().inject(span, headers, SETTER);
         propagate().injectPathwayContext(span, headers, SETTER, CLIENT_PATHWAY_EDGE_TAGS);
         return activateSpan(span);
       }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
@@ -2,9 +2,10 @@ package datadog.trace.instrumentation.grpc.client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.grpc.Metadata;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public final class GrpcInjectAdapter implements AgentPropagation.Setter<Metadata> {
-
   public static final GrpcInjectAdapter SETTER = new GrpcInjectAdapter();
 
   @Override

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.http_url_connection;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -85,7 +86,7 @@ public class HttpUrlConnectionInstrumentation extends InstrumenterModule.Tracing
         if (!state.hasSpan() && !state.isFinished()) {
           final AgentSpan span = state.start(thiz);
           if (!connected) {
-            propagate().inject(span, thiz, SETTER);
+            defaultPropagator().inject(span, thiz, SETTER);
             propagate()
                 .injectPathwayContext(
                     span, thiz, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.httpclient;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.KEEP;
@@ -18,7 +19,7 @@ public class HeadersAdvice {
   public static void methodExit(@Advice.Return(readOnly = false) HttpHeaders headers) {
     final Map<String, List<String>> headerMap = new HashMap<>(headers.map());
     final AgentSpan span = activeSpan();
-    propagate().inject(span, headerMap, SETTER);
+    defaultPropagator().inject(span, headerMap, SETTER);
     propagate()
         .injectPathwayContext(
             span, headerMap, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
@@ -1,14 +1,18 @@
 package datadog.trace.instrumentation.jaxrs.v1;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.core.MultivaluedMap;
 
-public final class InjectAdapter implements AgentPropagation.Setter<MultivaluedMap> {
+@ParametersAreNonnullByDefault
+public final class InjectAdapter
+    implements AgentPropagation.Setter<MultivaluedMap<String, Object>> {
 
   public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public void set(final MultivaluedMap headers, final String key, final String value) {
+  public void set(
+      final MultivaluedMap<String, Object> headers, final String key, final String value) {
     // Don't allow duplicates.
     headers.putSingle(key, value);
   }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jaxrs.v1;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
@@ -75,7 +76,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
 
-        propagate().inject(span, request.getHeaders(), SETTER);
+        defaultPropagator().inject(span, request.getHeaders(), SETTER);
         propagate()
             .injectPathwayContext(
                 span, request.getHeaders(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jaxrs;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -28,7 +29,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
 
-      propagate().inject(span, requestContext.getHeaders(), SETTER);
+      defaultPropagator().inject(span, requestContext.getHeaders(), SETTER);
       propagate()
           .injectPathwayContext(
               span,

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
@@ -1,14 +1,18 @@
 package datadog.trace.instrumentation.jaxrs;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.core.MultivaluedMap;
 
-public final class InjectAdapter implements AgentPropagation.Setter<MultivaluedMap> {
+@ParametersAreNonnullByDefault
+public final class InjectAdapter
+    implements AgentPropagation.Setter<MultivaluedMap<String, Object>> {
 
   public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public void set(final MultivaluedMap headers, final String key, final String value) {
+  public void set(
+      final MultivaluedMap<String, Object> headers, final String key, final String value) {
     // Don't allow duplicates.
     headers.putSingle(key, value);
   }

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jetty_client10;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jetty_client.HeadersInjectAdapter.SETTER;
@@ -25,7 +26,7 @@ public class SendAdvice {
     responseListeners.add(0, new SpanFinishingCompleteListener(span));
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    propagate().inject(span, request, SETTER);
+    defaultPropagator().inject(span, request, SETTER);
     propagate()
         .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     return span;

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/main/java17/datadog/trace/instrumentation/jetty_client12/SendAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/main/java17/datadog/trace/instrumentation/jetty_client12/SendAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jetty_client12;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -20,7 +21,7 @@ public class SendAdvice {
     InstrumentationContext.get(Request.class, AgentSpan.class).put(request, span);
     JettyClientDecorator.DECORATE.afterStart(span);
     JettyClientDecorator.DECORATE.onRequest(span, request);
-    propagate().inject(span, request, SETTER);
+    defaultPropagator().inject(span, request, SETTER);
     propagate()
         .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     return activateSpan(span);

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jetty_client91;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -91,7 +92,7 @@ public class JettyClientInstrumentation extends InstrumenterModule.Tracing
       responseListeners.add(0, new SpanFinishingCompleteListener(span));
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-common/src/main/java/datadog/trace/instrumentation/jetty_client/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-common/src/main/java/datadog/trace/instrumentation/jetty_client/HeadersInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.jetty_client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.eclipse.jetty.client.api.Request;
 
+@ParametersAreNonnullByDefault
 public class HeadersInjectAdapter implements AgentPropagation.Setter<Request> {
 
   public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.jms;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
@@ -94,7 +94,7 @@ public final class JMSMessageProducerInstrumentation
       if (JMSDecorator.canInject(message)) {
         if (Config.get().isJmsPropagationEnabled()
             && (null == producerState || !producerState.isPropagationDisabled())) {
-          propagate().inject(span, message, SETTER);
+          defaultPropagator().inject(span, message, SETTER);
         }
         if (TIME_IN_QUEUE_ENABLED) {
           if (null != producerState) {
@@ -140,9 +140,8 @@ public final class JMSMessageProducerInstrumentation
       PRODUCER_DECORATE.onProduce(span, resourceName);
       if (JMSDecorator.canInject(message)) {
         if (Config.get().isJmsPropagationEnabled()
-            && !Config.get().isJmsPropagationDisabledForDestination(destinationName)) {
-          propagate().inject(span, message, SETTER);
-        }
+            && !Config.get().isJmsPropagationDisabledForDestination(destinationName))
+          defaultPropagator().inject(span, message, SETTER);
         if (TIME_IN_QUEUE_ENABLED) {
           MessageProducerState producerState =
               InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -7,6 +7,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.jms.MessageBatchState;
 import datadog.trace.bootstrap.instrumentation.jms.MessageProducerState;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.jms.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,7 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
 
   public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
 
+  @ParametersAreNonnullByDefault
   @SuppressForbidden
   @Override
   public void set(final Message carrier, final String key, final String value) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
@@ -148,7 +149,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
       sortedTags.put(TOPIC_TAG, record.topic());
       sortedTags.put(TYPE_TAG, "kafka");
       try {
-        propagate().inject(span, record.headers(), setter);
+        defaultPropagator().inject(span, record.headers(), setter);
         if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
             || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
           // inject the context in the headers, but delay sending the stats until we know the
@@ -169,7 +170,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
                 record.value(),
                 record.headers());
 
-        propagate().inject(span, record.headers(), setter);
+        defaultPropagator().inject(span, record.headers(), setter);
         if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
             || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
           propagate()

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
@@ -1,7 +1,9 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.kafka.common.header.Headers;
 
+@ParametersAreNonnullByDefault
 public class NoopTextMapInjectAdapter implements TextMapInjectAdapterInterface {
   public static final NoopTextMapInjectAdapter NOOP_SETTER = new NoopTextMapInjectAdapter();
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -4,8 +4,10 @@ import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_P
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.ByteBuffer;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.kafka.common.header.Headers;
 
+@ParametersAreNonnullByDefault
 public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -72,7 +73,7 @@ public class ProducerAdvice {
     sortedTags.put(TOPIC_TAG, record.topic());
     sortedTags.put(TYPE_TAG, "kafka");
     try {
-      propagate().inject(span, record.headers(), setter);
+      defaultPropagator().inject(span, record.headers(), setter);
       if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
           || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
         // inject the context in the headers, but delay sending the stats until we know the
@@ -93,7 +94,7 @@ public class ProducerAdvice {
               record.value(),
               record.headers());
 
-      propagate().inject(span, record.headers(), setter);
+      defaultPropagator().inject(span, record.headers(), setter);
       if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
           || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
         propagate()

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.netty38.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -65,7 +66,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
         decorate.onPeerConnection(span, (InetSocketAddress) socketAddress);
       }
 
-      propagate().inject(span, request.headers(), SETTER);
+      defaultPropagator().inject(span, request.headers(), SETTER);
       propagate()
           .injectPathwayContext(
               span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyResponseInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.netty38.client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 
+@ParametersAreNonnullByDefault
 public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
   public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.netty40.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -88,7 +89,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        propagate().inject(span, request.headers(), SETTER);
+        defaultPropagator().inject(span, request.headers(), SETTER);
         propagate()
             .injectPathwayContext(
                 span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.netty40.client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpHeaders;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
   public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.netty41.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -89,7 +90,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        propagate().inject(span, request.headers(), SETTER);
+        defaultPropagator().inject(span, request.headers(), SETTER);
         propagate()
             .injectPathwayContext(
                 span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.netty41.client;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpHeaders;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
   public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/RequestBuilderInjectAdapter.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/RequestBuilderInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.okhttp2;
 
 import com.squareup.okhttp.Request;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class RequestBuilderInjectAdapter implements AgentPropagation.Setter<Request.Builder> {
   public static final RequestBuilderInjectAdapter SETTER = new RequestBuilderInjectAdapter();
 

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.okhttp2;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -26,7 +27,7 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      propagate().inject(span, requestBuilder, SETTER);
+      defaultPropagator().inject(span, requestBuilder, SETTER);
       propagate()
           .injectPathwayContext(
               span, requestBuilder, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/RequestBuilderInjectAdapter.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/RequestBuilderInjectAdapter.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.okhttp3;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.Request;
 
 /**
@@ -8,6 +9,7 @@ import okhttp3.Request;
  *
  * @author Pavol Loffay
  */
+@ParametersAreNonnullByDefault
 public class RequestBuilderInjectAdapter implements AgentPropagation.Setter<Request.Builder> {
 
   public static final RequestBuilderInjectAdapter SETTER = new RequestBuilderInjectAdapter();

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.okhttp3;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -29,7 +30,7 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      propagate().inject(span, requestBuilder, SETTER);
+      defaultPropagator().inject(span, requestBuilder, SETTER);
       propagate()
           .injectPathwayContext(
               span, requestBuilder, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OpenTelemetryInstrumentation.java
@@ -44,7 +44,6 @@ public class OpenTelemetryInstrumentation extends InstrumenterModule.Tracing
       packageName + ".OtelContextPropagators",
       packageName + ".OtelContextPropagators$1", // switch statement
       packageName + ".OtelContextPropagators$OtelHttpTextFormat",
-      packageName + ".OtelContextPropagators$OtelSetter",
       packageName + ".OtelContextPropagators$OtelGetter",
       packageName + ".TypeConverter",
     };

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelContextPropagators.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelContextPropagators.java
@@ -1,6 +1,9 @@
 package datadog.trace.instrumentation.opentelemetry;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.grpc.Context;
@@ -39,7 +42,10 @@ public class OtelContextPropagators implements ContextPropagators {
       if (span == null || !span.getContext().isValid()) {
         return;
       }
-      tracer.propagate().inject(converter.toAgentSpan(span), carrier, new OtelSetter<>(setter));
+      AgentSpan agentSpan = converter.toAgentSpan(span);
+      if (agentSpan != null) {
+        defaultPropagator().inject(agentSpan, carrier, setter::set);
+      }
     }
 
     @Override
@@ -48,19 +54,6 @@ public class OtelContextPropagators implements ContextPropagators {
           tracer.propagate().extract(carrier, new OtelGetter<>(getter));
       return TracingContextUtils.withSpan(
           DefaultSpan.create(converter.toSpanContext(agentContext)), context);
-    }
-  }
-
-  private static class OtelSetter<C> implements AgentPropagation.Setter<C> {
-    private final HttpTextFormat.Setter<C> setter;
-
-    private OtelSetter(final HttpTextFormat.Setter<C> setter) {
-      this.setter = setter;
-    }
-
-    @Override
-    public void set(final C carrier, final String key, final String value) {
-      setter.set(carrier, key, value);
     }
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.opentracing31;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromSpanContext;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -49,8 +52,8 @@ public class OTTracer implements Tracer {
   public <C> void inject(final SpanContext spanContext, final Format<C> format, final C carrier) {
     if (carrier instanceof TextMap) {
       final AgentSpanContext context = converter.toContext(spanContext);
-
-      tracer.propagate().inject(context, (TextMap) carrier, OTTextMapSetter.INSTANCE);
+      AgentSpan span = fromSpanContext(context);
+      defaultPropagator().inject(span, (TextMap) carrier, OTTextMapSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.opentracing32;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromSpanContext;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -61,8 +64,8 @@ public class OTTracer implements Tracer {
   public <C> void inject(final SpanContext spanContext, final Format<C> format, final C carrier) {
     if (carrier instanceof TextMapInject) {
       final AgentSpanContext context = converter.toContext(spanContext);
-
-      tracer.propagate().inject(context, (TextMapInject) carrier, OTTextMapInjectSetter.INSTANCE);
+      AgentSpan span = fromSpanContext(context);
+      defaultPropagator().inject(span, (TextMapInject) carrier, OTTextMapInjectSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpClientHelpers.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpClientHelpers.java
@@ -4,6 +4,7 @@ import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.D
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.pekko.http.javadsl.model.headers.RawHeader;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 import org.apache.pekko.http.scaladsl.model.HttpResponse;
@@ -35,7 +36,7 @@ public final class PekkoHttpClientHelpers {
   public static class PekkoHttpHeaders implements AgentPropagation.Setter<HttpRequest> {
     private HttpRequest request;
     // Did this request have a span when the PekkoHttpHeaders object was created?
-    private boolean hadSpan;
+    private final boolean hadSpan;
 
     public PekkoHttpHeaders(final HttpRequest request) {
       hadSpan = request != null && request.getHeader(HasSpanHeader.class).isPresent();
@@ -51,6 +52,7 @@ public final class PekkoHttpClientHelpers {
       return hadSpan;
     }
 
+    @ParametersAreNonnullByDefault
     @Override
     public void set(final HttpRequest carrier, final String key, final String value) {
       // Coerce a Scala trait Self type into the correct type

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.pekkohttp;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
@@ -79,7 +80,7 @@ public final class PekkoHttpSingleRequestInstrumentation extends InstrumenterMod
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        propagate().inject(span, request, headers);
+        defaultPropagator().inject(span, request, headers);
         propagate()
             .injectPathwayContext(
                 span, request, headers, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws1;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +30,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws21;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +30,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws2;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +30,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/HeadersInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.playws;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import play.shaded.ahc.org.asynchttpclient.Request;
 
+@ParametersAreNonnullByDefault
 public class HeadersInjectAdapter implements AgentPropagation.Setter<Request> {
 
   public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.rabbitmq.amqp;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEndsWith;
@@ -189,7 +190,7 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
         if (TIME_IN_QUEUE_ENABLED) {
           RabbitDecorator.injectTimeInQueueStart(headers);
         }
-        propagate().inject(span, headers, SETTER);
+        defaultPropagator().inject(span, headers, SETTER);
         LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
         sortedTags.put(DIRECTION_TAG, DIRECTION_OUT);
         sortedTags.put(EXCHANGE_TAG, exchange);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.rabbitmq.amqp;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.util.Map;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class TextMapInjectAdapter implements AgentPropagation.Setter<Map<String, Object>> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/ServletRequestSetter.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/ServletRequestSetter.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.servlet;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.servlet.ServletRequest;
 
 /** Inject into request attributes since the request headers can't be modified. */
+@ParametersAreNonnullByDefault
 public class ServletRequestSetter implements AgentPropagation.Setter<ServletRequest> {
   public static final ServletRequestSetter SETTER = new ServletRequestSetter();
 

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.servlet.dispatcher;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
@@ -121,7 +122,7 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       span.setSpanType(InternalSpanTypes.HTTP_SERVER);
 
       // In case we lose context, inject trace into to the request.
-      propagate().inject(span, request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
@@ -1,9 +1,9 @@
 package datadog.trace.instrumentation.synapse3;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.SYNAPSE_REQUEST;
@@ -86,7 +86,7 @@ public final class SynapseClientInstrumentation extends InstrumenterModule.Traci
       DECORATE.afterStart(span);
 
       // add trace id to client-side request before it gets submitted as an HttpRequest
-      propagate().inject(span, TargetContext.getRequest(connection), SETTER);
+      defaultPropagator().inject(span, TargetContext.getRequest(connection), SETTER);
 
       // capture span to be finished by one of the various client response advices
       connection.getContext().setAttribute(SYNAPSE_SPAN_KEY, span);

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/TargetRequestInjectAdapter.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/TargetRequestInjectAdapter.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.synapse3;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.synapse.transport.passthru.TargetRequest;
 
+@ParametersAreNonnullByDefault
 public final class TargetRequestInjectAdapter implements AgentPropagation.Setter<TargetRequest> {
   public static final TargetRequestInjectAdapter SETTER = new TargetRequestInjectAdapter();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.DDTags.DJM_ENABLED;
 import static datadog.trace.api.DDTags.DSM_ENABLED;
 import static datadog.trace.api.DDTags.PROFILING_CONTEXT_ENGINE;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.TRACING_CONCERN;
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
 import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetricsAggregator;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
@@ -90,6 +91,7 @@ import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.HttpCodec;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.propagation.TracingPropagator;
+import datadog.trace.core.propagation.XRayPropagator;
 import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.core.taginterceptor.RuleFlags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
@@ -724,6 +726,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         new CorePropagation(builtExtractor, injector, injectors, dataStreamContextInjector);
 
     Propagators.register(TRACING_CONCERN, new TracingPropagator(injector, extractor));
+    Propagators.register(XRAY_TRACING_CONCERN, new XRayPropagator(config), false);
 
     this.tagInterceptor =
         null == tagInterceptor ? new TagInterceptor(new RuleFlags(config)) : tagInterceptor;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/StandaloneAsmPropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/StandaloneAsmPropagator.java
@@ -1,0 +1,40 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.TRACING_CONCERN;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
+
+import datadog.context.Context;
+import datadog.context.propagation.CarrierSetter;
+import datadog.context.propagation.CarrierVisitor;
+import datadog.context.propagation.Propagator;
+import datadog.context.propagation.Propagators;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.core.DDSpanContext;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class StandaloneAsmPropagator implements Propagator {
+  @Override
+  public <C> void inject(Context context, C carrier, CarrierSetter<C> setter) {
+    // Stop propagation if appsec propagation is disabled (no ASM events), stop propagation
+    AgentSpan span;
+    if ((span = fromContext(context)) != null) {
+      AgentSpanContext spanContext = span.context();
+      if (spanContext instanceof DDSpanContext) {
+        DDSpanContext ddSpanContext = (DDSpanContext) spanContext;
+        if (!ddSpanContext.getPropagationTags().isAppsecPropagationEnabled()) {
+          return;
+        }
+      }
+      // Only propagate tracing for appsec standalone product
+      Propagators.forConcern(TRACING_CONCERN).inject(span, carrier, setter);
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, CarrierVisitor<C> visitor) {
+    // Only propagate tracing for appsec standalone product
+    return Propagators.forConcern(TRACING_CONCERN).extract(context, carrier, visitor);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayPropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayPropagator.java
@@ -1,0 +1,58 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
+
+import datadog.context.Context;
+import datadog.context.propagation.CarrierSetter;
+import datadog.context.propagation.CarrierVisitor;
+import datadog.context.propagation.Propagator;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.core.DDSpanContext;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * AWS X-Ray Tracking context propagator.
+ *
+ * <p>Only injection is supported. For full-fledged context propagation support, use the default
+ * {@link TracingPropagator} instead.
+ *
+ * @see XRayHttpCodec
+ */
+@ParametersAreNonnullByDefault
+public class XRayPropagator implements Propagator {
+  private final HttpCodec.Injector injector;
+
+  /**
+   * Constructor.
+   *
+   * @param config the config get the baggage mapping from.
+   */
+  public XRayPropagator(Config config) {
+    this.injector = XRayHttpCodec.newInjector(config.getBaggageMapping());
+  }
+
+  @Override
+  public <C> void inject(Context context, C carrier, CarrierSetter<C> setter) {
+    AgentSpan span;
+    //noinspection ConstantValue
+    if (context == null
+        || carrier == null
+        || setter == null
+        || (span = fromContext(context)) == null) {
+      return;
+    }
+    AgentSpanContext spanContext = span.context();
+    if (spanContext instanceof DDSpanContext) {
+      DDSpanContext ddSpanContext = (DDSpanContext) spanContext;
+      ddSpanContext.getTraceCollector().setSamplingPriorityIfNecessary();
+      this.injector.inject(ddSpanContext, carrier, setter::set);
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, CarrierVisitor<C> visitor) {
+    return context;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/TracingPropagatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/TracingPropagatorTest.groovy
@@ -11,6 +11,7 @@ import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN
 
 class TracingPropagatorTest extends DDCoreSpecification {
   HttpCodec.Injector injector
@@ -134,6 +135,25 @@ class TracingPropagatorTest extends DDCoreSpecification {
     cleanup:
     child.finish()
     root.finish()
+    tracer.close()
+  }
+
+  def 'test AWS X-Ray propagator'() {
+    setup:
+    def tracer = tracerBuilder().build()
+    def span = tracer.buildSpan('test', 'operation').start()
+    def propagator = Propagators.forConcerns(XRAY_TRACING_CONCERN)
+    def setter = Mock(CarrierSetter)
+    def carrier = new Object()
+
+    when:
+    propagator.inject(span, carrier, setter)
+
+    then:
+    1 * setter.set(carrier, 'X-Amzn-Trace-Id', _)
+
+    cleanup:
+    span.finish()
     tracer.close()
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,5 +1,8 @@
 package datadog.opentracing;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromSpanContext;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
@@ -475,8 +478,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   public <C> void inject(final SpanContext spanContext, final Format<C> format, final C carrier) {
     if (carrier instanceof TextMap) {
       final AgentSpanContext context = converter.toContext(spanContext);
-
-      tracer.propagate().inject(context, (TextMap) carrier, TextMapSetter.INSTANCE);
+      AgentSpan span = fromSpanContext(context);
+      defaultPropagator().inject(span, (TextMap) carrier, TextMapSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -10,6 +10,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 public interface AgentPropagation {
   Concern TRACING_CONCERN = Concern.named("tracing");
+  Concern XRAY_TRACING_CONCERN = Concern.named("tracing-xray");
 
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import static datadog.context.propagation.Concern.named;
+
 import datadog.context.propagation.CarrierSetter;
 import datadog.context.propagation.CarrierVisitor;
 import datadog.context.propagation.Concern;
@@ -9,8 +11,9 @@ import java.util.function.BiConsumer;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 public interface AgentPropagation {
-  Concern TRACING_CONCERN = Concern.named("tracing");
-  Concern XRAY_TRACING_CONCERN = Concern.named("tracing-xray");
+  Concern TRACING_CONCERN = named("tracing");
+  Concern XRAY_TRACING_CONCERN = named("tracing-xray");
+  Concern STANDALONE_ASM_CONCERN = named("asm-standalone");
 
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -25,7 +25,7 @@ public interface AgentSpan
    * @return the span if existing, {@code null} otherwise.
    */
   static AgentSpan fromContext(Context context) {
-    return context.get(SPAN_KEY);
+    return context == null ? null : context.get(SPAN_KEY);
   }
 
   /**


### PR DESCRIPTION
# What Does This Do

This PR migrates the `AgentPropagation` API call to the new context tracking API for context injection.

# Motivation

Migrate to context-first API and deprecate / remove the `AgentPropagation`.

# Additional Notes

Context extraction will be migrated in a following PR.
Simplification of carrier visitor / getter / setter will come in another PR.
Some injection calls will be simplified in a later PR with DSM propagator introduction.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
