### PR TITLE
Muzzle: do not generate references for primitive arrays in method body

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -390,6 +390,9 @@ public class ReferenceCreator extends ClassVisitor {
 
     @Override
     public void visitTypeInsn(final int opcode, final String stype) {
+      if (ignoreReference(stype)) {
+        return;
+      }
       Type type = underlyingType(Type.getObjectType(stype));
 
       if (ignoreReference(type.getInternalName())) {

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/TestAdviceClasses.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/TestAdviceClasses.java
@@ -16,6 +16,10 @@ public class TestAdviceClasses {
       a.b.aMethodWithArrays(new String[0]);
       B.aStaticMethod();
       A.staticB.aMethod("bar");
+      Object barr = new byte[0];
+      if (barr instanceof byte[]) {
+        barr = null;
+      }
     }
 
     public static class A {


### PR DESCRIPTION
# What Does This Do

If a helper/advice class contains this kind of code:

```
if (something instanceof byte[]) {
..
}
```

muzzle will create a reference for `B` since, for methods, it checks only the underlying type without checking if it's a primitive array `[B`

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
