### PR TITLE
Skip benchmarks on release

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -8,6 +8,9 @@
   rules:
     - if: '$POPULATE_CACHE'
       when: never
+    - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: manual
+      allow_failure: true
     - when: on_success
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"


### PR DESCRIPTION
# What Does This Do

Makes benchmarks optional and manual during releases.

# Motivation
Most of the benchmarks make incorrect assumptions about artifacts that are not true for releases. This leads to the benchmark jobs failing on the release


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
