### PR TITLE
Create metric: appsec.rasp.error

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -232,11 +232,11 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public int getRaspError(int code) {
     switch (code) {
-      case -3:
+      case DD_WAF_RUN_INTERNAL_ERROR:
         return raspInternalErrors;
-      case -2:
+      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
         return raspInvalidObjectErrors;
-      case -1:
+      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
         return raspInvalidArgumentErrors;
       default:
         return 0;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -77,9 +77,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   public static final Set<String> RESPONSE_HEADERS_ALLOW_LIST =
       new TreeSet<>(
           Arrays.asList("content-length", "content-type", "content-encoding", "content-language"));
-  private static final int DD_WAF_RUN_INTERNAL_ERROR = -3;
-  private static final int DD_WAF_RUN_INVALID_OBJECT_ERROR = -2;
-  private static final int DD_WAF_RUN_INVALID_ARGUMENT_ERROR = -1;
+  public static final int DD_WAF_RUN_INTERNAL_ERROR = -3;
+  public static final int DD_WAF_RUN_INVALID_OBJECT_ERROR = -2;
+  public static final int DD_WAF_RUN_INVALID_ARGUMENT_ERROR = -1;
 
   static {
     REQUEST_HEADERS_ALLOW_LIST.addAll(DEFAULT_REQUEST_HEADERS_ALLOW_LIST);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -77,6 +77,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   public static final Set<String> RESPONSE_HEADERS_ALLOW_LIST =
       new TreeSet<>(
           Arrays.asList("content-length", "content-type", "content-encoding", "content-language"));
+  private static final int DD_WAF_RUN_INTERNAL_ERROR = -3;
+  private static final int DD_WAF_RUN_INVALID_OBJECT_ERROR = -2;
+  private static final int DD_WAF_RUN_INVALID_ARGUMENT_ERROR = -1;
 
   static {
     REQUEST_HEADERS_ALLOW_LIST.addAll(DEFAULT_REQUEST_HEADERS_ALLOW_LIST);
@@ -124,6 +127,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private volatile boolean blocked;
   private volatile int wafTimeouts;
   private volatile int raspTimeouts;
+  private volatile int raspInternalErrors;
+  private volatile int raspInvalidObjectErrors;
+  private volatile int raspInvalidArgumentErrors;
 
   // keep a reference to the last published usr.id
   private volatile String userId;
@@ -138,6 +144,18 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "wafTimeouts");
   private static final AtomicIntegerFieldUpdater<AppSecRequestContext> RASP_TIMEOUTS_UPDATER =
       AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "raspTimeouts");
+
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
+      RASP_INTERNAL_ERRORS_UPDATER =
+          AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "raspInternalErrors");
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
+      RASP_INVALID_OBJECT_ERRORS_UPDATER =
+          AtomicIntegerFieldUpdater.newUpdater(
+              AppSecRequestContext.class, "raspInvalidObjectErrors");
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
+      RASP_INVALID_ARGUMENT_ERRORS_UPDATER =
+          AtomicIntegerFieldUpdater.newUpdater(
+              AppSecRequestContext.class, "raspInvalidArgumentErrors");
 
   // to be called by the Event Dispatcher
   public void addAll(DataBundle newData) {
@@ -188,12 +206,41 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     RASP_TIMEOUTS_UPDATER.incrementAndGet(this);
   }
 
+  public void increaseRaspErrorCode(int code) {
+    switch (code) {
+      case DD_WAF_RUN_INTERNAL_ERROR:
+        RASP_INTERNAL_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
+        RASP_INVALID_OBJECT_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
+        RASP_INVALID_ARGUMENT_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      default:
+        break;
+    }
+  }
+
   public int getWafTimeouts() {
     return wafTimeouts;
   }
 
   public int getRaspTimeouts() {
     return raspTimeouts;
+  }
+
+  public int getRaspError(int code) {
+    switch (code) {
+      case -3:
+        return raspInternalErrors;
+      case -2:
+        return raspInvalidObjectErrors;
+      case -1:
+        return raspInvalidArgumentErrors;
+      default:
+        return 0;
+    }
   }
 
   public Additive getOrCreateAdditive(PowerwafContext ctx, boolean createMetrics, boolean isRasp) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -47,6 +47,7 @@ import io.sqreen.powerwaf.RuleSetInfo;
 import io.sqreen.powerwaf.exception.AbstractPowerwafException;
 import io.sqreen.powerwaf.exception.InvalidRuleSetException;
 import io.sqreen.powerwaf.exception.TimeoutPowerwafException;
+import io.sqreen.powerwaf.exception.UnclassifiedPowerwafException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
@@ -440,9 +441,19 @@ public class PowerWAFModule implements AppSecModule {
           log.debug(LogCollector.EXCLUDE_TELEMETRY, "Timeout calling the WAF", tpe);
         }
         return;
-      } catch (AbstractPowerwafException e) {
+      } catch (UnclassifiedPowerwafException e) {
         if (!reqCtx.isAdditiveClosed()) {
           log.error("Error calling WAF", e);
+        }
+        return;
+      } catch (AbstractPowerwafException e) {
+        if (gwCtx.isRasp) {
+          reqCtx.increaseRaspErrorCode(e.code);
+          WafMetricCollector.get().raspErrorCode(gwCtx.raspRuleType, e.code);
+        } else {
+          // TODO APPSEC-56703
+          // reqCtx.increaseWafErrorCode(e.code);
+          // WafMetricCollector.get().wafErrorCode(e.code);
         }
         return;
       } finally {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -293,14 +293,14 @@ class AppSecRequestContextSpecification extends DDSpecification {
 
   def "test increase and get RaspErrors"() {
     when:
-    ctx.increaseRaspErrorCode(-3)
-    ctx.increaseRaspErrorCode(-3)
-    ctx.increaseRaspErrorCode(-2)
+    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
+    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
+    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR)
 
     then:
-    ctx.getRaspError(-3) == 2
-    ctx.getRaspError(-2) == 1
-    ctx.getRaspError(-1) == 0
+    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR) == 2
+    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR) == 1
+    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
     ctx.getRaspError(0) == 0
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -290,4 +290,17 @@ class AppSecRequestContextSpecification extends DDSpecification {
     then:
     ctx.getRaspTimeouts() == 2
   }
+
+  def "test increase and get RaspErrors"() {
+    when:
+    ctx.increaseRaspErrorCode(-3)
+    ctx.increaseRaspErrorCode(-3)
+    ctx.increaseRaspErrorCode(-2)
+
+    then:
+    ctx.getRaspError(-3) == 2
+    ctx.getRaspError(-2) == 1
+    ctx.getRaspError(-1) == 0
+    ctx.getRaspError(0) == 0
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit
 
 class WafMetricCollectorTest extends DDSpecification {
 
+  public static final int DD_WAF_RUN_INTERNAL_ERROR = -3
+  public static final int DD_WAF_RUN_INVALID_OBJECT_ERROR = -2
+
   def "no metrics - drain empty list"() {
     when:
     WafMetricCollector.get().prepareMetrics()
@@ -32,8 +35,8 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().raspRuleMatch(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspTimeout(RuleType.SQL_INJECTION)
-    WafMetricCollector.get().raspErrorCode(RuleType.SHELL_INJECTION, -3)
-    WafMetricCollector.get().raspErrorCode(RuleType.SQL_INJECTION, -2)
+    WafMetricCollector.get().raspErrorCode(RuleType.SHELL_INJECTION, DD_WAF_RUN_INTERNAL_ERROR)
+    WafMetricCollector.get().raspErrorCode(RuleType.SQL_INJECTION, DD_WAF_RUN_INVALID_OBJECT_ERROR)
 
     WafMetricCollector.get().prepareMetrics()
 
@@ -144,7 +147,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_type:command_injection',
       'rule_variant:shell',
       'event_rules_version:rules.3',
-      'waf_error:-3'
+      'waf_error:' + DD_WAF_RUN_INTERNAL_ERROR
     ].toSet()
 
     def raspInvalidObjectCode = (WafMetricCollector.RaspError)metrics[11]
@@ -152,7 +155,12 @@ class WafMetricCollectorTest extends DDSpecification {
     raspInvalidObjectCode.value == 1
     raspInvalidObjectCode.namespace == 'appsec'
     raspInvalidObjectCode.metricName == 'rasp.error'
-    raspInvalidObjectCode.tags.toSet() == ['rule_type:sql_injection', 'waf_version:waf_ver1', 'waf_error:-2'].toSet()
+    raspInvalidObjectCode.tags.toSet() == [
+      'rule_type:sql_injection',
+      'waf_version:waf_ver1',
+      'waf_error:' + DD_WAF_RUN_INVALID_OBJECT_ERROR
+    ]
+    .toSet()
   }
 
   def "overflowing WafMetricCollector does not crash"() {
@@ -326,7 +334,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().raspRuleMatch(ruleType)
     WafMetricCollector.get().raspRuleEval(ruleType)
     WafMetricCollector.get().raspTimeout(ruleType)
-    WafMetricCollector.get().raspErrorCode(ruleType, -3)
+    WafMetricCollector.get().raspErrorCode(ruleType, DD_WAF_RUN_INTERNAL_ERROR)
     WafMetricCollector.get().prepareMetrics()
 
     then:
@@ -378,7 +386,7 @@ class WafMetricCollectorTest extends DDSpecification {
       'rule_type:command_injection',
       'rule_variant:' + ruleType.variant,
       'event_rules_version:rules.1',
-      'waf_error:-3'
+      'waf_error:' + DD_WAF_RUN_INTERNAL_ERROR
     ].toSet()
 
     where:


### PR DESCRIPTION
# What Does This Do
Creates appsec.rasp.error: this metric can be used to count the number of errors generated when calling ddwaf_run on RASP-specific instrumentation

# Motivation
RASP metrics  provide an aggregate view of the deployment health for the deployment of RASP rules. 

# Additional Notes
This metric notably holds the field waf_error that contains the numeric code returned by the ddwaf_run

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56678]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56678]: https://datadoghq.atlassian.net/browse/APPSEC-56678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ