### PR TITLE
Migrate context extraction calls to context-first APIs 

### DIFF
--- a/components/context/src/main/java/datadog/context/propagation/CompositePropagator.java
+++ b/components/context/src/main/java/datadog/context/propagation/CompositePropagator.java
@@ -14,8 +14,8 @@ class CompositePropagator implements Propagator {
 
   @Override
   public <C> void inject(Context context, C carrier, CarrierSetter<C> setter) {
-    for (Propagator propagator : this.propagators) {
-      propagator.inject(context, carrier, setter);
+    for (int i = this.propagators.length - 1; i >= 0; i--) {
+      this.propagators[i].inject(context, carrier, setter);
     }
   }
 

--- a/components/context/src/main/java/datadog/context/propagation/Propagators.java
+++ b/components/context/src/main/java/datadog/context/propagation/Propagators.java
@@ -78,7 +78,8 @@ public final class Propagators {
    * Creates a composite propagator.
    *
    * @param propagators the elements that composes the returned propagator.
-   * @return the composite propagator that will apply the propagators in their given order.
+   * @return the composite propagator that will apply the propagators in their given order for
+   *     context extraction, and reverse given order for context injection.
    */
   public static Propagator composite(Propagator... propagators) {
     if (propagators.length == 0) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -32,7 +32,6 @@ import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.TraceConfig;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.flare.TracerFlare;
@@ -79,7 +78,6 @@ import datadog.trace.common.writer.Writer;
 import datadog.trace.common.writer.WriterFactory;
 import datadog.trace.common.writer.ddintake.DDIntakeTraceInterceptor;
 import datadog.trace.context.TraceScope;
-import datadog.trace.core.datastreams.DataStreamContextInjector;
 import datadog.trace.core.datastreams.DataStreamsMonitoring;
 import datadog.trace.core.datastreams.DefaultDataStreamsMonitoring;
 import datadog.trace.core.flare.TracerFlarePoller;
@@ -719,13 +717,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     HttpCodec.Extractor builtExtractor =
         extractor == null ? HttpCodec.createExtractor(config, this::captureTraceConfig) : extractor;
     builtExtractor = this.dataStreamsMonitoring.extractor(builtExtractor);
-    // Create all HTTP injectors plus the DSM one
-    Map<TracePropagationStyle, HttpCodec.Injector> injectors =
-        HttpCodec.allInjectorsFor(config, invertMap(baggageMapping));
-    DataStreamContextInjector dataStreamContextInjector = this.dataStreamsMonitoring.injector();
     // Store all propagators to propagation
-    this.propagation =
-        new CorePropagation(builtExtractor, injector, injectors, dataStreamContextInjector);
+    this.propagation = new CorePropagation(builtExtractor, this.dataStreamsMonitoring.injector());
 
     // Check if standalone AppSec is enabled:
     // If enabled, use the standalone AppSec propagator by default that will limit tracing concern

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/CorePropagation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/CorePropagation.java
@@ -1,18 +1,11 @@
 package datadog.trace.core.propagation;
 
-import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
-import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.datastreams.DataStreamContextInjector;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class CorePropagation implements AgentPropagation {
-  private final HttpCodec.Injector injector;
-  private final Map<TracePropagationStyle, HttpCodec.Injector> injectors;
   private final DataStreamContextInjector dataStreamContextInjector;
   private final HttpCodec.Extractor extractor;
 
@@ -20,60 +13,13 @@ public class CorePropagation implements AgentPropagation {
    * Constructor
    *
    * @param extractor The context extractor.
-   * @param defaultInjector The default injector when no {@link TracePropagationStyle} given.
-   * @param injectors All the other injectors available for context injection.
    * @param dataStreamContextInjector The DSM context injector, as a specific object until generic
    *     context injection is available.
    */
   public CorePropagation(
-      HttpCodec.Extractor extractor,
-      HttpCodec.Injector defaultInjector,
-      Map<TracePropagationStyle, HttpCodec.Injector> injectors,
-      DataStreamContextInjector dataStreamContextInjector) {
+      HttpCodec.Extractor extractor, DataStreamContextInjector dataStreamContextInjector) {
     this.extractor = extractor;
-    this.injector = defaultInjector;
-    this.injectors = injectors;
     this.dataStreamContextInjector = dataStreamContextInjector;
-  }
-
-  @Override
-  public <C> void inject(final AgentSpan span, final C carrier, final Setter<C> setter) {
-    inject(span.context(), carrier, setter, null);
-  }
-
-  @Override
-  public <C> void inject(AgentSpanContext context, C carrier, Setter<C> setter) {
-    inject(context, carrier, setter, null);
-  }
-
-  @Override
-  public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {
-    inject(span.context(), carrier, setter, style);
-  }
-
-  private <C> void inject(
-      AgentSpanContext context, C carrier, Setter<C> setter, TracePropagationStyle style) {
-    if (!(context instanceof DDSpanContext)) {
-      return;
-    }
-
-    final DDSpanContext ddSpanContext = (DDSpanContext) context;
-    ddSpanContext.getTraceCollector().setSamplingPriorityIfNecessary();
-
-    /**
-     * If the experimental appsec standalone feature is enabled and appsec propagation is disabled
-     * (no ASM events), stop propagation
-     */
-    if (Config.get().isAppSecStandaloneEnabled()
-        && !ddSpanContext.getPropagationTags().isAppsecPropagationEnabled()) {
-      return;
-    }
-
-    if (null == style) {
-      injector.inject(ddSpanContext, carrier, setter);
-    } else {
-      injectors.get(style).inject(ddSpanContext, carrier, setter);
-    }
   }
 
   @Override
@@ -99,10 +45,5 @@ public class CorePropagation implements AgentPropagation {
       AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {
     this.dataStreamContextInjector.injectPathwayContextWithoutSendingStats(
         span, carrier, setter, sortedTags);
-  }
-
-  @Override
-  public <C> AgentSpanContext.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
-    return extractor.extract(carrier, getter);
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -19,8 +19,6 @@ import datadog.trace.common.sampling.Sampler
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
-import datadog.trace.core.datastreams.DataStreamContextExtractor
-import datadog.trace.core.propagation.HttpCodec
 import datadog.trace.core.tagprocessor.TagsPostProcessorFactory
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
@@ -54,9 +52,6 @@ class CoreTracerTest extends DDCoreSpecification {
     tracer.initialSampler instanceof RateByServiceTraceSampler
     tracer.writer instanceof DDAgentWriter
     tracer.statsDClient != null && tracer.statsDClient != StatsDClient.NO_OP
-
-    tracer.propagate().injector instanceof HttpCodec.CompoundInjector
-    tracer.propagate().extractor instanceof DataStreamContextExtractor
 
     cleanup:
     tracer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/CorePropagationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/CorePropagationTest.groovy
@@ -1,115 +1,106 @@
 package datadog.trace.core.propagation
 
-import datadog.trace.api.TracePropagationStyle
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
-import datadog.trace.common.writer.LoggingWriter
-import datadog.trace.core.ControllableSampler
 import datadog.trace.core.datastreams.DataStreamContextInjector
 import datadog.trace.core.test.DDCoreSpecification
 
-import static datadog.trace.api.TracePropagationStyle.B3MULTI
-import static datadog.trace.api.TracePropagationStyle.DATADOG
-import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT
-import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
-
 class CorePropagationTest extends DDCoreSpecification {
   HttpCodec.Extractor extractor
-  HttpCodec.Injector datadogInjector
-  HttpCodec.Injector b3Injector
-  HttpCodec.Injector traceContextInjector
-  Map<TracePropagationStyle, HttpCodec.Injector> allInjectors
+  //  HttpCodec.Injector datadogInjector
+  //  HttpCodec.Injector b3Injector
+  //  HttpCodec.Injector traceContextInjector
+  //  Map<TracePropagationStyle, HttpCodec.Injector> allInjectors
   DataStreamContextInjector dataStreamContextInjector
   AgentPropagation propagation
 
   def setup() {
     extractor = Mock(HttpCodec.Extractor)
-    datadogInjector = Mock(HttpCodec.Injector)
-    b3Injector = Mock(HttpCodec.Injector)
-    traceContextInjector = Mock(HttpCodec.Injector)
-    allInjectors = [
-      (DATADOG)     : datadogInjector,
-      (B3MULTI)     : b3Injector,
-      (TRACECONTEXT): traceContextInjector,
-    ]
+    //    datadogInjector = Mock(HttpCodec.Injector)
+    //    b3Injector = Mock(HttpCodec.Injector)
+    //    traceContextInjector = Mock(HttpCodec.Injector)
+    //    allInjectors = [
+    //      (DATADOG)     : datadogInjector,
+    //      (B3MULTI)     : b3Injector,
+    //      (TRACECONTEXT): traceContextInjector,
+    //    ]
     dataStreamContextInjector = Mock(DataStreamContextInjector)
-    propagation = new CorePropagation(extractor, datadogInjector, allInjectors, dataStreamContextInjector)
+    propagation = new CorePropagation(extractor, dataStreamContextInjector)
   }
 
-  def 'test default injector for span'() {
-    setup:
-    def tracer = tracerBuilder().build()
-    def span = tracer.buildSpan('test', 'operation').start()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    propagation.inject(span, carrier, setter)
-
-    then:
-    1 * datadogInjector.inject(_, carrier, setter)
-    0 * b3Injector.inject(_, carrier, setter)
-    0 * traceContextInjector.inject(_, carrier, setter)
-    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
-
-    cleanup:
-    span.finish()
-    tracer.close()
-  }
-
-  def 'test default injector for span context'() {
-    setup:
-    def tracer = tracerBuilder().build()
-    def span = tracer.buildSpan("test", "operation").start()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    def spanContext = span.context()
-    propagation.inject(spanContext, carrier, setter)
-
-    then:
-    1 * datadogInjector.inject(_, carrier, setter)
-    0 * b3Injector.inject(_, carrier, setter)
-    0 * traceContextInjector.inject(_, carrier, setter)
-    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
-
-    cleanup:
-    span.finish()
-    tracer.close()
-  }
-
-  def 'test injector style selection'() {
-    setup:
-    def injector = allInjectors.get(style, datadogInjector)
-    def tracer = tracerBuilder().build()
-    def span = tracer.buildSpan('test', 'operation').start()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    propagation.inject(span, carrier, setter, style)
-
-    then:
-    1 * injector.inject(_, carrier, setter)
-    if (injector != datadogInjector) {
-      0 * datadogInjector.inject(_, carrier, setter)
-    }
-    if (injector != b3Injector) {
-      0 * b3Injector.inject(_, carrier, setter)
-    }
-    if (injector != traceContextInjector) {
-      0 * traceContextInjector.inject(_, carrier, setter)
-    }
-    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
-
-    cleanup:
-    span.finish()
-    tracer.close()
-
-    where:
-    style << [DATADOG, B3MULTI, TRACECONTEXT, null]
-  }
+  //  def 'test default injector for span'() {
+  //    setup:
+  //    def tracer = tracerBuilder().build()
+  //    def span = tracer.buildSpan('test', 'operation').start()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    propagation.inject(span, carrier, setter)
+  //
+  //    then:
+  //    1 * datadogInjector.inject(_, carrier, setter)
+  //    0 * b3Injector.inject(_, carrier, setter)
+  //    0 * traceContextInjector.inject(_, carrier, setter)
+  //    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+  //
+  //    cleanup:
+  //    span.finish()
+  //    tracer.close()
+  //  }
+  //
+  //  def 'test default injector for span context'() {
+  //    setup:
+  //    def tracer = tracerBuilder().build()
+  //    def span = tracer.buildSpan("test", "operation").start()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    def spanContext = span.context()
+  //    propagation.inject(spanContext, carrier, setter)
+  //
+  //    then:
+  //    1 * datadogInjector.inject(_, carrier, setter)
+  //    0 * b3Injector.inject(_, carrier, setter)
+  //    0 * traceContextInjector.inject(_, carrier, setter)
+  //    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+  //
+  //    cleanup:
+  //    span.finish()
+  //    tracer.close()
+  //  }
+  //
+  //  def 'test injector style selection'() {
+  //    setup:
+  //    def injector = allInjectors.get(style, datadogInjector)
+  //    def tracer = tracerBuilder().build()
+  //    def span = tracer.buildSpan('test', 'operation').start()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    propagation.inject(span, carrier, setter, style)
+  //
+  //    then:
+  //    1 * injector.inject(_, carrier, setter)
+  //    if (injector != datadogInjector) {
+  //      0 * datadogInjector.inject(_, carrier, setter)
+  //    }
+  //    if (injector != b3Injector) {
+  //      0 * b3Injector.inject(_, carrier, setter)
+  //    }
+  //    if (injector != traceContextInjector) {
+  //      0 * traceContextInjector.inject(_, carrier, setter)
+  //    }
+  //    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+  //
+  //    cleanup:
+  //    span.finish()
+  //    tracer.close()
+  //
+  //    where:
+  //    style << [DATADOG, B3MULTI, TRACECONTEXT, null]
+  //  }
 
   def 'test context extractor'() {
     setup:
@@ -123,107 +114,107 @@ class CorePropagationTest extends DDCoreSpecification {
     1 * extractor.extract(carrier, getter)
   }
 
-  def 'span priority set when injecting'() {
-    given:
-    injectSysConfig('writer.type', 'LoggingWriter')
-    def tracer = tracerBuilder().build()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    def root = tracer.buildSpan('test', 'operation').start()
-    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
-    tracer.propagate().inject(child, carrier, setter)
-
-    then:
-    root.getSamplingPriority() == SAMPLER_KEEP as int
-    child.getSamplingPriority() == root.getSamplingPriority()
-    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
-
-    cleanup:
-    child.finish()
-    root.finish()
-    tracer.close()
-  }
-
-  def 'span priority only set after first injection'() {
-    given:
-    def sampler = new ControllableSampler()
-    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    def root = tracer.buildSpan('test', 'operation').start()
-    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
-    tracer.propagate().inject(child, carrier, setter)
-
-    then:
-    root.getSamplingPriority() == SAMPLER_KEEP as int
-    child.getSamplingPriority() == root.getSamplingPriority()
-    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
-
-    when:
-    sampler.nextSamplingPriority = PrioritySampling.SAMPLER_DROP as int
-    def child2 = tracer.buildSpan('test', 'my_child2').asChildOf(root).start()
-    tracer.propagate().inject(child2, carrier, setter)
-
-    then:
-    root.getSamplingPriority() == SAMPLER_KEEP as int
-    child.getSamplingPriority() == root.getSamplingPriority()
-    child2.getSamplingPriority() == root.getSamplingPriority()
-    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
-
-    cleanup:
-    child.finish()
-    child2.finish()
-    root.finish()
-    tracer.close()
-  }
-
-  def "injection doesn't override set priority"() {
-    given:
-    def sampler = new ControllableSampler()
-    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    def root = tracer.buildSpan('test', 'operation').start()
-    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
-    child.setSamplingPriority(PrioritySampling.USER_DROP)
-    tracer.propagate().inject(child, carrier, setter)
-
-    then:
-    root.getSamplingPriority() == PrioritySampling.USER_DROP as int
-    child.getSamplingPriority() == root.getSamplingPriority()
-    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(PrioritySampling.USER_DROP))
-
-    cleanup:
-    child.finish()
-    root.finish()
-    tracer.close()
-  }
-
-  def 'test ASM standalone billing stop propagation'() {
-    setup:
-    injectSysConfig("experimental.appsec.standalone.enabled", "true")
-    def tracer = tracerBuilder().build()
-    def span = tracer.buildSpan('test', 'operation').start()
-    def setter = Mock(AgentPropagation.Setter)
-    def carrier = new Object()
-
-    when:
-    propagation.inject(span, carrier, setter)
-
-    then:
-    0 * datadogInjector.inject(_, carrier, setter)
-    0 * b3Injector.inject(_, carrier, setter)
-    0 * traceContextInjector.inject(_, carrier, setter)
-    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
-
-    cleanup:
-    span.finish()
-    tracer.close()
-  }
+  //  def 'span priority set when injecting'() {
+  //    given:
+  //    injectSysConfig('writer.type', 'LoggingWriter')
+  //    def tracer = tracerBuilder().build()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    def root = tracer.buildSpan('test', 'operation').start()
+  //    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+  //    tracer.propagate().inject(child, carrier, setter)
+  //
+  //    then:
+  //    root.getSamplingPriority() == SAMPLER_KEEP as int
+  //    child.getSamplingPriority() == root.getSamplingPriority()
+  //    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+  //
+  //    cleanup:
+  //    child.finish()
+  //    root.finish()
+  //    tracer.close()
+  //  }
+  //
+  //  def 'span priority only set after first injection'() {
+  //    given:
+  //    def sampler = new ControllableSampler()
+  //    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    def root = tracer.buildSpan('test', 'operation').start()
+  //    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+  //    tracer.propagate().inject(child, carrier, setter)
+  //
+  //    then:
+  //    root.getSamplingPriority() == SAMPLER_KEEP as int
+  //    child.getSamplingPriority() == root.getSamplingPriority()
+  //    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+  //
+  //    when:
+  //    sampler.nextSamplingPriority = PrioritySampling.SAMPLER_DROP as int
+  //    def child2 = tracer.buildSpan('test', 'my_child2').asChildOf(root).start()
+  //    tracer.propagate().inject(child2, carrier, setter)
+  //
+  //    then:
+  //    root.getSamplingPriority() == SAMPLER_KEEP as int
+  //    child.getSamplingPriority() == root.getSamplingPriority()
+  //    child2.getSamplingPriority() == root.getSamplingPriority()
+  //    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+  //
+  //    cleanup:
+  //    child.finish()
+  //    child2.finish()
+  //    root.finish()
+  //    tracer.close()
+  //  }
+  //
+  //  def "injection doesn't override set priority"() {
+  //    given:
+  //    def sampler = new ControllableSampler()
+  //    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    def root = tracer.buildSpan('test', 'operation').start()
+  //    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+  //    child.setSamplingPriority(PrioritySampling.USER_DROP)
+  //    tracer.propagate().inject(child, carrier, setter)
+  //
+  //    then:
+  //    root.getSamplingPriority() == PrioritySampling.USER_DROP as int
+  //    child.getSamplingPriority() == root.getSamplingPriority()
+  //    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(PrioritySampling.USER_DROP))
+  //
+  //    cleanup:
+  //    child.finish()
+  //    root.finish()
+  //    tracer.close()
+  //  }
+  //
+  //  def 'test ASM standalone billing stop propagation'() {
+  //    setup:
+  //    injectSysConfig("experimental.appsec.standalone.enabled", "true")
+  //    def tracer = tracerBuilder().build()
+  //    def span = tracer.buildSpan('test', 'operation').start()
+  //    def setter = Mock(AgentPropagation.Setter)
+  //    def carrier = new Object()
+  //
+  //    when:
+  //    propagation.inject(span, carrier, setter)
+  //
+  //    then:
+  //    0 * datadogInjector.inject(_, carrier, setter)
+  //    0 * b3Injector.inject(_, carrier, setter)
+  //    0 * traceContextInjector.inject(_, carrier, setter)
+  //    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+  //
+  //    cleanup:
+  //    span.finish()
+  //    tracer.close()
+  //  }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -2,10 +2,11 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import static datadog.context.propagation.Concern.named;
 
+import datadog.context.Context;
 import datadog.context.propagation.CarrierSetter;
 import datadog.context.propagation.CarrierVisitor;
 import datadog.context.propagation.Concern;
-import datadog.trace.api.TracePropagationStyle;
+import datadog.context.propagation.Propagators;
 import java.util.LinkedHashMap;
 import java.util.function.BiConsumer;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -14,12 +15,6 @@ public interface AgentPropagation {
   Concern TRACING_CONCERN = named("tracing");
   Concern XRAY_TRACING_CONCERN = named("tracing-xray");
   Concern STANDALONE_ASM_CONCERN = named("asm-standalone");
-
-  <C> void inject(AgentSpan span, C carrier, Setter<C> setter);
-
-  <C> void inject(AgentSpanContext context, C carrier, Setter<C> setter);
-
-  <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style);
 
   // The input tags should be sorted.
   <C> void injectPathwayContext(
@@ -40,7 +35,11 @@ public interface AgentPropagation {
     void set(C carrier, String key, String value);
   }
 
-  <C> AgentSpanContext.Extracted extract(C carrier, ContextVisitor<C> getter);
+  default <C> AgentSpanContext.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
+    Context extracted = Propagators.defaultPropagator().extract(Context.root(), carrier, getter);
+    AgentSpan extractedSpan = AgentSpan.fromContext(extracted);
+    return extractedSpan == null ? null : (AgentSpanContext.Extracted) extractedSpan.context();
+  }
 
   interface KeyClassifier {
     boolean accept(String key, String value);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -7,7 +7,6 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.TraceConfig;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.experimental.DataStreamsContextCarrier;
 import datadog.trace.api.gateway.CallbackProvider;
@@ -586,17 +585,6 @@ public class AgentTracer {
     static final NoopAgentPropagation INSTANCE = new NoopAgentPropagation();
 
     @Override
-    public <C> void inject(final AgentSpan span, final C carrier, final Setter<C> setter) {}
-
-    @Override
-    public <C> void inject(
-        final AgentSpanContext context, final C carrier, final Setter<C> setter) {}
-
-    @Override
-    public <C> void inject(
-        AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {}
-
-    @Override
     public <C> void injectPathwayContext(
         AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {}
 
@@ -612,11 +600,6 @@ public class AgentTracer {
     @Override
     public <C> void injectPathwayContextWithoutSendingStats(
         AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {}
-
-    @Override
-    public <C> AgentSpanContext.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
-      return NoopSpanContext.INSTANCE;
-    }
   }
 
   static class NoopContinuation implements AgentScope.Continuation {

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/SpanLinkTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/SpanLinkTest.groovy
@@ -3,12 +3,12 @@ package datadog.trace.bootstrap.instrumentation.api
 
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.test.util.DDSpecification
+import spock.lang.Specification
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentSpanLink.DEFAULT_FLAGS
 import static datadog.trace.bootstrap.instrumentation.api.AgentSpanLink.SAMPLED_FLAG
 
-class SpanLinkTest extends DDSpecification {
+class SpanLinkTest extends Specification {
   def "test span link from context"() {
     setup:
     def traceId = DDTraceId.fromHex("11223344556677889900aabbccddeeff")


### PR DESCRIPTION
# What Does This Do

This PR continue migrating the context propagation using the new Context API:

* Implement new default extraction into legacy core propagation API
* Remove core propagation injection API (fully migrated)
* Improve composite propagator application order

# Motivation

# Additional Notes

Most `CorePropagationTest` is commented and will be deleted in the next related PR.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-295]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
