### PR TITLE
Move continuation capture methods from scope to tracer

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
@@ -12,11 +12,6 @@ public class OtelScope implements Scope, TraceScope {
   }
 
   @Override
-  public Continuation capture() {
-    return delegate.capture();
-  }
-
-  @Override
   public void close() {
     delegate.close();
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -63,11 +63,6 @@ public class OTScopeManager implements ScopeManager {
       return converter.toSpan(delegate.span());
     }
 
-    @Override
-    public Continuation capture() {
-      return delegate.capture();
-    }
-
     public boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -73,11 +73,6 @@ public class OTScopeManager implements ScopeManager {
       return converter.toSpan(delegate.span());
     }
 
-    @Override
-    public Continuation capture() {
-      return delegate.capture();
-    }
-
     public boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws1;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
@@ -22,7 +22,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = capture();
+    continuation = captureSpan(span);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws21;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
@@ -27,7 +27,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = capture();
+    continuation = captureSpan(span);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws2;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
@@ -26,7 +26,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = capture();
+    continuation = captureSpan(span);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servicetalk/src/test/groovy/ContextPreservingInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servicetalk/src/test/groovy/ContextPreservingInstrumentationTest.groovy
@@ -113,7 +113,7 @@ class ContextPreservingInstrumentationTest extends AgentTestRunner {
    */
   private class ParentContext {
     final ContextMap contextMap = AsyncContext.context().copy()
-    final AgentScope.Continuation spanContinuation = AgentTracer.captureSpan(AgentTracer.activeSpan())
+    final AgentScope.Continuation spanContinuation = AgentTracer.captureActiveSpan()
 
     def releaseParentSpan() {
       spanContinuation.cancel()

--- a/dd-java-agent/instrumentation/servicetalk/src/test/groovy/ContextPreservingInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servicetalk/src/test/groovy/ContextPreservingInstrumentationTest.groovy
@@ -113,7 +113,7 @@ class ContextPreservingInstrumentationTest extends AgentTestRunner {
    */
   private class ParentContext {
     final ContextMap contextMap = AsyncContext.context().copy()
-    final AgentScope.Continuation spanContinuation = AgentTracer.capture()
+    final AgentScope.Continuation spanContinuation = AgentTracer.captureSpan(AgentTracer.activeSpan())
 
     def releaseParentSpan() {
       spanContinuation.cancel()

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
@@ -1,10 +1,8 @@
 package datadog.trace.instrumentation.zio.v2_0;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 
@@ -18,8 +16,7 @@ public class FiberContext {
     this.state = state;
     this.scope = null;
     this.oldState = null;
-    AgentSpan span = activeSpan();
-    this.continuation = null != span ? captureSpan(span) : null;
+    this.continuation = captureActiveSpan();
   }
 
   public static FiberContext create() {

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.zio.v2_0;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 
@@ -16,7 +18,8 @@ public class FiberContext {
     this.state = state;
     this.scope = null;
     this.oldState = null;
-    this.continuation = capture();
+    AgentSpan span = activeSpan();
+    this.continuation = null != span ? captureSpan(span) : null;
   }
 
   public static FiberContext create() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -26,14 +26,6 @@ public class GlobalTracer {
         }
 
         @Override
-        public boolean isAsyncPropagationEnabled() {
-          return false;
-        }
-
-        @Override
-        public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {}
-
-        @Override
         public boolean addTraceInterceptor(TraceInterceptor traceInterceptor) {
           return false;
         }
@@ -42,6 +34,19 @@ public class GlobalTracer {
         public TraceScope muteTracing() {
           return NoopTraceScope.INSTANCE;
         }
+
+        @Override
+        public TraceScope.Continuation captureActiveSpan() {
+          return NoopTraceScope.NoopContinuation.INSTANCE;
+        }
+
+        @Override
+        public boolean isAsyncPropagationEnabled() {
+          return false;
+        }
+
+        @Override
+        public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {}
       };
 
   private static final Collection<Callback> installationCallbacks = new ArrayList<>();

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -15,6 +15,29 @@ public interface Tracer {
   String getSpanId();
 
   /**
+   * Add a new interceptor to the tracer. Interceptors with duplicate priority to existing ones are
+   * ignored.
+   *
+   * @param traceInterceptor
+   * @return false if an interceptor with same priority exists.
+   */
+  boolean addTraceInterceptor(TraceInterceptor traceInterceptor);
+
+  TraceScope muteTracing();
+
+  /**
+   * Prevent the currently active trace from reporting until the returned Continuation is either
+   * activated (and the returned scope is closed), or canceled.
+   *
+   * <p>Should be called on the parent thread.
+   *
+   * @deprecated Unstable API. Might be removed at any time.
+   * @return Continuation of the active span, no-op continuation if there's no active span.
+   */
+  @Deprecated
+  TraceScope.Continuation captureActiveSpan();
+
+  /**
    * Checks whether asynchronous propagation is enabled, meaning this context will propagate across
    * asynchronous boundaries.
    *
@@ -36,15 +59,4 @@ public interface Tracer {
    */
   @Deprecated
   void setAsyncPropagationEnabled(boolean asyncPropagationEnabled);
-
-  /**
-   * Add a new interceptor to the tracer. Interceptors with duplicate priority to existing ones are
-   * ignored.
-   *
-   * @param traceInterceptor
-   * @return false if an interceptor with same priority exists.
-   */
-  boolean addTraceInterceptor(TraceInterceptor traceInterceptor);
-
-  TraceScope muteTracing();
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -26,13 +26,15 @@ public interface Tracer {
   TraceScope muteTracing();
 
   /**
-   * Prevent the currently active trace from reporting until the returned Continuation is either
-   * activated (and the returned scope is closed), or canceled.
+   * When asynchronous propagation is enabled, prevent the currently active trace from reporting
+   * until the returned Continuation is either activated (and the returned scope is closed) or the
+   * continuation is canceled.
    *
    * <p>Should be called on the parent thread.
    *
    * @deprecated Unstable API. Might be removed at any time.
-   * @return Continuation of the active span, no-op continuation if there's no active span.
+   * @return Continuation of the active span, no-op continuation if there's no active span or
+   *     asynchronous propagation is disabled.
    */
   @Deprecated
   TraceScope.Continuation captureActiveSpan();

--- a/dd-trace-api/src/main/java/datadog/trace/context/NoopTraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/NoopTraceScope.java
@@ -25,10 +25,5 @@ public class NoopTraceScope implements TraceScope {
   private NoopTraceScope() {}
 
   @Override
-  public Continuation capture() {
-    return NoopContinuation.INSTANCE;
-  }
-
-  @Override
   public void close() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -43,10 +43,12 @@ public interface TraceScope extends Closeable {
 
   /**
    * @deprecated Replaced by {@link Tracer#captureActiveSpan()}.
-   *     <p>Prevent the <strong>currently active trace</strong>, which may differ from this scope
-   *     instance, from reporting until the returned Continuation is either activated (and the
-   *     returned scope is closed), or canceled. Should be called on the parent thread.
-   * @return Continuation of the active span, no-op continuation if there's no active span.
+   *     <p>When asynchronous propagation is enabled, prevent the <strong>currently active
+   *     trace</strong>, which may differ from this scope instance, from reporting until the
+   *     returned Continuation is either activated (and the returned scope is closed) or the
+   *     continuation is canceled. Should be called on the parent thread.
+   * @return Continuation of the active span, no-op continuation if there's no active span or
+   *     asynchronous propagation is disabled.
    */
   @Deprecated
   default Continuation capture() {
@@ -61,7 +63,7 @@ public interface TraceScope extends Closeable {
 
   /**
    * @deprecated Replaced by {@link Tracer#isAsyncPropagationEnabled()}.
-   *     <p>Calling this method will check whether asynchronous propagation is active <strong>for
+   *     <p>Calling this method will check whether asynchronous propagation is enabled <strong>for
    *     the active scope</strong>, not this scope instance.
    * @return {@code true} if asynchronous propagation is enabled <strong>for the active
    *     scope</strong>, {@code false} otherwise.

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -13,9 +13,9 @@ public interface TraceScope extends Closeable {
 
   /**
    * @deprecated Replaced by {@link Tracer#captureActiveSpan()}.
-   *     <p>Prevent the currently active trace from reporting until the returned Continuation is
-   *     either activated (and the returned scope is closed), or canceled. Should be called on the
-   *     parent thread.
+   *     <p>Prevent the <strong>currently active trace</strong>, which may differ from this scope
+   *     instance, from reporting until the returned Continuation is either activated (and the
+   *     returned scope is closed), or canceled. Should be called on the parent thread.
    * @return Continuation of the active span, no-op continuation if there's no active span.
    */
   @Deprecated

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -6,23 +6,28 @@ import java.io.Closeable;
 
 /** An object which can propagate a datadog trace across multiple threads. */
 public interface TraceScope extends Closeable {
+
+  /** Close the activated context and allow any underlying spans to finish. */
+  @Override
+  void close();
+
   /**
-   * Prevent the trace attached to this TraceScope from reporting until the returned Continuation is
-   * either activated (and the returned scope is closed), or canceled.
-   *
-   * <p>Should be called on the parent thread.
+   * @deprecated Replaced by {@link Tracer#captureActiveSpan()}.
+   *     <p>Prevent the currently active trace from reporting until the returned Continuation is
+   *     either activated (and the returned scope is closed), or canceled. Should be called on the
+   *     parent thread.
+   * @return Continuation of the active span, no-op continuation if there's no active span.
    */
-  Continuation capture();
+  @Deprecated
+  default Continuation capture() {
+    return GlobalTracer.get().captureActiveSpan();
+  }
 
   /** @deprecated Replaced by {@code capture().hold()}. */
   @Deprecated
   default Continuation captureConcurrent() {
     return capture().hold();
   }
-
-  /** Close the activated context and allow any underlying spans to finish. */
-  @Override
-  void close();
 
   /**
    * @deprecated Replaced by {@link Tracer#isAsyncPropagationEnabled()}.

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -931,9 +931,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentScope.Continuation captureActiveSpan() {
-    AgentSpan span = scopeManager.activeSpan();
-    if (null != span) {
-      return scopeManager.captureSpan(span);
+    AgentScope activeScope = this.scopeManager.active();
+    if (null != activeScope && activeScope.isAsyncPropagating()) {
+      return scopeManager.captureSpan(activeScope.span());
     } else {
       return AgentTracer.noopContinuation();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -932,8 +932,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public AgentScope.Continuation captureActiveSpan() {
     AgentScope activeScope = this.scopeManager.active();
-    if (null != activeScope && activeScope.isAsyncPropagating()) {
-      return scopeManager.captureSpan(activeScope.span());
+    if (null != activeScope) {
+      return activeScope.capture();
     } else {
       return AgentTracer.noopContinuation();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -930,6 +930,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public AgentScope.Continuation captureActiveSpan() {
+    AgentSpan span = scopeManager.activeSpan();
+    if (null != span) {
+      return scopeManager.captureSpan(span);
+    } else {
+      return AgentTracer.noopContinuation();
+    }
+  }
+
+  @Override
   public AgentScope.Continuation captureSpan(final AgentSpan span) {
     return scopeManager.captureSpan(span);
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -430,16 +430,6 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   }
 
   @Override
-  public boolean isAsyncPropagationEnabled() {
-    return tracer.isAsyncPropagationEnabled();
-  }
-
-  @Override
-  public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {
-    tracer.setAsyncPropagationEnabled(asyncPropagationEnabled);
-  }
-
-  @Override
   public boolean addTraceInterceptor(final TraceInterceptor traceInterceptor) {
     return tracer.addTraceInterceptor(traceInterceptor);
   }
@@ -447,6 +437,21 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   @Override
   public TraceScope muteTracing() {
     return tracer.muteTracing();
+  }
+
+  @Override
+  public TraceScope.Continuation captureActiveSpan() {
+    return tracer.captureActiveSpan();
+  }
+
+  @Override
+  public boolean isAsyncPropagationEnabled() {
+    return tracer.isAsyncPropagationEnabled();
+  }
+
+  @Override
+  public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {
+    tracer.setAsyncPropagationEnabled(asyncPropagationEnabled);
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -91,11 +91,6 @@ class OTScopeManager implements ScopeManager {
       return delegate.hashCode();
     }
 
-    @Override
-    public Continuation capture() {
-      return delegate.capture();
-    }
-
     boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -130,11 +130,6 @@ public class AgentTracer {
     return get().activeScope();
   }
 
-  public static AgentScope.Continuation capture() {
-    final AgentScope activeScope = activeScope();
-    return activeScope == null ? null : activeScope.capture();
-  }
-
   /**
    * Checks whether asynchronous propagation is enabled, meaning this context will propagate across
    * asynchronous boundaries.

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -93,6 +93,10 @@ public class AgentTracer {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
+  public static AgentScope.Continuation captureActiveSpan() {
+    return get().captureActiveSpan();
+  }
+
   public static AgentScope.Continuation captureSpan(final AgentSpan span) {
     return get().captureSpan(span);
   }
@@ -285,6 +289,9 @@ public class AgentTracer {
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
+    @Override
+    AgentScope.Continuation captureActiveSpan();
+
     AgentScope.Continuation captureSpan(AgentSpan span);
 
     void closePrevious(boolean finishSpan);
@@ -422,6 +429,11 @@ public class AgentTracer {
     public AgentScope activateSpan(
         final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
       return NoopScope.INSTANCE;
+    }
+
+    @Override
+    public AgentScope.Continuation captureActiveSpan() {
+      return NoopContinuation.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

`TraceScope.capture()` now delegates to `Tracer.captureActiveSpan()` - when asynchronous propagation is enabled, this method prevents the currently active trace from reporting until the returned continuation is either activated (and the returned scope is closed) or the continuation is canceled  

Note: previously it was technically possible to call `TraceScope.capture()` on a scope which wasn't part of the currently active trace. This is no longer allowed, calling `capture()` will now always capture the active trace at that point. In practice this shouldn't make any difference because this API was used to capture active scopes.

# Motivation

We want to move away from the old scope-specific API towards tracer methods that work on the active span/trace.

# Additional Notes

Further migration/evolution of the `AgentTracer` API and internals will be covered in a separate PR.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-955]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-955]: https://datadoghq.atlassian.net/browse/APMAPI-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ