### PR TITLE
Ensure usr.exists tag is not overridden by auto instrumentation

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -279,9 +279,6 @@ public class GatewayBridge {
 
     // update span tags
     segment.setTagTop("appsec.events." + eventName + ".track", true, true);
-    if (exists != null) {
-      segment.setTagTop("appsec.events." + eventName + ".usr.exists", exists, true);
-    }
     if (metadata != null && !metadata.isEmpty()) {
       segment.setTagTop("appsec.events." + eventName, metadata, true);
     }
@@ -313,6 +310,10 @@ public class GatewayBridge {
         segment.setTagTop("appsec.events." + eventName + ".usr.id", user, true);
       }
       segment.setTagTop("_dd.appsec.user.collection_mode", mode.fullName());
+    }
+
+    if (exists != null) {
+      segment.setTagTop("appsec.events." + eventName + ".usr.exists", exists, true);
     }
 
     // update user span tags

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -1285,6 +1285,41 @@ class GatewayBridgeSpecification extends DDSpecification {
     0 * eventDispatcher.publishDataEvent
   }
 
+  void "test onLoginFailure (automated login events should not overwrite SDK)"() {
+    setup:
+    final firstUser = 'user1'
+    final secondUser = 'user2'
+    eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
+
+    when:
+    loginEventCB.apply(ctx, SDK, 'users.login.failure', true, firstUser, null)
+
+    then:
+    1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.login', firstUser, true)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.sdk', true, true)
+    1 * traceSegment.setTagTop('_dd.appsec.user.collection_mode', 'sdk')
+    1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.exists', true, true)
+
+    0 * traceSegment.setTagTop('_dd.appsec.usr.login', _)
+    0 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', _, _)
+
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, _ as GatewayContext) >> NoopFlow.INSTANCE
+
+    when:
+    loginEventCB.apply(ctx, IDENTIFICATION, 'users.login.failure', false, secondUser, null)
+
+    then:
+    0 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.login', _, _)
+    0 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.sdk', _, _)
+    0 * traceSegment.setTagTop('_dd.appsec.user.collection_mode', _)
+    0 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.exists', _, _)
+
+    1 * traceSegment.setTagTop('_dd.appsec.usr.login', secondUser)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', IDENTIFICATION.fullName(), true)
+
+    0 * eventDispatcher.publishDataEvent
+  }
+
   void 'test configuration updates should reset cached subscriptions'() {
     when:
     requestSessionCB.apply(ctx, UUID.randomUUID().toString())


### PR DESCRIPTION
# What Does This Do

Makes sure that the automated instrumentation does not override the span tag `appsec.events.users.login.failure.usr.exists` when already provided by a call to the SDK.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56744]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56744]: https://datadoghq.atlassian.net/browse/APPSEC-56744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ