### PR TITLE
Create metric: appsec.waf.input_truncated

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '11.2.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '11.3.0'
   implementation libs.moshi
 
   testImplementation libs.bytebuddy

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -45,7 +45,6 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.util.stacktrace.StackTraceEvent;
 import datadog.trace.util.stacktrace.StackUtils;
 import io.sqreen.powerwaf.PowerwafMetrics;
-import io.sqreen.powerwaf.metrics.InputTruncatedType;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -827,17 +826,20 @@ public class GatewayBridge {
 
       PowerwafMetrics wafMetrics = ctx.getWafMetrics();
       if (wafMetrics != null) {
-        final long stringTooLong =
-            wafMetrics.getWafInputsTruncatedCount(InputTruncatedType.STRING_TOO_LONG);
-        final long listMapTooLarge =
-            wafMetrics.getWafInputsTruncatedCount(InputTruncatedType.LIST_MAP_TOO_LARGE);
-        final long objectTooDeep =
-            wafMetrics.getWafInputsTruncatedCount(InputTruncatedType.OBJECT_TOO_DEEP);
+        final long stringTooLong = wafMetrics.getWafInputsTruncatedStringTooLongCount();
+        final long listMapTooLarge = wafMetrics.getWafInputsTruncatedListMapTooLargeCount();
+        final long objectTooDeep = wafMetrics.getWafInputsTruncatedObjectTooDeepCount();
 
-        WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, stringTooLong);
-        WafMetricCollector.get()
-            .wafInputTruncated(TruncatedType.LIST_MAP_TOO_LARGE, listMapTooLarge);
-        WafMetricCollector.get().wafInputTruncated(TruncatedType.OBJECT_TOO_DEEP, objectTooDeep);
+        if (stringTooLong > 0) {
+          WafMetricCollector.get().wafInputTruncated(TruncatedType.STRING_TOO_LONG, stringTooLong);
+        }
+        if (listMapTooLarge > 0) {
+          WafMetricCollector.get()
+              .wafInputTruncated(TruncatedType.LIST_MAP_TOO_LARGE, listMapTooLarge);
+        }
+        if (objectTooDeep > 0) {
+          WafMetricCollector.get().wafInputTruncated(TruncatedType.OBJECT_TOO_DEEP, objectTooDeep);
+        }
       }
 
       if (ctx.isBlocked()) {

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
@@ -6,7 +6,6 @@ public enum TruncatedType {
   OBJECT_TOO_DEEP(4);
 
   private final int value;
-  private static final int numValues = RuleType.values().length;
 
   TruncatedType(int value) {
     this.value = value;
@@ -14,9 +13,5 @@ public enum TruncatedType {
 
   public int getValue() {
     return this.value;
-  }
-
-  public static int getNumValues() {
-    return numValues;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/TruncatedType.java
@@ -1,0 +1,22 @@
+package datadog.trace.api.telemetry;
+
+public enum TruncatedType {
+  STRING_TOO_LONG(1),
+  LIST_MAP_TOO_LARGE(2),
+  OBJECT_TOO_DEEP(4);
+
+  private final int value;
+  private static final int numValues = RuleType.values().length;
+
+  TruncatedType(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return this.value;
+  }
+
+  public static int getNumValues() {
+    return numValues;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -35,7 +35,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   private static final AtomicRequestCounter wafBlockedRequestCounter = new AtomicRequestCounter();
   private static final AtomicRequestCounter wafTimeoutRequestCounter = new AtomicRequestCounter();
   private static final AtomicLongArray wafInputTruncatedCounter =
-      new AtomicLongArray(TruncatedType.getNumValues());
+      new AtomicLongArray(TruncatedType.values().length);
   private static final AtomicLongArray raspRuleEvalCounter =
       new AtomicLongArray(RuleType.getNumValues());
   private static final AtomicLongArray raspRuleMatchCounter =

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -304,7 +304,7 @@ class WafMetricCollectorTest extends DDSpecification {
     }
   }
 
-  def "test WAF #inputTruncated metrics"() {
+  def "test WAF #truncatedType metrics"() {
     when:
     WafMetricCollector.get().wafInit('waf_ver1', 'rules.1', true)
     WafMetricCollector.get().wafInputTruncated(truncatedType, 5)


### PR DESCRIPTION
# What Does This Do
This adds a new value to some metrics which is necessary for the consolidation of ASM Span Tags, Metrics, and Logs across all supported languages. The newly value will be implemented in the following metrics:
- **appsec.waf.input_truncated**:
  - _truncation_reason_: Bit with the type of truncation (1, 2, 4)

# Motivation
Our goal is to implement all the missing ASM Span Tags, Metrics, and Logs.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56479]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56479]: https://datadoghq.atlassian.net/browse/APPSEC-56479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ