### PR TITLE
Ensure usr.exists tag is not overridden when UsernameNotFoundException is thrown

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -288,6 +288,12 @@ public class GatewayBridge {
       segment.setTagTop("_dd.appsec.events." + eventName + ".auto.mode", mode.fullName(), true);
     }
 
+    if (exists != null) {
+      if (mode == SDK || ctx.getUserLoginSource() != SDK) {
+        segment.setTagTop("appsec.events." + eventName + ".usr.exists", exists, true);
+      }
+    }
+
     final String user = anonymizeUser(mode, originalUser);
     if (user == null) {
       // can happen in custom events
@@ -310,10 +316,6 @@ public class GatewayBridge {
         segment.setTagTop("appsec.events." + eventName + ".usr.id", user, true);
       }
       segment.setTagTop("_dd.appsec.user.collection_mode", mode.fullName());
-    }
-
-    if (exists != null) {
-      segment.setTagTop("appsec.events." + eventName + ".usr.exists", exists, true);
     }
 
     // update user span tags

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -1320,6 +1320,21 @@ class GatewayBridgeSpecification extends DDSpecification {
     0 * eventDispatcher.publishDataEvent
   }
 
+  void 'test onUserNotFound'() {
+    setup:
+    eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
+
+    when:
+    loginEventCB.apply(ctx, IDENTIFICATION, 'users.login.failure', exists, null, null)
+
+    then:
+    1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.exists', exists, true)
+    0 * eventDispatcher.publishDataEvent
+
+    where:
+    exists << [true, false]
+  }
+
   void 'test configuration updates should reset cached subscriptions'() {
     when:
     requestSessionCB.apply(ctx, UUID.randomUUID().toString())

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
@@ -198,7 +198,7 @@ class AppSecEventTrackerSpecification extends DDSpecification {
 
     then:
     if (mode != DISABLED) {
-      1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.exists', false)
+      1 * loginEvent.apply(_ as RequestContext, mode, 'users.login.failure', false, null, null) >> NoopFlow.INSTANCE
     }
     0 * _
 

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -14,7 +14,6 @@ import datadog.trace.api.gateway.EventType;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -63,15 +62,9 @@ public class AppSecEventTracker extends EventTracker {
     if (!isEnabled(mode)) {
       return;
     }
-    final AgentTracer.TracerAPI tracer = tracer();
-    if (tracer == null) {
-      return;
-    }
-    final TraceSegment segment = tracer.getTraceSegment();
-    if (segment == null) {
-      return;
-    }
-    segment.setTagTop("appsec.events.users.login.failure.usr.exists", false);
+    dispatch(
+        EVENTS.loginEvent(),
+        (ctx, callback) -> callback.apply(ctx, mode, "users.login.failure", false, null, null));
   }
 
   public void onUserEvent(final UserIdCollectionMode mode, final String userId) {


### PR DESCRIPTION
# What Does This Do

This is a follow-up PR to https://github.com/DataDog/dd-trace-java/pull/8374 that includes a missing operation when a `org.springframework.security.core.userdetails.UsernameNotFoundException` is thrown.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56744]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56744]: https://datadoghq.atlassian.net/browse/APPSEC-56744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ