### PR TITLE
Make sure budgets apply to line probes, too.

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -204,29 +204,6 @@ public class LogProbeTest {
   }
 
   @Test
-  public void testDebugLineProbes() {
-    BudgetSink sink = new BudgetSink(getConfig(), mock(ProbeStatusSink.class));
-    DebuggerAgentHelper.injectSink(sink);
-
-    TracerAPI tracer =
-        CoreTracer.builder().idGenerationStrategy(IdGenerationStrategy.fromName("random")).build();
-    AgentTracer.registerIfAbsent(tracer);
-    int runs = 100;
-    for (int i = 0; i < runs; i++) {
-      runTrace(tracer, true);
-    }
-    assertEquals(runs * LogProbe.CAPTURING_PROBE_BUDGET, sink.captures);
-
-    sink = new BudgetSink(getConfig(), mock(ProbeStatusSink.class));
-    DebuggerAgentHelper.injectSink(sink);
-    runs = 1010;
-    for (int i = 0; i < runs; i++) {
-      runTrace(tracer, false);
-    }
-    assertEquals(runs * LogProbe.NON_CAPTURING_PROBE_BUDGET, sink.highRate);
-  }
-
-  @Test
   public void log() {
     LogProbe logProbe = createLog(null).build();
     assertNull(logProbe.getTemplate());


### PR DESCRIPTION
# What Does This Do
Make sure budgets apply to line probes, too.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3496]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3496]: https://datadoghq.atlassian.net/browse/DEBUG-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ