### PR TITLE
Create metric: appsec.waf.error

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -130,6 +130,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private volatile int raspInternalErrors;
   private volatile int raspInvalidObjectErrors;
   private volatile int raspInvalidArgumentErrors;
+  private volatile int wafInternalErrors;
+  private volatile int wafInvalidObjectErrors;
+  private volatile int wafInvalidArgumentErrors;
 
   // keep a reference to the last published usr.id
   private volatile String userId;
@@ -156,6 +159,17 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       RASP_INVALID_ARGUMENT_ERRORS_UPDATER =
           AtomicIntegerFieldUpdater.newUpdater(
               AppSecRequestContext.class, "raspInvalidArgumentErrors");
+
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext> WAF_INTERNAL_ERRORS_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "wafInternalErrors");
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
+      WAF_INVALID_OBJECT_ERRORS_UPDATER =
+          AtomicIntegerFieldUpdater.newUpdater(
+              AppSecRequestContext.class, "wafInvalidObjectErrors");
+  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
+      WAF_INVALID_ARGUMENT_ERRORS_UPDATER =
+          AtomicIntegerFieldUpdater.newUpdater(
+              AppSecRequestContext.class, "wafInvalidArgumentErrors");
 
   // to be called by the Event Dispatcher
   public void addAll(DataBundle newData) {
@@ -222,6 +236,22 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     }
   }
 
+  public void increaseWafErrorCode(int code) {
+    switch (code) {
+      case DD_WAF_RUN_INTERNAL_ERROR:
+        WAF_INTERNAL_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
+        WAF_INVALID_OBJECT_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
+        WAF_INVALID_ARGUMENT_ERRORS_UPDATER.incrementAndGet(this);
+        break;
+      default:
+        break;
+    }
+  }
+
   public int getWafTimeouts() {
     return wafTimeouts;
   }
@@ -238,6 +268,19 @@ public class AppSecRequestContext implements DataBundle, Closeable {
         return raspInvalidObjectErrors;
       case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
         return raspInvalidArgumentErrors;
+      default:
+        return 0;
+    }
+  }
+
+  public int getWafError(int code) {
+    switch (code) {
+      case DD_WAF_RUN_INTERNAL_ERROR:
+        return wafInternalErrors;
+      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
+        return wafInvalidObjectErrors;
+      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
+        return wafInvalidArgumentErrors;
       default:
         return 0;
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -451,9 +451,8 @@ public class PowerWAFModule implements AppSecModule {
           reqCtx.increaseRaspErrorCode(e.code);
           WafMetricCollector.get().raspErrorCode(gwCtx.raspRuleType, e.code);
         } else {
-          // TODO APPSEC-56703
-          // reqCtx.increaseWafErrorCode(e.code);
-          // WafMetricCollector.get().wafErrorCode(e.code);
+          reqCtx.increaseWafErrorCode(e.code);
+          WafMetricCollector.get().wafErrorCode(gwCtx.raspRuleType, e.code);
         }
         return;
       } finally {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -303,4 +303,17 @@ class AppSecRequestContextSpecification extends DDSpecification {
     ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
     ctx.getRaspError(0) == 0
   }
+
+  def "test increase and get WafErrors"() {
+    when:
+    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
+    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
+    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR)
+
+    then:
+    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR) == 2
+    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR) == 1
+    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
+    ctx.getWafError(0) == 0
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -36,7 +36,9 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().raspRuleEval(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspTimeout(RuleType.SQL_INJECTION)
     WafMetricCollector.get().raspErrorCode(RuleType.SHELL_INJECTION, DD_WAF_RUN_INTERNAL_ERROR)
+    WafMetricCollector.get().wafErrorCode(RuleType.SHELL_INJECTION, DD_WAF_RUN_INTERNAL_ERROR)
     WafMetricCollector.get().raspErrorCode(RuleType.SQL_INJECTION, DD_WAF_RUN_INVALID_OBJECT_ERROR)
+    WafMetricCollector.get().wafErrorCode(RuleType.SQL_INJECTION, DD_WAF_RUN_INVALID_OBJECT_ERROR)
 
     WafMetricCollector.get().prepareMetrics()
 
@@ -150,7 +152,20 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:' + DD_WAF_RUN_INTERNAL_ERROR
     ].toSet()
 
-    def raspInvalidObjectCode = (WafMetricCollector.RaspError)metrics[11]
+    def wafInvalidCode = (WafMetricCollector.WafError)metrics[11]
+    wafInvalidCode.type == 'count'
+    wafInvalidCode.value == 1
+    wafInvalidCode.namespace == 'appsec'
+    wafInvalidCode.metricName == 'waf.error'
+    wafInvalidCode.tags.toSet() == [
+      'waf_version:waf_ver1',
+      'rule_type:command_injection',
+      'rule_variant:shell',
+      'event_rules_version:rules.3',
+      'waf_error:' +DD_WAF_RUN_INTERNAL_ERROR
+    ].toSet()
+
+    def raspInvalidObjectCode = (WafMetricCollector.RaspError)metrics[12]
     raspInvalidObjectCode.type == 'count'
     raspInvalidObjectCode.value == 1
     raspInvalidObjectCode.namespace == 'appsec'
@@ -161,6 +176,17 @@ class WafMetricCollectorTest extends DDSpecification {
       'waf_error:' + DD_WAF_RUN_INVALID_OBJECT_ERROR
     ]
     .toSet()
+
+    def wafInvalidObjectCode = (WafMetricCollector.WafError)metrics[13]
+    wafInvalidObjectCode.type == 'count'
+    wafInvalidObjectCode.value == 1
+    wafInvalidObjectCode.namespace == 'appsec'
+    wafInvalidObjectCode.metricName == 'waf.error'
+    wafInvalidObjectCode.tags.toSet() == [
+      'rule_type:sql_injection',
+      'waf_version:waf_ver1',
+      'waf_error:'+DD_WAF_RUN_INVALID_OBJECT_ERROR
+    ].toSet()
   }
 
   def "overflowing WafMetricCollector does not crash"() {
@@ -335,6 +361,7 @@ class WafMetricCollectorTest extends DDSpecification {
     WafMetricCollector.get().raspRuleEval(ruleType)
     WafMetricCollector.get().raspTimeout(ruleType)
     WafMetricCollector.get().raspErrorCode(ruleType, DD_WAF_RUN_INTERNAL_ERROR)
+    WafMetricCollector.get().wafErrorCode(ruleType, DD_WAF_RUN_INTERNAL_ERROR)
     WafMetricCollector.get().prepareMetrics()
 
     then:
@@ -382,6 +409,19 @@ class WafMetricCollectorTest extends DDSpecification {
     raspInvalidCode.namespace == 'appsec'
     raspInvalidCode.metricName == 'rasp.error'
     raspInvalidCode.tags.toSet() == [
+      'waf_version:waf_ver1',
+      'rule_type:command_injection',
+      'rule_variant:' + ruleType.variant,
+      'event_rules_version:rules.1',
+      'waf_error:' + DD_WAF_RUN_INTERNAL_ERROR
+    ].toSet()
+
+    def wafInvalidCode = (WafMetricCollector.WafError)metrics[5]
+    wafInvalidCode.type == 'count'
+    wafInvalidCode.value == 1
+    wafInvalidCode.namespace == 'appsec'
+    wafInvalidCode.metricName == 'waf.error'
+    wafInvalidCode.tags.toSet() == [
       'waf_version:waf_ver1',
       'rule_type:command_injection',
       'rule_variant:' + ruleType.variant,


### PR DESCRIPTION
# What Does This Do
This metric can be used to count the number of errors generated when calling ddwaf_run when evaluating WAF addresses, or rather non-RASP addresses. 

# Motivation

# Additional Notes
Counterpart to the appsec.rasp.error found here https://github.com/DataDog/dd-trace-java/pull/8364

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56703]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56703]: https://datadoghq.atlassian.net/browse/APPSEC-56703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ