### PR TITLE
Update muzzle directive for ignite 2.17.0 to use Java 11

### DIFF
--- a/dd-java-agent/instrumentation/ignite-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ignite-2.0/build.gradle
@@ -7,7 +7,14 @@ muzzle {
   pass {
     group = 'org.apache.ignite'
     module = 'ignite-core'
-    versions = "[2.0.0,3)"
+    versions = "[2.0.0,2.17.0)"
+  }
+  // ignite-core 2.17.0 is compiled with Java 11
+  pass {
+    group = 'org.apache.ignite'
+    module = 'ignite-core'
+    versions = "[2.17.0,3)"
+    javaVersion = 11
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Updates the muzzle directive for the `ignite` instrumentation. Version `2.17.0` released on Feb, 9th is compiled with Java 11, causing a failure in the muzzle check.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
