### PR TITLE
Move stackId from Vulnerability to Location

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -81,7 +81,7 @@ public class Reporter {
         String stackId =
             addVulnerabilityStackTrace(span, String.valueOf(batch.getVulnerabilities().size()));
         if (stackId != null) {
-          vulnerability.setStackId(stackId);
+          vulnerability.getLocation().setStackId(stackId);
         }
       }
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
@@ -15,6 +15,8 @@ public final class Location {
 
   @Nullable private transient String serviceName;
 
+  private @Nullable String stackId;
+
   private Location(
       @Nullable final Long spanId,
       @Nullable final String path,
@@ -84,6 +86,15 @@ public final class Location {
       this.spanId = span.getSpanId();
       this.serviceName = span.getServiceName();
     }
+  }
+
+  @Nullable
+  public String getStackId() {
+    return stackId;
+  }
+
+  public void setStackId(@Nullable String stackId) {
+    this.stackId = stackId;
   }
 
   @Nullable

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
@@ -12,8 +12,6 @@ public final class Vulnerability {
 
   private final @Nullable Evidence evidence;
 
-  private @Nullable String stackId;
-
   private long hash;
 
   public Vulnerability(@Nonnull final VulnerabilityType type, @Nonnull final Location location) {
@@ -43,15 +41,6 @@ public final class Vulnerability {
   @Nullable
   public Evidence getEvidence() {
     return evidence;
-  }
-
-  @Nullable
-  public String getStackId() {
-    return stackId;
-  }
-
-  public void setStackId(@Nullable String stackId) {
-    this.stackId = stackId;
   }
 
   public long getHash() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -78,9 +78,9 @@ class ReporterTest extends DDSpecification {
             "spanId":123456,
             "line":1,
             "path": "foo",
-            "method": "foo"
+            "method": "foo",
+            "stackId":"1"
           },
-          "stackId":"1",
           "type":"WEAK_HASH"
         }
       ]
@@ -187,9 +187,9 @@ class ReporterTest extends DDSpecification {
             "spanId":123456,
             "line":1,
             "path":"foo",
-            "method": "foo"
+            "method": "foo",
+            "stackId":"1"
           },
-          "stackId":"1",
           "type":"WEAK_HASH"
         },
         {
@@ -199,9 +199,9 @@ class ReporterTest extends DDSpecification {
             "spanId":123456,
             "line":2,
             "path":"foo",
-            "method": "foo"
+            "method": "foo",
+            "stackId":"2"
           },
-          "stackId":"2",
           "type":"WEAK_HASH"
         }
       ]
@@ -578,7 +578,7 @@ class ReporterTest extends DDSpecification {
     StackTraceEvent currentStackTrace = null
     for (int i = 0; i < vulnerabilities.size(); i++) {
       for (StackTraceEvent event : batch.get("vulnerability")) {
-        if(event.getId() == vulnerabilities[i].getStackId()) {
+        if(event.getId() == vulnerabilities[i].getLocation().getStackId()) {
           currentStackTrace = event
           break
         }


### PR DESCRIPTION
# What Does This Do

Move stackId from Vulnerability to Location

# Motivation

The RFC specifies that 

> Location
> In order to link the stack with the vulnerability, we will add a stack field to the vulnerability’s location, containing the stack id in the vulnerabilities section of stacks of the span.

However, this stackId was incorrectly added to the vulnerability instead of to the Location.

# Additional Notes

[RFC](https://docs.google.com/document/d/1ga7yCKq2htgcwgQsInYZKktV0hNlv4drY9XzSxT-o5U/edit?tab=t.0#heading=h.e4lbumn4upwy)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56772]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56772]: https://datadoghq.atlassian.net/browse/APPSEC-56772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ