### PR TITLE
Capture continuations via agent tracer

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -1,10 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 /** Helper utils for Runnable/Callable instrumentation */
 public class AdviceUtils {
@@ -51,14 +53,14 @@ public class AdviceUtils {
   }
 
   public static <T> void capture(ContextStore<T, State> contextStore, T task) {
-    AgentScope activeScope = activeScope();
-    if (null != activeScope && activeScope.isAsyncPropagating()) {
+    AgentSpan span = activeSpan();
+    if (span != null && isAsyncPropagationEnabled()) {
       State state = contextStore.get(task);
       if (null == state) {
         state = State.FACTORY.create();
         contextStore.put(task, state);
       }
-      state.captureAndSetContinuation(activeScope);
+      state.captureAndSetContinuation(span);
     }
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
@@ -18,7 +18,7 @@ final class ContinuationClaim implements AgentScope.Continuation {
   }
 
   @Override
-  public AgentSpan getSpan() {
+  public AgentSpan span() {
     throw new IllegalStateException();
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFil
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,24 +37,22 @@ public final class ExecutorInstrumentationUtils {
   }
 
   /**
-   * Create task state given current scope.
+   * Create task state given current span.
    *
    * @param contextStore context storage
    * @param task task instance
-   * @param scope current scope
+   * @param span current span
    * @param <T> task class type
    * @return new state
    */
   public static <T> State setupState(
-      final ContextStore<T, State> contextStore, final T task, final AgentScope scope) {
+      final ContextStore<T, State> contextStore, final T task, final AgentSpan span) {
 
     final State state = contextStore.putIfAbsent(task, State.FACTORY);
 
-    if (!state.captureAndSetContinuation(scope)) {
+    if (!state.captureAndSetContinuation(span)) {
       log.debug(
-          "continuation was already set for {} in scope {}, no continuation captured.",
-          task,
-          scope);
+          "continuation was already set for {} in span {}, no continuation captured.", task, span);
     }
 
     return state;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
@@ -60,7 +60,7 @@ public final class State {
   public AgentSpan getSpan() {
     AgentScope.Continuation continuation = CONTINUATION.get(this);
     if (null != continuation) {
-      return continuation.getSpan();
+      return continuation.span();
     }
     return null;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ContinuationClaim.CLAIMED;
 
 import datadog.trace.api.profiling.Timing;
@@ -25,7 +26,7 @@ public final class State {
 
   private State() {}
 
-  public boolean captureAndSetContinuation(final AgentScope scope) {
+  public boolean captureAndSetContinuation(final AgentSpan span) {
     if (CONTINUATION.compareAndSet(this, null, CLAIMED)) {
       // it's a real pain to do this twice, and this can actually
       // happen systematically - WITHOUT RACES - because of broken
@@ -33,7 +34,7 @@ public final class State {
       // "double instruments" calls to ScheduledExecutorService.submit/schedule
       //
       // lazy write is guaranteed to be seen by getAndSet
-      CONTINUATION.lazySet(this, scope.capture());
+      CONTINUATION.lazySet(this, captureSpan(span));
       return true;
     }
     return false;

--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.aerospike4;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.instrumentation.aerospike4.AerospikeClientDecorator.DECORATE;
 import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -71,7 +72,7 @@ public final class AerospikeClientInstrumentation extends InstrumenterModule.Tra
       AgentSpan clientSpan = DECORATE.startAerospikeSpan(methodName);
       AgentScope scope = activateSpan(clientSpan);
       // always want to wrap even when there's no listener so we get the true async time
-      listener = new TracingListener(clientSpan, scope.capture(), listener);
+      listener = new TracingListener(clientSpan, captureSpan(clientSpan), listener);
       return scope;
     }
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 
@@ -15,15 +16,11 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
   private final FutureCallback<T> delegate;
 
   public TraceContinuedFutureCallback(
-      final AgentScope parentScope,
+      final AgentScope.Continuation parentContinuation,
       final AgentSpan clientSpan,
       final HttpContext context,
       final FutureCallback<T> delegate) {
-    if (parentScope != null) {
-      parentContinuation = parentScope.capture();
-    } else {
-      parentContinuation = null;
-    }
+    this.parentContinuation = parentContinuation;
     this.clientSpan = clientSpan;
     this.context = context;
     // Note: this can be null in real life, so we have to handle this carefully
@@ -36,7 +33,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
@@ -53,7 +50,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
@@ -69,7 +66,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 
@@ -18,15 +19,11 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
   private final FutureCallback<T> delegate;
 
   public TraceContinuedFutureCallback(
-      final AgentScope parentScope,
+      final AgentScope.Continuation parentContinuation,
       final AgentSpan clientSpan,
       final HttpContext context,
       final FutureCallback<T> delegate) {
-    if (parentScope != null) {
-      parentContinuation = parentScope.capture();
-    } else {
-      parentContinuation = null;
-    }
+    this.parentContinuation = parentContinuation;
     this.clientSpan = clientSpan;
     this.context = context;
     // Note: this can be null in real life, so we have to handle this carefully
@@ -39,7 +36,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
@@ -56,7 +53,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
@@ -72,7 +69,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     DECORATE.beforeFinish(clientSpan);
     clientSpan.finish(); // Finish span before calling delegate
 
-    if (parentContinuation == null) {
+    if (parentContinuation == noopContinuation()) {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {

--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.guava10;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -11,7 +11,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -56,15 +56,17 @@ public class ListenableFutureInstrumentation extends InstrumenterModule.Tracing
     public static State addListenerEnter(
         @Advice.Argument(value = 0, readOnly = false) Runnable task,
         @Advice.Argument(1) final Executor executor) {
-      final AgentScope scope = activeScope();
-      final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-      // It is important to check potentially wrapped task if we can instrument task in this
-      // executor. Some executors do not support wrapped tasks.
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
-        task = newTask;
-        final ContextStore<Runnable, State> contextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+      final AgentSpan span = activeSpan();
+      if (null != span) {
+        final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
+        // It is important to check potentially wrapped task if we can instrument task in this
+        // executor. Some executors do not support wrapped tasks.
+        if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
+          task = newTask;
+          final ContextStore<Runnable, State> contextStore =
+              InstrumentationContext.get(Runnable.class, State.class);
+          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, span);
+        }
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/java/util/concurrent/CompletableFutureAdvice.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/java/util/concurrent/CompletableFutureAdvice.java
@@ -1,11 +1,12 @@
 package java.util.concurrent;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.concurrent.CompletableFuture.ASYNC;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ConcurrentState;
 import java.util.concurrent.CompletableFuture.UniCompletion;
 import net.bytebuddy.asm.Advice;
@@ -16,11 +17,11 @@ public final class CompletableFutureAdvice {
   public static final class UniConstructor {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterInit(@Advice.This UniCompletion zis) {
-      AgentScope scope = activeScope();
-      if (zis.isLive() && scope != null) {
+      AgentSpan span = activeSpan();
+      if (zis.isLive() && span != null) {
         ContextStore<UniCompletion, ConcurrentState> contextStore =
             InstrumentationContext.get(UniCompletion.class, ConcurrentState.class);
-        ConcurrentState.captureScope(contextStore, zis, scope);
+        ConcurrentState.captureContinuation(contextStore, zis, span);
       }
     }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/JavaExecutorInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.java.concurrent.executor;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -9,7 +9,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -46,8 +46,8 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
       // there are cased like ScheduledExecutorService.submit (which we instrument)
       // which calls ScheduledExecutorService.schedule (which we also instrument)
       // where all of this could be dodged the second time
-      final AgentScope scope = activeScope();
-      if (null != scope) {
+      final AgentSpan span = activeSpan();
+      if (null != span) {
         final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
         // It is important to check potentially wrapped task if we can instrument task in this
         // executor. Some executors do not support wrapped tasks.
@@ -55,7 +55,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
           task = newTask;
           final ContextStore<Runnable, State> contextStore =
               InstrumentationContext.get(Runnable.class, State.class);
-          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, span);
         }
       }
       return null;

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/runnable/ConsumerTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/runnable/ConsumerTaskInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.java.concurrent.runnable;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
 import static datadog.trace.instrumentation.java.concurrent.ConcurrentInstrumentationNames.EXECUTOR_INSTRUMENTATION_NAME;
@@ -13,6 +13,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Map;
 import java.util.concurrent.ForkJoinTask;
@@ -50,10 +51,10 @@ public class ConsumerTaskInstrumentation extends InstrumenterModule.Tracing
   public static class Construct {
     @Advice.OnMethodExit
     public static void construct(@Advice.This ForkJoinTask<?> task) {
-      AgentScope activeScope = activeScope();
-      if (null != activeScope) {
+      AgentSpan span = activeSpan();
+      if (null != span) {
         State state = State.FACTORY.create();
-        state.captureAndSetContinuation(activeScope);
+        state.captureAndSetContinuation(span);
         InstrumentationContext.get(ForkJoinTask.class, State.class).put(task, state);
       }
     }

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyRunnableWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty12;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
@@ -27,9 +28,9 @@ public class JettyRunnableWrapper implements Runnable {
     if (task instanceof JettyRunnableWrapper || exclude(RUNNABLE, task)) {
       return task;
     }
-    AgentScope scope = activeScope();
-    if (null != scope) {
-      return new JettyRunnableWrapper(task, scope.capture());
+    AgentScope.Continuation continuation = captureActiveSpan();
+    if (continuation != noopContinuation()) {
+      return new JettyRunnableWrapper(task, continuation);
     }
     return task; // don't wrap unless there is a scope to propagate
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/ScopeStateCoroutineContext.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/ScopeStateCoroutineContext.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
+
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -119,10 +121,7 @@ public class ScopeStateCoroutineContext implements ThreadContextElement<ScopeSta
      */
     public void maybeInitialize() {
       if (!isInitialized) {
-        final AgentScope activeScope = AgentTracer.get().activeScope();
-        if (activeScope != null && activeScope.isAsyncPropagating()) {
-          continuation = activeScope.capture().hold();
-        }
+        continuation = captureActiveSpan().hold();
         isInitialized = true;
       }
     }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/CallbackWrapper.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/CallbackWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.mongo;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 
 import com.mongodb.internal.async.SingleResultCallback;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -54,9 +55,9 @@ public class CallbackWrapper<T> implements SingleResultCallback<Object> {
   }
 
   public static SingleResultCallback<Object> wrapIfRequired(SingleResultCallback<Object> callback) {
-    AgentScope scope = activeScope();
-    if (null != scope && scope.isAsyncPropagating()) {
-      return new CallbackWrapper<>(scope.capture(), callback);
+    AgentScope.Continuation continuation = captureActiveSpan();
+    if (continuation != noopContinuation()) {
+      return new CallbackWrapper<>(continuation, callback);
     }
     return callback;
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -3,7 +3,8 @@ package datadog.trace.instrumentation.netty40;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -185,15 +186,12 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
   public static class ConnectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        final AgentScope.Continuation continuation = scope.capture();
-        if (null != continuation) {
-          final Attribute<AgentScope.Continuation> attribute =
-              pipeline.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY);
-          if (!attribute.compareAndSet(null, continuation)) {
-            continuation.cancel();
-          }
+      AgentScope.Continuation continuation = captureActiveSpan();
+      if (continuation != noopContinuation()) {
+        final Attribute<AgentScope.Continuation> attribute =
+            pipeline.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY);
+        if (!attribute.compareAndSet(null, continuation)) {
+          continuation.cancel();
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/DeliveryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/DeliveryInstrumentation.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.springamqp;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
@@ -8,7 +8,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -39,10 +39,10 @@ public class DeliveryInstrumentation extends InstrumenterModule.Tracing
   public static class CaptureActiveScope {
     @Advice.OnMethodExit
     public static void captureActiveScope(@Advice.This Delivery delivery) {
-      AgentScope scope = activeScope();
-      if (null != scope) {
+      AgentSpan span = activeSpan();
+      if (span != null) {
         State state = State.FACTORY.create();
-        state.captureAndSetContinuation(scope);
+        state.captureAndSetContinuation(span);
         InstrumentationContext.get(Delivery.class, State.class).put(delivery, state);
       }
     }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
@@ -34,7 +35,11 @@ public class SpannedMethodInvocation implements MethodInvocation {
   @Override
   public Object proceed() throws Throwable {
     CharSequence spanName = DECORATE.spanNameForMethod(delegate.getMethod());
-    return null == continuation ? invokeWithSpan(spanName) : invokeWithContinuation(spanName);
+    if (continuation != noopContinuation()) {
+      return invokeWithContinuation(spanName);
+    } else {
+      return invokeWithSpan(spanName);
+    }
   }
 
   private Object invokeWithContinuation(CharSequence spanName) throws Throwable {

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
@@ -1,8 +1,7 @@
 package datadog.trace.instrumentation.springscheduling;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -11,7 +10,6 @@ public class SpringAsyncAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void scheduleAsync(
       @Advice.Argument(value = 0, readOnly = false) MethodInvocation invocation) {
-    AgentScope scope = activeScope();
-    invocation = new SpannedMethodInvocation(null == scope ? null : scope.capture(), invocation);
+    invocation = new SpannedMethodInvocation(captureActiveSpan(), invocation);
   }
 }

--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
@@ -119,7 +119,7 @@ public class UndertowBlockingHandler implements HttpHandler {
   private static void markAsEffectivelyBlocked(HttpServerExchange xchg) {
     AgentScope.Continuation continuation = xchg.getAttachment(DD_UNDERTOW_CONTINUATION);
     if (continuation != null) {
-      continuation.getSpan().getRequestContext().getTraceSegment().effectivelyBlocked();
+      continuation.span().getRequestContext().getTraceSegment().effectivelyBlocked();
     }
   }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ExchangeEndSpanListener.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ExchangeEndSpanListener.java
@@ -21,7 +21,7 @@ public class ExchangeEndSpanListener implements ExchangeCompletionListener {
       return;
     }
 
-    AgentSpan span = continuation.getSpan();
+    AgentSpan span = continuation.span();
 
     Throwable throwable = exchange.getAttachment(DefaultResponseListener.EXCEPTION);
     if (throwable != null) {

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.undertow;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.instrumentation.undertow.UndertowBlockingHandler.REQUEST_BLOCKING_DATA;
 import static datadog.trace.instrumentation.undertow.UndertowBlockingHandler.TRACE_SEGMENT;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
@@ -87,8 +88,8 @@ public final class HandlerInstrumentation extends InstrumenterModule.Tracing
 
       AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
       if (continuation != null) {
-        scope = continuation.activate();
-        exchange.putAttachment(DD_UNDERTOW_CONTINUATION, scope.capture());
+        // not yet complete, not ready to do final activation of continuation
+        scope = activateSpan(continuation.span());
         return;
       }
 
@@ -98,7 +99,7 @@ public final class HandlerInstrumentation extends InstrumenterModule.Tracing
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, exchange, exchange, extractedContext);
 
-      exchange.putAttachment(DD_UNDERTOW_CONTINUATION, scope.capture());
+      exchange.putAttachment(DD_UNDERTOW_CONTINUATION, captureSpan(span));
 
       exchange.addExchangeCompleteListener(ExchangeEndSpanListener.INSTANCE);
 

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpServerExchangeSenderInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpServerExchangeSenderInstrumentation.java
@@ -69,7 +69,7 @@ public class HttpServerExchangeSenderInstrumentation extends InstrumenterModule.
       }
       xchg.putAttachment(IgnoreSendAttribute.IGNORE_SEND_KEY, IgnoreSendAttribute.INSTANCE);
 
-      AgentSpan span = continuation.getSpan();
+      AgentSpan span = continuation.span();
       Flow<Void> flow =
           UndertowDecorator.DECORATE.callIGCallbackResponseAndHeaders(
               span, xchg, xchg.getStatusCode(), UndertowExtractAdapter.Response.GETTER);

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -66,7 +66,7 @@ public final class ServletInstrumentation extends InstrumenterModule.Tracing
         @Advice.Argument(1) final ServletRequestContext servletRequestContext) {
       AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
       if (continuation != null) {
-        AgentSpan undertowSpan = continuation.getSpan();
+        AgentSpan undertowSpan = continuation.span();
         ServletRequest request = servletRequestContext.getServletRequest();
         request.setAttribute(DD_SPAN_ATTRIBUTE, undertowSpan);
         undertowSpan.setSpanName(SERVLET_REQUEST);

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.undertow;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
@@ -31,10 +32,10 @@ public class UndertowRunnableWrapper implements Runnable {
     if (task instanceof UndertowRunnableWrapper || exclude(RUNNABLE, task)) {
       return task;
     }
-    AgentScope scope = activeScope();
-    if (null != scope) {
-      return new UndertowRunnableWrapper(task, exchange, scope.capture());
+    AgentScope.Continuation continuation = captureActiveSpan();
+    if (continuation != noopContinuation()) {
+      return new UndertowRunnableWrapper(task, exchange, continuation);
     }
-    return task; // don't wrap unless there is a scope to propagate
+    return task; // don't wrap unless there is a span to propagate
   }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
@@ -58,7 +58,7 @@ public final class JakartaServletInstrumentation extends InstrumenterModule.Trac
         @Advice.Argument(1) final ServletRequestContext servletRequestContext) {
       AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
       if (continuation != null) {
-        AgentSpan undertowSpan = continuation.getSpan();
+        AgentSpan undertowSpan = continuation.span();
         ServletRequest request = servletRequestContext.getServletRequest();
         request.setAttribute(DD_SPAN_ATTRIBUTE, undertowSpan);
         undertowSpan.setSpanName(SERVLET_REQUEST);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -934,8 +934,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public AgentScope.Continuation captureActiveSpan() {
     AgentScope activeScope = this.scopeManager.active();
-    if (null != activeScope) {
-      return activeScope.capture();
+    if (null != activeScope && activeScope.isAsyncPropagating()) {
+      return scopeManager.captureSpan(activeScope.span(), activeScope.source());
     } else {
       return AgentTracer.noopContinuation();
     }
@@ -943,7 +943,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentScope.Continuation captureSpan(final AgentSpan span) {
-    return scopeManager.captureSpan(span);
+    return scopeManager.captureSpan(span, ScopeSource.INSTRUMENTATION.id());
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -5,7 +5,6 @@ import datadog.trace.api.scopemanager.ExtendedScopeListener;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -128,19 +127,6 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   @Override
   public final void setAsyncPropagation(final boolean value) {
     isAsyncPropagating = value;
-  }
-
-  /**
-   * The continuation returned must be closed or activated or the trace will not finish.
-   *
-   * @return The new continuation, or {@link AgentTracer#noopContinuation()} if this scope is not
-   *     async propagating.
-   */
-  @Override
-  public final Continuation capture() {
-    return isAsyncPropagating
-        ? new ScopeContinuation(scopeManager, span, source()).register()
-        : AgentTracer.noopContinuation();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -90,9 +90,8 @@ public final class ContinuableScopeManager implements ScopeStateAware {
     return activate(span, source.id(), true, isAsyncPropagating);
   }
 
-  public AgentScope.Continuation captureSpan(final AgentSpan span) {
-    ScopeContinuation continuation =
-        new ScopeContinuation(this, span, ScopeSource.INSTRUMENTATION.id());
+  public AgentScope.Continuation captureSpan(final AgentSpan span, byte source) {
+    ScopeContinuation continuation = new ScopeContinuation(this, span, source);
     continuation.register();
     healthMetrics.onCaptureContinuation();
     return continuation;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
@@ -113,7 +113,7 @@ final class ScopeContinuation implements AgentScope.Continuation {
   }
 
   @Override
-  public AgentSpan getSpan() {
+  public AgentSpan span() {
     return spanUnderScope;
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -496,7 +496,7 @@ class PendingTraceBufferTest extends DDSpecification {
 
   def addContinuation(DDSpan span) {
     def scope = scopeManager.activate(span, ScopeSource.INSTRUMENTATION, true)
-    continuations << scope.capture()
+    continuations << scopeManager.captureSpan(span, ScopeSource.INSTRUMENTATION.id())
     scope.close()
     return span
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -8,7 +8,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
     when:
     def scope = tracer.activateSpan(rootSpan)
     setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()
 
@@ -40,7 +40,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
     when:
     def scope = tracer.activateSpan(rootSpan)
     setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -52,7 +52,7 @@ class PendingTraceTest extends PendingTraceTestBase {
     when:
     def scope = tracer.activateSpan(rootSpan)
     setAsyncPropagationEnabled(true)
-    scope.capture()
+    tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -253,16 +253,16 @@ class ScopeManagerTest extends DDCoreSpecification {
   def "DDScope creates no-op continuations when propagation is not set"() {
     when:
     def span = tracer.buildSpan("test", "test").start()
-    def scope = tracer.activateSpan(span)
+    tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(false)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
 
     then:
     continuation == noopContinuation()
 
     when:
     tracer.setAsyncPropagationEnabled(true)
-    continuation = scope.capture()
+    continuation = tracer.captureActiveSpan()
 
     then:
     continuation != noopContinuation() && continuation != null
@@ -276,7 +276,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
 
     then:
     continuation != null
@@ -294,7 +294,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scopeRef.get().capture()
+    def continuation = tracer.captureActiveSpan()
 
     then:
     continuation != null
@@ -322,7 +322,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
 
     then:
     continuation != null
@@ -356,7 +356,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def childScope = tracer.activateSpan(childSpan)
     tracer.setAsyncPropagationEnabled(true)
 
-    def continuation = childScope.capture()
+    def continuation = tracer.captureActiveSpan()
     childScope.close()
 
     then:
@@ -390,7 +390,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     writer == []
 
     when: "creating and activating a second continuation"
-    def newContinuation = newScope.capture()
+    def newContinuation = tracer.captureActiveSpan()
     newScope.close()
     def secondContinuedScope = newContinuation.activate()
     secondContinuedScope.close()
@@ -409,7 +409,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
 
@@ -695,7 +695,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
 
@@ -778,7 +778,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation = scope.capture()
+    def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
 
@@ -805,7 +805,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span2 = tracer.buildSpan("test", "test").start()
     def scope2 = tracer.activateSpan(span2)
     tracer.setAsyncPropagationEnabled(true)
-    def continuation2 = scope2.capture()
+    def continuation2 = tracer.captureActiveSpan()
 
     then:
     continuation2 != null
@@ -840,7 +840,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
-    continuation = scope.capture()
+    continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -9,9 +9,6 @@ public interface AgentScope extends TraceScope, Closeable {
   byte source();
 
   @Override
-  Continuation capture();
-
-  @Override
   void close();
 
   interface Continuation extends TraceScope.Continuation {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -22,6 +22,6 @@ public interface AgentScope extends TraceScope, Closeable {
     AgentScope activate();
 
     /** Provide access to the captured span */
-    AgentSpan getSpan();
+    AgentSpan span();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.annotation.Nonnull;
 
 public class AgentTracer {
   private static final String DEFAULT_INSTRUMENTATION_NAME = "datadog";
@@ -93,10 +94,30 @@ public class AgentTracer {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
+  /**
+   * When asynchronous propagation is enabled, prevent the currently active trace from reporting
+   * until the returned Continuation is either activated (and the returned scope is closed) or the
+   * continuation is canceled.
+   *
+   * <p>Should be called on the parent thread.
+   *
+   * @return Continuation of the active span, no-op continuation if there's no active span or
+   *     asynchronous propagation is disabled.
+   */
+  @Nonnull
   public static AgentScope.Continuation captureActiveSpan() {
     return get().captureActiveSpan();
   }
 
+  /**
+   * Prevent the trace of the given span from reporting until the returned Continuation is either
+   * activated (and the returned scope is closed) or the continuation is canceled.
+   *
+   * <p>Should be called on the parent thread.
+   *
+   * @return Continuation of the given span.
+   */
+  @Nonnull
   public static AgentScope.Continuation captureSpan(final AgentSpan span) {
     return get().captureSpan(span);
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopContinuation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopContinuation.java
@@ -16,7 +16,7 @@ final class NoopContinuation implements AgentScope.Continuation {
   }
 
   @Override
-  public AgentSpan getSpan() {
+  public AgentSpan span() {
     return NoopSpan.INSTANCE;
   }
 


### PR DESCRIPTION
# What Does This Do

Migrates auto-instrumentation to capture continuations via `AgentTracer`
* use `captureActiveSpan()` when you want to capture whatever span is active
* use `captureSpan(span)` when you know the exact span you want to capture

# Motivation

Removes use of deprecated scope method in our code.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-955]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-955]: https://datadoghq.atlassian.net/browse/APMAPI-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ