### PR TITLE
Check async propagation flag via agent tracer

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -1,10 +1,10 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 
 import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
@@ -26,14 +26,10 @@ public final class ExecutorInstrumentationUtils {
     if (task == null) {
       return false;
     }
-
     if (ExcludeFilter.exclude(ExcludeType.EXECUTOR, task)) {
       return false;
     }
-
-    final AgentScope scope = activeScope();
-
-    return scope != null && scope.isAsyncPropagating();
+    return activeSpan() != null && isAsyncPropagationEnabled();
   }
 
   /**

--- a/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
@@ -79,7 +79,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
                       serverReceived << value.message
 
                       (1..msgCount).each {
-                        if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                        if (TEST_TRACER.isAsyncPropagationEnabled()) {
                           observer.onNext(value)
                         } else {
                           observer.onError(new IllegalStateException("not async propagating!"))
@@ -89,7 +89,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
 
                     @Override
                     void onError(Throwable t) {
-                      if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                      if (TEST_TRACER.isAsyncPropagationEnabled()) {
                         error.set(t)
                         observer.onError(t)
                       } else {
@@ -99,7 +99,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
 
                     @Override
                     void onCompleted() {
-                      if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                      if (TEST_TRACER.isAsyncPropagationEnabled()) {
                         observer.onCompleted()
                       } else {
                         observer.onError(new IllegalStateException("not async propagating!"))
@@ -122,7 +122,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
     def streamObserver = client.conversation(new StreamObserver<Helloworld.Response>() {
         @Override
         void onNext(Helloworld.Response value) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             clientReceived << value.message
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -131,7 +131,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
 
         @Override
         void onError(Throwable t) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(t)
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -140,7 +140,7 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
 
         @Override
         void onCompleted() {
-          if (!TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (!TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(new IllegalStateException("not async propagating!"))
           }
         }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcCodeOriginTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcCodeOriginTest.groovy
@@ -69,7 +69,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
                 serverReceived << value.message
 
                 (1..msgCount).each {
-                  if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                  if (TEST_TRACER.isAsyncPropagationEnabled()) {
                     observer.onNext(value)
                   } else {
                     observer.onError(new IllegalStateException("not async propagating!"))
@@ -79,7 +79,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
 
               @Override
               void onError(Throwable t) {
-                if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                if (TEST_TRACER.isAsyncPropagationEnabled()) {
                   error.set(t)
                   observer.onError(t)
                 } else {
@@ -89,7 +89,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
 
               @Override
               void onCompleted() {
-                if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                if (TEST_TRACER.isAsyncPropagationEnabled()) {
                   observer.onCompleted()
                 } else {
                   observer.onError(new IllegalStateException("not async propagating!"))
@@ -109,7 +109,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
     def streamObserver = client.conversation(new StreamObserver<Helloworld.Response>() {
         @Override
         void onNext(Helloworld.Response value) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             clientReceived << value.message
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -118,7 +118,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
 
         @Override
         void onError(Throwable t) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(t)
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -127,7 +127,7 @@ abstract class GrpcCodeOriginTest extends VersionedNamingTestBase {
 
         @Override
         void onCompleted() {
-          if (!TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (!TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(new IllegalStateException("not async propagating!"))
           }
         }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -67,7 +67,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
                 serverReceived << value.message
 
                 (1..msgCount).each {
-                  if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                  if (TEST_TRACER.isAsyncPropagationEnabled()) {
                     observer.onNext(value)
                   } else {
                     observer.onError(new IllegalStateException("not async propagating!"))
@@ -77,7 +77,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
               @Override
               void onError(Throwable t) {
-                if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                if (TEST_TRACER.isAsyncPropagationEnabled()) {
                   error.set(t)
                   observer.onError(t)
                 } else {
@@ -87,7 +87,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
               @Override
               void onCompleted() {
-                if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+                if (TEST_TRACER.isAsyncPropagationEnabled()) {
                   observer.onCompleted()
                 } else {
                   observer.onError(new IllegalStateException("not async propagating!"))
@@ -107,7 +107,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
     def streamObserver = client.conversation(new StreamObserver<Helloworld.Response>() {
         @Override
         void onNext(Helloworld.Response value) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             clientReceived << value.message
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -116,7 +116,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
         @Override
         void onError(Throwable t) {
-          if (TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(t)
           } else {
             error.set(new IllegalStateException("not async propagating!"))
@@ -125,7 +125,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
         @Override
         void onCompleted() {
-          if (!TEST_TRACER.activeScope().isAsyncPropagating()) {
+          if (!TEST_TRACER.isAsyncPropagationEnabled()) {
             error.set(new IllegalStateException("not async propagating!"))
           }
         }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
@@ -1,6 +1,6 @@
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
@@ -177,7 +177,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     String greeting = "Hello Spring Kafka Sender!"
     runUnderTrace("parent") {
       producer.send(new ProducerRecord(SHARED_TOPIC, greeting)) { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -1,7 +1,7 @@
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
@@ -147,7 +147,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     AvroMock message = new AvroMock("{\"name\":\"test\"}")
     runUnderTrace("parent") {
       producer.send(new ProducerRecord(SHARED_TOPIC, message)) { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {
@@ -227,7 +227,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     String greeting = "Hello Spring Kafka Sender!"
     runUnderTrace("parent") {
       producer.send(new ProducerRecord(SHARED_TOPIC, greeting)) { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
@@ -38,8 +38,8 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 
 abstract class KafkaClientTestBase extends VersionedNamingTestBase {
   static final SHARED_TOPIC = "shared.topic"
@@ -201,7 +201,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     String greeting = "Hello Spring Kafka Sender!"
     runUnderTrace("parent") {
       producer.send(new ProducerRecord(SHARED_TOPIC,greeting)) { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {
@@ -368,7 +368,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     String greeting = "Hello Spring Kafka Sender!"
     runUnderTrace("parent") {
       kafkaTemplate.send(SHARED_TOPIC, greeting).whenComplete { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaCodeOriginForkedTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaCodeOriginForkedTest.groovy
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.asserts.TagsAssert.assertTags
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 
 class KafkaCodeOriginForkedTest extends VersionedNamingTestBase {
   static final SHARED_TOPIC = "shared.topic"
@@ -147,7 +147,7 @@ class KafkaCodeOriginForkedTest extends VersionedNamingTestBase {
     String greeting = "Hello Spring Kafka Sender!"
     runUnderTrace("parent") {
       producer.send(new ProducerRecord(SHARED_TOPIC,greeting)) { meta, ex ->
-        assert activeScope().isAsyncPropagating()
+        assert isAsyncPropagationEnabled()
         if (ex == null) {
           runUnderTrace("producer callback") {}
         } else {

--- a/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.scala;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
@@ -28,9 +28,9 @@ public class PromiseHelper {
    * @return the Span or null
    */
   public static AgentSpan getSpan() {
-    final AgentScope scope = activeScope();
-    if (null != scope && scope.isAsyncPropagating()) {
-      return scope.span();
+    final AgentSpan span = activeSpan();
+    if (null != span && isAsyncPropagationEnabled()) {
+      return span;
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
@@ -18,8 +18,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
@@ -254,7 +254,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
@@ -254,7 +254,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Span should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-3.9/src/test/java/server/IastVertx39TestVerticle.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.9/src/test/java/server/IastVertx39TestVerticle.java
@@ -252,7 +252,7 @@ public class IastVertx39TestVerticle extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Span should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-3.9/src/test/java/server/IastVertx39TestVerticle.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.9/src/test/java/server/IastVertx39TestVerticle.java
@@ -16,8 +16,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
@@ -252,7 +252,7 @@ public class IastVertx39TestVerticle extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/latestDepTest/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/latestDepTest/java/server/VertxTestServer.java
@@ -18,8 +18,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
@@ -271,7 +271,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/latestDepTest/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/latestDepTest/java/server/VertxTestServer.java
@@ -271,7 +271,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Span should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -281,7 +281,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Span should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -18,8 +18,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
@@ -281,7 +281,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
@@ -18,8 +18,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
@@ -271,7 +271,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
@@ -271,7 +271,7 @@ public class VertxTestServer extends AbstractVerticle {
   private static void controller(
       RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
     assert activeSpan() != null : "Controller should have a parent span.";
-    assert isAsyncPropagationEnabled() : "Scope should be propagating async.";
+    assert isAsyncPropagationEnabled() : "Span should be propagating async.";
     ctx.response()
         .putHeader(
             HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -528,7 +528,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   static <T> T controller(ServerEndpoint endpoint, Closure<T> closure) {
     assert activeSpan() != null: "Controller should have a parent span."
     assert activeSpan() != noopSpan(): "Parent span shouldn't be noopSpan"
-    assert isAsyncPropagationEnabled(): "Scope should be propagating async."
+    assert isAsyncPropagationEnabled(): "Span should be propagating async."
     if (endpoint == NOT_FOUND || endpoint == UNKNOWN) {
       return closure()
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -84,9 +84,9 @@ import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
 import static datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType.JSON
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.SERVER_PATHWAY_EDGE_TAGS
 import static java.nio.charset.StandardCharsets.UTF_8
@@ -528,7 +528,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   static <T> T controller(ServerEndpoint endpoint, Closure<T> closure) {
     assert activeSpan() != null: "Controller should have a parent span."
     assert activeSpan() != noopSpan(): "Parent span shouldn't be noopSpan"
-    assert activeScope().asyncPropagating: "Scope should be propagating async."
+    assert isAsyncPropagationEnabled(): "Scope should be propagating async."
     if (endpoint == NOT_FOUND || endpoint == UNKNOWN) {
       return closure()
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -380,7 +380,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then: "the continued scope becomes active and span state doesnt change"
     newScope instanceof ContinuableScope
-    newScope.isAsyncPropagating()
+    tracer.isAsyncPropagationEnabled()
     scopeManager.active() == newScope
     newScope != childScope
     newScope != parentScope


### PR DESCRIPTION
# What Does This Do

Migrates tests and helpers to check async-propagation flag via `AgentTracer`

# Motivation

Removes use of deprecated scope method in our code.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-954]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-954]: https://datadoghq.atlassian.net/browse/APMAPI-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ