### PR TITLE
Add 1 minute fail-safe to JUL/JMX class-loading callback

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -329,8 +329,6 @@ public class Agent {
       if (appUsingCustomJMXBuilder) {
         log.debug("Custom JMX builder detected. Delaying JMXFetch initialization.");
         registerMBeanServerBuilderCallback(new StartJmxCallback(jmxStartDelay));
-        // one minute fail-safe in case nothing touches JMX and callback isn't triggered
-        scheduleJmxStart(60 + jmxStartDelay);
       } else if (appUsingCustomLogManager) {
         log.debug("Custom logger detected. Delaying JMXFetch initialization.");
         registerLogManagerCallback(new StartJmxCallback(jmxStartDelay));
@@ -437,6 +435,8 @@ public class Agent {
   }
 
   private static void registerLogManagerCallback(final ClassLoadCallBack callback) {
+    // one minute fail-safe in case the class was unintentionally loaded during premain
+    AgentTaskScheduler.INSTANCE.schedule(callback, 1, TimeUnit.MINUTES);
     try {
       final Class<?> agentInstallerClass = AGENT_CLASSLOADER.loadClass(AGENT_INSTALLER_CLASS_NAME);
       final Method registerCallbackMethod =
@@ -448,6 +448,8 @@ public class Agent {
   }
 
   private static void registerMBeanServerBuilderCallback(final ClassLoadCallBack callback) {
+    // one minute fail-safe in case the class was unintentionally loaded during premain
+    AgentTaskScheduler.INSTANCE.schedule(callback, 1, TimeUnit.MINUTES);
     try {
       final Class<?> agentInstallerClass = AGENT_CLASSLOADER.loadClass(AGENT_INSTALLER_CLASS_NAME);
       final Method registerCallbackMethod =
@@ -459,8 +461,14 @@ public class Agent {
   }
 
   protected abstract static class ClassLoadCallBack implements Runnable {
+    private final AtomicBoolean starting = new AtomicBoolean();
+
     @Override
     public void run() {
+      if (starting.getAndSet(true)) {
+        return; // someone has already called us
+      }
+
       /*
        * This callback is called from within bytecode transformer. This can be a problem if callback tries
        * to load classes being transformed. To avoid this we start a thread here that calls the callback.
@@ -558,6 +566,7 @@ public class Agent {
     }
 
     private void resumeRemoteComponents() {
+      log.debug("Resuming remote components.");
       try {
         // remote components were paused for custom log-manager/jmx-builder
         // add small delay before resuming remote I/O to help stabilization


### PR DESCRIPTION
# Motivation

Add a timeout in case the class used to trigger resuming of remote components was already unintentionally loaded during premain - in such cases we may not receive a class-load callback from byte-buddy.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-14743]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
