### PR TITLE
Fix APM Tracing disabled for SCA

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -36,9 +36,7 @@ public interface Sampler {
     public static Sampler forConfig(final Config config, final TraceConfig traceConfig) {
       Sampler sampler;
       if (config != null) {
-        if (!config.isApmTracingEnabled()
-            && (config.getAppSecActivation() == ProductActivation.FULLY_ENABLED
-                || config.getIastActivation() == ProductActivation.FULLY_ENABLED)) {
+        if (!config.isApmTracingEnabled() && isAsmEnabled(config)) {
           log.debug("APM is disabled. Only 1 trace per minute will be sent.");
           return new AsmStandaloneSampler(Clock.systemUTC());
         }
@@ -101,6 +99,12 @@ public interface Sampler {
         sampler = new AllSampler();
       }
       return sampler;
+    }
+
+    private static boolean isAsmEnabled(Config config) {
+      return config.getAppSecActivation() == ProductActivation.FULLY_ENABLED
+          || config.getIastActivation() == ProductActivation.FULLY_ENABLED
+          || config.isAppSecScaEnabled();
     }
 
     public static Sampler forConfig(final Properties config) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
@@ -31,6 +31,19 @@ class SamplerTest extends DDSpecification{
     sampler instanceof AsmStandaloneSampler
   }
 
+  void "test that AsmStandaloneSampler is selected when apm tracing disabled and sca enabled is enabled"() {
+    setup:
+    System.setProperty("dd.apm.tracing.enabled", "false")
+    System.setProperty("dd.appsec.sca.enabled", "true")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof AsmStandaloneSampler
+  }
+
   void "test that AsmStandaloneSampler is not selected when apm tracing and asm not enabled"() {
     setup:
     System.setProperty("dd.apm.tracing.enabled", "false")

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3981,8 +3981,8 @@ public class Config {
     return agentlessLogSubmissionProduct;
   }
 
-  public Boolean getAppSecScaEnabled() {
-    return appSecScaEnabled;
+  public boolean isAppSecScaEnabled() {
+    return appSecScaEnabled != null && appSecScaEnabled;
   }
 
   public boolean isAppSecRaspEnabled() {


### PR DESCRIPTION
# What Does This Do

Fix the Sampler to enable ASMStandaloneSampler also when SCA is enabled

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56438](https://datadoghq.atlassian.net/browse/APPSEC-56438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[APPSEC-56438]: https://datadoghq.atlassian.net/browse/APPSEC-56438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ