### PR TITLE
Add hasProductChangeEvent check to isEmpty

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -49,7 +49,8 @@ interface EventSource {
         && !hasDependencyEvent()
         && !hasMetricEvent()
         && !hasDistributionSeriesEvent()
-        && !hasLogMessageEvent();
+        && !hasLogMessageEvent()
+        && !hasProductChangeEvent();
   }
 
   final class Queued implements EventSource {

--- a/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
@@ -1,0 +1,65 @@
+package datadog.telemetry
+
+import datadog.telemetry.api.DistributionSeries
+import datadog.telemetry.api.Integration
+import datadog.telemetry.api.LogMessage
+import datadog.telemetry.api.Metric
+import datadog.telemetry.dependency.Dependency
+import datadog.trace.api.ConfigOrigin
+import datadog.trace.api.ConfigSetting
+import datadog.trace.api.telemetry.ProductChange
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.LinkedBlockingQueue
+
+class EventSourceTest extends DDSpecification{
+
+  void "test isEmpty when adding and clearing #eventType"() {
+    setup:
+    final eventQueues = [
+      configChangeQueue      : new LinkedBlockingQueue<ConfigSetting>(),
+      integrationQueue       : new LinkedBlockingQueue<Integration>(),
+      dependencyQueue        : new LinkedBlockingQueue<Dependency>(),
+      metricQueue            : new LinkedBlockingQueue<Metric>(),
+      distributionSeriesQueue: new LinkedBlockingQueue<DistributionSeries>(),
+      logMessageQueue        : new LinkedBlockingQueue<LogMessage>(),
+      productChanges         : new LinkedBlockingQueue<ProductChange>()
+    ]
+
+    def eventSource = new EventSource.Queued(
+      eventQueues.configChangeQueue,
+      eventQueues.integrationQueue,
+      eventQueues.dependencyQueue,
+      eventQueues.metricQueue,
+      eventQueues.distributionSeriesQueue,
+      eventQueues.logMessageQueue,
+      eventQueues.productChanges
+    )
+
+    expect:
+    eventSource.isEmpty()
+
+    when: "add an event to the queue"
+    eventQueues[eventQueueName].add(eventInstance)
+
+    then: "eventSource should not be empty"
+    !eventSource.isEmpty()
+
+    when: "clear the queue"
+    eventQueues[eventQueueName].clear()
+
+    then: "eventSource should be empty again"
+    eventSource.isEmpty()
+
+    where:
+    eventType             | eventQueueName            | eventInstance
+    "Config Change"       | "configChangeQueue"       | new ConfigSetting("key", "value", ConfigOrigin.ENV)
+    "Integration"         | "integrationQueue"        | new Integration("name", true)
+    "Dependency"          | "dependencyQueue"         | new Dependency("name", "version", "type", null)
+    "Metric"              | "metricQueue"             | new Metric()
+    "Distribution Series" | "distributionSeriesQueue" | new DistributionSeries()
+    "Log Message"         | "logMessageQueue"         | new LogMessage()
+    "Product Change"      | "productChanges"          | new ProductChange()
+  }
+
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/EventSourceTest.groovy
@@ -34,7 +34,7 @@ class EventSourceTest extends DDSpecification{
       eventQueues.distributionSeriesQueue,
       eventQueues.logMessageQueue,
       eventQueues.productChanges
-    )
+      )
 
     expect:
     eventSource.isEmpty()
@@ -61,5 +61,4 @@ class EventSourceTest extends DDSpecification{
     "Log Message"         | "logMessageQueue"         | new LogMessage()
     "Product Change"      | "productChanges"          | new ProductChange()
   }
-
 }


### PR DESCRIPTION
# What Does This Do

When support for **product change events** was added, it was not included in the `isEmpty` method.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
