### PR TITLE
fix bug on proto schema extraction

### DIFF
--- a/dd-java-agent/instrumentation/protobuf/src/main/java/datadog/trace/instrumentation/protobuf_java/SchemaExtractor.java
+++ b/dd-java-agent/instrumentation/protobuf/src/main/java/datadog/trace/instrumentation/protobuf_java/SchemaExtractor.java
@@ -44,6 +44,9 @@ public class SchemaExtractor implements SchemaIterator {
     this.descriptor = descriptor;
   }
 
+  /**
+   * @return false if no more properties should be extracted
+   */
   public static boolean extractProperty(
       FieldDescriptor field,
       String schemaName,
@@ -107,9 +110,7 @@ public class SchemaExtractor implements SchemaIterator {
       case TYPE_MESSAGE:
         ref = "#/components/schemas/" + field.getMessageType().getFullName();
         // Recursively add nested message schemas
-        if (!extractSchema(field.getMessageType(), builder, depth)) {
-          return false;
-        }
+        extractSchema(field.getMessageType(), builder, depth);
         builder.addToHash(field.getMessageType().getFullName());
         break;
       case TYPE_BYTES:
@@ -154,22 +155,20 @@ public class SchemaExtractor implements SchemaIterator {
         schemaName, fieldName, array, type, description, ref, format, enumValues, extensions);
   }
 
-  public static boolean extractSchema(Descriptor descriptor, SchemaBuilder builder, int depth) {
+  public static void extractSchema(Descriptor descriptor, SchemaBuilder builder, int depth) {
     depth++;
     String schemaName = descriptor.getFullName();
-    if (!builder.shouldExtractSchema(schemaName, depth)) {
-      return false;
-    }
-    // iterate fields in number order to ensure hash stability
-    for (FieldDescriptor field :
-        descriptor.getFields().stream()
-            .sorted(Comparator.comparingInt(FieldDescriptor::getNumber))
-            .collect(Collectors.toList())) {
-      if (!extractProperty(field, schemaName, field.getName(), builder, depth)) {
-        return false;
+    if (builder.shouldExtractSchema(schemaName, depth)) {
+      for (FieldDescriptor field :
+          descriptor.getFields().stream()
+              // iterate fields in number order to ensure hash stability
+              .sorted(Comparator.comparingInt(FieldDescriptor::getNumber))
+              .collect(Collectors.toList())) {
+        if (!extractProperty(field, schemaName, field.getName(), builder, depth)) {
+          break; // we have reached the max nb of properties to extract
+        }
       }
     }
-    return true;
   }
 
   public static Schema extractSchemas(Descriptor descriptor) {

--- a/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
@@ -2,6 +2,7 @@ package com.datadog.instrumentation.protobuf
 
 import com.datadog.instrumentation.protobuf.generated.Message.MyMessage
 import com.datadog.instrumentation.protobuf.generated.Message.OtherMessage
+import com.datadog.instrumentation.protobuf.generated.Message.RecursiveMessage
 import com.google.protobuf.InvalidProtocolBufferException
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
@@ -16,11 +17,68 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
     return true
   }
 
-  String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"value\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"type\":\"string\"},\"other_message\":{\"extensions\":{\"x-protobuf-number\":\"3\"},\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"age\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
-  String expectedSchemaID = "4690647329509494987"
-
-
   void 'test extract protobuf schema on serialize & deserialize'() {
+
+    String expectedSchema = "{" +
+      '   "components":{' +
+      '      "schemas":{' +
+      '         "com.datadog.instrumentation.protobuf.generated.MyMessage":{' +
+      '            "properties":{' +
+      '               "id":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"1"' +
+      '                  },' +
+      '                  "type":"string"' +
+      '               },' +
+      '               "value":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"2"' +
+      '                  },' +
+      '                  "type":"string"' +
+      '               },' +
+      '               "other_message":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"3"' +
+      '                  },' +
+      '                  "items":{' +
+      '                     "$ref":"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage"' +
+      '                  },' +
+      '                  "type":"array"' +
+      '               },' +
+      '               "nested":{' +
+      '                  "$ref":"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage",' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"4"' +
+      '                  }' +
+      '               }' +
+      '            },' +
+      '            "type":"object"' +
+      '         },' +
+      '         "com.datadog.instrumentation.protobuf.generated.OtherMessage":{' +
+      '            "properties":{' +
+      '               "name":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"1"' +
+      '                  },' +
+      '                  "type":"string"' +
+      '               },' +
+      '               "age":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"2"' +
+      '                  },' +
+      '                  "format":"int32",' +
+      '                  "type":"integer"' +
+      '               }' +
+      '            },' +
+      '            "type":"object"' +
+      '         }' +
+      '      }' +
+      '   },' +
+      '   "openapi":"3.0.0"' +
+      '}'
+    expectedSchema = expectedSchema.replaceAll(" ", "") // the spaces are just here to make it readable
+    String expectedSchemaID = "2792908287829424040"
+
     setup:
     MyMessage message = MyMessage.newBuilder()
     .setId("1")
@@ -72,6 +130,94 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
             "$DDTags.SCHEMA_WEIGHT" 1
             "$DDTags.SCHEMA_TYPE" "protobuf"
             "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.MyMessage"
+            "$DDTags.SCHEMA_OPERATION" "deserialization"
+            "$DDTags.SCHEMA_ID" expectedSchemaID
+            defaultTags(false)
+          }
+        }
+      }
+    }
+  }
+
+  void 'test extract protobuf schema with recursive message'() {
+    String expectedSchema = '{' +
+      '   "components":{' +
+      '      "schemas":{' +
+      '         "com.datadog.instrumentation.protobuf.generated.RecursiveMessage":{' +
+      '            "properties":{' +
+      '               "value":{' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"1"' +
+      '                  },' +
+      '                  "format":"int32",' +
+      '                  "type":"integer"' +
+      '               },' +
+      '               "next":{' +
+      '                  "$ref":"#/components/schemas/com.datadog.instrumentation.protobuf.generated.RecursiveMessage",' +
+      '                  "extensions":{' +
+      '                     "x-protobuf-number":"2"' +
+      '                  }' +
+      '               }' +
+      '            },' +
+      '            "type":"object"' +
+      '         }' +
+      '      }' +
+      '   },' +
+      '   "openapi":"3.0.0"' +
+      '}'
+    expectedSchema = expectedSchema.replaceAll(" ", "") // the spaces are just here to make it readable
+    String expectedSchemaID = "8377547842972884891"
+
+    setup:
+    getTEST_DATA_STREAMS_MONITORING()
+    RecursiveMessage message = RecursiveMessage.newBuilder()
+      .setValue(12)
+      .build()
+    when:
+    byte[] bytes
+    runUnderTrace("parent_serialize") {
+      AgentSpan span = activeSpan()
+      span.setTag(DDTags.MANUAL_KEEP, true)
+      bytes = message.toByteArray()
+    }
+    runUnderTrace("parent_deserialize") {
+      AgentSpan span = activeSpan()
+      span.setTag(DDTags.MANUAL_KEEP, true)
+      MyMessage.parseFrom(bytes)
+    }
+    TEST_WRITER.waitForTraces(2)
+    then:
+    assertTraces(2, SORT_TRACES_BY_ID) {
+      trace(1) {
+        span {
+          hasServiceName()
+          operationName "parent_serialize"
+          resourceName "parent_serialize"
+          errored false
+          measured false
+          tags {
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
+            "$DDTags.SCHEMA_WEIGHT" 1
+            "$DDTags.SCHEMA_TYPE" "protobuf"
+            "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.RecursiveMessage"
+            "$DDTags.SCHEMA_OPERATION" "serialization"
+            "$DDTags.SCHEMA_ID" expectedSchemaID
+            defaultTags(false)
+          }
+        }
+      }
+      trace(1) {
+        span {
+          hasServiceName()
+          operationName "parent_deserialize"
+          resourceName "parent_deserialize"
+          errored false
+          measured false
+          tags {
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
+            "$DDTags.SCHEMA_WEIGHT" 1
+            "$DDTags.SCHEMA_TYPE" "protobuf"
+            "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.RecursiveMessage"
             "$DDTags.SCHEMA_OPERATION" "deserialization"
             "$DDTags.SCHEMA_ID" expectedSchemaID
             defaultTags(false)

--- a/dd-java-agent/instrumentation/protobuf/src/test/proto/message.proto
+++ b/dd-java-agent/instrumentation/protobuf/src/test/proto/message.proto
@@ -1,3 +1,5 @@
+// run gradle target generateTestProto when you modify this
+
 syntax = "proto3";
 
 package com.datadog.instrumentation.protobuf.generated;
@@ -12,4 +14,9 @@ message MyMessage {
   string value = 2;
   repeated OtherMessage other_message = 3;
   OtherMessage nested = 4;
+}
+
+message RecursiveMessage {
+  int32 value = 1;
+  RecursiveMessage next = 2;
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -432,6 +432,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
   @Override
   public void clear() {
     timeToBucket.clear();
+    schemaSamplers.clear();
   }
 
   void report() {


### PR DESCRIPTION
# What Does This Do

Fix a bug in the protobuf instrumentation where schema extraction would stop on the first occurence of an already-extracted message

# Motivation

Noticed the bug as I was working on system tests. Basically, we didn't differentiate "stop" from "skip". A message already extracted, or reaching the max depth should be a "skip" event, while reaching max properties is a "stop" event (it's actually the only one I think).
With this fix, it means that we'll not stop extracting at exactly `maxProperties`. Once we reach it, we still "resolve" the properties up the hierarchy, but since that is capped too by `maxDepth`, the real max is `maxProperties + maxDepth`, which is close enough.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
