### PR TITLE
Exclude IBM Instana from IAST

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -39,6 +39,9 @@
 0 datadog.smoketest.*
 1 com.timgroup.statsd.*
 
+# -------- Agents -----------
+1. com.instana.*
+
 # -------- Libraries --------
 1 aj.org.objectweb.*
 1 akka.*


### PR DESCRIPTION
# What Does This Do
Exclude IBM Instana from IAST instrumentation. This avoids false positive on weak randomness, and hopefully also avoids performance or compatibility issues.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56799](https://datadoghq.atlassian.net/browse/APPSEC-56799)