### PR TITLE
Fix test name uniqueness

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
@@ -4,11 +4,11 @@ import datadog.communication.monitor.Counter
 import datadog.communication.monitor.Monitoring
 import datadog.communication.monitor.NoOpCounter
 import datadog.trace.api.StatsDClient
-import datadog.trace.test.util.DDSpecification
+import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-class CounterTest extends DDSpecification {
+class CounterTest extends Specification {
 
   def "counter counts stuff"() {
     StatsDClient statsd = Mock(StatsDClient)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -5,8 +5,8 @@ import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.RemoteApi
 import datadog.trace.common.writer.RemoteWriter
-import datadog.trace.test.util.DDSpecification
 import spock.lang.Ignore
+import spock.lang.Specification
 import spock.lang.Subject
 
 import java.util.concurrent.CountDownLatch
@@ -14,7 +14,7 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 
 
-class HealthMetricsTest extends DDSpecification {
+class HealthMetricsTest extends Specification {
   def statsD = Mock(StatsDClient)
 
   @Subject
@@ -25,6 +25,7 @@ class HealthMetricsTest extends DDSpecification {
   def "test onStart"() {
     setup:
     def writer = Mock(RemoteWriter)
+    def capacity = ThreadLocalRandom.current().nextInt()
 
     when:
     healthMetrics.onStart(writer)
@@ -32,9 +33,6 @@ class HealthMetricsTest extends DDSpecification {
     then:
     1 * writer.getCapacity() >> capacity
     0 * _
-
-    where:
-    capacity = ThreadLocalRandom.current().nextInt()
   }
 
   def "test onShutdown"() {
@@ -150,6 +148,7 @@ class HealthMetricsTest extends DDSpecification {
     setup:
     def latch = new CountDownLatch(1)
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
+    def bytes = ThreadLocalRandom.current().nextInt(10000)
     healthMetrics.start()
 
     when:
@@ -162,9 +161,6 @@ class HealthMetricsTest extends DDSpecification {
 
     cleanup:
     healthMetrics.close()
-
-    where:
-    bytes = ThreadLocalRandom.current().nextInt(10000)
   }
 
   def "test onFailedSerialize"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -4,12 +4,12 @@ import datadog.communication.monitor.Monitoring
 import datadog.communication.monitor.NoOpRecording
 import datadog.communication.monitor.Recording
 import datadog.trace.api.StatsDClient
-import datadog.trace.test.util.DDSpecification
 import org.junit.jupiter.api.Assertions
+import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-class TimingTest extends DDSpecification {
+class TimingTest extends Specification {
 
   def "timer times stuff"() {
     setup:


### PR DESCRIPTION
# What Does This Do

This PR fixes test name uniqueness.

# Motivation

This will help with CI monitoring to keep track of test execution.

# Additional Notes

This also moved specification from `DDSpecification` to Spock `Specification` for the tests will be lighter.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
