### PR TITLE
Fix IAST Vulnerabilities stack trace generation when multiple vulnerabilities share location

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -77,7 +77,9 @@ public class Reporter {
     final VulnerabilityBatch batch = getOrCreateVulnerabilityBatch(span);
     if (batch != null) {
       batch.add(vulnerability);
-      if (Config.get().isIastStackTraceEnabled() && batch.getVulnerabilities() != null) {
+      if (Config.get().isIastStackTraceEnabled()
+          && batch.getVulnerabilities() != null
+          && vulnerability.getLocation().getStackId() == null) {
         String stackId =
             addVulnerabilityStackTrace(span, String.valueOf(batch.getVulnerabilities().size()));
         if (stackId != null) {


### PR DESCRIPTION
# What Does This Do

# Motivation

If multiple vulnerabilities share the same location, it is not necessary to generate the stack trace again, as they should share it

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56803]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56803]: https://datadoghq.atlassian.net/browse/APPSEC-56803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ