### PR TITLE
Skip mule-core 4.9.1 due to missing mule-artifact-ast:1.5.1 dependency

### DIFF
--- a/dd-java-agent/instrumentation/mule-4/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4/build.gradle
@@ -15,6 +15,7 @@ muzzle {
     group = 'org.mule.runtime'
     module = 'mule-core'
     versions = "[$muleVersion,)"
+    skipVersions = ['4.9.1'] // missing transitive dependency
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
@@ -24,20 +25,11 @@ muzzle {
     group = 'org.mule.runtime'
     module = 'mule-tracer-customization-impl'
     versions = "[$muleVersion,)"
+    skipVersions = ['4.9.1'] // missing transitive dependency
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
     additionalDependencies +="org.mule.runtime:mule-core:$muleVersion"
-  }
-  pass {
-    name = 'before-4.5.0'
-    group = 'org.mule.runtime'
-    module = 'mule-core'
-    versions = "[$muleVersion,)"
-    javaVersion = "17"
-    excludeDependency 'om.google.guava:guava'
-    excludeDependency 'com.google.code.findbugs:jsr305'
-    additionalDependencies +="org.mule.runtime:mule-tracer-customization-impl:$muleVersion"
   }
 
   fail {


### PR DESCRIPTION
# Motivation

Skip mule-core 4.9.1 due to missing mule-artifact-ast:1.5.1 dependency - looks like a partial deployment issue

also removed redundant muzzle block, which appears to duplicate one of the blocks above