### PR TITLE
Only fork jps when required

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -73,7 +73,7 @@ public final class TempLocationManager {
   private final class CleanupVisitor implements FileVisitor<Path> {
     private boolean shouldClean;
 
-    private final Set<String> pidSet = PidHelper.getJavaPids();
+    private Set<String> pidSet;
 
     private final boolean cleanSelf;
     private final Instant cutoff;
@@ -120,7 +120,14 @@ public final class TempLocationManager {
       // the JFR repository directories are under <basedir>/pid_<pid>
       String pid = fileName.startsWith(TEMPDIR_PREFIX) ? fileName.substring(4) : null;
       boolean isSelfPid = pid != null && pid.equals(PidHelper.getPid());
-      shouldClean |= cleanSelf ? isSelfPid : !isSelfPid && !pidSet.contains(pid);
+      if (cleanSelf) {
+        shouldClean |= isSelfPid;
+      } else if (!isSelfPid) {
+        if (pidSet == null) {
+          pidSet = PidHelper.getJavaPids(); // only fork jps when required
+        }
+        shouldClean |= !pidSet.contains(pid);
+      }
       if (shouldClean) {
         log.debug("Cleaning temporary location {}", dir);
       }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
@@ -239,7 +239,7 @@ public class TempLocationManagerTest {
     Files.createFile(otherTempdir.resolve("dummy"));
     boolean rslt =
         instance.cleanup(
-            selfCleanup, (long) (timeoutMs * (shouldSucceed ? 10 : 0.5d)), TimeUnit.MILLISECONDS);
+            selfCleanup, (long) (timeoutMs * (shouldSucceed ? 20 : 0.5d)), TimeUnit.MILLISECONDS);
     assertEquals(shouldSucceed, rslt);
   }
 


### PR DESCRIPTION
# Motivation

Ideally we wouldn't need to use `jps` at all, but we can still avoid calling it until necessary to reduce overhead - as well as reducing the risk of port collisions, such as reported in #8148

# Additional Notes

We might want to introduce a `CachingSupplier` helper class or similar to simplify this approach if we end up using it in more places.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
