### PR TITLE
Actually use CleanupTask in TempLocationManager

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -294,7 +294,7 @@ public final class TempLocationManager {
     tempDir = baseTempDir.resolve(TEMPDIR_PREFIX + pid);
     if (runStartupCleanup) {
       // do not execute the background cleanup task when running in tests
-      AgentTaskScheduler.INSTANCE.execute(() -> cleanup(false));
+      AgentTaskScheduler.INSTANCE.execute(cleanupTask);
     }
 
     Thread selfCleanup =


### PR DESCRIPTION
# Motivation

This task was never scheduled or executed, but its countdown-latch was waited on during shutdown.

This resulted in the following log message each time a process was launched with profiling enabled:
```
[dd.trace 2025-02-18 15:07:21:489 +0000] [Temp Location Manager Cleanup] INFO com.datadog.profiling.controller.TempLocationManager - Cleanup task timed out. /var/folders/6l/65lfwqj14ps6w4gt7495gly80000gq/T/ddprof/pid_4866 temp directory might not have been cleaned up properly
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
