### PR TITLE
Revert "FIXME: temporarily ignore hostname assertions on CircleCI (#8411)"

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -20,6 +20,7 @@ import delight.fileupload.FileUpload;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -257,8 +258,7 @@ class JFRBasedProfilingIntegrationTest {
       assertEquals("smoke-test-java-app", requestTags.get("service"));
       assertEquals("jvm", requestTags.get("language"));
       assertNotNull(requestTags.get("runtime-id"));
-      // FIXME: temporarily ignore this assertion on CircleCI
-      // assertEquals(InetAddress.getLocalHost().getHostName(), requestTags.get("host"));
+      assertEquals(InetAddress.getLocalHost().getHostName(), requestTags.get("host"));
 
       assertFalse(logHasErrors(logFilePath));
       IItemCollection events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(rawJfr.get()));

--- a/telemetry/src/test/groovy/datadog/telemetry/HostInfoTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/HostInfoTest.groovy
@@ -35,8 +35,7 @@ class HostInfoTest extends Specification {
     Assume.assumeTrue('uname -a'.execute().waitFor() == 0)
 
     expect:
-    // FIXME: temporarily ignore this assertion on CircleCI
-    // HostInfo.getHostname() == 'uname -n'.execute().text.trim()
+    HostInfo.getHostname() == 'uname -n'.execute().text.trim()
     HostInfo.getOsName() == 'uname -s'.execute().text.trim()
     HostInfo.getKernelName() == 'uname -s'.execute().text.trim()
     if (Platform.isMac()) {


### PR DESCRIPTION
Revert "FIXME: temporarily ignore hostname assertions on CircleCI (#8411)

This reverts commit ebdbdd43a21b0c229ba18441eac014ee509d8489.

Circle CI confirmed this was an issue on their side, and it should be fixed now.

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
