### PR TITLE
Add support for JBoss jar:file format to DependencyResolver

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -71,7 +71,9 @@ public class DependencyResolver {
       path = path.substring("file:".length());
       final int sepIdx = path.indexOf("!/");
       if (sepIdx == -1) {
-        throw new IllegalArgumentException("Invalid nested jar path: " + path);
+        // JBoss may use the "jar:file" format to reference jar files instead of nested jars.
+        // These look like: jar:file:/path/to.jar!/
+        return JarReader.readJarFile(path);
       }
       final String outerPath = path.substring(0, sepIdx);
       final String innerPath = path.substring(sepIdx + 2);


### PR DESCRIPTION
# What Does This Do

- Add support for JBoss jar:file format to DependencyResolver
- improve tests

# Motivation

The current implementation only considered dependency analysis with the `jar:file` format for nested jars. However, thanks to the bug reported in APPSEC-56111, we discovered that this format is also used in JBoss to reference jar files instead of nested jars

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56111]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56111]: https://datadoghq.atlassian.net/browse/APPSEC-56111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ