### PR TITLE
Fix ignite-2.0 latestDepTest compilation

### DIFF
--- a/dd-java-agent/instrumentation/ignite-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ignite-2.0/build.gradle
@@ -1,6 +1,10 @@
 ext {
   // See https://ignite.apache.org/docs/latest/quick-start/java#running-ignite-with-java-11-or-later
+  // FIXME: Because of this condition, tests only run in Java 8, and latestDepTest never run, as they require Java 11+.
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
+  // ignite 2.17.0+ requires Java 11+
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+  latestDepForkedTestMinJavaVersionForTests = JavaVersion.VERSION_11
 }
 
 muzzle {
@@ -21,6 +25,10 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
+// ignite 2.16.0 latest version compatible with Java 8
+addTestSuiteForDir('ignite216Test', 'test')
+addTestSuiteExtendingForDir('ignite216ForkedTest', 'ignite216Test', 'test')
 
 dependencies {
   compileOnly group: 'org.apache.ignite', name: 'ignite-core', version: '2.0.0'
@@ -28,6 +36,15 @@ dependencies {
   testImplementation group: 'org.apache.ignite', name: 'ignite-core', version: '2.0.0'
   testImplementation group: 'org.apache.ignite', name: 'ignite-indexing', version: '2.0.0'
 
+  ignite216TestImplementation group: 'org.apache.ignite', name: 'ignite-core', version: '2.16.0'
+  ignite216TestImplementation group: 'org.apache.ignite', name: 'ignite-indexing', version: '2.16.0'
+
   latestDepTestImplementation group: 'org.apache.ignite', name: 'ignite-core', version: '2.+'
   latestDepTestImplementation group: 'org.apache.ignite', name: 'ignite-indexing', version: '2.+'
+}
+
+for (task in ['compileLatestDepTestGroovy', 'compileLatestDepForkedTestGroovy']) {
+  tasks.named(task, GroovyCompile) {
+    it.javaLauncher = getJavaLauncherFor(11)
+  }
 }


### PR DESCRIPTION
# What Does This Do
* Set latestDepTest for ignite-2.0 compile with Java 11+, since ignite-2.17.0+ requires it (discovered on dependency bump: https://github.com/DataDog/dd-trace-java/pull/8398).
* Add a new test variant for ignite 2.16.0 (last version compatible with Java 8).
* Note that latestDepTest do not run with Java 11+. This was an old problem, and still not addressed by this PR.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
