### PR TITLE
Add log warning in AgentJarIndex if an entryKey has multiple prefixIds.

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -145,9 +145,8 @@ public final class AgentJarIndex {
           int existingPrefixId = prefixTrie.apply(entryKey);
           if (-1 != existingPrefixId && prefixId != existingPrefixId) {
             log.warn(
-                "entryKey '{}' has multiple prefixIds: overriding existing prefixId with '{}'.",
-                entryKey,
-                prefixId);
+                "Detected duplicate content under this directory: '{}'. Ensure your content is under a distinct directory.",
+                entryKey);
           }
           prefixTrie.put(entryKey, prefixId);
           if (entryKey.endsWith("*")) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -142,7 +142,8 @@ public final class AgentJarIndex {
       if (null != prefixRoot) {
         String entryKey = computeEntryKey(prefixRoot.relativize(file));
         if (null != entryKey) {
-          if (-1 != prefixTrie.apply(entryKey)) {
+          int existingPrefixId = prefixTrie.apply(entryKey);
+          if (-1 != existingPrefixId && prefixId != existingPrefixId) {
             log.warn(
                 "entryKey '{}' has multiple prefixIds: overriding existing prefixId with '{}'.",
                 entryKey,

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -142,6 +142,12 @@ public final class AgentJarIndex {
       if (null != prefixRoot) {
         String entryKey = computeEntryKey(prefixRoot.relativize(file));
         if (null != entryKey) {
+          if (-1 != prefixTrie.apply(entryKey)) {
+            log.warn(
+                "entryKey '{}' has multiple prefixIds: overriding existing prefixId with '{}'.",
+                entryKey,
+                prefixId);
+          }
           prefixTrie.put(entryKey, prefixId);
           if (entryKey.endsWith("*")) {
             // optimization: wildcard will match everything under here so can skip

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -145,7 +145,7 @@ public final class AgentJarIndex {
           int existingPrefixId = prefixTrie.apply(entryKey);
           if (-1 != existingPrefixId && prefixId != existingPrefixId) {
             log.warn(
-                "Detected duplicate content under this directory: '{}'. Ensure your content is under a distinct directory.",
+                "Detected duplicate content under '{}'. Ensure your content is under a distinct directory.",
                 entryKey);
           }
           prefixTrie.put(entryKey, prefixId);


### PR DESCRIPTION
# What Does This Do

This PR adds a log warning when duplicated content is found in a directory of the AgentJarIndex. In this case, the AgentJarIndex will map the content to the last directory that the content was found under.

# Motivation

While developing #8314 UDS support, we came across the issue where certain classes were incorrectly added under multiple directories. Since the AgentJarIndex only maintains the last class-directory mapping, the indexing was incorrect and our build was unable to find the relevant classes. Adding this warning should help highlight this issue when content is duplicated.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
