### PR TITLE
Fix GHCR registry pruning

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,7 +87,7 @@ _Recovery:_ Check at the milestone for the related issues and update them manual
 
 ### prune-github-container-registry [🔗](prune-github-container-registry.yaml)
 
-_Trigger:_ Every week or manually.
+_Trigger:_ Every day or manually.
 
 _Action:_ Clean up old lib-injection OCI images from GitHub Container Registry.
 

--- a/.github/workflows/prune-github-container-registry.yaml
+++ b/.github/workflows/prune-github-container-registry.yaml
@@ -23,5 +23,5 @@ jobs:
           keep-tags: |
             latest_snapshot
           prune-tags-regexes: |
-            ^[a-z0-9]{40}$
+            ^[a-z0-9]{40}(-arm64|-amd64)?$
           prune-untagged: true


### PR DESCRIPTION
# What Does This Do

System tests start pushing new tags using architecture.
Those are new pruned from the registry.

# Motivation

Keep the registry healthy.

# Additional Notes

We can expect system tests disruption as we will reach API call limits when trying to clean up 10k tags from the registry.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-326]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-326]: https://datadoghq.atlassian.net/browse/LANGPLAT-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ