### PR TITLE
Fix Scalatest tracing for tests that are reported asynchronously

### DIFF
--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestInstrumentation.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.scalatest;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -11,14 +10,12 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
 import org.scalatest.Reporter;
 import org.scalatest.events.Event;
 
 @AutoService(InstrumenterModule.class)
 public class ScalatestInstrumentation extends InstrumenterModule.CiVisibility
-    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
 
   public ScalatestInstrumentation() {
     super("ci-visibility", "scalatest");
@@ -30,13 +27,10 @@ public class ScalatestInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   @Override
-  public String hierarchyMarkerType() {
-    return "org.scalatest.Reporter";
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "org.scalatest.DispatchReporter", "org.scalatest.tools.TestSortingReporter",
+    };
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Fixes https://github.com/DataDog/dd-trace-java/issues/8435

# Additional Notes

Scalatest instrumentation works by plugging into `org.scalatest.DispatchReporter` and intercepting events reported by the framework.
When running async test cases, another reporter is used: `org.scalatest.tools.TestSortingReporter`. This reporter stores received events in memory and reports them asynchronously, potentially in a different thread.
The fix is to intercept the events as they're passed to the async reporter (the same way it is done for dispatch reporter) and suppress interception when they're "re-fired" asynchronously (as they've already been traced at initial interception point).

I could not find a way to re-create the problem with instrumentation tests, so testing is covered by a new test-environment project: https://github.com/DataDog/test-environment/pull/382

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
