### PR TITLE
Remove warning log when JUnit 4 test method cannot be retrieved

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -139,7 +139,6 @@ public abstract class JUnit4Utils {
       return testClass.getMethod(methodName);
     } catch (NoSuchMethodException e) {
       LOGGER.debug("Could not get method named {} in class {}", methodName, testClass, e);
-      LOGGER.warn("Could not get test method", e);
       return null;
     }
   }


### PR DESCRIPTION
# What Does This Do

Fixes https://github.com/DataDog/dd-trace-java/issues/8441

# Additional Notes

With some JUnit4-based frameworks (such as Scala MUnit) it is expected that the tracer cannot determine test case method (with Scala MUnit the necessary information is not available at runtime).
Therefore we should not be reporting this as a warning, and clutter the users' logs.
It will still be reported with debug logging level and will be available in telemetry logs.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
