### PR TITLE
Extend NonBlockingSemaphore and make release for 1-permit case atomic

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/NonBlockingSemaphore.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/NonBlockingSemaphore.java
@@ -66,7 +66,7 @@ public interface NonBlockingSemaphore {
     @Override
     public int release(final int count) {
       reset();
-      return available();
+      return 1;
     }
 
     @Override

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
@@ -1,7 +1,8 @@
 package com.datadog.iast.util
 
-import datadog.trace.test.util.DDSpecification
+
 import groovy.transform.CompileDynamic
+import spock.lang.Specification
 
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 @CompileDynamic
-class NonBlockingSemaphoreTest extends DDSpecification {
+class NonBlockingSemaphoreTest extends Specification {
 
   void 'test that the semaphore controls access to a shared resource (#permitCount)'(final int permitCount) {
     given:
@@ -71,6 +72,40 @@ class NonBlockingSemaphoreTest extends DDSpecification {
     2           | _
   }
 
+  void 'can never acquire more permits than the total'(final int permitCount) {
+    given:
+    final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
+
+    when:
+    final acquired = semaphore.acquire(permitCount+1)
+
+    then:
+    !acquired
+
+    where:
+    permitCount | _
+    1           | _
+    2           | _
+  }
+
+  void 'can perform extra releases'(final int permitCount) {
+    given:
+    final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
+
+    when:
+    for (int i = 0; i < permitCount * 2; i++) {
+      assert semaphore.release() == permitCount
+    }
+
+    then:
+    semaphore.available() == permitCount
+
+    where:
+    permitCount | _
+    1           | _
+    2           | _
+  }
+
   void 'reset helps recover when there is starvation (#permitCount)'(final int permitCount) {
     given:
     final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
@@ -97,24 +132,41 @@ class NonBlockingSemaphoreTest extends DDSpecification {
     given:
     final int threads = 100
     final semaphore = NonBlockingSemaphore.unlimited()
-    final latch = new CountDownLatch(threads)
-    final executors = Executors.newFixedThreadPool(threads)
 
     when:
     final acquired = (1..threads).collect {
-      executors.submit({
-        latch.countDown()
-        if (semaphore.acquire()) {
-          TimeUnit.MILLISECONDS.sleep(100)
-          semaphore.release()
-          return 1
-        }
-        return 0
-      } as Callable<Integer>)
-    }.collect { it.get() }.sum()
+      semaphore.acquire()? 1 : 0
+    }.collect { it }.sum()
 
     then:
     acquired == threads
     semaphore.available() == Integer.MAX_VALUE
+
+    when:
+    int availableAfterRelease = semaphore.release()
+
+    then:
+    availableAfterRelease == Integer.MAX_VALUE
+    semaphore.available() == Integer.MAX_VALUE
+
+    when:
+    semaphore.reset()
+
+    then:
+    semaphore.available() == Integer.MAX_VALUE
+  }
+
+  void 'cannot create a semaphore without at least 1 permit'() {
+    when:
+    NonBlockingSemaphore.withPermitCount(0)
+
+    then:
+    thrown(AssertionError)
+
+    when:
+    NonBlockingSemaphore.withPermitCount(-1)
+
+    then:
+    thrown(AssertionError)
   }
 }


### PR DESCRIPTION
# What Does This Do
* Move `NonBlockingSemaphore` to `internal-api`.
* Extend its tests.
* Make `release` for the boolean semaphore truly atomic. By definition, a release there always leads to `1` available. While first releasing and then getting the available count will return `0` or `1` inconsistently.

# Motivation
`NonBlockingSemaphore` was written originally for IAST, but we plan to reuse it in AppSec (https://github.com/DataDog/dd-trace-java/pull/8178), and it may be useful for others.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
