### PR TITLE
Fix Exception Replay with Lambda proxy classes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
@@ -6,9 +6,11 @@ import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
 import datadog.trace.util.ClassNameTrie;
 import java.util.Collections;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /** A class to filter out classes based on their package name. */
 public class ClassNameFiltering implements ClassNameFilter {
+  private static final Pattern LAMBDA_PROXY_CLASS_PATTERN = Pattern.compile(".*\\$\\$Lambda.*/.*");
 
   private final ClassNameTrie includeTrie;
   private final ClassNameTrie excludeTrie;
@@ -33,7 +35,12 @@ public class ClassNameFiltering implements ClassNameFilter {
   }
 
   public boolean isExcluded(String className) {
-    return includeTrie.apply(className) < 0 && excludeTrie.apply(className) > 0;
+    return (includeTrie.apply(className) < 0 && excludeTrie.apply(className) > 0)
+        || isLambdaProxyClass(className);
+  }
+
+  static boolean isLambdaProxyClass(String className) {
+    return LAMBDA_PROXY_CLASS_PATTERN.matcher(className).matches();
   }
 
   public static ClassNameFiltering allowAll() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
@@ -92,4 +92,25 @@ class ClassNameFilteringTest {
         new ClassNameFiltering(ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(config));
     assertTrue(classNameFiltering.isExcluded(input));
   }
+
+  @Test
+  void lambdaProxyClasses() {
+    // jdk8:  at
+    // datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda$231/1770027171.apply(<Unknown>:1000008)
+    // jdk11: at
+    // datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda$262/0x0000000800467040.apply(Unknown Source)
+    // jdk17:	at
+    // datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda$303/0x00000008013dd1f8.apply(Unknown Source)
+    // jdk21: at
+    // datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda/0x000000b801392c58.apply(Unknown Source)
+    assertTrue(
+        ClassNameFiltering.isLambdaProxyClass(
+            "datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda$231/1770027171"));
+    assertTrue(
+        ClassNameFiltering.isLambdaProxyClass(
+            "datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda$262/0x0000000800467040"));
+    assertTrue(
+        ClassNameFiltering.isLambdaProxyClass(
+            "at datadog.smoketest.debugger.ServerDebuggerTestApplication$$Lambda/0x000000b801392c58"));
+  }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -138,6 +139,8 @@ public class ServerDebuggerTestApplication {
       tracedMethodWithException(42, "foobar", 3.42, map, "var1", "var2", "var3");
     } else if ("deepOops".equals(arg)) {
       tracedMethodWithDeepException1(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    } else if ("lambdaOops".equals(arg)) {
+      tracedMethodWithLambdaException(42, "foobar", 3.42, map, "var1", "var2", "var3");
     } else {
       tracedMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
     }
@@ -213,6 +216,19 @@ public class ServerDebuggerTestApplication {
   private static void tracedMethodWithDeepException5(
       int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
     tracedMethodWithException(argInt, argStr, argDouble, argMap, argVar);
+  }
+
+  private static void tracedMethodWithLambdaException(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    throw toRuntimeException("lambdaOops");
+  }
+
+  private static RuntimeException toRuntimeException(String msg) {
+    return toException(RuntimeException::new, msg);
+  }
+
+  private static <S extends Throwable> S toException(Function<String, S> constructor, String msg) {
+    return constructor.apply(msg);
   }
 
   private static class AppDispatcher extends Dispatcher {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
@@ -50,7 +50,7 @@ public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_METHOD));
                 assertEquals(
                     "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_SIGNATURE));
-                assertEquals("133", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_LINE));
+                assertEquals("134", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_LINE));
                 codeOrigin.set(true);
               }
             }


### PR DESCRIPTION
# What Does This Do
If JVM is started with `-XX:+ShowHiddenFrames` lambda proxy classes dynamically generated are shown in the stacktraces which may be used in the fingerprinting for Exception Replay. The proxy class generated contains an id that is different for each loading of the class. Upon re-transformation this id is changing which led to a different fingerprint for the same stacktrace which will trigger a new instrumentation and a re-transformation. And again new fingerprint... We are fixing this by filtering out lambda proxy classes if detected.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3500]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3500]: https://datadoghq.atlassian.net/browse/DEBUG-3500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ