### PR TITLE
Test more getters to improve coverage in datadog.trace.api.Config

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1,6 +1,10 @@
 package datadog.trace.api
 
+import datadog.trace.api.config.IastConfig
 import datadog.trace.api.env.FixedCapturedEnvironment
+import datadog.trace.api.iast.IastContext
+import datadog.trace.api.iast.IastDetectionMode
+import datadog.trace.api.iast.telemetry.Verbosity
 import datadog.trace.bootstrap.config.provider.AgentArgsInjector
 import datadog.trace.bootstrap.config.provider.ConfigConverter
 import datadog.trace.bootstrap.config.provider.ConfigProvider
@@ -258,6 +262,27 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(EXCEPTION_REPLAY_ENABLED, "true")
     prop.setProperty(TRACE_X_DATADOG_TAGS_MAX_LENGTH, "128")
 
+    //IAST properties
+    prop.setProperty(IastConfig.IAST_WEAK_HASH_ALGORITHMS, "SHA1,MD5")
+    prop.setProperty(IastConfig.IAST_DEBUG_ENABLED, "true")
+    prop.setProperty(IastConfig.IAST_TELEMETRY_VERBOSITY, "DEBUG")
+    prop.setProperty(IastConfig.IAST_DETECTION_MODE, "FULL")
+    prop.setProperty(IastConfig.IAST_REDACTION_ENABLED, "true")
+    prop.setProperty(IastConfig.IAST_REDACTION_NAME_PATTERN, ".*password.*")
+    prop.setProperty(IastConfig.IAST_REDACTION_VALUE_PATTERN, ".*secret.*")
+    prop.setProperty(IastConfig.IAST_STACK_TRACE_LEAK_SUPPRESS, "false")
+    prop.setProperty(IastConfig.IAST_STACKTRACE_LEAK_SUPPRESS_DEPRECATED, "false") // Deprecated alias
+    prop.setProperty(IastConfig.IAST_HARDCODED_SECRET_ENABLED, "true")
+    prop.setProperty(IastConfig.IAST_TRUNCATION_MAX_VALUE_LENGTH, "1024")
+    prop.setProperty(IastConfig.IAST_CONTEXT_MODE, "GLOBAL")
+    prop.setProperty(IastConfig.IAST_ANONYMOUS_CLASSES_ENABLED, "false")
+    prop.setProperty(IastConfig.IAST_SOURCE_MAPPING_ENABLED, "true")
+    prop.setProperty(IastConfig.IAST_SOURCE_MAPPING_MAX_SIZE, "500")
+    prop.setProperty(IastConfig.IAST_EXPERIMENTAL_PROPAGATION_ENABLED, "false")
+    prop.setProperty(IastConfig.IAST_STACK_TRACE_ENABLED, "true")
+    prop.setProperty(IastConfig.IAST_SECURITY_CONTROLS_CONFIGURATION, "/etc/iast/security-config.json")
+    prop.setProperty(IastConfig.IAST_DB_ROWS_TO_TAINT, "5")
+
     when:
     Config config = Config.get(prop)
 
@@ -350,6 +375,27 @@ class ConfigTest extends DDSpecification {
     config.debuggerExceptionEnabled == true
 
     config.xDatadogTagsMaxLength == 128
+
+    //iast properties
+    config.getIastWeakHashAlgorithms() == ["SHA1", "MD5"] as Set
+    config.isIastDebugEnabled()
+    config.getIastTelemetryVerbosity() == Verbosity.DEBUG
+    config.getIastDetectionMode() == IastDetectionMode.FULL
+    config.isIastRedactionEnabled()
+    config.getIastRedactionNamePattern() == ".*password.*"
+    config.getIastRedactionValuePattern() == ".*secret.*"
+    !config.isIastStacktraceLeakSuppress()
+    config.isIastHardcodedSecretEnabled()
+    config.getIastTruncationMaxValueLength() == 1024
+    config.getIastContextMode() == IastContext.Mode.GLOBAL
+    !config.isIastAnonymousClassesEnabled()
+    config.isIastSourceMappingEnabled()
+    config.getIastSourceMappingMaxSize() == 500
+    !config.isIastExperimentalPropagationEnabled()
+    config.isIastStackTraceEnabled()
+    config.getIastSecurityControlsConfiguration() == "/etc/iast/security-config.json"
+    config.getIastDbRowsToTaint() == 5
+
   }
 
   def "specify overrides via system properties"() {


### PR DESCRIPTION
# What Does This Do

Test more properties to raise datadog.trace.api.Config coverage

# Motivation

task ':internal-api:jacocoTestCoverageVerification' is failing due to current datadog.trace.api.Config coverage it's lower than 0.8

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
