### PR TITLE
Don't instrument trigger probes if the distributed debugger is disabled

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-el/build.gradle
@@ -12,7 +12,8 @@ excludedClassesCoverage += [
   'com.datadog.debugger.el.Script*',
   'com.datadog.debugger.el.ValueScript*',
   'com.datadog.debugger.el.values.CollectionValue*',
-  'com.datadog.debugger.el.InvalidValueException'
+  'com.datadog.debugger.el.InvalidValueException',
+  'com.datadog.debugger.el.EvaluationException'
 ]
 
 dependencies {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
@@ -26,12 +26,14 @@ public class EvaluationException extends RuntimeException {
     }
 
     EvaluationException that = (EvaluationException) o;
-    return Objects.equals(getMessage(), that.getMessage())
-        && Objects.equals(getExpr(), that.getExpr());
+    return Objects.equals(getExpr(), that.getExpr())
+        && Objects.equals(getMessage(), that.getMessage());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getExpr());
+    int result = Objects.hashCode(getExpr());
+    result = 31 * result + Objects.hashCode(getMessage());
+    return result;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el;
 
+import java.util.Objects;
+
 public class EvaluationException extends RuntimeException {
   private final String expr;
 
@@ -15,5 +17,21 @@ public class EvaluationException extends RuntimeException {
 
   public String getExpr() {
     return expr;
+  }
+
+  @Override
+  public final boolean equals(Object o) {
+    if (!(o instanceof EvaluationException)) {
+      return false;
+    }
+
+    EvaluationException that = (EvaluationException) o;
+    return Objects.equals(getMessage(), that.getMessage())
+        && Objects.equals(getExpr(), that.getExpr());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getExpr());
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -634,7 +634,10 @@ public class DebuggerTransformer implements ClassFileTransformer {
       // Log and span decoration probe shared the same instrumentor: CaptureContextInstrumentor
       // and therefore need to be instrumented once
       // note: exception probes are log probes and are handled the same way
-      if (isCapturedContextProbe(definition)) {
+      if (!Config.get().isDistributedDebuggerEnabled() && definition instanceof TriggerProbe) {
+        log.debug(
+            "The distributed debugger feature is disabled. Trigger probes will not be installed.");
+      } else if (isCapturedContextProbe(definition)) {
         if (definition.isLineProbe()) {
           capturedContextLineProbes
               .computeIfAbsent(definition.getWhere(), key -> new ArrayList<>())

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -59,10 +59,6 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
         .instrument();
   }
 
-  public String getSessionId() {
-    return sessionId;
-  }
-
   public TriggerProbe setSessionId(String sessionId) {
     this.sessionId = sessionId;
     return this;
@@ -86,6 +82,7 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
   public void evaluate(
       CapturedContext context, CapturedContext.Status status, MethodLocation location) {
 
+    Sampling sampling = getSampling();
     if (sampling == null || !sampling.inCoolDown()) {
       boolean sample = true;
       if (!hasCondition()) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/trigger/TriggerProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/trigger/TriggerProbeTest.java
@@ -5,11 +5,14 @@ import static com.datadog.debugger.util.TestHelper.setFieldInConfig;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
 
 import com.datadog.debugger.agent.CapturingTestBase;
 import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.agent.MockSampler;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.probe.Sampling;
 import com.datadog.debugger.probe.TriggerProbe;
@@ -50,6 +53,53 @@ public class TriggerProbeTest extends CapturingTestBase {
 
     setFieldInConfig(Config.get(), "debuggerCodeOriginEnabled", true);
     setFieldInConfig(InstrumenterConfig.get(), "codeOriginEnabled", true);
+    setFieldInConfig(Config.get(), "distributedDebuggerEnabled", true);
+  }
+
+  @Test
+  public void conditions() throws IOException, URISyntaxException {
+    final String className = "com.datadog.debugger.TriggerProbe02";
+    TriggerProbe probe1 =
+        createTriggerProbe(
+            TRIGGER_PROBE_ID1,
+            TRIGGER_PROBE_SESSION_ID,
+            className,
+            "entry",
+            "(int)",
+            new ProbeCondition(when(lt(ref("value"), value(25))), "value < 25"),
+            new Sampling(10.0));
+    installProbes(Configuration.builder().setService(SERVICE_NAME).add(probe1).build());
+    Class<?> testClass = compileAndLoadClass(className);
+    for (int i = 0; i < 100; i++) {
+      Reflect.onClass(testClass).call("main", i).get();
+    }
+    List<List<? extends MutableSpan>> allTraces = traceInterceptor.getAllTraces();
+    long count =
+        allTraces.stream()
+            .map(span -> span.get(0))
+            .filter(
+                span -> {
+                  DDSpan ddSpan = (DDSpan) span;
+                  PropagationTags tags = ddSpan.context().getPropagationTags();
+                  return (TRIGGER_PROBE_SESSION_ID + ":1").equals(tags.getDebugPropagation());
+                })
+            .count();
+    assertEquals(100, allTraces.size(), "actual traces: " + allTraces.size());
+    assertTrue(count <= 25, "Should have at most 25 debug sessions.  found: " + count);
+  }
+
+  private static TriggerProbe createTriggerProbe(
+      ProbeId id,
+      String sessionId,
+      String typeName,
+      String methodName,
+      String signature,
+      ProbeCondition probeCondition,
+      Sampling sampling) {
+    return new TriggerProbe(id, Where.of(typeName, methodName, signature))
+        .setSessionId(sessionId)
+        .setProbeCondition(probeCondition)
+        .setSampling(sampling);
   }
 
   @Test
@@ -105,6 +155,58 @@ public class TriggerProbeTest extends CapturingTestBase {
   }
 
   @Test
+  public void badCondition() throws IOException, URISyntaxException {
+    String className = "com.datadog.debugger.TriggerProbe02";
+    TriggerProbe probe1 =
+        createTriggerProbe(
+            TRIGGER_PROBE_ID1,
+            TRIGGER_PROBE_SESSION_ID,
+            className,
+            "entry",
+            "(int)",
+            new ProbeCondition(when(lt(ref("limit"), value(25))), "limit < 25"),
+            new Sampling(10.0));
+
+    installProbes(Configuration.builder().setService(SERVICE_NAME).add(probe1).build());
+    Class<?> testClass = compileAndLoadClass(className);
+    Reflect.onClass(testClass).call("main", 0).get();
+    verify(probeStatusSink)
+        .addError(
+            eq(TRIGGER_PROBE_ID1),
+            eq(new EvaluationException("Cannot find symbol: limit", "limit")));
+  }
+
+  @Test
+  public void debuggerDisabled() throws IOException, URISyntaxException {
+    boolean original = Config.get().isDistributedDebuggerEnabled();
+    try {
+      setFieldInConfig(Config.get(), "distributedDebuggerEnabled", false);
+
+      MockSampler sampler = new MockSampler();
+      ProbeRateLimiter.setSamplerSupplier(value -> sampler);
+
+      final String className = "com.datadog.debugger.TriggerProbe02";
+      TriggerProbe probe1 =
+          createTriggerProbe(
+              TRIGGER_PROBE_ID1,
+              TRIGGER_PROBE_SESSION_ID,
+              className,
+              "entry",
+              "(int)",
+              new ProbeCondition(when(lt(ref("value"), value(25))), "value < 25"),
+              new Sampling(10.0));
+      installProbes(Configuration.builder().setService(SERVICE_NAME).add(probe1).build());
+      Class<?> testClass = compileAndLoadClass(className);
+      Reflect.onClass(testClass).call("main", 0).get();
+
+      assertEquals(0, sampler.getCallCount());
+    } finally {
+      setFieldInConfig(Config.get(), "distributedDebuggerEnabled", original);
+      ProbeRateLimiter.setSamplerSupplier(null);
+    }
+  }
+
+  @Test
   public void sampling() throws IOException, URISyntaxException {
     try {
       MockSampler sampler = new MockSampler();
@@ -131,52 +233,5 @@ public class TriggerProbeTest extends CapturingTestBase {
     } finally {
       ProbeRateLimiter.setSamplerSupplier(null);
     }
-  }
-
-  @Test
-  public void conditions() throws IOException, URISyntaxException {
-
-    final String className = "com.datadog.debugger.TriggerProbe02";
-    TriggerProbe probe1 =
-        createTriggerProbe(
-            TRIGGER_PROBE_ID1,
-            TRIGGER_PROBE_SESSION_ID,
-            className,
-            "entry",
-            "(int)",
-            new ProbeCondition(when(lt(ref("value"), value(25))), "value < 25"),
-            new Sampling(10.0));
-    installProbes(Configuration.builder().setService(SERVICE_NAME).add(probe1).build());
-    Class<?> testClass = compileAndLoadClass(className);
-    for (int i = 0; i < 100; i++) {
-      Reflect.onClass(testClass).call("main", i).get();
-    }
-    List<List<? extends MutableSpan>> allTraces = traceInterceptor.getAllTraces();
-    long count =
-        allTraces.stream()
-            .map(span -> span.get(0))
-            .filter(
-                span -> {
-                  DDSpan ddSpan = (DDSpan) span;
-                  PropagationTags tags = ddSpan.context().getPropagationTags();
-                  return (TRIGGER_PROBE_SESSION_ID + ":1").equals(tags.getDebugPropagation());
-                })
-            .count();
-    assertEquals(100, allTraces.size(), "actual traces: " + allTraces.size());
-    assertTrue(count <= 25, "Should have at most 25 debug sessions.  found: " + count);
-  }
-
-  public static TriggerProbe createTriggerProbe(
-      ProbeId id,
-      String sessionId,
-      String typeName,
-      String methodName,
-      String signature,
-      ProbeCondition probeCondition,
-      Sampling sampling) {
-    return new TriggerProbe(id, Where.of(typeName, methodName, signature))
-        .setSessionId(sessionId)
-        .setProbeCondition(probeCondition)
-        .setSampling(sampling);
   }
 }


### PR DESCRIPTION
# What Does This Do

If the distributed debugger is disabled for a service, do not instrument any trigger probe definitions received from the backend.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3547]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3547]: https://datadoghq.atlassian.net/browse/DEBUG-3547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ