### PR TITLE
Fix Stable Config telemetry source names

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1213,13 +1213,13 @@ public class Agent {
     final String featureSystemProp = feature.getSystemProp();
     String featureEnabled = System.getProperty(featureSystemProp);
     if (featureEnabled == null) {
-      featureEnabled = getStableConfig(StableConfigSource.MANAGED, featureConfigKey);
+      featureEnabled = getStableConfig(StableConfigSource.FLEET, featureConfigKey);
     }
     if (featureEnabled == null) {
       featureEnabled = ddGetEnv(featureSystemProp);
     }
     if (featureEnabled == null) {
-      featureEnabled = getStableConfig(StableConfigSource.USER, featureConfigKey);
+      featureEnabled = getStableConfig(StableConfigSource.LOCAL, featureConfigKey);
     }
 
     if (feature.isEnabledByDefault()) {
@@ -1243,13 +1243,13 @@ public class Agent {
     final String featureSystemProp = feature.getSystemProp();
     String settingValue = getNullIfEmpty(System.getProperty(featureSystemProp));
     if (settingValue == null) {
-      settingValue = getNullIfEmpty(getStableConfig(StableConfigSource.MANAGED, featureConfigKey));
+      settingValue = getNullIfEmpty(getStableConfig(StableConfigSource.FLEET, featureConfigKey));
     }
     if (settingValue == null) {
       settingValue = getNullIfEmpty(ddGetEnv(featureSystemProp));
     }
     if (settingValue == null) {
-      settingValue = getNullIfEmpty(getStableConfig(StableConfigSource.USER, featureConfigKey));
+      settingValue = getNullIfEmpty(getStableConfig(StableConfigSource.LOCAL, featureConfigKey));
     }
 
     // defaults to inactive

--- a/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
@@ -8,9 +8,9 @@ public enum ConfigOrigin {
   /** configurations that are set through JVM properties */
   JVM_PROP("jvm_prop"),
   /** configuration read in the stable config file, managed by users */
-  USER_STABLE_CONFIG("user_stable_config"),
+  USER_STABLE_CONFIG("local_stable_config"),
   /** configuration read in the stable config file, managed by fleet */
-  MANAGED_STABLE_CONFIG("managed_stable_config"),
+  MANAGED_STABLE_CONFIG("fleet_stable_config"),
   /** set when the user has not set any configuration for the key (defaults to a value) */
   DEFAULT("default");
 

--- a/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
@@ -8,9 +8,9 @@ public enum ConfigOrigin {
   /** configurations that are set through JVM properties */
   JVM_PROP("jvm_prop"),
   /** configuration read in the stable config file, managed by users */
-  USER_STABLE_CONFIG("local_stable_config"),
+  LOCAL_STABLE_CONFIG("local_stable_config"),
   /** configuration read in the stable config file, managed by fleet */
-  MANAGED_STABLE_CONFIG("fleet_stable_config"),
+  FLEET_STABLE_CONFIG("fleet_stable_config"),
   /** set when the user has not set any configuration for the key (defaults to a value) */
   DEFAULT("default");
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -356,19 +356,19 @@ public final class ConfigProvider {
     if (configProperties.isEmpty()) {
       return new ConfigProvider(
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           new OtelEnvironmentConfigSource(),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
       return new ConfigProvider(
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           new PropertiesConfigSource(configProperties, true),
           new OtelEnvironmentConfigSource(configProperties),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     }
   }
@@ -382,20 +382,20 @@ public final class ConfigProvider {
       return new ConfigProvider(
           false,
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           new OtelEnvironmentConfigSource(),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
       return new ConfigProvider(
           false,
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           new PropertiesConfigSource(configProperties, true),
           new OtelEnvironmentConfigSource(configProperties),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     }
   }
@@ -411,21 +411,21 @@ public final class ConfigProvider {
     if (configProperties.isEmpty()) {
       return new ConfigProvider(
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           providedConfigSource,
           new OtelEnvironmentConfigSource(),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
       return new ConfigProvider(
           providedConfigSource,
           new SystemPropertiesConfigSource(),
-          StableConfigSource.MANAGED,
+          StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
           new PropertiesConfigSource(configProperties, true),
           new OtelEnvironmentConfigSource(configProperties),
-          StableConfigSource.USER,
+          StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/StableConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/StableConfigSource.java
@@ -12,15 +12,15 @@ import org.slf4j.LoggerFactory;
 public final class StableConfigSource extends ConfigProvider.Source {
   private static final Logger log = LoggerFactory.getLogger(StableConfigSource.class);
 
-  public static final String USER_STABLE_CONFIG_PATH =
+  public static final String LOCAL_STABLE_CONFIG_PATH =
       "/etc/datadog-agent/application_monitoring.yaml";
-  public static final String MANAGED_STABLE_CONFIG_PATH =
+  public static final String FLEET_STABLE_CONFIG_PATH =
       "/etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml";
-  public static final StableConfigSource USER =
-      new StableConfigSource(USER_STABLE_CONFIG_PATH, ConfigOrigin.USER_STABLE_CONFIG);
-  public static final StableConfigSource MANAGED =
+  public static final StableConfigSource LOCAL =
+      new StableConfigSource(LOCAL_STABLE_CONFIG_PATH, ConfigOrigin.LOCAL_STABLE_CONFIG);
+  public static final StableConfigSource FLEET =
       new StableConfigSource(
-          StableConfigSource.MANAGED_STABLE_CONFIG_PATH, ConfigOrigin.MANAGED_STABLE_CONFIG);
+          StableConfigSource.FLEET_STABLE_CONFIG_PATH, ConfigOrigin.FLEET_STABLE_CONFIG);
 
   private final ConfigOrigin fileOrigin;
 

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.groovy
@@ -14,7 +14,7 @@ class StableConfigSourceTest extends DDSpecification {
 
   def "test file doesn't exist"() {
     setup:
-    StableConfigSource config = new StableConfigSource(StableConfigSource.USER_STABLE_CONFIG_PATH, ConfigOrigin.USER_STABLE_CONFIG)
+    StableConfigSource config = new StableConfigSource(StableConfigSource.LOCAL_STABLE_CONFIG_PATH, ConfigOrigin.LOCAL_STABLE_CONFIG)
 
     expect:
     config.getKeys().size() == 0
@@ -27,7 +27,7 @@ class StableConfigSourceTest extends DDSpecification {
     if (filePath == null) {
       throw new AssertionError("Failed to create test file")
     }
-    StableConfigSource config = new StableConfigSource(filePath.toString(), ConfigOrigin.USER_STABLE_CONFIG)
+    StableConfigSource config = new StableConfigSource(filePath.toString(), ConfigOrigin.LOCAL_STABLE_CONFIG)
 
     then:
     config.getKeys().size() == 0
@@ -49,7 +49,7 @@ class StableConfigSourceTest extends DDSpecification {
       throw new AssertionError("Failed to write to file: ${e.message}")
     }
 
-    StableConfigSource cfg = new StableConfigSource(filePath.toString(), ConfigOrigin.USER_STABLE_CONFIG)
+    StableConfigSource cfg = new StableConfigSource(filePath.toString(), ConfigOrigin.LOCAL_STABLE_CONFIG)
 
     then:
     cfg.get("service") == "svc"
@@ -74,7 +74,7 @@ class StableConfigSourceTest extends DDSpecification {
       throw new AssertionError("Failed to write to file: ${e.message}")
     }
 
-    StableConfigSource stableCfg = new StableConfigSource(filePath.toString(), ConfigOrigin.USER_STABLE_CONFIG)
+    StableConfigSource stableCfg = new StableConfigSource(filePath.toString(), ConfigOrigin.LOCAL_STABLE_CONFIG)
 
     then:
     stableCfg.getConfigId() == null
@@ -100,7 +100,7 @@ class StableConfigSourceTest extends DDSpecification {
       throw new AssertionError("Failed to write to file: ${e.message}")
     }
 
-    StableConfigSource stableCfg = new StableConfigSource(filePath.toString(), ConfigOrigin.USER_STABLE_CONFIG)
+    StableConfigSource stableCfg = new StableConfigSource(filePath.toString(), ConfigOrigin.LOCAL_STABLE_CONFIG)
 
     then:
     for (key in configs.keySet()) {


### PR DESCRIPTION
# What Does This Do
This PR fixes Stable Config source names:
- `managed_stable_config` --> `fleet_stable_config`
- `user_stable_config` --> `local_stable_config`

# Motivation
Align with other languages, the RFC, & system tests. The goal is to enable system tests for Java.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: NOJIRA

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
