### PR TITLE
Look in another location for grpc service methods

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/MethodHandlersInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/MethodHandlersInstrumentation.java
@@ -53,7 +53,10 @@ public class MethodHandlersInstrumentation extends InstrumenterModule.Tracing
     public static void onEnter(@Advice.Argument(0) Object serviceImpl) {
       try {
         Class<?> serviceClass = serviceImpl.getClass();
-        Class<?> superClass = findImplBase(serviceClass);
+        Class<?> superClass = serviceClass.getSuperclass();
+        while (superClass != null && !superClass.getSimpleName().endsWith("ImplBase")) {
+          superClass = superClass.getSuperclass();
+        }
         if (superClass != null) {
           Method[] declaredMethods = superClass.getDeclaredMethods();
           // bindService() would be the only method in this case and it's irrelevant
@@ -76,14 +79,6 @@ public class MethodHandlersInstrumentation extends InstrumenterModule.Tracing
       } catch (Throwable e) {
         // this should be logged somehow
       }
-    }
-
-    public static Class<?> findImplBase(Class<?> serviceClass) {
-      Class<?> superclass = serviceClass.getSuperclass();
-      while (superclass != null && !superclass.getSimpleName().endsWith("ImplBase")) {
-        superclass = superclass.getSuperclass();
-      }
-      return superclass;
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

The version of grpc used by the tracer’s testing is older than the version used by logs-backend and so the generated code is slightly different.  In the tracer version, the proto interface gets generated into a `FooImplBase` for the proto type `foo`.  In logs-backed, `FooImplBase` implements an interface called `AsyncService` and all the pertinent method definitions are there instead.  The fix here, then, is to look first at the `ImplBase` type and if the only method is `bindService()`, look for the methods on the generated `AsyncService` interface instead.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3563]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3563]: https://datadoghq.atlassian.net/browse/DEBUG-3563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ