### PR TITLE
Remove all old testing OCI images

### DIFF
--- a/.github/workflows/prune-github-container-registry.yaml
+++ b/.github/workflows/prune-github-container-registry.yaml
@@ -20,8 +20,6 @@ jobs:
           container: dd-trace-java/dd-lib-java-init
           keep-younger-than: 7 # days
           keep-last: 10
-          keep-tags: |
-            latest_snapshot
           prune-tags-regexes: |
-            ^[a-z0-9]{40}(-arm64|-amd64)?$
+            .+
           prune-untagged: true


### PR DESCRIPTION
# What Does This Do

There is no point keep tags of old versions as 1. there are not used, 2. clean up is broken with multi-arch packaging.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-326]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-326]: https://datadoghq.atlassian.net/browse/LANGPLAT-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ