### PR TITLE
Consider modified tests when applying fail-fast tests ordering

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
@@ -29,7 +29,7 @@ public interface TestFrameworkModule {
 
   boolean isFlaky(@Nonnull TestIdentifier test);
 
-  boolean isModified(TestSourceData testSourceData);
+  boolean isModified(@Nonnull TestSourceData testSourceData);
 
   boolean isQuarantined(TestIdentifier test);
 
@@ -48,6 +48,12 @@ public interface TestFrameworkModule {
 
   @Nonnull
   TestExecutionPolicy executionPolicy(TestIdentifier test, TestSourceData testSource);
+
+  /**
+   * Returns the priority of the test execution that can be used for ordering tests. The higher the
+   * value, the higher the priority, meaning that the test should be executed earlier.
+   */
+  int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSource);
 
   void end(Long startTime);
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
@@ -100,7 +100,7 @@ public class ProxyTestModule implements TestFrameworkModule {
   }
 
   @Override
-  public boolean isModified(TestSourceData testSourceData) {
+  public boolean isModified(@Nonnull TestSourceData testSourceData) {
     return executionStrategy.isModified(testSourceData);
   }
 
@@ -129,6 +129,11 @@ public class ProxyTestModule implements TestFrameworkModule {
   @Nonnull
   public TestExecutionPolicy executionPolicy(TestIdentifier test, TestSourceData testSource) {
     return executionStrategy.executionPolicy(test, testSource);
+  }
+
+  @Override
+  public int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSource) {
+    return executionStrategy.executionPriority(test, testSource);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -85,7 +85,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
   }
 
   @Override
-  public boolean isModified(TestSourceData testSourceData) {
+  public boolean isModified(@Nonnull TestSourceData testSourceData) {
     return executionStrategy.isModified(testSourceData);
   }
 
@@ -114,6 +114,11 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
   @Nonnull
   public TestExecutionPolicy executionPolicy(TestIdentifier test, TestSourceData testSource) {
     return executionStrategy.executionPolicy(test, testSource);
+  }
+
+  @Override
+  public int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSource) {
+    return executionStrategy.executionPriority(test, testSource);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
@@ -115,6 +115,12 @@ public class NoOpTestEventsHandler<SuiteKey, TestKey>
   }
 
   @Override
+  public int executionPriority(
+      @Nullable TestIdentifier test, @Nonnull TestSourceData testSourceData) {
+    return 0;
+  }
+
+  @Override
   public void close() {
     // do nothing
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -300,6 +300,11 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
   }
 
   @Override
+  public int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSource) {
+    return testModule.executionPriority(test, testSource);
+  }
+
+  @Override
   public boolean isNew(@Nonnull TestIdentifier test) {
     return testModule.isNew(test);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -187,7 +187,7 @@ public class ExecutionStrategy {
     return detectionsUsed > threshold;
   }
 
-  public boolean isModified(TestSourceData testSourceData) {
+  public boolean isModified(@Nonnull TestSourceData testSourceData) {
     Class<?> testClass = testSourceData.getTestClass();
     if (testClass == null) {
       return false;
@@ -218,5 +218,29 @@ public class ExecutionStrategy {
     } else {
       return linesResolver.getMethodLines(testMethod);
     }
+  }
+
+  /**
+   * Returns the priority of the test execution that can be used for ordering tests. The higher the
+   * value, the higher the priority, meaning that the test should be executed earlier.
+   */
+  public int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSource) {
+    if (test == null) {
+      return 0;
+    }
+    if (isNew(test)) {
+      // execute new tests first
+      return 300;
+    }
+    if (isModified(testSource)) {
+      // then modified tests
+      return 200;
+    }
+    if (isFlaky(test)) {
+      // then tests known to be flaky
+      return 100;
+    }
+    // then the rest
+    return 0;
   }
 }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.IClass;
@@ -234,6 +235,7 @@ public abstract class TestNGUtils {
     }
   }
 
+  @Nonnull
   public static TestIdentifier toTestIdentifier(
       Method method, Object instance, Object[] parameters) {
     Class<?> testClass = instance != null ? instance.getClass() : method.getDeclaringClass();
@@ -243,6 +245,7 @@ public abstract class TestNGUtils {
     return new TestIdentifier(testSuiteName, testName, testParameters);
   }
 
+  @Nonnull
   public static TestIdentifier toTestIdentifier(ITestResult result) {
     String testSuiteName = result.getInstanceName();
     String testName =
@@ -251,6 +254,7 @@ public abstract class TestNGUtils {
     return new TestIdentifier(testSuiteName, testName, testParameters);
   }
 
+  @Nonnull
   public static TestSuiteDescriptor toSuiteDescriptor(ITestClass testClass) {
     String testSuiteName = testClass.getName();
     Class<?> testSuiteClass = testClass.getRealClass();

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -91,6 +91,12 @@ public interface TestEventsHandler<SuiteKey, TestKey> extends Closeable {
   TestExecutionPolicy executionPolicy(TestIdentifier test, TestSourceData source);
 
   /**
+   * Returns the priority of the test execution that can be used for ordering tests. The higher the
+   * value, the higher the priority, meaning that the test should be executed earlier.
+   */
+  int executionPriority(@Nullable TestIdentifier test, @Nonnull TestSourceData testSourceData);
+
+  /**
    * Returns the reason for skipping a test IF it can be skipped.
    *
    * @param test Test to be checked


### PR DESCRIPTION
# What Does This Do

When applying fail-fast tests ordering, "impacted tests" (test cases whose body was modified) are considered for reordering along with new and flaky tests.

# Additional Notes

"Execution priority" heuristic is added to the execution strategy to encapsulate ordering logic and reuse it for different testing frameworks.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1512]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1512]: https://datadoghq.atlassian.net/browse/SDTEST-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ