### PR TITLE
Bump grpc versions in tests to match the current logs-backend versions

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.9.4'
 }
 
 muzzle {
@@ -14,12 +14,12 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'idea'
 
 // First version with Mac M1 support
-def grpcVersion = '1.42.2'
+def grpcVersion = '1.62.2'
 protobuf {
   protoc {
     // Download compiler rather than using locally installed version:
     // First version with Mac M1 support
-    artifact = 'com.google.protobuf:protoc:3.17.3'
+    artifact = 'com.google.protobuf:protoc:3.25.5'
   }
   plugins {
     // First version with aarch support
@@ -35,6 +35,8 @@ addTestSuiteForDir('latestDepTest', 'test')
 dependencies {
   compileOnly group: 'io.grpc', name: 'grpc-core', version: grpcVersion
 
+  testImplementation group: 'io.grpc', name: 'grpc-core', version: grpcVersion
+  testImplementation group: 'io.grpc', name: 'grpc-inprocess', version: grpcVersion
   testImplementation group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
   testImplementation group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
   testImplementation group: 'io.grpc', name: 'grpc-stub', version: grpcVersion


### PR DESCRIPTION
# What Does This Do
The versions here lag behind what's currently in use in logs-backed by quite some bit.  This suggested PR bumps these versions up to something closer to parity with logs-backend.  We have resolved the issues this caused for us with code origins so the urgency is low but thought it might be a good time/reason to bump up versions.  I don't know either the policies around version bumps nor any nuances this change might cause so if it's deemed to risky or simply undesirable, that's ok.  I don't have a particular need for this upgrade beyond just trying to keep dependencies relatively up to date where possible.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
