### PR TITLE
Remove activeScope() use in OpenTracing shim

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
@@ -44,6 +44,7 @@ public class GlobalTracerInstrumentation extends InstrumenterModule.Tracing
       packageName + ".OTTextMapSetter",
       packageName + ".OTScopeManager",
       packageName + ".OTScopeManager$OTScope",
+      packageName + ".OTScopeManager$FakeScope",
       packageName + ".TypeConverter",
       packageName + ".OTSpan",
       packageName + ".OTSpanContext",

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -97,7 +97,7 @@ public class OTScopeManager implements ScopeManager {
     @Override
     public void close() {
       if (agentSpan == tracer.activeSpan()) {
-        tracer.closeActiveSpan();
+        tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
         throw new RuntimeException("Tried to close scope when not on top");
       } else {

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -99,9 +99,9 @@ public class OTScopeManager implements ScopeManager {
       if (agentSpan == tracer.activeSpan()) {
         tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
-        throw new RuntimeException("Tried to close scope when not on top");
+        throw new RuntimeException("Tried to close " + agentSpan + " scope when not on top");
       } else {
-        log.warn("Tried to close scope when not on top");
+        log.warn("Tried to close {} scope when not on top", agentSpan);
       }
     }
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.opentracing31;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -8,8 +9,12 @@ import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OTScopeManager implements ScopeManager {
+  static final Logger log = LoggerFactory.getLogger(OTScopeManager.class);
+
   private final TypeConverter converter;
   private final AgentTracer.TracerAPI tracer;
 
@@ -33,8 +38,12 @@ public class OTScopeManager implements ScopeManager {
   @Deprecated
   @Override
   public Scope active() {
+    AgentSpan agentSpan = tracer.activeSpan();
+    if (null == agentSpan) {
+      return null;
+    }
     // WARNING... Making an assumption about finishSpanOnClose
-    return converter.toScope(tracer.activeScope(), false);
+    return new OTScope(new FakeScope(agentSpan), false, converter);
   }
 
   static class OTScope implements Scope, TraceScope {
@@ -65,6 +74,35 @@ public class OTScopeManager implements ScopeManager {
 
     public boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
+    }
+  }
+
+  private final class FakeScope implements AgentScope {
+    private final AgentSpan agentSpan;
+
+    FakeScope(AgentSpan agentSpan) {
+      this.agentSpan = agentSpan;
+    }
+
+    @Override
+    public AgentSpan span() {
+      return agentSpan;
+    }
+
+    @Override
+    public byte source() {
+      return ScopeSource.MANUAL.id();
+    }
+
+    @Override
+    public void close() {
+      if (agentSpan == tracer.activeSpan()) {
+        tracer.closeActiveSpan();
+      } else if (Config.get().isScopeStrictMode()) {
+        throw new RuntimeException("Tried to close scope when not on top");
+      } else {
+        log.warn("Tried to close scope when not on top");
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -258,7 +258,7 @@ class OpenTracing31Test extends AgentTestRunner {
     firstScope.close()
 
     then:
-    tracer.scopeManager().active().delegate == secondScope.delegate
+    tracer.scopeManager().active().span() == secondScope.span()
     _ * TEST_PROFILING_CONTEXT_INTEGRATION._
     0 * _
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/GlobalTracerInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/GlobalTracerInstrumentation.java
@@ -35,6 +35,7 @@ public class GlobalTracerInstrumentation extends InstrumenterModule.Tracing
       packageName + ".OTTextMapInjectSetter",
       packageName + ".OTScopeManager",
       packageName + ".OTScopeManager$OTScope",
+      packageName + ".OTScopeManager$FakeScope",
       packageName + ".TypeConverter",
       packageName + ".OTSpan",
       packageName + ".OTSpanContext",

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -107,7 +107,7 @@ public class OTScopeManager implements ScopeManager {
     @Override
     public void close() {
       if (agentSpan == tracer.activeSpan()) {
-        tracer.closeActiveSpan();
+        tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
         throw new RuntimeException("Tried to close scope when not on top");
       } else {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -109,9 +109,9 @@ public class OTScopeManager implements ScopeManager {
       if (agentSpan == tracer.activeSpan()) {
         tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
-        throw new RuntimeException("Tried to close scope when not on top");
+        throw new RuntimeException("Tried to close " + agentSpan + " scope when not on top");
       } else {
-        log.warn("Tried to close scope when not on top");
+        log.warn("Tried to close {} scope when not on top", agentSpan);
       }
     }
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -273,7 +273,7 @@ class OpenTracing32Test extends AgentTestRunner {
     firstScope.close()
 
     then:
-    tracer.scopeManager().active().delegate == secondScope.delegate
+    tracer.scopeManager().active().span() == secondScope.span()
     _ * TEST_PROFILING_CONTEXT_INTEGRATION._
     0 * _
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -978,6 +978,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public void closeActiveSpan() {
+    AgentScope activeScope = this.scopeManager.active();
+    if (activeScope != null) {
+      activeScope.close();
+    }
+  }
+
+  @Override
   public AgentSpanContext notifyExtensionStart(Object event) {
     return LambdaHandler.notifyStartInvocation(this, event);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -978,7 +978,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public void closeActiveSpan() {
+  public void closeActive() {
     AgentScope activeScope = this.scopeManager.active();
     if (activeScope != null) {
       activeScope.close();

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -55,7 +55,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
       byte source = source();
       scopeManager.healthMetrics.onScopeCloseError(source);
       if (source == ScopeSource.MANUAL.id() && scopeManager.strictMode) {
-        throw new RuntimeException("Tried to close scope when not on top");
+        throw new RuntimeException("Tried to close " + span + " scope when not on top");
       }
     }
 

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -15,6 +15,7 @@ minimumInstructionCoverage = 0.5
 excludedClassesCoverage += [
   // This is mainly equals() and hashCode()
   "datadog.opentracing.OTScopeManager.OTScope",
+  "datadog.opentracing.OTScopeManager.FakeScope",
   "datadog.opentracing.OTSpan",
   "datadog.opentracing.OTSpanContext",
   "datadog.opentracing.CustomScopeManagerWrapper.CustomScopeState",

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -1,5 +1,6 @@
 package datadog.opentracing;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -8,9 +9,13 @@ import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** One of the two possible scope managers. See CustomScopeManagerWrapper */
 class OTScopeManager implements ScopeManager {
+  static final Logger log = LoggerFactory.getLogger(OTScopeManager.class);
+
   private final TypeConverter converter;
   private final AgentTracer.TracerAPI tracer;
 
@@ -39,8 +44,12 @@ class OTScopeManager implements ScopeManager {
   @Deprecated
   @Override
   public Scope active() {
+    AgentSpan agentSpan = tracer.activeSpan();
+    if (null == agentSpan) {
+      return null;
+    }
     // WARNING... Making an assumption about finishSpanOnClose
-    return converter.toScope(tracer.activeScope(), false);
+    return new OTScope(new FakeScope(agentSpan), false, converter);
   }
 
   @Override
@@ -83,16 +92,45 @@ class OTScopeManager implements ScopeManager {
         return false;
       }
       final OTScope otScope = (OTScope) o;
-      return delegate.equals(otScope.delegate);
+      return delegate.span().equals(otScope.delegate.span());
     }
 
     @Override
     public int hashCode() {
-      return delegate.hashCode();
+      return delegate.span().hashCode();
     }
 
     boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
+    }
+  }
+
+  private final class FakeScope implements AgentScope {
+    private final AgentSpan agentSpan;
+
+    FakeScope(AgentSpan agentSpan) {
+      this.agentSpan = agentSpan;
+    }
+
+    @Override
+    public AgentSpan span() {
+      return agentSpan;
+    }
+
+    @Override
+    public byte source() {
+      return ScopeSource.MANUAL.id();
+    }
+
+    @Override
+    public void close() {
+      if (agentSpan == tracer.activeSpan()) {
+        tracer.closeActiveSpan();
+      } else if (Config.get().isScopeStrictMode()) {
+        throw new RuntimeException("Tried to close scope when not on top");
+      } else {
+        log.warn("Tried to close scope when not on top");
+      }
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -125,7 +125,7 @@ class OTScopeManager implements ScopeManager {
     @Override
     public void close() {
       if (agentSpan == tracer.activeSpan()) {
-        tracer.closeActiveSpan();
+        tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
         throw new RuntimeException("Tried to close scope when not on top");
       } else {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -127,9 +127,9 @@ class OTScopeManager implements ScopeManager {
       if (agentSpan == tracer.activeSpan()) {
         tracer.closeActive();
       } else if (Config.get().isScopeStrictMode()) {
-        throw new RuntimeException("Tried to close scope when not on top");
+        throw new RuntimeException("Tried to close " + agentSpan + " scope when not on top");
       } else {
-        log.warn("Tried to close scope when not on top");
+        log.warn("Tried to close {} scope when not on top", agentSpan);
       }
     }
   }

--- a/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
+++ b/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
@@ -63,7 +63,6 @@ class OT33ApiTest extends DDSpecification {
 
     then:
     tracer.activeSpan().delegate == span.delegate
-    coreTracer.activeScope().span() == span.delegate
     coreTracer.activeSpan() == span.delegate
 
     cleanup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
@@ -40,7 +40,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope1.span() == span1
-    scopeManager.active().delegate == scope1
+    scopeManager.active().span().delegate == span1
     !spanFinished(span1)
 
     when:
@@ -54,7 +54,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope2.span() == span2
-    scopeManager.active().delegate == scope2
+    scopeManager.active().span().delegate == span2
     !spanFinished(span2)
 
     when:
@@ -69,7 +69,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope3.span() == span3
-    scopeManager.active().delegate == scope3
+    scopeManager.active().span().delegate == span3
     !spanFinished(span3)
 
     when:
@@ -96,7 +96,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope1.span() == span1
-    scopeManager.active().delegate == scope1
+    scopeManager.active().span().delegate == span1
     !spanFinished(span1)
 
     when:
@@ -110,7 +110,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope2.span() == span2
-    scopeManager.active().delegate == scope2
+    scopeManager.active().span().delegate == span2
     !spanFinished(span2)
 
     when:
@@ -124,7 +124,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope3.span() == span3
-    scopeManager.active().delegate == scope3
+    scopeManager.active().span().delegate == span3
     !spanFinished(span3)
 
     // close and finish the surrounding (non-iteration) span to complete the trace
@@ -150,7 +150,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope1.span() == span1
-    scopeManager.active().delegate == scope1
+    scopeManager.active().span().delegate == span1
     !spanFinished(span1)
 
     when:
@@ -168,7 +168,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope1A1.span() == span1A1
-    scopeManager.active().delegate == scope1A1
+    scopeManager.active().span().delegate == span1A1
     !spanFinished(span1A1)
 
     when:
@@ -182,7 +182,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     and:
     scope1A2.span() == span1A2
-    scopeManager.active().delegate == scope1A2
+    scopeManager.active().span().delegate == span1A2
     !spanFinished(span1A2)
 
     when:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -122,11 +122,13 @@ public class AgentTracer {
   }
 
   /**
-   * Closes the scope for the currently active span. Prefer closing the scope returned by {@link
-   * #activateSpan} when available.
+   * Closes the scope for the currently active span.
+   *
+   * @deprecated Prefer closing the scope returned by {@link #activateSpan} when available.
    */
-  public static void closeActiveSpan() {
-    get().closeActiveSpan();
+  @Deprecated
+  public static void closeActive() {
+    get().closeActive();
   }
 
   /**
@@ -318,6 +320,8 @@ public class AgentTracer {
 
     AgentScope.Continuation captureSpan(AgentSpan span);
 
+    void closeActive();
+
     void closePrevious(boolean finishSpan);
 
     AgentScope activateNext(AgentSpan span);
@@ -325,8 +329,6 @@ public class AgentTracer {
     AgentSpan activeSpan();
 
     AgentScope activeScope();
-
-    void closeActiveSpan();
 
     default AgentSpan blackholeSpan() {
       final AgentSpan active = activeSpan();
@@ -474,6 +476,9 @@ public class AgentTracer {
     public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {}
 
     @Override
+    public void closeActive() {}
+
+    @Override
     public void closePrevious(final boolean finishSpan) {}
 
     @Override
@@ -490,9 +495,6 @@ public class AgentTracer {
     public AgentScope activeScope() {
       return null;
     }
-
-    @Override
-    public void closeActiveSpan() {}
 
     @Override
     public AgentSpan blackholeSpan() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -122,6 +122,14 @@ public class AgentTracer {
   }
 
   /**
+   * Closes the scope for the currently active span. Prefer closing the scope returned by {@link
+   * #activateSpan} when available.
+   */
+  public static void closeActiveSpan() {
+    get().closeActiveSpan();
+  }
+
+  /**
    * Closes the immediately previous iteration scope. Should be called before creating a new span
    * for {@link #activateNext(AgentSpan)}.
    */
@@ -318,6 +326,8 @@ public class AgentTracer {
 
     AgentScope activeScope();
 
+    void closeActiveSpan();
+
     default AgentSpan blackholeSpan() {
       final AgentSpan active = activeSpan();
       return new BlackHoleSpan(active != null ? active.getTraceId() : DDTraceId.ZERO);
@@ -480,6 +490,9 @@ public class AgentTracer {
     public AgentScope activeScope() {
       return null;
     }
+
+    @Override
+    public void closeActiveSpan() {}
 
     @Override
     public AgentSpan blackholeSpan() {


### PR DESCRIPTION
# Motivation

This was only used to implement the deprecated 'active()' OpenTracing method. We take a best effort approach of using a 'fake' scope which lets the caller close the active scope if it matches the expected span, and otherwise logs a warning (or throws an exception in strict mode.)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-956]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-956]: https://datadoghq.atlassian.net/browse/APMAPI-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ