### PR TITLE
Add setUser to user monitoring SDK

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
@@ -3,6 +3,7 @@ package com.datadog.appsec.user
 import com.datadog.appsec.gateway.NoopFlow
 import datadog.appsec.api.blocking.BlockingContentType
 import datadog.appsec.api.blocking.BlockingException
+import datadog.appsec.api.user.User
 import datadog.trace.api.EventTracker
 import datadog.trace.api.GlobalTracer
 import datadog.trace.api.ProductTraceSource
@@ -31,6 +32,7 @@ import static datadog.trace.api.gateway.Events.EVENTS
 import static datadog.trace.api.telemetry.LoginEvent.LOGIN_FAILURE
 import static datadog.trace.api.telemetry.LoginEvent.LOGIN_SUCCESS
 import static datadog.trace.api.telemetry.LoginEvent.SIGN_UP
+import static datadog.appsec.api.user.User.setUser
 
 class AppSecEventTrackerSpecification extends DDSpecification {
 
@@ -72,6 +74,7 @@ class AppSecEventTrackerSpecification extends DDSpecification {
         }
       }
     GlobalTracer.setEventTracker(tracker)
+    User.setUserService(tracker)
     ActiveSubsystems.APPSEC_ACTIVE = true
   }
 
@@ -128,6 +131,30 @@ class AppSecEventTrackerSpecification extends DDSpecification {
     0 * _
   }
 
+  def 'test track user (SDK)'() {
+    when:
+    setUser(USER_ID, ['key1': 'value1', 'key2': 'value2'], propagated)
+
+    then:
+    1 * traceSegment.setTagTop('usr.id', USER_ID)
+    1 * traceSegment.setTagTop('usr', ['key1':'value1', 'key2':'value2'])
+    1 * traceSegment.setTagTop('_dd.appsec.user.collection_mode', SDK.fullName())
+    1 * traceSegment.setTagTop('asm.keep', true)
+    1 * traceSegment.setTagTop('_dd.p.ts', ProductTraceSource.ASM)
+    if (propagated) {
+      1 * traceSegment.setTagTop('_dd.p.usr.id', USER_ID.bytes.encodeBase64().toString())
+    } else {
+      0 * traceSegment.setTagTop('_dd.p.usr.id', _)
+    }
+    1 * user.apply(_ as RequestContext, USER_ID) >> NoopFlow.INSTANCE
+    0 * _
+
+    where:
+    propagated | _
+    true       | _
+    false      | _
+  }
+
   def 'test wrong event argument validation (SDK)'() {
     when:
     GlobalTracer.getEventTracker().trackLoginSuccessEvent(null, null)
@@ -161,6 +188,12 @@ class AppSecEventTrackerSpecification extends DDSpecification {
 
     when:
     GlobalTracer.getEventTracker().trackCustomEvent('', null)
+
+    then:
+    thrown IllegalArgumentException
+
+    when:
+    setUser(null, null)
 
     then:
     thrown IllegalArgumentException

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
@@ -133,7 +133,7 @@ class AppSecEventTrackerSpecification extends DDSpecification {
 
   def 'test track user (SDK)'() {
     when:
-    setUser(USER_ID, ['key1': 'value1', 'key2': 'value2'], propagated)
+    setUser(USER_ID, ['key1': 'value1', 'key2': 'value2'])
 
     then:
     1 * traceSegment.setTagTop('usr.id', USER_ID)
@@ -141,18 +141,8 @@ class AppSecEventTrackerSpecification extends DDSpecification {
     1 * traceSegment.setTagTop('_dd.appsec.user.collection_mode', SDK.fullName())
     1 * traceSegment.setTagTop('asm.keep', true)
     1 * traceSegment.setTagTop('_dd.p.ts', ProductTraceSource.ASM)
-    if (propagated) {
-      1 * traceSegment.setTagTop('_dd.p.usr.id', USER_ID.bytes.encodeBase64().toString())
-    } else {
-      0 * traceSegment.setTagTop('_dd.p.usr.id', _)
-    }
     1 * user.apply(_ as RequestContext, USER_ID) >> NoopFlow.INSTANCE
     0 * _
-
-    where:
-    propagated | _
-    true       | _
-    false      | _
   }
 
   def 'test wrong event argument validation (SDK)'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/EventTrackerAppSecDisabledForkedTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/EventTrackerAppSecDisabledForkedTest.groovy
@@ -1,6 +1,6 @@
 package com.datadog.appsec.user
 
-
+import datadog.appsec.api.user.User
 import datadog.trace.api.GlobalTracer
 import datadog.trace.api.UserIdCollectionMode
 import datadog.trace.api.appsec.AppSecEventTracker
@@ -26,7 +26,7 @@ class EventTrackerAppSecDisabledForkedTest extends DDSpecification {
   void setup() {
     tracker = new AppSecEventTracker()
     GlobalTracer.setEventTracker(tracker)
-
+    User.setUserService(tracker)
     traceSegment = Mock(TraceSegment)
     final tracer = Stub(AgentTracer.TracerAPI) {
       getTraceSegment() >> traceSegment

--- a/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecHttpServerTest.groovy
+++ b/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecHttpServerTest.groovy
@@ -4,7 +4,6 @@ import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.communication.monitor.Monitoring
 import datadog.trace.agent.test.base.WithHttpServer
 import datadog.trace.api.Config
-import datadog.trace.api.GlobalTracer
 import datadog.trace.api.appsec.AppSecEventTracker
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.gateway.SubscriptionService
@@ -26,8 +25,7 @@ abstract class AppSecHttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     sco.createRemaining(config)
     assert sco.configurationPoller(config) == null
     assert sco.monitoring instanceof Monitoring.DisabledMonitoring
-
-    GlobalTracer.setEventTracker(new AppSecEventTracker())
+    AppSecEventTracker.install()
 
     AppSecSystem.start(ss, sco)
   }

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -36,6 +36,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.experimental.DataStreamsContextCarrier',
   'datadog.trace.api.experimental.DataStreamsContextCarrier.NoOp',
   'datadog.appsec.api.blocking.*',
+  'datadog.appsec.api.user.*',
   // Default fallback methods to not break legacy API
   'datadog.trace.context.TraceScope',
   'datadog.trace.context.NoopTraceScope.NoopContinuation',

--- a/dd-trace-api/src/main/java/datadog/appsec/api/user/User.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/user/User.java
@@ -1,0 +1,40 @@
+package datadog.appsec.api.user;
+
+import java.util.Map;
+
+public class User {
+
+  private static volatile UserService SERVICE = UserService.NO_OP;
+
+  /**
+   * Controls the implementation for user service. The AppSec subsystem calls this method on
+   * startup. This can be called explicitly for e.g. testing purposes.
+   *
+   * @param service the implementation for the user service.
+   */
+  public static void setUserService(final UserService service) {
+    SERVICE = service;
+  }
+
+  /**
+   * Sets the user monitoring tags on the root span using the prefix {@code usr}
+   *
+   * @param id identifier of the user
+   * @param metadata custom metadata data represented as key/value map
+   */
+  public static void setUser(final String id, final Map<String, String> metadata) {
+    setUser(id, metadata, false);
+  }
+
+  /**
+   * Sets the user monitoring tags on the root span using the prefix {@code usr}
+   *
+   * @param id identifier of the user
+   * @param metadata custom metadata data represented as key/value map
+   * @param propagated propagate the id to downstream services
+   */
+  public static void setUser(
+      final String id, final Map<String, String> metadata, final boolean propagated) {
+    SERVICE.trackUserEvent(id, metadata, propagated);
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/user/User.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/user/User.java
@@ -23,18 +23,6 @@ public class User {
    * @param metadata custom metadata data represented as key/value map
    */
   public static void setUser(final String id, final Map<String, String> metadata) {
-    setUser(id, metadata, false);
-  }
-
-  /**
-   * Sets the user monitoring tags on the root span using the prefix {@code usr}
-   *
-   * @param id identifier of the user
-   * @param metadata custom metadata data represented as key/value map
-   * @param propagated propagate the id to downstream services
-   */
-  public static void setUser(
-      final String id, final Map<String, String> metadata, final boolean propagated) {
-    SERVICE.trackUserEvent(id, metadata, propagated);
+    SERVICE.trackUserEvent(id, metadata);
   }
 }

--- a/dd-trace-api/src/main/java/datadog/appsec/api/user/UserService.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/user/UserService.java
@@ -1,0 +1,15 @@
+package datadog.appsec.api.user;
+
+import java.util.Map;
+
+public interface UserService {
+
+  UserService NO_OP =
+      new UserService() {
+        @Override
+        public void trackUserEvent(
+            final String userId, final Map<String, String> metadata, final boolean propagated) {}
+      };
+
+  void trackUserEvent(String userId, Map<String, String> metadata, boolean propagated);
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/user/UserService.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/user/UserService.java
@@ -7,9 +7,8 @@ public interface UserService {
   UserService NO_OP =
       new UserService() {
         @Override
-        public void trackUserEvent(
-            final String userId, final Map<String, String> metadata, final boolean propagated) {}
+        public void trackUserEvent(final String userId, final Map<String, String> metadata) {}
       };
 
-  void trackUserEvent(String userId, Map<String, String> metadata, boolean propagated);
+  void trackUserEvent(String userId, Map<String, String> metadata);
 }

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -75,12 +75,11 @@ public class AppSecEventTracker extends EventTracker implements UserService {
   }
 
   @Override
-  public void trackUserEvent(
-      final String userId, final Map<String, String> metadata, final boolean propagated) {
+  public void trackUserEvent(final String userId, final Map<String, String> metadata) {
     if (userId == null || userId.isEmpty()) {
       throw new IllegalArgumentException("UserId is null or empty");
     }
-    onUserEvent(SDK, userId, metadata, propagated);
+    onUserEvent(SDK, userId, metadata);
   }
 
   public void onUserNotFound(final UserIdCollectionMode mode) {
@@ -103,14 +102,11 @@ public class AppSecEventTracker extends EventTracker implements UserService {
   }
 
   public void onUserEvent(final UserIdCollectionMode mode, final String userId) {
-    onUserEvent(mode, userId, emptyMap(), false);
+    onUserEvent(mode, userId, emptyMap());
   }
 
   public void onUserEvent(
-      final UserIdCollectionMode mode,
-      final String userId,
-      final Map<String, String> metadata,
-      final boolean propagated) {
+      final UserIdCollectionMode mode, final String userId, final Map<String, String> metadata) {
     if (!isEnabled(mode)) {
       return;
     }
@@ -128,9 +124,6 @@ public class AppSecEventTracker extends EventTracker implements UserService {
     }
     if (mode != SDK) {
       segment.setTagTop("_dd.appsec.usr.id", finalUserId);
-    } else if (propagated) {
-      // only the SDK can propagate usr.id
-      segment.setTagTop("_dd.p.usr.id", encodeBase64(finalUserId));
     }
     if (isNewUser(mode, segment)) {
       segment.setTagTop("usr.id", finalUserId);

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -8,8 +8,11 @@ import static datadog.trace.api.telemetry.LoginEvent.LOGIN_FAILURE;
 import static datadog.trace.api.telemetry.LoginEvent.LOGIN_SUCCESS;
 import static datadog.trace.api.telemetry.LoginEvent.SIGN_UP;
 import static datadog.trace.util.Strings.toHexString;
+import static java.util.Collections.emptyMap;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.appsec.api.user.User;
+import datadog.appsec.api.user.UserService;
 import datadog.trace.api.EventTracker;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.ProductTraceSource;
@@ -27,10 +30,11 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-public class AppSecEventTracker extends EventTracker {
+public class AppSecEventTracker extends EventTracker implements UserService {
 
   private static final int HASH_SIZE_BYTES = 16; // 128 bits
   private static final String ANON_PREFIX = "anon_";
@@ -40,7 +44,9 @@ public class AppSecEventTracker extends EventTracker {
   private static final String SIGNUP_TAG = "users.signup";
 
   public static void install() {
-    GlobalTracer.setEventTracker(new AppSecEventTracker());
+    final AppSecEventTracker tracker = new AppSecEventTracker();
+    GlobalTracer.setEventTracker(tracker);
+    User.setUserService(tracker);
   }
 
   @Override
@@ -68,6 +74,15 @@ public class AppSecEventTracker extends EventTracker {
     onCustomEvent(SDK, eventName, metadata);
   }
 
+  @Override
+  public void trackUserEvent(
+      final String userId, final Map<String, String> metadata, final boolean propagated) {
+    if (userId == null || userId.isEmpty()) {
+      throw new IllegalArgumentException("UserId is null or empty");
+    }
+    onUserEvent(SDK, userId, metadata, propagated);
+  }
+
   public void onUserNotFound(final UserIdCollectionMode mode) {
     if (!isEnabled(mode)) {
       return;
@@ -88,6 +103,14 @@ public class AppSecEventTracker extends EventTracker {
   }
 
   public void onUserEvent(final UserIdCollectionMode mode, final String userId) {
+    onUserEvent(mode, userId, emptyMap(), false);
+  }
+
+  public void onUserEvent(
+      final UserIdCollectionMode mode,
+      final String userId,
+      final Map<String, String> metadata,
+      final boolean propagated) {
     if (!isEnabled(mode)) {
       return;
     }
@@ -105,9 +128,15 @@ public class AppSecEventTracker extends EventTracker {
     }
     if (mode != SDK) {
       segment.setTagTop("_dd.appsec.usr.id", finalUserId);
+    } else if (propagated) {
+      // only the SDK can propagate usr.id
+      segment.setTagTop("_dd.p.usr.id", encodeBase64(finalUserId));
     }
     if (isNewUser(mode, segment)) {
       segment.setTagTop("usr.id", finalUserId);
+      if (metadata != null && !metadata.isEmpty()) {
+        segment.setTagTop("usr", metadata);
+      }
       segment.setTagTop("_dd.appsec.user.collection_mode", mode.fullName());
       segment.setTagTop(Tags.ASM_KEEP, true);
       segment.setTagTop(Tags.PROPAGATED_TRACE_SOURCE, ProductTraceSource.ASM);
@@ -355,6 +384,10 @@ public class AppSecEventTracker extends EventTracker {
       hash = temp;
     }
     return ANON_PREFIX + toHexString(hash);
+  }
+
+  protected static String encodeBase64(final String userId) {
+    return Base64.getEncoder().encodeToString(userId.getBytes());
   }
 
   protected boolean isEnabled(final UserIdCollectionMode mode) {


### PR DESCRIPTION
# What Does This Do
Adds a public API for customers to set user related data in the spans aligned with what other tracers are [doing](http://docs.datadoghq.com/security/application_security/threats/add-user-info/?tab=set_user&code-lang=python#adding-authenticated-user-information-to-traces-and-enabling-user-blocking-capability). 

Before:

```java
import io.opentracing.Span;
import io.opentracing.util.GlobalTracer;
import datadog.appsec.api.blocking.Blocking;
import datadog.trace.api.interceptor.MutableSpan;

// Get the active span
final Span span = GlobalTracer.get().activeSpan();
if ((span instanceof MutableSpan)) {
   MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
   // Setting the mandatory user id tag
   localRootSpan.setTag("usr.id", "d131dd02c56eec4");
   // Setting optional user monitoring tags
   localRootSpan.setTag("usr.name", "Jean Example");
   localRootSpan.setTag("usr.email", "jean.example@example.com");
   localRootSpan.setTag("usr.session_id", "987654321");
   localRootSpan.setTag("usr.role", "admin");
   localRootSpan.setTag("usr.scope", "read:message, write:files");
}

Blocking
    .forUser("d131dd02c56eec4")
    .blockIfMatch();
```

After:

```java
import static datadog.appsec.api.user.User.setUser;

final Map<String, String> metadata = new HashMap<>();
metadata.put("name", "Jean Example");
metadata.put("email", "jean.example@example.com");
metadata.put("session_id", "987654321");
metadata.put("role", "admin");
metadata.put("scope", "read:message, write:files");

setUser("d131dd02c56eec4", metadata);
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56436]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56436]: https://datadoghq.atlassian.net/browse/APPSEC-56436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ