### PR TITLE
Remove API Security sampling configuration via remote configuration

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -73,10 +73,7 @@ public class AppSecSystem {
     // may throw and abort startup
     APP_SEC_CONFIG_SERVICE =
         new AppSecConfigServiceImpl(
-            config,
-            configurationPoller,
-            requestSampler,
-            () -> reloadSubscriptions(REPLACEABLE_EVENT_PRODUCER));
+            config, configurationPoller, () -> reloadSubscriptions(REPLACEABLE_EVENT_PRODUCER));
     APP_SEC_CONFIG_SERVICE.init();
 
     sco.createRemaining(config);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecFeatures.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecFeatures.java
@@ -3,9 +3,6 @@ package com.datadog.appsec.config;
 public class AppSecFeatures {
   public Asm asm;
 
-  @com.squareup.moshi.Json(name = "api_security")
-  public ApiSecurity apiSecurity;
-
   @com.squareup.moshi.Json(name = "auto_user_instrum")
   public AutoUserInstrum autoUserInstrum;
 
@@ -15,16 +12,6 @@ public class AppSecFeatures {
     @Override
     public String toString() {
       return "Asm{" + "enabled=" + enabled + '}';
-    }
-  }
-
-  public static class ApiSecurity {
-    @com.squareup.moshi.Json(name = "request_sample_rate")
-    public Float requestSampleRate;
-
-    @Override
-    public String toString() {
-      return "ApiSecurity{" + "requestSampleRate=" + requestSampleRate + '}';
     }
   }
 
@@ -39,13 +26,6 @@ public class AppSecFeatures {
 
   @Override
   public String toString() {
-    return "AppSecFeatures{"
-        + "asm="
-        + asm
-        + ", apiSecurity="
-        + apiSecurity
-        + ", autoUserInstrum="
-        + autoUserInstrum
-        + '}';
+    return "AppSecFeatures{" + "asm=" + asm + ", autoUserInstrum=" + autoUserInstrum + '}';
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/MergedAsmFeatures.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/MergedAsmFeatures.java
@@ -31,7 +31,6 @@ public class MergedAsmFeatures {
 
   private AppSecFeatures merge(final AppSecFeatures target, final AppSecFeatures newFeatures) {
     mergeAsm(target, newFeatures.asm);
-    mergeApiSecurity(target, newFeatures.apiSecurity);
     mergeAutoUserInstrum(target, newFeatures.autoUserInstrum);
     return target;
   }
@@ -41,14 +40,6 @@ public class MergedAsmFeatures {
       return;
     }
     target.asm = newValue;
-  }
-
-  private void mergeApiSecurity(
-      final AppSecFeatures target, final AppSecFeatures.ApiSecurity newValue) {
-    if (newValue == null || newValue.requestSampleRate == null) {
-      return;
-    }
-    target.apiSecurity = newValue;
   }
 
   private void mergeAutoUserInstrum(

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/MergedAsmFeaturesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/MergedAsmFeaturesSpecification.groovy
@@ -25,23 +25,6 @@ class MergedAsmFeaturesSpecification extends Specification {
     features.mergedData.asm.enabled
   }
 
-  void 'test merging and removing api security sampling'() {
-    setup:
-    final features = new MergedAsmFeatures()
-
-    when:
-    features.addConfig('api_security_1', apiSecurity(2.0))
-
-    then:
-    features.mergedData.apiSecurity.requestSampleRate == 2.0
-
-    when:
-    features.addConfig('api_security_1', apiSecurity(3.0))
-
-    then:
-    features.mergedData.apiSecurity.requestSampleRate == 3.0
-  }
-
   void 'test merging and removing auto user instrum'() {
     setup:
     final features = new MergedAsmFeatures()
@@ -61,10 +44,6 @@ class MergedAsmFeaturesSpecification extends Specification {
 
   private static AppSecFeatures asm(boolean enabled) {
     return new AppSecFeatures(asm: new AppSecFeatures.Asm(enabled: enabled))
-  }
-
-  private static AppSecFeatures apiSecurity(float sampling) {
-    new AppSecFeatures(apiSecurity: new AppSecFeatures.ApiSecurity(requestSampleRate: sampling))
   }
 
   private static AppSecFeatures autoUserInstrum(UserIdCollectionMode mode) {


### PR DESCRIPTION
# What Does This Do
Remove the old system to configure API Security sampling rate via remote config. This is currently not exposed in the UI, and the backend is being decomisioned.  It was never in operation in production.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
