### PR TITLE
Add DBMTracePreparedStatements to tracer configuration log

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4407,6 +4407,8 @@ public class Config {
         + dbClientSplitByHost
         + ", DBMPropagationMode="
         + DBMPropagationMode
+        + ", DBMTracePreparedStatements="
+        + DBMTracePreparedStatements
         + ", splitByTags="
         + splitByTags
         + ", jeeSplitByDeployment="


### PR DESCRIPTION
# What Does This Do
Add the value of the configuration key `dd.dbm.trace_prepared_statements` to  the tracer configuration log in order to help troubleshooting any issue related to this feature

# Motivation
Help troubleshooting issues related to the DBM feature, involving prepared statements.
