### PR TITLE
Improve detection of missing request end events

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   testImplementation project(':utils:test-utils')
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
   testImplementation group: 'com.flipkart.zjsonpatch', name: 'zjsonpatch', version: '0.4.11'
+  testImplementation libs.logback.classic
 
   testFixturesApi project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -767,6 +767,7 @@ public class GatewayBridge {
     if (ctx == null) {
       return NoopFlow.INSTANCE;
     }
+    ctx.setRequestEndCalled();
 
     maybeExtractSchemas(ctx);
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -5,6 +5,8 @@ import com.datadog.appsec.config.CurrentAppSecConfig
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.event.data.MapDataBundle
 import com.datadog.appsec.report.AppSecEvent
+import datadog.trace.api.telemetry.LogCollector
+import datadog.trace.test.logging.TestLogCollector
 import datadog.trace.util.stacktrace.StackTraceEvent
 import com.datadog.appsec.test.StubAppSecConfigService
 import datadog.trace.test.util.DDSpecification
@@ -315,5 +317,22 @@ class AppSecRequestContextSpecification extends DDSpecification {
     ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR) == 1
     ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
     ctx.getWafError(0) == 0
+  }
+
+  void 'close logs if request end was not called'() {
+    given:
+    TestLogCollector.enable()
+    def ctx = new AppSecRequestContext()
+
+    when:
+    ctx.close()
+
+    then:
+    def log = TestLogCollector.drainCapturedLogs().find { it.message.contains('Request end event was not called before close') }
+    log != null
+    log.marker == LogCollector.SEND_TELEMETRY
+
+    cleanup:
+    TestLogCollector.disable()
   }
 }

--- a/dd-java-agent/appsec/src/test/resources/logback-test.xml
+++ b/dd-java-agent/appsec/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="TEST" class="datadog.trace.test.logging.TestLogbackAppender"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="DEBUG">
+    <appender-ref ref="TEST"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
# What Does This Do
Improve detection of missing or out of order request events.

# Motivation
This has been a problem for a while, and there are still some cases with unknown root cause.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
