### PR TITLE
Fix NPE when calculating code coverage for Gradle projects with non-standard directory layout

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/CoverageCalculator.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/CoverageCalculator.java
@@ -14,7 +14,7 @@ public interface CoverageCalculator {
 
     T moduleCoverage(
         long moduleId,
-        BuildModuleLayout moduleLayout,
+        @Nullable BuildModuleLayout moduleLayout,
         ExecutionSettings executionSettings,
         T sessionCoverage);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/JacocoCoverageCalculator.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/JacocoCoverageCalculator.java
@@ -77,7 +77,7 @@ public class JacocoCoverageCalculator implements CoverageCalculator {
     @Override
     public JacocoCoverageCalculator moduleCoverage(
         long moduleId,
-        BuildModuleLayout moduleLayout,
+        @Nullable BuildModuleLayout moduleLayout,
         ExecutionSettings executionSettings,
         JacocoCoverageCalculator sessionCoverage) {
       return new JacocoCoverageCalculator(
@@ -130,7 +130,7 @@ public class JacocoCoverageCalculator implements CoverageCalculator {
       ExecutionSettings executionSettings,
       String repoRoot,
       long moduleId,
-      BuildModuleLayout moduleLayout,
+      @Nullable BuildModuleLayout moduleLayout,
       ModuleSignalRouter moduleSignalRouter,
       @Nonnull JacocoCoverageCalculator parent) {
     this.parent = parent;
@@ -149,7 +149,11 @@ public class JacocoCoverageCalculator implements CoverageCalculator {
         moduleId, SignalType.MODULE_COVERAGE_DATA_JACOCO, this::addCoverageData);
   }
 
-  private void addModuleLayout(BuildModuleLayout moduleLayout) {
+  private void addModuleLayout(@Nullable BuildModuleLayout moduleLayout) {
+    if (moduleLayout == null) {
+      LOGGER.debug("Received null module layout, will not be able to calculate coverage");
+      return;
+    }
     synchronized (coverageDataLock) {
       for (SourceSet sourceSet : moduleLayout.getSourceSets()) {
         if (sourceSet.getType() == SourceSet.Type.TEST) {


### PR DESCRIPTION
# What Does This Do

Fixes a `NullPointerException` in code coverage calculation logic, that occurs when the tracer cannot infer the directory structure of the instrumented Gradle project.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
