### PR TITLE
Reduce footprint of SourceFile tracking

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/InnerHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/InnerHelper.java
@@ -3,4 +3,6 @@ package com.datadog.debugger.agent;
 public class InnerHelper {
 
   public static class MyInner {}
+
+  public static class MySecondInner {}
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -58,12 +58,22 @@ class SourceFileTrackingTransformerTest {
         null,
         null,
         getClassFileBytes(InnerHelper.MyInner.class));
+    sourceFileTrackingTransformer.transform(
+        null,
+        getInternalName(InnerHelper.MySecondInner.class),
+        null,
+        null,
+        getClassFileBytes(InnerHelper.MySecondInner.class));
     changedClasses =
         finder.getAllLoadedChangedClasses(
-            new Class[] {InnerHelper.class, InnerHelper.MyInner.class}, comparer);
-    assertEquals(2, changedClasses.size());
+            new Class[] {
+              InnerHelper.class, InnerHelper.MyInner.class, InnerHelper.MySecondInner.class
+            },
+            comparer);
+    assertEquals(3, changedClasses.size());
     assertEquals(InnerHelper.class, changedClasses.get(0));
     assertEquals(InnerHelper.MyInner.class, changedClasses.get(1));
+    assertEquals(InnerHelper.MySecondInner.class, changedClasses.get(2));
   }
 
   private ConfigurationComparer createComparer(String sourceFile) {


### PR DESCRIPTION
# What Does This Do
classNamesBySourceFile map used for SourceFile tracking can have a lot of entries (different SourceFiles) and for each entry we have a list (If any inner classe or non-public top-level classes). Compacting to a comma-separated list reduce the footprint of this map. As the usage is very unfrequent we can pay the price to "deserialize" the list to go through the classname that we need to retransform as a dependency

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3575]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3575]: https://datadoghq.atlassian.net/browse/DEBUG-3575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ