### PR TITLE
Rename classes to better reflect their counterparts in libddwaf

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 1de04c42cbd9783432258004e46eb5982bbc9fe5
+default_system_tests_commit: &default_system_tests_commit 55cc62fb333b8de1466f8a0ecfdfa55fe9f57031
 
 parameters:
   nightly:

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '12.0.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '13.0.1'
   implementation libs.moshi
 
   testImplementation libs.bytebuddy
@@ -68,8 +68,8 @@ ext {
   minimumInstructionCoverage = 0.8
   excludedClassesCoverage = [
     'com.datadog.appsec.config.MergedAsmData.InvalidAsmDataException',
-    'com.datadog.appsec.powerwaf.LibSqreenInitialization',
-    'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFDataCallback',
+    'com.datadog.appsec.ddwaf.WafInitialization',
+    'com.datadog.appsec.ddwaf.WAFModule.WAFDataCallback',
     'com.datadog.appsec.report.*',
     'com.datadog.appsec.config.AppSecConfigServiceImpl.SubscribeFleetServiceRunnable.1',
     'com.datadog.appsec.util.StandardizedLogging',
@@ -90,7 +90,6 @@ ext {
     'com.datadog.appsec.config.CurrentAppSecConfig',
     // equals() / hashCode() are not well covered
     'com.datadog.appsec.config.AppSecConfig.Helper',
-    'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFEventsCallback',
     // assert never fails
     'com.datadog.appsec.util.StandardizedLogging',
     'com.datadog.appsec.util.AbortStartupException',

--- a/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/BenchmarkUtil.java
+++ b/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/BenchmarkUtil.java
@@ -1,9 +1,9 @@
 package datadog.appsec.benchmark;
 
 import ch.qos.logback.classic.Logger;
-import io.sqreen.powerwaf.Powerwaf;
-import io.sqreen.powerwaf.exception.AbstractPowerwafException;
-import io.sqreen.powerwaf.exception.UnsupportedVMException;
+import com.datadog.ddwaf.Waf;
+import com.datadog.ddwaf.exception.AbstractWafException;
+import com.datadog.ddwaf.exception.UnsupportedVMException;
 import java.lang.reflect.UndeclaredThrowableException;
 import org.slf4j.LoggerFactory;
 
@@ -16,10 +16,10 @@ public class BenchmarkUtil {
     }
   }
 
-  public static void initializePowerwaf() {
+  public static void initializeWaf() {
     try {
-      Powerwaf.initialize(false);
-    } catch (AbstractPowerwafException e) {
+      Waf.initialize(false);
+    } catch (AbstractWafException e) {
       throw new UndeclaredThrowableException(e);
     } catch (UnsupportedVMException e) {
       throw new UndeclaredThrowableException(e);

--- a/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/WafBenchmark.java
+++ b/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/WafBenchmark.java
@@ -6,11 +6,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.datadog.appsec.config.AppSecConfig;
 import com.datadog.appsec.config.AppSecConfigDeserializer;
 import com.datadog.appsec.event.data.KnownAddresses;
-import io.sqreen.powerwaf.Additive;
-import io.sqreen.powerwaf.Powerwaf;
-import io.sqreen.powerwaf.PowerwafContext;
-import io.sqreen.powerwaf.PowerwafMetrics;
-import io.sqreen.powerwaf.exception.AbstractPowerwafException;
+import com.datadog.ddwaf.Waf;
+import com.datadog.ddwaf.WafContext;
+import com.datadog.ddwaf.WafHandle;
+import com.datadog.ddwaf.WafMetrics;
+import com.datadog.ddwaf.exception.AbstractWafException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -37,21 +37,21 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(MICROSECONDS)
 @Fork(value = 3)
-public class PowerwafBenchmark {
+public class WafBenchmark {
 
   static {
     BenchmarkUtil.disableLogging();
-    BenchmarkUtil.initializePowerwaf();
+    BenchmarkUtil.initializeWaf();
   }
 
-  PowerwafContext ctx;
+  WafHandle ctx;
   Map<String, Object> wafData = new HashMap<>();
-  Powerwaf.Limits limits = new Powerwaf.Limits(50, 500, 1000, 5000000, 5000000);
+  Waf.Limits limits = new Waf.Limits(50, 500, 1000, 5000000, 5000000);
 
   @Benchmark
   public void withMetrics() throws Exception {
-    PowerwafMetrics metricsCollector = ctx.createMetrics();
-    Additive add = ctx.openAdditive();
+    WafMetrics metricsCollector = ctx.createMetrics();
+    WafContext add = ctx.openContext();
     try {
       add.run(wafData, limits, metricsCollector);
     } finally {
@@ -61,7 +61,7 @@ public class PowerwafBenchmark {
 
   @Benchmark
   public void withoutMetrics() throws Exception {
-    Additive add = ctx.openAdditive();
+    WafContext add = ctx.openContext();
     try {
       add.run(wafData, limits, null);
     } finally {
@@ -70,12 +70,12 @@ public class PowerwafBenchmark {
   }
 
   @Setup(Level.Trial)
-  public void setUp() throws AbstractPowerwafException, IOException {
+  public void setUp() throws AbstractWafException, IOException {
     InputStream stream = getClass().getClassLoader().getResourceAsStream("test_multi_config.json");
     Map<String, AppSecConfig> cfg =
         Collections.singletonMap("waf", AppSecConfigDeserializer.INSTANCE.deserialize(stream));
     AppSecConfig waf = cfg.get("waf");
-    ctx = Powerwaf.createContext("waf", waf.getRawConfig());
+    ctx = Waf.createHandle("waf", waf.getRawConfig());
 
     wafData.put(KnownAddresses.REQUEST_METHOD.getKey(), "POST");
     wafData.put(

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -6,10 +6,10 @@ import com.datadog.appsec.api.security.AppSecSpanPostProcessor;
 import com.datadog.appsec.blocking.BlockingServiceImpl;
 import com.datadog.appsec.config.AppSecConfigService;
 import com.datadog.appsec.config.AppSecConfigServiceImpl;
+import com.datadog.appsec.ddwaf.WAFModule;
 import com.datadog.appsec.event.EventDispatcher;
 import com.datadog.appsec.event.ReplaceableEventProducerService;
 import com.datadog.appsec.gateway.GatewayBridge;
-import com.datadog.appsec.powerwaf.PowerWAFModule;
 import com.datadog.appsec.util.AbortStartupException;
 import com.datadog.appsec.util.StandardizedLogging;
 import datadog.appsec.api.blocking.Blocking;
@@ -151,7 +151,7 @@ public class AppSecSystem {
     EventDispatcher.DataSubscriptionSet dataSubscriptionSet =
         new EventDispatcher.DataSubscriptionSet();
 
-    final List<AppSecModule> modules = Collections.singletonList(new PowerWAFModule(monitoring));
+    final List<AppSecModule> modules = Collections.singletonList(new WAFModule(monitoring));
     for (AppSecModule module : modules) {
       log.debug("Starting appsec module {}", module.getName());
       try {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/api/security/AppSecSpanPostProcessor.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/api/security/AppSecSpanPostProcessor.java
@@ -61,7 +61,7 @@ public class AppSecSpanPostProcessor implements SpanPostProcessor {
         // XXX: Close the additive first. This is not strictly needed, but it'll prevent getting it
         // detected as a
         // missed request-ended event.
-        ctx.closeAdditive();
+        ctx.closeWafContext();
         ctx.close();
       } catch (Exception e) {
         log.debug("Error closing AppSecRequestContext", e);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -405,7 +405,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
       AppSecSystem.setActive(newState);
       if (AppSecSystem.isActive()) {
         // On remote activation, we need to re-distribute the last known configuration.
-        // This may trigger initializations, including PowerWAF if it was lazy loaded.
+        // This may trigger initializations, including WAF if it was lazy loaded.
         this.currentAppSecConfig.dirtyStatus.markAllDirty();
       }
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFInitializationResultReporter.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFInitializationResultReporter.java
@@ -1,21 +1,21 @@
-package com.datadog.appsec.powerwaf;
+package com.datadog.appsec.ddwaf;
 
 import com.datadog.appsec.config.TraceSegmentPostProcessor;
 import com.datadog.appsec.gateway.AppSecRequestContext;
 import com.datadog.appsec.report.AppSecEvent;
+import com.datadog.ddwaf.RuleSetInfo;
+import com.datadog.ddwaf.Waf;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import io.sqreen.powerwaf.Powerwaf;
-import io.sqreen.powerwaf.RuleSetInfo;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class PowerWAFInitializationResultReporter implements TraceSegmentPostProcessor {
+public class WAFInitializationResultReporter implements TraceSegmentPostProcessor {
   private static final String WAF_VERSION = "_dd.appsec.waf.version";
   private static final String RULE_ERRORS = "_dd.appsec.event_rules.errors";
   private static final String RULES_LOADED = "_dd.appsec.event_rules.loaded";
@@ -48,7 +48,7 @@ public class PowerWAFInitializationResultReporter implements TraceSegmentPostPro
     segment.setTagTop(RULE_ERRORS, RULES_ERRORS_ADAPTER.toJson(report.getErrors()));
     segment.setTagTop(RULES_LOADED, report.getNumRulesOK());
     segment.setTagTop(RULE_ERROR_COUNT, report.getNumRulesError());
-    segment.setTagTop(WAF_VERSION, Powerwaf.LIB_VERSION);
+    segment.setTagTop(WAF_VERSION, Waf.LIB_VERSION);
 
     segment.setTagTop(Tags.ASM_KEEP, true);
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
@@ -1,4 +1,4 @@
-package com.datadog.appsec.powerwaf;
+package com.datadog.appsec.ddwaf;
 
 import static datadog.trace.util.stacktrace.StackTraceEvent.DEFAULT_LANGUAGE;
 import static java.util.Collections.emptyList;
@@ -18,6 +18,16 @@ import com.datadog.appsec.gateway.GatewayContext;
 import com.datadog.appsec.gateway.RateLimiter;
 import com.datadog.appsec.report.AppSecEvent;
 import com.datadog.appsec.util.StandardizedLogging;
+import com.datadog.ddwaf.RuleSetInfo;
+import com.datadog.ddwaf.Waf;
+import com.datadog.ddwaf.WafConfig;
+import com.datadog.ddwaf.WafContext;
+import com.datadog.ddwaf.WafHandle;
+import com.datadog.ddwaf.WafMetrics;
+import com.datadog.ddwaf.exception.AbstractWafException;
+import com.datadog.ddwaf.exception.InvalidRuleSetException;
+import com.datadog.ddwaf.exception.TimeoutWafException;
+import com.datadog.ddwaf.exception.UnclassifiedWafException;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
@@ -39,16 +49,6 @@ import datadog.trace.util.RandomUtils;
 import datadog.trace.util.stacktrace.StackTraceEvent;
 import datadog.trace.util.stacktrace.StackTraceFrame;
 import datadog.trace.util.stacktrace.StackUtils;
-import io.sqreen.powerwaf.Additive;
-import io.sqreen.powerwaf.Powerwaf;
-import io.sqreen.powerwaf.PowerwafConfig;
-import io.sqreen.powerwaf.PowerwafContext;
-import io.sqreen.powerwaf.PowerwafMetrics;
-import io.sqreen.powerwaf.RuleSetInfo;
-import io.sqreen.powerwaf.exception.AbstractPowerwafException;
-import io.sqreen.powerwaf.exception.InvalidRuleSetException;
-import io.sqreen.powerwaf.exception.TimeoutPowerwafException;
-import io.sqreen.powerwaf.exception.UnclassifiedPowerwafException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
@@ -74,18 +74,18 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PowerWAFModule implements AppSecModule {
-  private static final Logger log = LoggerFactory.getLogger(PowerWAFModule.class);
+public class WAFModule implements AppSecModule {
+  private static final Logger log = LoggerFactory.getLogger(WAFModule.class);
 
   private static final int MAX_DEPTH = 10;
   private static final int MAX_ELEMENTS = 150;
   private static final int MAX_STRING_SIZE = 4096;
-  private static volatile Powerwaf.Limits LIMITS;
+  private static volatile Waf.Limits LIMITS;
   private static final Class<?> PROXY_CLASS =
-      Proxy.getProxyClass(PowerWAFModule.class.getClassLoader(), Set.class);
+      Proxy.getProxyClass(WAFModule.class.getClassLoader(), Set.class);
   private static final Constructor<?> PROXY_CLASS_CONSTRUCTOR;
 
-  private static final JsonAdapter<List<PowerWAFResultData>> RES_JSON_ADAPTER;
+  private static final JsonAdapter<List<WAFResultData>> RES_JSON_ADAPTER;
 
   private static final Map<String, ActionInfo> DEFAULT_ACTIONS;
 
@@ -103,12 +103,12 @@ public class PowerWAFModule implements AppSecModule {
 
   private static class CtxAndAddresses {
     final Collection<Address<?>> addressesOfInterest;
-    final PowerwafContext ctx;
+    final WafHandle ctx;
     final Map<String /* id */, ActionInfo> actionInfoMap;
 
     private CtxAndAddresses(
         Collection<Address<?>> addressesOfInterest,
-        PowerwafContext ctx,
+        WafHandle ctx,
         Map<String, ActionInfo> actionInfoMap) {
       this.addressesOfInterest = addressesOfInterest;
       this.ctx = ctx;
@@ -124,8 +124,7 @@ public class PowerWAFModule implements AppSecModule {
     }
 
     Moshi moshi = new Moshi.Builder().build();
-    RES_JSON_ADAPTER =
-        moshi.adapter(Types.newParameterizedType(List.class, PowerWAFResultData.class));
+    RES_JSON_ADAPTER = moshi.adapter(Types.newParameterizedType(List.class, WAFResultData.class));
 
     Map<String, Object> actionParams = new HashMap<>();
     actionParams.put("status_code", 403);
@@ -139,12 +138,12 @@ public class PowerWAFModule implements AppSecModule {
   // used in testing
   static void createLimitsObject() {
     LIMITS =
-        new Powerwaf.Limits(
+        new Waf.Limits(
             MAX_DEPTH,
             MAX_ELEMENTS,
             MAX_STRING_SIZE,
             /* set effectively infinite budgets. Don't use Long.MAX_VALUE, because
-             * traditionally powerwaf has had problems with too large budgets */
+             * traditionally ddwaf has had problems with too large budgets */
             ((long) Integer.MAX_VALUE) * 1000,
             Config.get().getAppSecWafTimeout());
   }
@@ -152,18 +151,18 @@ public class PowerWAFModule implements AppSecModule {
   private final boolean wafMetricsEnabled =
       Config.get().isAppSecWafMetrics(); // could be static if not for tests
   private final AtomicReference<CtxAndAddresses> ctxAndAddresses = new AtomicReference<>();
-  private final PowerWAFInitializationResultReporter initReporter =
-      new PowerWAFInitializationResultReporter();
-  private final PowerWAFStatsReporter statsReporter = new PowerWAFStatsReporter();
+  private final WAFInitializationResultReporter initReporter =
+      new WAFInitializationResultReporter();
+  private final WAFStatsReporter statsReporter = new WAFStatsReporter();
   private final RateLimiter rateLimiter;
 
   private String currentRulesVersion;
 
-  public PowerWAFModule() {
+  public WAFModule() {
     this(null);
   }
 
-  public PowerWAFModule(Monitoring monitoring) {
+  public WAFModule(Monitoring monitoring) {
     this.rateLimiter = getRateLimiter(monitoring);
   }
 
@@ -203,7 +202,7 @@ public class PowerWAFModule implements AppSecModule {
 
     CtxAndAddresses curCtxAndAddresses = this.ctxAndAddresses.get();
 
-    if (!LibSqreenInitialization.ONLINE) {
+    if (!WafInitialization.ONLINE) {
       throw new AppSecModuleActivationException(
           "In-app WAF initialization failed. See previous log entries");
     }
@@ -220,7 +219,7 @@ public class PowerWAFModule implements AppSecModule {
       throw new AppSecModuleActivationException("Could not initialize/update waf", e);
     } finally {
       if (curCtxAndAddresses == null) {
-        WafMetricCollector.get().wafInit(Powerwaf.LIB_VERSION, currentRulesVersion, success);
+        WafMetricCollector.get().wafInit(Waf.LIB_VERSION, currentRulesVersion, success);
       } else {
         WafMetricCollector.get().wafUpdates(currentRulesVersion, success);
       }
@@ -236,19 +235,19 @@ public class PowerWAFModule implements AppSecModule {
     RuleSetInfo initReport = null;
 
     AppSecConfig ruleConfig = config.getMergedUpdateConfig();
-    PowerwafContext newPwafCtx = null;
+    WafHandle newWafCtx = null;
     try {
       String uniqueId = RandomUtils.randomUUID().toString();
 
       if (prevContextAndAddresses == null) {
-        PowerwafConfig pwConfig = createPowerwafConfig();
-        newPwafCtx = Powerwaf.createContext(uniqueId, pwConfig, ruleConfig.getRawConfig());
+        WafConfig pwConfig = createWafConfig();
+        newWafCtx = Waf.createHandle(uniqueId, pwConfig, ruleConfig.getRawConfig());
       } else {
-        newPwafCtx = prevContextAndAddresses.ctx.update(uniqueId, ruleConfig.getRawConfig());
+        newWafCtx = prevContextAndAddresses.ctx.update(uniqueId, ruleConfig.getRawConfig());
       }
 
-      initReport = newPwafCtx.getRuleSetInfo();
-      Collection<Address<?>> addresses = getUsedAddresses(newPwafCtx);
+      initReport = newWafCtx.getRuleSetInfo();
+      Collection<Address<?>> addresses = getUsedAddresses(newWafCtx);
 
       // Update current rules' version if you need
       if (initReport != null && initReport.rulesetVersion != null) {
@@ -271,16 +270,16 @@ public class PowerWAFModule implements AppSecModule {
       Map<String, ActionInfo> actionInfoMap =
           calculateEffectiveActions(prevContextAndAddresses, ruleConfig);
 
-      newContextAndAddresses = new CtxAndAddresses(addresses, newPwafCtx, actionInfoMap);
+      newContextAndAddresses = new CtxAndAddresses(addresses, newWafCtx, actionInfoMap);
       if (initReport != null) {
         this.statsReporter.rulesVersion = initReport.rulesetVersion;
       }
     } catch (InvalidRuleSetException irse) {
       initReport = irse.ruleSetInfo;
       throw new AppSecModuleActivationException("Error creating WAF rules", irse);
-    } catch (RuntimeException | AbstractPowerwafException e) {
-      if (newPwafCtx != null) {
-        newPwafCtx.close();
+    } catch (RuntimeException | AbstractWafException e) {
+      if (newWafCtx != null) {
+        newWafCtx.close();
       }
       throw new AppSecModuleActivationException("Error creating WAF rules", e);
     } finally {
@@ -290,7 +289,7 @@ public class PowerWAFModule implements AppSecModule {
     }
 
     if (!this.ctxAndAddresses.compareAndSet(prevContextAndAddresses, newContextAndAddresses)) {
-      newPwafCtx.close();
+      newWafCtx.close();
       throw new AppSecModuleActivationException("Concurrent update of WAF configuration");
     }
 
@@ -333,8 +332,8 @@ public class PowerWAFModule implements AppSecModule {
     return actionInfoMap;
   }
 
-  private PowerwafConfig createPowerwafConfig() {
-    PowerwafConfig pwConfig = new PowerwafConfig();
+  private WafConfig createWafConfig() {
+    WafConfig pwConfig = new WafConfig();
     Config config = Config.get();
     String keyRegexp = config.getAppSecObfuscationParameterKeyRegexp();
     if (keyRegexp != null) {
@@ -364,17 +363,17 @@ public class PowerWAFModule implements AppSecModule {
 
   @Override
   public String getName() {
-    return "powerwaf";
+    return "ddwaf";
   }
 
   @Override
   public String getInfo() {
     CtxAndAddresses ctxAndAddresses = this.ctxAndAddresses.get();
     if (ctxAndAddresses == null) {
-      return "powerwaf(libddwaf: " + Powerwaf.LIB_VERSION + ") no rules loaded";
+      return "ddwaf(libddwaf: " + Waf.LIB_VERSION + ") no rules loaded";
     }
 
-    return "powerwaf(libddwaf: " + Powerwaf.LIB_VERSION + ") loaded";
+    return "ddwaf(libddwaf: " + Waf.LIB_VERSION + ") loaded";
   }
 
   @Override
@@ -382,10 +381,10 @@ public class PowerWAFModule implements AppSecModule {
     if (this.ctxAndAddresses.get() == null) {
       return Collections.emptyList();
     }
-    return singletonList(new PowerWAFDataCallback());
+    return singletonList(new WAFDataCallback());
   }
 
-  private static Collection<Address<?>> getUsedAddresses(PowerwafContext ctx) {
+  private static Collection<Address<?>> getUsedAddresses(WafHandle ctx) {
     String[] usedAddresses = ctx.getUsedAddresses();
     Set<Address<?>> addressList = new HashSet<>(usedAddresses.length);
     for (String addrKey : usedAddresses) {
@@ -397,8 +396,8 @@ public class PowerWAFModule implements AppSecModule {
     return addressList;
   }
 
-  private class PowerWAFDataCallback extends DataSubscription {
-    public PowerWAFDataCallback() {
+  private class WAFDataCallback extends DataSubscription {
+    public WAFDataCallback() {
       super(ctxAndAddresses.get().addressesOfInterest, Priority.DEFAULT);
     }
 
@@ -408,14 +407,14 @@ public class PowerWAFModule implements AppSecModule {
         AppSecRequestContext reqCtx,
         DataBundle newData,
         GatewayContext gwCtx) {
-      Powerwaf.ResultWithData resultWithData;
+      Waf.ResultWithData resultWithData;
       CtxAndAddresses ctxAndAddr = ctxAndAddresses.get();
       if (ctxAndAddr == null) {
         log.debug("Skipped; the WAF is not configured");
         return;
       }
 
-      if (reqCtx.isAdditiveClosed()) {
+      if (reqCtx.isWafContextClosed()) {
         log.debug("Skipped; the WAF context is closed");
         if (gwCtx.isRasp) {
           WafMetricCollector.get().raspRuleSkipped(gwCtx.raspRuleType);
@@ -434,8 +433,8 @@ public class PowerWAFModule implements AppSecModule {
       }
 
       try {
-        resultWithData = doRunPowerwaf(reqCtx, newData, ctxAndAddr, gwCtx);
-      } catch (TimeoutPowerwafException tpe) {
+        resultWithData = doRunWaf(reqCtx, newData, ctxAndAddr, gwCtx);
+      } catch (TimeoutWafException tpe) {
         if (gwCtx.isRasp) {
           reqCtx.increaseRaspTimeouts();
           WafMetricCollector.get().raspTimeout(gwCtx.raspRuleType);
@@ -445,13 +444,13 @@ public class PowerWAFModule implements AppSecModule {
           log.debug(LogCollector.EXCLUDE_TELEMETRY, "Timeout calling the WAF", tpe);
         }
         return;
-      } catch (UnclassifiedPowerwafException e) {
-        if (!reqCtx.isAdditiveClosed()) {
+      } catch (UnclassifiedWafException e) {
+        if (!reqCtx.isWafContextClosed()) {
           log.error("Error calling WAF", e);
         }
         WafMetricCollector.get().wafRequestError();
         return;
-      } catch (AbstractPowerwafException e) {
+      } catch (AbstractWafException e) {
         if (gwCtx.isRasp) {
           reqCtx.increaseRaspErrorCode(e.code);
           WafMetricCollector.get().raspErrorCode(gwCtx.raspRuleType, e.code);
@@ -466,7 +465,7 @@ public class PowerWAFModule implements AppSecModule {
           StandardizedLogging.finishedExecutionWAF(log, elapsed);
         }
         if (!gwCtx.isRasp) {
-          PowerwafMetrics wafMetrics = reqCtx.getWafMetrics();
+          WafMetrics wafMetrics = reqCtx.getWafMetrics();
           if (wafMetrics != null) {
             final long stringTooLong = wafMetrics.getTruncatedStringTooLongCount();
             final long listMapTooLarge = wafMetrics.getTruncatedListMapTooLargeCount();
@@ -490,7 +489,7 @@ public class PowerWAFModule implements AppSecModule {
 
       StandardizedLogging.inAppWafReturn(log, resultWithData);
 
-      if (resultWithData.result != Powerwaf.Result.OK) {
+      if (resultWithData.result != Waf.Result.OK) {
         if (log.isDebugEnabled()) {
           log.warn("WAF signalled result {}: {}", resultWithData.result, resultWithData.data);
         }
@@ -622,16 +621,16 @@ public class PowerWAFModule implements AppSecModule {
       return new StackTraceEvent(result, DEFAULT_LANGUAGE, stackId, EXPLOIT_DETECTED_MSG);
     }
 
-    private Powerwaf.ResultWithData doRunPowerwaf(
+    private Waf.ResultWithData doRunWaf(
         AppSecRequestContext reqCtx,
         DataBundle newData,
         CtxAndAddresses ctxAndAddr,
         GatewayContext gwCtx)
-        throws AbstractPowerwafException {
+        throws AbstractWafException {
 
-      Additive additive =
-          reqCtx.getOrCreateAdditive(ctxAndAddr.ctx, wafMetricsEnabled, gwCtx.isRasp);
-      PowerwafMetrics metrics;
+      WafContext wafContext =
+          reqCtx.getOrCreateWafContext(ctxAndAddr.ctx, wafMetricsEnabled, gwCtx.isRasp);
+      WafMetrics metrics;
       if (gwCtx.isRasp) {
         metrics = reqCtx.getRaspMetrics();
         reqCtx.getRaspMetricsCounter().incrementAndGet();
@@ -640,29 +639,29 @@ public class PowerWAFModule implements AppSecModule {
       }
 
       if (gwCtx.isTransient) {
-        return runPowerwafTransient(additive, metrics, newData, ctxAndAddr);
+        return runWafTransient(wafContext, metrics, newData, ctxAndAddr);
       } else {
-        return runPowerwafAdditive(additive, metrics, newData, ctxAndAddr);
+        return runWafContext(wafContext, metrics, newData, ctxAndAddr);
       }
     }
 
-    private Powerwaf.ResultWithData runPowerwafAdditive(
-        Additive additive, PowerwafMetrics metrics, DataBundle newData, CtxAndAddresses ctxAndAddr)
-        throws AbstractPowerwafException {
-      return additive.run(
+    private Waf.ResultWithData runWafContext(
+        WafContext wafContext, WafMetrics metrics, DataBundle newData, CtxAndAddresses ctxAndAddr)
+        throws AbstractWafException {
+      return wafContext.run(
           new DataBundleMapWrapper(ctxAndAddr.addressesOfInterest, newData), LIMITS, metrics);
     }
   }
 
-  private Powerwaf.ResultWithData runPowerwafTransient(
-      Additive additive, PowerwafMetrics metrics, DataBundle bundle, CtxAndAddresses ctxAndAddr)
-      throws AbstractPowerwafException {
-    return additive.runEphemeral(
+  private Waf.ResultWithData runWafTransient(
+      WafContext wafContext, WafMetrics metrics, DataBundle bundle, CtxAndAddresses ctxAndAddr)
+      throws AbstractWafException {
+    return wafContext.runEphemeral(
         new DataBundleMapWrapper(ctxAndAddr.addressesOfInterest, bundle), LIMITS, metrics);
   }
 
-  private Collection<AppSecEvent> buildEvents(Powerwaf.ResultWithData actionWithData) {
-    Collection<PowerWAFResultData> listResults;
+  private Collection<AppSecEvent> buildEvents(Waf.ResultWithData actionWithData) {
+    Collection<WAFResultData> listResults;
     try {
       listResults = RES_JSON_ADAPTER.fromJson(actionWithData.data);
     } catch (IOException e) {
@@ -678,7 +677,7 @@ public class PowerWAFModule implements AppSecModule {
     return emptyList();
   }
 
-  private AppSecEvent buildEvent(PowerWAFResultData wafResult) {
+  private AppSecEvent buildEvent(WAFResultData wafResult) {
 
     if (wafResult == null || wafResult.rule == null || wafResult.rule_matches == null) {
       log.warn("WAF result is empty: {}", wafResult);
@@ -709,7 +708,7 @@ public class PowerWAFModule implements AppSecModule {
       this.dataBundle = dataBundle;
     }
 
-    // powerwaf only calls entrySet().iterator() and size()
+    // ddwaf only calls entrySet().iterator() and size()
     @Nonnull
     @Override
     public Set<Entry<String, Object>> entrySet() {
@@ -749,7 +748,7 @@ public class PowerWAFModule implements AppSecModule {
             if (next == null) {
               throw new NoSuchElementException();
             }
-            // the usage pattern in powerwaf allows object recycling here
+            // the usage pattern in ddwaf allows object recycling here
             entry.key = next.getKey();
             entry.value =
                 addressesOfInterest.contains(next) ? dataBundle.get(next) : Collections.emptyMap();

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFResultData.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFResultData.java
@@ -1,9 +1,9 @@
-package com.datadog.appsec.powerwaf;
+package com.datadog.appsec.ddwaf;
 
 import java.util.List;
 import java.util.Map;
 
-public class PowerWAFResultData {
+public class WAFResultData {
   Rule rule;
   List<RuleMatch> rule_matches;
   String stack_id;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFStatsReporter.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFStatsReporter.java
@@ -1,13 +1,13 @@
-package com.datadog.appsec.powerwaf;
+package com.datadog.appsec.ddwaf;
 
 import com.datadog.appsec.config.TraceSegmentPostProcessor;
 import com.datadog.appsec.gateway.AppSecRequestContext;
 import com.datadog.appsec.report.AppSecEvent;
+import com.datadog.ddwaf.WafMetrics;
 import datadog.trace.api.internal.TraceSegment;
-import io.sqreen.powerwaf.PowerwafMetrics;
 import java.util.Collection;
 
-public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
+public class WAFStatsReporter implements TraceSegmentPostProcessor {
   private static final String WAF_TOTAL_DURATION_US_TAG = "_dd.appsec.waf.duration_ext";
   private static final String WAF_TOTAL_DDWAF_RUN_DURATION_US_TAG = "_dd.appsec.waf.duration";
   private static final String RASP_TOTAL_DURATION_US_TAG = "_dd.appsec.rasp.duration_ext";
@@ -24,14 +24,14 @@ public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
   @Override
   public void processTraceSegment(
       TraceSegment segment, AppSecRequestContext ctx, Collection<AppSecEvent> collectedEvents) {
-    PowerwafMetrics wafMetrics = ctx.getWafMetrics();
+    WafMetrics wafMetrics = ctx.getWafMetrics();
     if (wafMetrics != null) {
       segment.setTagTop(WAF_TOTAL_DURATION_US_TAG, wafMetrics.getTotalRunTimeNs() / 1000L);
       segment.setTagTop(
           WAF_TOTAL_DDWAF_RUN_DURATION_US_TAG, wafMetrics.getTotalDdwafRunTimeNs() / 1000L);
     }
 
-    PowerwafMetrics raspMetrics = ctx.getRaspMetrics();
+    WafMetrics raspMetrics = ctx.getRaspMetrics();
     if (raspMetrics != null) {
       segment.setTagTop(RASP_TOTAL_DURATION_US_TAG, raspMetrics.getTotalRunTimeNs() / 1000L);
       segment.setTagTop(

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WafInitialization.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WafInitialization.java
@@ -1,22 +1,22 @@
-package com.datadog.appsec.powerwaf;
+package com.datadog.appsec.ddwaf;
 
 import com.datadog.appsec.util.StandardizedLogging;
-import io.sqreen.powerwaf.Powerwaf;
+import com.datadog.ddwaf.Waf;
 import java.io.File;
 import java.io.IOException;
 import java.util.Scanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LibSqreenInitialization {
-  public static final boolean ONLINE = initPowerWAF();
+public class WafInitialization {
+  public static final boolean ONLINE = initWAF();
 
-  private static boolean initPowerWAF() {
+  private static boolean initWAF() {
     try {
       boolean simpleLoad = System.getProperty("POWERWAF_SIMPLE_LOAD") != null;
-      Powerwaf.initialize(simpleLoad);
+      Waf.initialize(simpleLoad);
     } catch (Exception e) {
-      Logger logger = LoggerFactory.getLogger(LibSqreenInitialization.class);
+      Logger logger = LoggerFactory.getLogger(WafInitialization.class);
       logger.warn("Error initializing WAF library", e);
       StandardizedLogging.libddwafCannotBeLoaded(logger, getLibc());
       return false;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -670,7 +670,7 @@ public class GatewayBridge {
     if (maybeSampleForApiSecurity(ctx, spanInfo, tags)) {
       ctx.setKeepOpenForApiSecurityPostProcessing(true);
     } else {
-      ctx.closeAdditive();
+      ctx.closeWafContext();
     }
 
     // AppSec report metric and events for web span only

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
@@ -1,7 +1,7 @@
 package com.datadog.appsec.report;
 
-import static com.datadog.appsec.powerwaf.PowerWAFResultData.Rule;
-import static com.datadog.appsec.powerwaf.PowerWAFResultData.RuleMatch;
+import static com.datadog.appsec.ddwaf.WAFResultData.Rule;
+import static com.datadog.appsec.ddwaf.WAFResultData.RuleMatch;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/StandardizedLogging.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/StandardizedLogging.java
@@ -1,10 +1,10 @@
 package com.datadog.appsec.util;
 
-import static com.datadog.appsec.powerwaf.PowerWAFResultData.Rule;
+import static com.datadog.appsec.ddwaf.WAFResultData.Rule;
 
 import com.datadog.appsec.event.data.Address;
 import com.datadog.appsec.report.AppSecEvent;
-import io.sqreen.powerwaf.Powerwaf;
+import com.datadog.ddwaf.Waf;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
@@ -127,7 +127,7 @@ public class StandardizedLogging {
    */
 
   // D5
-  public static void inAppWafReturn(Logger logger, Powerwaf.ResultWithData resultWithData) {
+  public static void inAppWafReturn(Logger logger, Waf.ResultWithData resultWithData) {
     logger.debug("AppSec In-App WAF returned: {}", resultWithData);
   }
 
@@ -185,9 +185,7 @@ public class StandardizedLogging {
   public static void _initialConfigSourceAndLibddwafVersion(Logger logger, String source) {
     if (logger.isDebugEnabled()) {
       logger.info(
-          "AppSec initial configuration from {}, libddwaf version: {}",
-          source,
-          Powerwaf.LIB_VERSION);
+          "AppSec initial configuration from {}, libddwaf version: {}", source, Waf.LIB_VERSION);
     }
   }
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -42,7 +42,7 @@ class AppSecSystemSpecification extends DDSpecification {
     AppSecSystem.start(subService, sharedCommunicationObjects())
 
     then:
-    'powerwaf' in AppSecSystem.startedModulesInfo
+    'ddwaf' in AppSecSystem.startedModulesInfo
   }
 
   void 'throws if custom config does not exist'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/api/security/AppSecSpanPostProcessorTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/api/security/AppSecSpanPostProcessorTest.groovy
@@ -37,7 +37,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * producer.publishDataEvent(_, ctx, _, _)
     1 * ctx.commitDerivatives(traceSegment)
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close()
     1 * sampler.releaseOne()
     0 * _
@@ -62,7 +62,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * ctx.isKeepOpenForApiSecurityPostProcessing() >> true
     1 * sampler.sampleRequest(_) >> false
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close()
     1 * sampler.releaseOne()
     0 * _
@@ -90,7 +90,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * reqCtx.getTraceSegment() >> traceSegment
     1 * producer.getDataSubscribers(_) >> null
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close() >> { throw new RuntimeException() }
     1 * sampler.releaseOne()
     0 * _
@@ -114,7 +114,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * reqCtx.getData(_) >> ctx
     1 * ctx.isKeepOpenForApiSecurityPostProcessing() >> true
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close()
     1 * sampler.releaseOne()
     0 * _
@@ -212,7 +212,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * producer.getDataSubscribers(_) >> subInfo
     1 * subInfo.isEmpty() >> true
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close()
     1 * sampler.releaseOne()
     0 * _
@@ -243,7 +243,7 @@ class AppSecSpanPostProcessorTest extends DDSpecification {
     1 * subInfo.isEmpty() >> false
     1 * producer.publishDataEvent(_, ctx, _, _) >> { throw new ExpiredSubscriberInfoException() }
     1 * ctx.setKeepOpenForApiSecurityPostProcessing(false)
-    1 * ctx.closeAdditive()
+    1 * ctx.closeWafContext()
     1 * ctx.close()
     1 * sampler.releaseOne()
     0 * _

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/DataBundleMapWrapperSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/DataBundleMapWrapperSpecification.groovy
@@ -1,4 +1,4 @@
-package com.datadog.appsec.powerwaf
+package com.datadog.appsec.ddwaf
 
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
@@ -11,7 +11,7 @@ class DataBundleMapWrapperSpecification extends DDSpecification {
     (KnownAddresses.REQUEST_URI_RAW): '/b',
     (KnownAddresses.REQUEST_CLIENT_IP): '::1'])
   Map<String, Object> mapWrapper =
-  new PowerWAFModule.DataBundleMapWrapper(
+  new WAFModule.DataBundleMapWrapper(
   [KnownAddresses.REQUEST_URI_RAW], // REQUEST_CLIENT_IP will be filtered into an empty map
   dataBundle)
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFStatsReporterSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFStatsReporterSpecification.groovy
@@ -1,20 +1,20 @@
-package com.datadog.appsec.powerwaf
+package com.datadog.appsec.ddwaf
 
 import com.datadog.appsec.gateway.AppSecRequestContext
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.test.util.DDSpecification
-import io.sqreen.powerwaf.PowerwafMetrics
+import com.datadog.ddwaf.WafMetrics
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
-class PowerWAFStatsReporterSpecification extends DDSpecification {
-  PowerWAFStatsReporter reporter = new PowerWAFStatsReporter()
+class WAFStatsReporterSpecification extends DDSpecification {
+  WAFStatsReporter reporter = new WAFStatsReporter()
   AppSecRequestContext ctx = Mock()
 
   void 'reporter reports waf timings and version'() {
     setup:
-    PowerwafMetrics metrics = new PowerwafMetrics()
+    WafMetrics metrics = new WafMetrics()
     metrics.totalRunTimeNs = new AtomicLong(2_000)
     metrics.totalDdwafRunTimeNs = new AtomicLong(1_000)
     TraceSegment segment = Mock()
@@ -37,11 +37,11 @@ class PowerWAFStatsReporterSpecification extends DDSpecification {
 
   void 'reporter reports rasp timings and version'() {
     setup:
-    PowerwafMetrics metrics = new PowerwafMetrics()
+    WafMetrics metrics = new WafMetrics()
     metrics.totalRunTimeNs = new AtomicLong(2_000)
     metrics.totalDdwafRunTimeNs = new AtomicLong(1_000)
 
-    PowerwafMetrics raspMetrics = new PowerwafMetrics()
+    WafMetrics raspMetrics = new WafMetrics()
     raspMetrics.totalRunTimeNs = new AtomicLong(4_000)
     raspMetrics.totalDdwafRunTimeNs = new AtomicLong(3_000)
     TraceSegment segment = Mock()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecificationForkedTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecificationForkedTest.groovy
@@ -2,7 +2,7 @@ package com.datadog.appsec.event.data
 
 import spock.lang.Specification
 
-class KnownAddressesSpecification extends Specification {
+class KnownAddressesSpecificationForkedTest extends Specification {
   void 'forName works for address #name'() {
     expect:
     KnownAddresses.forName(name).key == name

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -11,9 +11,9 @@ import datadog.trace.util.stacktrace.StackTraceEvent
 import com.datadog.appsec.test.StubAppSecConfigService
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.stacktrace.StackTraceFrame
-import io.sqreen.powerwaf.Additive
-import io.sqreen.powerwaf.Powerwaf
-import io.sqreen.powerwaf.PowerwafContext
+import com.datadog.ddwaf.WafContext
+import com.datadog.ddwaf.Waf
+import com.datadog.ddwaf.WafHandle
 
 class AppSecRequestContextSpecification extends DDSpecification {
 
@@ -203,28 +203,28 @@ class AppSecRequestContextSpecification extends DDSpecification {
       'accept': ['application/json', 'application/xml']] as Map
   }
 
-  private Additive createAdditive() {
-    Powerwaf.initialize false
+  private WafContext createWafContext() {
+    Waf.initialize false
     def service = new StubAppSecConfigService()
     service.init()
     CurrentAppSecConfig config = service.lastConfig['waf']
     String uniqueId = UUID.randomUUID() as String
     config.dirtyStatus.markAllDirty()
-    PowerwafContext context = Powerwaf.createContext(uniqueId, config.mergedUpdateConfig.rawConfig)
-    new Additive(context)
+    WafHandle context = Waf.createHandle(uniqueId, config.mergedUpdateConfig.rawConfig)
+    new WafContext(context)
   }
 
-  void 'close closes the additive'() {
+  void 'close closes the wafContext'() {
     setup:
-    def additive = createAdditive()
+    def wafContext = createWafContext()
 
     when:
-    ctx.additive = additive
+    ctx.wafContext = wafContext
     ctx.close()
 
     then:
-    ctx.additive == null
-    !additive.online
+    ctx.wafContext == null
+    !wafContext.online
   }
 
   void 'test isThrottled'(){
@@ -258,13 +258,12 @@ class AppSecRequestContextSpecification extends DDSpecification {
     ctx.collectedCookies = [cookie : ['test']]
     ctx.persistentData.put(KnownAddresses.REQUEST_METHOD, 'GET')
     ctx.derivatives = ['a': 'b']
-    ctx.additive = createAdditive()
+    ctx.wafContext = createWafContext()
     ctx.close()
 
     then:
-    ctx.additive == null
+    ctx.wafContext == null
     ctx.derivatives == null
-    ctx.additive == null
 
     ctx.requestHeaders.isEmpty()
     ctx.responseHeaders.isEmpty()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/AppSecEventWrapperTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/AppSecEventWrapperTest.groovy
@@ -1,8 +1,8 @@
 package com.datadog.appsec.report
 
-import com.datadog.appsec.powerwaf.PowerWAFResultData.Rule
-import com.datadog.appsec.powerwaf.PowerWAFResultData.RuleMatch
-import com.datadog.appsec.powerwaf.PowerWAFResultData.Parameter
+import com.datadog.appsec.ddwaf.WAFResultData.Rule
+import com.datadog.appsec.ddwaf.WAFResultData.RuleMatch
+import com.datadog.appsec.ddwaf.WAFResultData.Parameter
 import datadog.trace.test.util.DDSpecification
 
 class AppSecEventWrapperTest extends DDSpecification {

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -16,7 +16,7 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
 
   public static WafMetricCollector INSTANCE = new WafMetricCollector();
   private static final int ABSTRACT_POWERWAF_EXCEPTION_NUMBER =
-      3; // only 3 error codes are possible for now in AbstractPowerwafException
+      3; // only 3 error codes are possible for now in AbstractWafException
 
   public static WafMetricCollector get() {
     return WafMetricCollector.INSTANCE;

--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -23,7 +23,7 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
     "jdk.",
     "sun.",
     "com.sun.",
-    "io.sqreen.powerwaf."
+    "com.datadog.ddwaf."
   };
 
   private static final String UNKNOWN = "<unknown>";
@@ -135,9 +135,7 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
     if (cn.isEmpty()) {
       return false;
     }
-    return cn.startsWith("datadog.")
-        || cn.startsWith("com.datadog.")
-        || cn.startsWith("io.sqreen.powerwaf.");
+    return cn.startsWith("datadog.") || cn.startsWith("com.datadog.");
   }
 
   private static boolean shouldRedactClass(final String className) {


### PR DESCRIPTION
# What Does This Do
Renames classes to reflect better for libddwaf upgrade 1.23.0. Also a minor change to KnownAddressSpecification test as it is affected by other tests(switch to forked)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55502]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55502]: https://datadoghq.atlassian.net/browse/APPSEC-55502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ