### PR TITLE
Remove unused ScopeStateAware API

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -62,7 +62,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.BlackHoleSpan;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.civisibility.interceptor.CiVisibilityApmProtocolInterceptor;
 import datadog.trace.civisibility.interceptor.CiVisibilityTelemetryInterceptor;
@@ -290,11 +289,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       return profilingContextIntegration.onRootSpanStarted(root);
     }
     return null;
-  }
-
-  @Override
-  public ScopeState newScopeState() {
-    return scopeManager.newScopeState();
   }
 
   public static class CoreTracerBuilder {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -16,8 +16,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-import datadog.trace.bootstrap.instrumentation.api.ScopeState;
-import datadog.trace.bootstrap.instrumentation.api.ScopeStateAware;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
@@ -37,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * from being reported even if all related spans are finished. It also delegates to other
  * ScopeInterceptors to provide additional functionality.
  */
-public final class ContinuableScopeManager implements ScopeStateAware {
+public final class ContinuableScopeManager {
   static final Logger log = LoggerFactory.getLogger(ContinuableScopeManager.class);
   static final RatelimitedLogger ratelimitedLog = new RatelimitedLogger(log, 1, MINUTES);
   static final long iterationKeepAlive =
@@ -278,26 +276,6 @@ public final class ContinuableScopeManager implements ScopeStateAware {
 
   ScopeStack scopeStack() {
     return this.tlsScopeStack.get();
-  }
-
-  @Override
-  public ScopeState newScopeState() {
-    return new ContinuableScopeState();
-  }
-
-  private class ContinuableScopeState implements ScopeState {
-
-    private ScopeStack localScopeStack = tlsScopeStack.initialValue();
-
-    @Override
-    public void activate() {
-      tlsScopeStack.set(localScopeStack);
-    }
-
-    @Override
-    public void fetchFromActive() {
-      localScopeStack = tlsScopeStack.get();
-    }
   }
 
   static final class ScopeStackThreadLocal extends ThreadLocal<ScopeStack> {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -6,12 +6,12 @@ import datadog.trace.api.Stateful
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
 import datadog.trace.api.scopemanager.ExtendedScopeListener
+import datadog.trace.api.scopemanager.ScopeListener
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.api.scopemanager.ScopeListener
 import datadog.trace.context.TraceScope
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
@@ -67,91 +67,6 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def cleanup() {
     tracer.close()
-  }
-
-  def "scope state should be able to fetch and activate state when there is no active span"() {
-    when:
-    def initialScopeState = scopeManager.newScopeState()
-    initialScopeState.fetchFromActive()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    def newScopeState = scopeManager.newScopeState()
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    def span = tracer.buildSpan("test", "test").start()
-    def scope = tracer.activateSpan(span)
-
-    then:
-    scope.span() == span
-    scopeManager.active() == scope
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == scope
-
-    when:
-    span.finish()
-    scope.close()
-    writer.waitForTraces(1)
-
-    then:
-    writer == [[scope.span()]]
-    scopeManager.active() == null
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-  }
-
-  def "scope state should be able to fetch and activate state when there is an active span"() {
-    when:
-    def span = tracer.buildSpan("test", "test").start()
-    def scope = tracer.activateSpan(span)
-    def initialScopeState = scopeManager.newScopeState()
-    initialScopeState.fetchFromActive()
-
-    then:
-    scope.span() == span
-    scopeManager.active() == scope
-
-    when:
-    def newScopeState = scopeManager.newScopeState()
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == scope
-
-    when:
-    span.finish()
-    scope.close()
-    writer.waitForTraces(1)
-
-    then:
-    scopeManager.active() == null
-    writer == [[scope.span()]]
   }
 
   def "non-ddspan activation results in a continuable scope"() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -292,7 +292,7 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer, InternalTracer, EndpointCheckpointer, ScopeStateAware {
+      extends datadog.trace.api.Tracer, InternalTracer, EndpointCheckpointer {
 
     /**
      * Create and start a new span.
@@ -634,11 +634,6 @@ public class AgentTracer {
 
     @Override
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
-
-    @Override
-    public ScopeState newScopeState() {
-      return null;
-    }
 
     @Override
     public AgentDataStreamsMonitoring getDataStreamsMonitoring() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
@@ -1,7 +1,0 @@
-package datadog.trace.bootstrap.instrumentation.api;
-
-public interface ScopeState {
-  void activate();
-
-  void fetchFromActive();
-}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
@@ -1,5 +1,0 @@
-package datadog.trace.bootstrap.instrumentation.api;
-
-public interface ScopeStateAware {
-  ScopeState newScopeState();
-}


### PR DESCRIPTION
# Motivation

With the kotlin coroutines and zio fiber instrumentations migrated to use the new `Context` API, the `ScopeStateAware` API can be removed.

# Additional Notes

Tests are expected to fail while the scope manager has not yet been replaced.

That's why the final target of this stacked PR is the `project/context` feature branch.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-963]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-963]: https://datadoghq.atlassian.net/browse/APMAPI-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ