### PR TITLE
Fix Test Optimization init when repo root cannot be determined

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public class CiVisibilityRepoServices {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CiVisibilityRepoServices.class);
 
-  final String repoRoot;
+  @Nullable final String repoRoot;
   final String moduleName;
   final Provider ciProvider;
   final Map<String, String> ciTags;
@@ -135,7 +136,7 @@ public class CiVisibilityRepoServices {
     }
   }
 
-  static String getModuleName(Config config, String repoRoot, Path path) {
+  static String getModuleName(Config config, @Nullable String repoRoot, Path path) {
     // if parent process is instrumented, it will provide build system's module name
     String parentModuleName = config.getCiVisibilityModuleName();
     if (parentModuleName != null) {
@@ -175,7 +176,7 @@ public class CiVisibilityRepoServices {
       GitRepoUnshallow gitRepoUnshallow,
       GitDataUploader gitDataUploader,
       PullRequestInfo pullRequestInfo,
-      String repoRoot) {
+      @Nullable String repoRoot) {
     ConfigurationApi configurationApi;
     if (backendApi == null) {
       LOGGER.warn(
@@ -208,7 +209,7 @@ public class CiVisibilityRepoServices {
       GitClient gitClient,
       GitRepoUnshallow gitRepoUnshallow,
       BackendApi backendApi,
-      String repoRoot) {
+      @Nullable String repoRoot) {
     if (!config.isCiVisibilityGitUploadEnabled()) {
       return () -> CompletableFuture.completedFuture(null);
     }
@@ -239,7 +240,7 @@ public class CiVisibilityRepoServices {
   }
 
   private static SourcePathResolver buildSourcePathResolver(
-      String repoRoot, RepoIndexProvider indexProvider) {
+      @Nullable String repoRoot, RepoIndexProvider indexProvider) {
     SourcePathResolver compilerAidedResolver =
         repoRoot != null
             ? new CompilerAidedSourcePathResolver(repoRoot)
@@ -248,7 +249,7 @@ public class CiVisibilityRepoServices {
     return new BestEffortSourcePathResolver(compilerAidedResolver, indexResolver);
   }
 
-  private static Codeowners buildCodeowners(String repoRoot) {
+  private static Codeowners buildCodeowners(@Nullable String repoRoot) {
     if (repoRoot != null) {
       return new CodeownersProvider().build(repoRoot);
     } else {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
@@ -54,7 +54,7 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
   private final GitRepoUnshallow gitRepoUnshallow;
   private final GitDataUploader gitDataUploader;
   private final PullRequestInfo pullRequestInfo;
-  private final String repositoryRoot;
+  @Nullable private final String repositoryRoot;
 
   public ExecutionSettingsFactoryImpl(
       Config config,
@@ -63,7 +63,7 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
       GitRepoUnshallow gitRepoUnshallow,
       GitDataUploader gitDataUploader,
       PullRequestInfo pullRequestInfo,
-      String repositoryRoot) {
+      @Nullable String repositoryRoot) {
     this.config = config;
     this.configurationApi = configurationApi;
     this.gitClient = gitClient;
@@ -75,21 +75,19 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
 
   /** @return Executions settings by module name */
   public Map<String, ExecutionSettings> create(@Nonnull JvmInfo jvmInfo) {
-    TracerEnvironment tracerEnvironment = buildTracerEnvironment(repositoryRoot, jvmInfo, null);
+    TracerEnvironment tracerEnvironment = buildTracerEnvironment(jvmInfo, null);
     return create(tracerEnvironment);
   }
 
   @Override
   public ExecutionSettings create(@Nonnull JvmInfo jvmInfo, @Nullable String moduleName) {
-    TracerEnvironment tracerEnvironment =
-        buildTracerEnvironment(repositoryRoot, jvmInfo, moduleName);
+    TracerEnvironment tracerEnvironment = buildTracerEnvironment(jvmInfo, moduleName);
     Map<String, ExecutionSettings> settingsByModule = create(tracerEnvironment);
     ExecutionSettings settings = settingsByModule.get(moduleName);
     return settings != null ? settings : settingsByModule.get(DEFAULT_SETTINGS);
   }
 
-  private TracerEnvironment buildTracerEnvironment(
-      String repositoryRoot, JvmInfo jvmInfo, @Nullable String moduleName) {
+  private TracerEnvironment buildTracerEnvironment(JvmInfo jvmInfo, @Nullable String moduleName) {
     GitInfo gitInfo = GitInfoProvider.INSTANCE.getGitInfo(repositoryRoot);
 
     TracerEnvironment.Builder builder = TracerEnvironment.builder();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/JacocoCoverageCalculator.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/percentage/JacocoCoverageCalculator.java
@@ -47,7 +47,6 @@ import org.jacoco.report.ISourceFileLocator;
 import org.jacoco.report.InputStreamSourceFileLocator;
 import org.jacoco.report.html.HTMLFormatter;
 import org.jacoco.report.xml.XMLFormatter;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,7 +318,6 @@ public class JacocoCoverageCalculator implements CoverageCalculator {
     }
   }
 
-  @NotNull
   private ISourceFileLocator createSourceFileLocator() {
     return repoRoot != null
         ? new RepoIndexFileLocator(repoIndexProvider.getIndex(), repoRoot)

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
@@ -15,7 +15,6 @@ import datadog.trace.civisibility.execution.Regular;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 public class NoOpTestEventsHandler<SuiteKey, TestKey>
     implements TestEventsHandler<SuiteKey, TestKey> {
@@ -99,7 +98,7 @@ public class NoOpTestEventsHandler<SuiteKey, TestKey>
     return null;
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public TestExecutionPolicy executionPolicy(
       TestIdentifier test, TestSourceData source, Collection<String> testTags) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -77,6 +77,6 @@ public interface GitClient {
       throws IOException, TimeoutException, InterruptedException;
 
   interface Factory {
-    GitClient create(String repoRoot);
+    GitClient create(@Nullable String repoRoot);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/NoOpGitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/NoOpGitClient.java
@@ -5,8 +5,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class NoOpGitClient implements GitClient {
 
@@ -54,7 +54,7 @@ public class NoOpGitClient implements GitClient {
     return null;
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public List<String> getTags(String commit) {
     return Collections.emptyList();
@@ -108,13 +108,13 @@ public class NoOpGitClient implements GitClient {
     return null;
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public List<String> getLatestCommits() {
     return Collections.emptyList();
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public List<String> getObjects(
       Collection<String> commitsToSkip, Collection<String> commitsToInclude) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
@@ -51,7 +51,7 @@ public class ShellGitClient implements GitClient {
    */
   ShellGitClient(
       CiVisibilityMetricCollector metricCollector,
-      String repoRoot,
+      @Nonnull String repoRoot,
       String latestCommitsSince,
       int latestCommitsLimit,
       long timeoutMillis) {
@@ -651,10 +651,15 @@ public class ShellGitClient implements GitClient {
     }
 
     @Override
-    public GitClient create(String repoRoot) {
+    public GitClient create(@Nullable String repoRoot) {
       long commandTimeoutMillis = config.getCiVisibilityGitCommandTimeoutMillis();
-      return new ShellGitClient(
-          metricCollector, repoRoot, "1 month ago", 1000, commandTimeoutMillis);
+      if (repoRoot != null) {
+        return new ShellGitClient(
+            metricCollector, repoRoot, "1 month ago", 1000, commandTimeoutMillis);
+      } else {
+        LOGGER.debug("Could not determine repository root, using no-op git client");
+        return NoOpGitClient.INSTANCE;
+      }
     }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/CachingRepoIndexBuilderFactory.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/CachingRepoIndexBuilderFactory.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import java.nio.file.FileSystem;
+import javax.annotation.Nullable;
 
 public class CachingRepoIndexBuilderFactory implements RepoIndexProvider.Factory {
 
@@ -25,7 +26,7 @@ public class CachingRepoIndexBuilderFactory implements RepoIndexProvider.Factory
   }
 
   @Override
-  public RepoIndexProvider create(String repoRoot) {
+  public RepoIndexProvider create(@Nullable String repoRoot) {
     if (repoRoot == null) {
       return () -> RepoIndex.EMPTY;
     }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
   public RepoIndexBuilder(
       Config config,
-      String repoRoot,
+      @Nonnull String repoRoot,
       PackageResolver packageResolver,
       ResourceResolver resourceResolver,
       FileSystem fileSystem) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexProvider.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexProvider.java
@@ -1,9 +1,11 @@
 package datadog.trace.civisibility.source.index;
 
+import javax.annotation.Nullable;
+
 public interface RepoIndexProvider {
   RepoIndex getIndex();
 
   interface Factory {
-    RepoIndexProvider create(String repoRoot);
+    RepoIndexProvider create(@Nullable String repoRoot);
   }
 }


### PR DESCRIPTION
# What Does This Do

Fixes a `NullPointerException` when initializing Test Optimization in an environment where Git repository root cannot be determined.
Marks `CiVisibilityRepoServices#repoRoot` as `@Nullable`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
