### PR TITLE
Remove AttachableWrapper aspect from scopes

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/TypeConverter.java
@@ -55,16 +55,6 @@ public class TypeConverter {
     if (scope == null) {
       return null;
     }
-    if (scope instanceof AttachableWrapper) {
-      AttachableWrapper attachableScopeWrapper = (AttachableWrapper) scope;
-      Object wrapper = attachableScopeWrapper.getWrapper();
-      if (wrapper instanceof Scope) {
-        return (Scope) wrapper;
-      }
-      Scope otScope = new OtelScope(scope);
-      attachableScopeWrapper.attachWrapper(otScope);
-      return otScope;
-    }
     if (scope == noopScope()) {
       return noopScopeWrapper;
     }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
@@ -1,19 +1,17 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.datastreams.NoopPathwayContext
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
-import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentelemetry.TypeConverter
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
 class TypeConverterTest extends AgentTestRunner {
   TypeConverter typeConverter = new TypeConverter()
@@ -45,20 +43,6 @@ class TypeConverterTest extends AgentTestRunner {
     def noopScope = noopScope()
     expect:
     typeConverter.toScope(noopScope) is typeConverter.toScope(noopScope)
-  }
-
-  def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false)
-    def context = createTestSpanContext()
-    def span1 = new DDSpan("test", 0, context, null)
-    def span2 = new DDSpan("test", 0, context, null)
-    def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
-    def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
-    expect:
-    // return the same wrapper for the same scope
-    typeConverter.toScope(scope1) is typeConverter.toScope(scope1)
-    // return distinct wrapper for another context
-    !typeConverter.toScope(scope1).is(typeConverter.toScope(scope2))
   }
 
   def createTestSpanContext() {

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
@@ -58,19 +58,6 @@ public class TypeConverter {
     if (scope == null) {
       return null;
     }
-    if (scope instanceof AttachableWrapper) {
-      AttachableWrapper attachableScopeWrapper = (AttachableWrapper) scope;
-      Object wrapper = attachableScopeWrapper.getWrapper();
-      if (wrapper instanceof OTScopeManager.OTScope) {
-        OTScopeManager.OTScope attachedScopeWrapper = (OTScopeManager.OTScope) wrapper;
-        if (attachedScopeWrapper.isFinishSpanOnClose() == finishSpanOnClose) {
-          return (Scope) wrapper;
-        }
-      }
-      Scope otScope = new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
-      attachableScopeWrapper.attachWrapper(otScope);
-      return otScope;
-    }
     if (scope == noopScope()) {
       return noopScopeWrapper;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -1,20 +1,18 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.datastreams.NoopPathwayContext
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
-import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing31.TypeConverter
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
 class TypeConverterTest extends AgentTestRunner {
   TypeConverter typeConverter = new TypeConverter(new DefaultLogHandler())
@@ -50,23 +48,6 @@ class TypeConverterTest extends AgentTestRunner {
     // noop scopes expected to be the same despite the finishSpanOnClose flag
     typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, false)
     typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, true)
-  }
-
-  def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false)
-    def context = createTestSpanContext()
-    def span1 = new DDSpan("test", 0, context, null)
-    def span2 = new DDSpan("test", 0, context, null)
-    def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
-    def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
-    expect:
-    // return the same wrapper for the same scope
-    typeConverter.toScope(scope1, true) is typeConverter.toScope(scope1, true)
-    typeConverter.toScope(scope1, false) is typeConverter.toScope(scope1, false)
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope1, false))
-    !typeConverter.toScope(scope1, false).is(typeConverter.toScope(scope1, true))
-    // return distinct wrapper for another context
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope2, true))
   }
 
   def createTestSpanContext() {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
@@ -58,19 +58,6 @@ public class TypeConverter {
     if (scope == null) {
       return null;
     }
-    if (scope instanceof AttachableWrapper) {
-      AttachableWrapper attachableScopeWrapper = (AttachableWrapper) scope;
-      Object wrapper = attachableScopeWrapper.getWrapper();
-      if (wrapper instanceof OTScopeManager.OTScope) {
-        OTScopeManager.OTScope attachedScopeWrapper = (OTScopeManager.OTScope) wrapper;
-        if (attachedScopeWrapper.isFinishSpanOnClose() == finishSpanOnClose) {
-          return (Scope) wrapper;
-        }
-      }
-      Scope otScope = new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
-      attachableScopeWrapper.attachWrapper(otScope);
-      return otScope;
-    }
     if (scope == noopScope()) {
       return noopScopeWrapper;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -1,20 +1,18 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.datastreams.NoopPathwayContext
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
-import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing32.TypeConverter
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
 class TypeConverterTest extends AgentTestRunner {
   TypeConverter typeConverter = new TypeConverter(new DefaultLogHandler())
@@ -50,23 +48,6 @@ class TypeConverterTest extends AgentTestRunner {
     // noop scopes expected to be the same despite the finishSpanOnClose flag
     typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, false)
     typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, true)
-  }
-
-  def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false)
-    def context = createTestSpanContext()
-    def span1 = new DDSpan("test", 0, context, null)
-    def span2 = new DDSpan("test", 0, context, null)
-    def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
-    def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
-    expect:
-    // return the same wrapper for the same scope
-    typeConverter.toScope(scope1, true) is typeConverter.toScope(scope1, true)
-    typeConverter.toScope(scope1, false) is typeConverter.toScope(scope1, false)
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope1, false))
-    !typeConverter.toScope(scope1, false).is(typeConverter.toScope(scope1, true))
-    // return distinct wrapper for another context
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope2, true))
   }
 
   def createTestSpanContext() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -5,12 +5,9 @@ import datadog.trace.api.scopemanager.ExtendedScopeListener;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
 
-class ContinuableScope implements AgentScope, AttachableWrapper {
+class ContinuableScope implements AgentScope {
   private final ContinuableScopeManager scopeManager;
 
   final AgentSpan span; // package-private so scopeManager can access it directly
@@ -26,10 +23,6 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   private final byte source;
 
   private short referenceCount = 1;
-
-  private volatile Object wrapper;
-  private static final AtomicReferenceFieldUpdater<ContinuableScope, Object> WRAPPER_FIELD_UPDATER =
-      AtomicReferenceFieldUpdater.newUpdater(ContinuableScope.class, Object.class, "wrapper");
 
   private final Stateful scopeState;
 
@@ -187,15 +180,5 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   @Override
   public byte source() {
     return (byte) (source & 0x7F);
-  }
-
-  @Override
-  public void attachWrapper(@Nonnull Object wrapper) {
-    WRAPPER_FIELD_UPDATER.set(this, wrapper);
-  }
-
-  @Override
-  public Object getWrapper() {
-    return WRAPPER_FIELD_UPDATER.get(this);
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -61,19 +61,6 @@ class TypeConverter {
     if (scope == null) {
       return null;
     }
-    if (scope instanceof AttachableWrapper) {
-      AttachableWrapper attachableScopeWrapper = (AttachableWrapper) scope;
-      Object wrapper = attachableScopeWrapper.getWrapper();
-      if (wrapper instanceof OTScopeManager.OTScope) {
-        OTScopeManager.OTScope attachedScopeWrapper = (OTScopeManager.OTScope) wrapper;
-        if (attachedScopeWrapper.isFinishSpanOnClose() == finishSpanOnClose) {
-          return (Scope) wrapper;
-        }
-      }
-      Scope otScope = new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
-      attachableScopeWrapper.attachWrapper(otScope);
-      return otScope;
-    }
     if (scope == noopScope()) {
       return noopScopeWrapper;
     }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -2,20 +2,18 @@ package datadog.opentracing
 
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.datastreams.NoopPathwayContext
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
-import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
 class TypeConverterTest extends DDSpecification {
   TypeConverter typeConverter = new TypeConverter(new DefaultLogHandler())
@@ -51,23 +49,6 @@ class TypeConverterTest extends DDSpecification {
     // noop scopes expected to be the same despite the finishSpanOnClose flag
     typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, false)
     typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, true)
-  }
-
-  def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false)
-    def context = createTestSpanContext()
-    def span1 = new DDSpan("test", 0, context, null)
-    def span2 = new DDSpan("test", 0, context, null)
-    def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
-    def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
-    expect:
-    // return the same wrapper for the same scope
-    typeConverter.toScope(scope1, true) is typeConverter.toScope(scope1, true)
-    typeConverter.toScope(scope1, false) is typeConverter.toScope(scope1, false)
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope1, false))
-    !typeConverter.toScope(scope1, false).is(typeConverter.toScope(scope1, true))
-    // return distinct wrapper for another context
-    !typeConverter.toScope(scope1, true).is(typeConverter.toScope(scope2, true))
   }
 
   def createTestSpanContext() {


### PR DESCRIPTION
# Motivation

In the majority of cases the scope wrapper will only be accessed once when activating a span or context. The other cases are deprecated calls to check the active scope, where the returned scope wrapper is short-lived and cheap to recreate.

# Additional Notes

The Kotlin, Zio, and some Otel context tests are expected to fail as the scope manager rework is still in-flight

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-960]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-960]: https://datadoghq.atlassian.net/browse/APMAPI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ