### PR TITLE
Remove ScopeSource from instrumentation API

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.debugger.DebuggerSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 
 public class DebuggerTracer implements DebuggerContext.Tracer {
   public static final String OPERATION_NAME = "dd.dynamic.span";
@@ -36,7 +35,7 @@ public class DebuggerTracer implements DebuggerContext.Tracer {
         dynamicSpan.setTag(tag.substring(0, idx), tag.substring(idx + 1));
       }
     }
-    AgentScope scope = tracerAPI.activateSpan(dynamicSpan, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(dynamicSpan);
     return new DebuggerSpanImpl(dynamicSpan, scope, probeStatusSink, encodedProbeId);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -27,7 +27,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.CoreTracer;
 import java.util.stream.Stream;
@@ -137,7 +136,7 @@ public class LogProbeTest {
     if (sessionId != null) {
       span.setTag(Tags.PROPAGATED_DEBUG, sessionId + ":1");
     }
-    try (AgentScope scope = tracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracer.activateManualSpan(span)) {
       Builder builder =
           createLog("Budget testing").probeId(ProbeId.newId()).captureSnapshot(captureSnapshot);
       if (sessionId != null) {
@@ -178,7 +177,7 @@ public class LogProbeTest {
         CoreTracer.builder().idGenerationStrategy(IdGenerationStrategy.fromName("random")).build();
     AgentTracer.registerIfAbsent(tracer);
     AgentSpan span = tracer.startSpan("log probe debug session testing", "test span");
-    try (AgentScope scope = tracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracer.activateManualSpan(span)) {
       if (status == DebugSessionStatus.ACTIVE) {
         span.setTag(Tags.PROPAGATED_DEBUG, DEBUG_SESSION_ID + ":1");
       } else if (status == DebugSessionStatus.DISABLED) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -4,7 +4,6 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.CoreTracer;
 
 import java.util.Arrays;
@@ -26,7 +25,7 @@ public class CapturedSnapshot20 {
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       if (arg.equals("exception") || arg.equals("illegal")) {
         return new CapturedSnapshot20().processWithException(arg);
       }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
@@ -4,7 +4,6 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.CoreTracer;
 
 import java.util.Arrays;
@@ -26,7 +25,7 @@ public class CapturedSnapshot21 {
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("rootProcess").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot21().rootProcess(arg);
     } finally {
       span.finish();
@@ -36,7 +35,7 @@ public class CapturedSnapshot21 {
   private int rootProcess(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process1").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process1(arg) + 1;
     } finally {
       span.finish();
@@ -46,7 +45,7 @@ public class CapturedSnapshot21 {
   private int process1(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process2").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process2(arg) + 1;
     } finally {
       span.finish();
@@ -56,7 +55,7 @@ public class CapturedSnapshot21 {
   private int process2(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process3").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process3(arg) + 1;
     } finally {
       span.finish();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
@@ -4,7 +4,6 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.CoreTracer;
 
 import java.util.Arrays;
@@ -27,7 +26,7 @@ public class CapturedSnapshot28 {
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process").start();
-    try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot28().process(arg);
     } finally {
       span.finish();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot29.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot29.java
@@ -4,7 +4,6 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.CoreTracer;
 
 import java.util.Arrays;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin01.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin01.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class CodeOrigin01 {
@@ -15,7 +14,7 @@ public class CodeOrigin01 {
 
   public static int main(String arg) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     if (arg.equals("debug_1")) {
       ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "1");
     } else if (arg.equals("debug_0")) {
@@ -32,13 +31,13 @@ public class CodeOrigin01 {
 
   private static void fullTrace() throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry();
     span.finish();
     scope.close();
 
     span = newSpan("exit");
-    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    scope = tracerAPI.activateManualSpan(span);
     exit();
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin02.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin02.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class CodeOrigin02 {
@@ -15,7 +14,7 @@ public class CodeOrigin02 {
 
   public static int main(String arg) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     if (arg.equals("debug_1")) {
       ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "1");
     } else if (arg.equals("debug_0")) {
@@ -32,13 +31,13 @@ public class CodeOrigin02 {
 
   private static void fullTrace() throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry();
     span.finish();
     scope.close();
 
     span = newSpan("exit");
-    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    scope = tracerAPI.activateManualSpan(span);
     exit();
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin03.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin03.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class CodeOrigin03 {
@@ -15,7 +14,7 @@ public class CodeOrigin03 {
 
   public static int main(String arg) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     if (arg.equals("debug_1")) {
       ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "1");
     } else if (arg.equals("debug_0")) {
@@ -32,13 +31,13 @@ public class CodeOrigin03 {
 
   private static void fullTrace() throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry();
     span.finish();
     scope.close();
 
     span = newSpan("exit");
-    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    scope = tracerAPI.activateManualSpan(span);
     exit();
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin04.java
@@ -4,7 +4,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 
 public class CodeOrigin04 {
   private int intField = 42;
@@ -24,7 +23,7 @@ public class CodeOrigin04 {
       AgentSpan span;
       AgentScope scope;
       span = newSpan("exit");
-      scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+      scope = tracerAPI.activateManualSpan(span);
       exit();
       span.finish();
       scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class CodeOrigin05 {
@@ -15,7 +14,7 @@ public class CodeOrigin05 {
 
   public static int main(String arg) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     if (arg.equals("debug_1")) {
       ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "1");
     } else if (arg.equals("debug_0")) {
@@ -32,13 +31,13 @@ public class CodeOrigin05 {
 
   private static void fullTrace() throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry();
     span.finish();
     scope.close();
 
     span = newSpan("exit");
-    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    scope = tracerAPI.activateManualSpan(span);
     exit();
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/TriggerProbe01.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/TriggerProbe01.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class TriggerProbe01 {
@@ -15,7 +14,7 @@ public class TriggerProbe01 {
 
   public static int main(String arg) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
 
     fullTrace();
 
@@ -27,13 +26,13 @@ public class TriggerProbe01 {
 
   private static void fullTrace() throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry();
     span.finish();
     scope.close();
 
     span = newSpan("exit");
-    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    scope = tracerAPI.activateManualSpan(span);
     exit();
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/TriggerProbe02.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/TriggerProbe02.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.core.DDSpan;
 
 public class TriggerProbe02 {
@@ -15,7 +14,7 @@ public class TriggerProbe02 {
 
   public static int main(Integer value) throws ReflectiveOperationException {
     AgentSpan span = newSpan("main");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
 
     fullTrace(value);
 
@@ -27,7 +26,7 @@ public class TriggerProbe02 {
 
   private static void fullTrace(int value) throws NoSuchMethodException {
     AgentSpan span = newSpan("entry");
-    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    AgentScope scope = tracerAPI.activateManualSpan(span);
     entry(value);
     span.finish();
     scope.close();

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -61,7 +61,7 @@ public class Reporter {
     }
     if (span == null) {
       final AgentSpan newSpan = startNewSpan();
-      try (final AgentScope autoClosed = tracer().activateSpan(newSpan, ScopeSource.MANUAL)) {
+      try (final AgentScope autoClosed = tracer().activateManualSpan(newSpan)) {
         vulnerability.updateSpan(newSpan);
         reportVulnerability(newSpan, vulnerability);
       } finally {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -16,7 +16,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.AgentTaskScheduler
 import datadog.trace.util.stacktrace.StackTraceEvent
@@ -232,7 +231,7 @@ class ReporterTest extends DDSpecification {
     then:
     noExceptionThrown()
     1 * tracerAPI.startSpan('iast', 'vulnerability', _ as AgentSpanContext) >> span
-    1 * tracerAPI.activateSpan(span, ScopeSource.MANUAL) >> scope
+    1 * tracerAPI.activateManualSpan(span) >> scope
     1 * span.getRequestContext() >> reqCtx
     1 * span.setSpanType(InternalSpanTypes.VULNERABILITY) >> span
     1 * span.setTag(ANALYZED.key(), ANALYZED.value())

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedThenSucceed.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedThenSucceed.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +17,7 @@ public class TestFailedThenSucceed {
   public void setUp() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get();
     AgentSpan span = agentTracer.buildSpan("junit-manual", "set-up").start();
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // tracing setup to verify that it is executed for every retry
     }
     span.finish();
@@ -33,7 +32,7 @@ public class TestFailedThenSucceed {
   public void tearDown() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get();
     AgentSpan span = agentTracer.buildSpan("junit-manual", "tear-down").start();
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // tracing teardown to verify that it is executed for every retry
     }
     span.finish();

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/org/example/TestParameterizedSetupSpecSpock.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/org/example/TestParameterizedSetupSpecSpock.groovy
@@ -3,7 +3,6 @@ package org.example
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import spock.lang.Specification
 
 class TestParameterizedSetupSpecSpock extends Specification {
@@ -11,7 +10,7 @@ class TestParameterizedSetupSpecSpock extends Specification {
   def setupSpec() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get()
     AgentSpan span = agentTracer.buildSpan("spock-manual", "spec-setup").start()
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // manually trace spec setup to check whether ITR skips it or not
     }
     span.finish()

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/org/example/TestSucceedSetupSpecSpock.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/org/example/TestSucceedSetupSpecSpock.groovy
@@ -3,7 +3,6 @@ package org.example
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import spock.lang.Specification
 
 class TestSucceedSetupSpecSpock extends Specification {
@@ -11,7 +10,7 @@ class TestSucceedSetupSpecSpock extends Specification {
   def setupSpec() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get()
     AgentSpan span = agentTracer.buildSpan("spock-manual", "spec-setup").start()
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // manually trace spec setup to check whether ITR skips it or not
     }
     span.finish()

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedThenSucceed.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedThenSucceed.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,7 @@ public class TestFailedThenSucceed {
   public void setUp() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get();
     AgentSpan span = agentTracer.buildSpan("junit-manual", "set-up").start();
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // tracing setup to verify that it is executed for every retry
     }
     span.finish();
@@ -33,7 +32,7 @@ public class TestFailedThenSucceed {
   public void tearDown() {
     AgentTracer.TracerAPI agentTracer = AgentTracer.get();
     AgentSpan span = agentTracer.buildSpan("junit-manual", "tear-down").start();
-    try (AgentScope scope = agentTracer.activateSpan(span, ScopeSource.MANUAL)) {
+    try (AgentScope scope = agentTracer.activateManualSpan(span)) {
       // tracing teardown to verify that it is executed for every retry
     }
     span.finish();

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -381,7 +380,7 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
 
   protected suspend fun AgentSpan.activateAndUse(block: suspend () -> Unit) {
     try {
-      get().activateSpan(this, INSTRUMENTATION).use {
+      get().activateManualSpan(this).use {
         block()
       }
     } finally {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.opentelemetry;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.context.Scope;
@@ -39,7 +38,7 @@ public class OtelTracer implements Tracer {
     }
 
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
+    final AgentScope agentScope = tracer.activateManualSpan(agentSpan);
     return converter.toScope(agentScope);
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -10,7 +10,6 @@ import io.opentelemetry.context.ImplicitContextKeyed
 import io.opentelemetry.context.ThreadLocalContextStorage
 import spock.lang.Subject
 
-import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
 import static datadog.opentelemetry.shim.context.OtelContext.OTEL_CONTEXT_ROOT_SPAN_KEY
 import static datadog.opentelemetry.shim.context.OtelContext.OTEL_CONTEXT_SPAN_KEY
 import static datadog.opentelemetry.shim.trace.OtelConventions.SPAN_KIND_INTERNAL
@@ -48,7 +47,7 @@ class ContextTest extends AgentTestRunner {
 
     when:
     def ddSpan = TEST_TRACER.startSpan("dd-api", "other-name")
-    def ddScope = TEST_TRACER.activateSpan(ddSpan, MANUAL)
+    def ddScope = TEST_TRACER.activateManualSpan(ddSpan)
     currentSpan = Span.current()
 
     then:
@@ -97,7 +96,7 @@ class ContextTest extends AgentTestRunner {
   def "test Context.makeCurrent() to activate a span with another currently active span"() {
     setup:
     def ddSpan = TEST_TRACER.startSpan("dd-api", "some-name")
-    def ddScope = TEST_TRACER.activateSpan(ddSpan, MANUAL)
+    def ddScope = TEST_TRACER.activateManualSpan(ddSpan)
     def builder = tracer.spanBuilder("other-name")
     def otelSpan = builder.startSpan()
 
@@ -135,7 +134,7 @@ class ContextTest extends AgentTestRunner {
   def "test Context.makeCurrent() to activate an already active span"() {
     when:
     def ddSpan = TEST_TRACER.startSpan("dd-api", "some-name")
-    def ddScope = TEST_TRACER.activateSpan(ddSpan, MANUAL)
+    def ddScope = TEST_TRACER.activateManualSpan(ddSpan)
     def currentSpan = Span.current()
 
     then:
@@ -196,7 +195,7 @@ class ContextTest extends AgentTestRunner {
 
     when:
     def ddChildSpan = TEST_TRACER.startSpan("dd-api", "other-name")
-    def ddChildScope = TEST_TRACER.activateSpan(ddChildSpan, MANUAL)
+    def ddChildScope = TEST_TRACER.activateManualSpan(ddChildSpan)
     def current = Span.current()
 
     then:

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/groovy/AddingSpanAttributesAnnotationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/groovy/AddingSpanAttributesAnnotationTest.groovy
@@ -1,6 +1,5 @@
 import annotatedsample.AnnotatedMethods
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 
 class AddingSpanAttributesAnnotationTest extends AgentTestRunner {
   @Override
@@ -14,7 +13,7 @@ class AddingSpanAttributesAnnotationTest extends AgentTestRunner {
     setup:
     def methodName = "sayHelloWith${typeName}Attribute"
     def testSpan = TEST_TRACER.startSpan("test", "operation")
-    def scope = TEST_TRACER.activateSpan(testSpan, ScopeSource.INSTRUMENTATION)
+    def scope = TEST_TRACER.activateManualSpan(testSpan)
     AnnotatedMethods."$methodName"(value)
     scope.close()
     testSpan.finish()

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -30,7 +29,7 @@ public class OTScopeManager implements ScopeManager {
     }
 
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
+    final AgentScope agentScope = tracer.activateManualSpan(agentSpan);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -157,8 +156,7 @@ public class OTTracer implements Tracer {
 
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
-      return converter.toScope(
-          tracer.activateSpan(delegate.start(), ScopeSource.MANUAL), finishSpanOnClose);
+      return converter.toScope(tracer.activateManualSpan(delegate.start()), finishSpanOnClose);
     }
   }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -35,7 +34,7 @@ public class OTScopeManager implements ScopeManager {
     }
 
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
+    final AgentScope agentScope = tracer.activateManualSpan(agentSpan);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -52,8 +51,7 @@ public class OTTracer implements Tracer {
       return null;
     }
 
-    return converter.toScope(
-        tracer.activateSpan(converter.toAgentSpan(span), ScopeSource.MANUAL), false);
+    return converter.toScope(tracer.activateManualSpan(converter.toAgentSpan(span)), false);
   }
 
   @Override
@@ -180,8 +178,7 @@ public class OTTracer implements Tracer {
 
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
-      return converter.toScope(
-          tracer.activateSpan(delegate.start(), ScopeSource.MANUAL), finishSpanOnClose);
+      return converter.toScope(tracer.activateManualSpan(delegate.start()), finishSpanOnClose);
     }
   }
 }

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
@@ -1,5 +1,4 @@
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION
 import zio._
 
 import java.util.concurrent.Executors
@@ -127,7 +126,7 @@ object ZioTestFixtures {
             .start()
         )
         ddScope <- ZIO.succeed(
-          AgentTracer.get().activateSpan(ddSpan, INSTRUMENTATION)
+          AgentTracer.get().activateManualSpan(ddSpan)
         )
         _ <- scope.addFinalizer(ZIO.succeed(ddScope.close()))
         _ <- scope.addFinalizer(ZIO.succeed(ddSpan.finish()))

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.Constants
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import spock.lang.Shared
 
 import java.util.concurrent.TimeoutException
@@ -115,7 +114,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
     when:
     AgentScope scope
     runUnderTrace("parent") {
-      scope = TEST_TRACER.activateSpan(noopSpan(), ScopeSource.INSTRUMENTATION)
+      scope = TEST_TRACER.activateManualSpan(noopSpan())
 
       blockUntilChildSpansFinished(1)
     }

--- a/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
@@ -9,7 +9,7 @@ class TraceCorrelationTest extends AgentTestRunner {
   def "access trace correlation only under trace"() {
     when:
     def span = TEST_TRACER.startSpan("test", "myspan")
-    def scope = TEST_TRACER.activateSpan(span)
+    def scope = TEST_TRACER.activateManualSpan(span)
 
     then:
     CorrelationIdentifier.traceId == (span.traceId.toHighOrderLong() == 0 ? span.traceId.toString() : span.traceId.toHexString())

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -911,13 +911,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
-    return scopeManager.activate(span, source);
+  public AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating) {
+    return scopeManager.activate(span, source, isAsyncPropagating);
   }
 
   @Override
-  public AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating) {
-    return scopeManager.activate(span, source, isAsyncPropagating);
+  public AgentScope activateManualSpan(final AgentSpan span) {
+    return scopeManager.activate(span, ScopeSource.MANUAL);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -907,12 +907,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   public AgentScope activateSpan(final AgentSpan span) {
-    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION, DEFAULT_ASYNC_PROPAGATING);
+    return activateSpan(span, DEFAULT_ASYNC_PROPAGATING);
   }
 
   @Override
-  public AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating) {
-    return scopeManager.activate(span, source, isAsyncPropagating);
+  public AgentScope activateSpan(AgentSpan span, boolean isAsyncPropagating) {
+    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -36,7 +35,7 @@ class OTScopeManager implements ScopeManager {
     }
 
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
+    final AgentScope agentScope = tracer.activateManualSpan(agentSpan);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -86,11 +86,11 @@ public class AgentTracer {
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
-    return get().activateSpan(span, ScopeSource.INSTRUMENTATION, DEFAULT_ASYNC_PROPAGATING);
+    return get().activateSpan(span, DEFAULT_ASYNC_PROPAGATING);
   }
 
   public static AgentScope activateSpan(final AgentSpan span, final boolean isAsyncPropagating) {
-    return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
+    return get().activateSpan(span, isAsyncPropagating);
   }
 
   /**
@@ -338,7 +338,8 @@ public class AgentTracer {
         AgentSpanContext parent,
         long startTimeMicros);
 
-    AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
+    /** Activate a span from inside auto-instrumentation. */
+    AgentScope activateSpan(AgentSpan span, boolean isAsyncPropagating);
 
     /** Activate a span from outside auto-instrumentation, i.e. a manual or custom span. */
     AgentScope activateManualSpan(AgentSpan span);
@@ -479,8 +480,7 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentScope activateSpan(
-        final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
+    public AgentScope activateSpan(final AgentSpan span, final boolean isAsyncPropagating) {
       return NoopScope.INSTANCE;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -338,9 +338,10 @@ public class AgentTracer {
         AgentSpanContext parent,
         long startTimeMicros);
 
-    AgentScope activateSpan(AgentSpan span, ScopeSource source);
-
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
+
+    /** Activate a span from outside auto-instrumentation, i.e. a manual or custom span. */
+    AgentScope activateManualSpan(AgentSpan span);
 
     @Override
     AgentScope.Continuation captureActiveSpan();
@@ -478,13 +479,13 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
+    public AgentScope activateSpan(
+        final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
       return NoopScope.INSTANCE;
     }
 
     @Override
-    public AgentScope activateSpan(
-        final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
+    public AgentScope activateManualSpan(final AgentSpan span) {
       return NoopScope.INSTANCE;
     }
 


### PR DESCRIPTION
# Motivation

Simplifies the internal `TracerAPI` to remove references to `ScopeSource`.

There are now two methods to activate spans:
* `activateSpan`
  * used by auto-instrumentation
  * always overrides the async propagation flag with the given value
* `activateManualSpan`
  * used by manual/test code, as well as custom instrumentation (via the OpenTelemetry API, etc.)
  * always inherits the async propagation flag from the surrounding scope

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-960]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-960]: https://datadoghq.atlassian.net/browse/APMAPI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ