### PR TITLE
Simplify activateSpan calls which use the default value for isAsyncPropagating

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -117,7 +117,7 @@ public class TestImpl implements DDTest {
 
     span = spanBuilder.start();
 
-    activateSpan(span, true);
+    activateSpan(span);
 
     span.setSpanType(InternalSpanTypes.TEST);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_TEST);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
@@ -131,7 +131,7 @@ public class TestSuiteImpl implements DDTestSuite {
     testDecorator.afterStart(span);
 
     if (!parallelized) {
-      activateSpan(span, true);
+      activateSpan(span);
     }
 
     metricCollector.add(CiVisibilityCountMetric.EVENT_CREATED, 1, instrumentation, EventType.SUITE);

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
@@ -32,7 +32,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span, true)) {
+      try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -16,7 +16,7 @@ public class DatadogWrapperHelper {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 
-    return activateSpan(span, true);
+    return activateSpan(span);
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -76,7 +76,7 @@ public class FinatraInstrumentation extends InstrumenterModule.Tracing
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.className(clazz));
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -78,7 +78,7 @@ public class GrizzlyHttpHandlerInstrumentation extends InstrumenterModule.Tracin
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, parentContext);
 
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
 
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
       request.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/FilterAdvice.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/FilterAdvice.java
@@ -17,7 +17,7 @@ public class FilterAdvice {
     if (span == null || activeSpan() != null) {
       return null;
     }
-    return activateSpan((AgentSpan) span, true);
+    return activateSpan((AgentSpan) span);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -116,7 +116,7 @@ public class GrizzlyDecorator
     HttpResponsePacket httpResponse = httpRequest.getResponse();
     AgentSpanContext.Extracted context = DECORATE.extract(httpRequest);
     AgentSpan span = DECORATE.startSpan(httpRequest, context);
-    AgentScope scope = activateSpan(span, true);
+    AgentScope scope = activateSpan(span);
     DECORATE.afterStart(span);
     ctx.getAttributes().setAttribute(DD_SPAN_ATTRIBUTE, span);
     ctx.getAttributes().setAttribute(DD_RESPONSE_ATTRIBUTE, httpResponse);

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
@@ -93,7 +93,7 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
 
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -149,7 +149,7 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
 
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
@@ -47,7 +47,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
           // can only be aborted inside the filter method
         }
 
-        final AgentScope scope = activateSpan(span, true);
+        final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);
         DECORATE.onJakartaRsSpan(span, parent, filterClass, method);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -123,7 +123,7 @@ public final class JakartaRsAnnotationsInstrumentation extends InstrumenterModul
       DECORATE.onJakartaRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
 
       if (contextStore != null && asyncResponse != null) {
         contextStore.put(asyncResponse, span);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
@@ -28,7 +28,7 @@ public class RequestFilterHelper {
         parent = activeSpan();
         span = startSpan(JAKARTA_RS_REQUEST_ABORT);
 
-        final AgentScope scope = activateSpan(span, true);
+        final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);
         DECORATE.onJakartaRsSpan(span, parent, resourceClass, method);

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
@@ -26,7 +26,7 @@ public class RecursiveThreadPoolExecution implements Runnable {
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span, true)) {
+    try (AgentScope scope = activateSpan(span)) {
       executor.execute(new RecursiveThreadPoolExecution(executor, maxDepth, depth + 1));
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
@@ -27,7 +27,7 @@ public class RecursiveThreadPoolMixedSubmissionAndExecution implements Runnable 
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span, true)) {
+    try (AgentScope scope = activateSpan(span)) {
       if (depth % 2 == 0) {
         executor.submit(
             new RecursiveThreadPoolMixedSubmissionAndExecution(executor, maxDepth, depth + 1));

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
@@ -26,7 +26,7 @@ public class RecursiveThreadPoolSubmission implements Runnable {
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span, true)) {
+    try (AgentScope scope = activateSpan(span)) {
       executor.submit(new RecursiveThreadPoolSubmission(executor, maxDepth, depth + 1));
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/forkjoin/LinearTask.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/forkjoin/LinearTask.java
@@ -34,7 +34,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span, true)) {
+      try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
@@ -31,7 +31,7 @@ public class SendAsyncAdvice {
         return null;
       }
       final AgentSpan span = AgentTracer.startSpan(JavaNetClientDecorator.OPERATION_NAME);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       if (bodyHandler != null) {
         bodyHandler = new BodyHandlerWrapper<>(bodyHandler, captureSpan(span));
       }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -100,7 +100,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -47,7 +47,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
           // can only be aborted inside the filter method
         }
 
-        final AgentScope scope = activateSpan(span, true);
+        final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);
         DECORATE.onJaxRsSpan(span, parent, filterClass, method);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -131,7 +131,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
 
       if (contextStore != null && asyncResponse != null) {
         contextStore.put(asyncResponse, span);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -27,7 +27,7 @@ public class RequestFilterHelper {
         parent = activeSpan();
         span = startSpan(JAX_RS_REQUEST_ABORT);
 
-        final AgentScope scope = activateSpan(span, true);
+        final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);
         DECORATE.onJaxRsSpan(span, parent, resourceClass, method);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -69,7 +69,7 @@ public final class DataSourceInstrumentation extends InstrumenterModule.Tracing
 
       span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
@@ -28,7 +28,7 @@ public class JettyServerAdvice {
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       span.setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
@@ -30,7 +30,7 @@ public class JettyServerAdvice {
 
       final AgentSpanContext.Extracted extractedContext = JettyDecorator.DECORATE.extract(req);
       final AgentSpan span = JettyDecorator.DECORATE.startSpan(req, extractedContext);
-      try (final AgentScope scope = activateSpan(span, true)) {
+      try (final AgentScope scope = activateSpan(span)) {
         span.setMeasured(true);
         JettyDecorator.DECORATE.afterStart(span);
         JettyDecorator.DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -158,7 +158,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -159,7 +159,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -173,7 +173,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -30,7 +30,7 @@ public class HandleAdvice {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, req, req, extractedContext);
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
     req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
     req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -39,7 +39,7 @@ public class KafkaProducerCallback implements Callback {
     span.finish();
     if (callback != null) {
       if (parent != null) {
-        try (final AgentScope scope = activateSpan(parent, true)) {
+        try (final AgentScope scope = activateSpan(parent)) {
           callback.onCompletion(metadata, exception);
         }
       } else {

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
@@ -38,7 +38,7 @@ public class KafkaProducerCallback implements Callback {
     span.finish();
     if (callback != null) {
       if (parent != null) {
-        try (final AgentScope scope = activateSpan(parent, true)) {
+        try (final AgentScope scope = activateSpan(parent)) {
           callback.onCompletion(metadata, exception);
         }
       } else {

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -108,7 +108,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(request);
       request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
       final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
       if (Config.get().isJeeSplitByDeployment()) {
         final IWebAppDispatcherContext dispatcherContext = request.getWebAppDispatcherContext();
         if (dispatcherContext != null) {

--- a/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
@@ -110,7 +110,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(request);
       request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
       final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
       if (Config.get().isJeeSplitByDeployment()) {
         final IWebAppDispatcherContext dispatcherContext = request.getWebAppDispatcherContext();
         if (dispatcherContext != null) {

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
@@ -48,7 +48,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       ctx.sendUpstream(msg);
     }
   }
@@ -76,7 +76,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       super.exceptionCaught(ctx, e);
     }
   }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
@@ -35,7 +35,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
       if (span == null) {
         ctx.sendUpstream(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, true)) {
+        try (final AgentScope scope = activateSpan(span)) {
           ctx.sendUpstream(msg); // superclass does not throw
         }
       }
@@ -50,7 +50,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     channelTraceContext.reset();
     channelTraceContext.setRequestHeaders(headers);
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, ctx.getChannel(), request, context);
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -37,7 +37,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       ctx.fireChannelRead(msg);
     }
   }
@@ -58,7 +58,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       super.exceptionCaught(ctx, cause);
     }
   }
@@ -76,7 +76,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       super.channelInactive(ctx);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -31,7 +31,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, true)) {
+        try (final AgentScope scope = activateSpan(span)) {
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -43,7 +43,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(headers);
     final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, channel, request, extractedContext);
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -46,7 +46,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       ctx.fireChannelRead(msg);
     }
   }
@@ -67,7 +67,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       super.exceptionCaught(ctx, cause);
     }
   }
@@ -85,7 +85,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, true)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       super.channelInactive(ctx);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -30,7 +30,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, true)) {
+        try (final AgentScope scope = activateSpan(span)) {
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -42,7 +42,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(headers);
     final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, channel, request, extractedContext);
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanAdvice.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanAdvice.java
@@ -14,7 +14,7 @@ public class WithSpanAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Origin final Method method) {
     AgentSpan span = DECORATE.startMethodSpan(method);
-    return activateSpan(span, true);
+    return activateSpan(span);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
@@ -16,7 +16,7 @@ public class DatadogWrapperHelper {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 
-    return activateSpan(span, true);
+    return activateSpan(span);
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -32,7 +32,7 @@ public class PlayAdvice {
       span.setMeasured(true);
     }
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     DECORATE.afterStart(span);
     return scope;
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -38,7 +38,7 @@ public class PlayAdvice {
       span.setMeasured(true);
     }
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     DECORATE.afterStart(span);
 
     req = RequestHelper.withTag(req, "_dd_HasPlayRequestSpan", "true");

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -38,7 +38,7 @@ public class PlayAdvice {
       // Do not extract the context.
       span = startSpan(PLAY_REQUEST);
     }
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     span.setMeasured(true);
     DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ActionWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ActionWrapper.java
@@ -22,7 +22,7 @@ public class ActionWrapper<T> implements Action<T> {
 
   @Override
   public void execute(final T t) throws Exception {
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       delegate.execute(t);
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/BlockWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/BlockWrapper.java
@@ -23,7 +23,7 @@ public class BlockWrapper implements Block {
 
   @Override
   public void execute() throws Exception {
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       delegate.execute();
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -42,7 +42,7 @@ public final class TracingHandler implements Handler {
 
     boolean setFinalizer = false;
 
-    try (final AgentScope scope = activateSpan(ratpackSpan, true)) {
+    try (final AgentScope scope = activateSpan(ratpackSpan)) {
 
       ctx.getResponse()
           .beforeSend(

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -483,7 +483,7 @@ class ReactorCoreTest extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span, true)
+    def scope = activateSpan(span)
 
     Publisher<Integer> publisher = publisherSupplier()
     try {
@@ -504,7 +504,7 @@ class ReactorCoreTest extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span, true)
+    AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()
     publisher.subscribe(new Subscriber<Integer>() {

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -483,7 +483,7 @@ class ReactorCoreTest extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span, true)
+    def scope = activateSpan(span)
 
     Publisher<Integer> publisher = publisherSupplier()
     try {
@@ -504,7 +504,7 @@ class ReactorCoreTest extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span, true)
+    AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()
     publisher.subscribe(new Subscriber<Integer>() {

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -33,7 +33,7 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
     final AgentSpan span = startSpan(operationName, parent != null ? parent.context() : null);
     afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       delegate.call(new TracedSubscriber(span, subscriber, decorator));
     }
   }

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
@@ -28,7 +28,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onStart() {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, true)) {
+      try (final AgentScope scope = activateSpan(span)) {
         delegate.onStart();
       }
     } else {
@@ -40,7 +40,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onNext(final T value) {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, true)) {
+      try (final AgentScope scope = activateSpan(span)) {
         delegate.onNext(value);
       } catch (final Throwable e) {
         onError(e);
@@ -55,7 +55,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       boolean errored = false;
-      try (final AgentScope scope = activateSpan(span, true)) {
+      try (final AgentScope scope = activateSpan(span)) {
         delegate.onCompleted();
       } catch (final Throwable e) {
         // Repopulate the spanRef for onError
@@ -78,7 +78,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onError(final Throwable e) {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, true)) {
+      try (final AgentScope scope = activateSpan(span)) {
         decorator.onError(span, e);
         delegate.onError(e);
       } catch (final Throwable e2) {

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
@@ -384,7 +384,7 @@ class RxJava2Test extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span, true)
+    def scope = activateSpan(span)
 
     def publisher = publisherSupplier()
     try {
@@ -405,7 +405,7 @@ class RxJava2Test extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span, true)
+    AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()
     if (publisher instanceof Maybe) {

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
@@ -32,7 +32,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span, true)) {
+      try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -55,7 +55,7 @@ public class Servlet2Advice {
 
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(httpServletRequest);
     final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = activateSpan(span, true);
+    scope = activateSpan(span);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -71,7 +71,7 @@ public class Servlet3Advice {
 
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(httpServletRequest);
     final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = activateSpan(span, true);
+    scope = activateSpan(span);
 
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -129,7 +129,7 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -74,7 +74,7 @@ public final class FilterInstrumentation extends InstrumenterModule.Tracing
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.
       span.setResourceName(DECORATE.spanNameForMethod(filter.getClass(), "doFilter"));
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -84,7 +84,7 @@ public final class HttpServletInstrumentation extends InstrumenterModule.Tracing
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".
       span.setResourceName(DECORATE.spanNameForMethod(method));
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -72,7 +72,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
 
       span.setResourceName(DECORATE.spanNameForMethod(HttpServletResponse.class, method));
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -27,7 +27,7 @@ public class SprayHttpServerRunSealedRouteAdvice {
       extractedContext = null;
       span = startSpan(DECORATE.spanName());
     }
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
@@ -35,7 +35,7 @@ final class RepositoryInterceptor implements MethodInterceptor {
     DECORATOR.afterStart(span);
     DECORATOR.onOperation(span, invokedMethod, repositoryInterface);
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
 
     Object result = null;
     try {

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -51,7 +51,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithSpan(CharSequence spanName) throws Throwable {
     AgentSpan span = startSpan(spanName);
-    try (AgentScope scope = activateSpan(span, true)) {
+    try (AgentScope scope = activateSpan(span)) {
       return delegate.proceed();
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -58,7 +58,7 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
         LEGACY_TRACING ? startSpan(SCHEDULED_CALL) : startSpan(SCHEDULED_CALL, null);
     DECORATE.afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.onRun(span, runnable);
 
       try {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -44,7 +44,7 @@ public class HandlerAdapterAdvice {
       span.setSpanName(operationName);
       span.setTag("handler.type", handlerType);
 
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
     }
 
     final AgentSpan parentSpan = exchange.getAttribute(AdviceUtils.PARENT_SPAN_ATTRIBUTE);

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -81,7 +81,7 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
@@ -34,7 +34,7 @@ public class ControllerAdvice {
     SpringWebHttpServerDecorator.DECORATE.afterStart(span);
     SpringWebHttpServerDecorator.DECORATE.onHandle(span, handler);
 
-    return activateSpan(span, true);
+    return activateSpan(span);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -126,7 +126,7 @@ public final class TomcatServerInstrumentation extends InstrumenterModule.Tracin
       req.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
 
       final AgentSpan span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       // This span is finished when Request.recycle() is called by RequestInstrumentation.
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -108,7 +108,7 @@ public class TwilioAsyncInstrumentation extends InstrumenterModule.Tracing
 
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     /** Method exit instrumentation. */

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -95,7 +95,7 @@ public final class HandlerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(exchange);
       final AgentSpan span = DECORATE.startSpan(exchange, extractedContext).setMeasured(true);
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, exchange, exchange, extractedContext);
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
@@ -111,7 +111,7 @@ public class RedisAPICallAdvice {
     The potential racy condition when the handler may be added to an already finished task is handled
     by RedisAPIImplSendAdvice.
     */
-    scope = activateSpan(clientSpan, true);
+    scope = activateSpan(clientSpan);
     ResponseHandlerWrapper respHandler =
         new ResponseHandlerWrapper(handler, clientSpan, parentContinuation);
     handler = respHandler;

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisFutureSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisFutureSendAdvice.java
@@ -62,7 +62,7 @@ public class RedisFutureSendAdvice {
         DECORATE.startAndDecorateSpan(
             request.command(), InstrumentationContext.get(Command.class, UTF8BytesString.class));
 
-    return activateSpan(clientSpan, true);
+    return activateSpan(clientSpan);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisSendAdvice.java
@@ -67,7 +67,7 @@ public class RedisSendAdvice {
             request.command(), InstrumentationContext.get(Command.class, UTF8BytesString.class));
 
     handler = new ResponseHandlerWrapper(handler, clientSpan, parentContinuation);
-    return activateSpan(clientSpan, true);
+    return activateSpan(clientSpan);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/CursorReadAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/CursorReadAdvice.java
@@ -37,7 +37,7 @@ public class CursorReadAdvice {
     }
     handler = new QueryResultHandlerWrapper<>(handler, clientSpan, parentContinuation);
 
-    return activateSpan(clientSpan, true);
+    return activateSpan(clientSpan);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
@@ -55,7 +55,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
 
       updateRoutingContextWithRoute(routingContext);
     }
-    try (final AgentScope scope = span != null ? activateSpan(span, true) : noopScope()) {
+    try (final AgentScope scope = span != null ? activateSpan(span) : noopScope()) {
       try {
         actual.handle(routingContext);
       } catch (final Throwable t) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -49,7 +49,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
       updateRoutingContextWithRoute(routingContext);
     }
 
-    try (final AgentScope scope = span != null ? activateSpan(span, true) : noopScope()) {
+    try (final AgentScope scope = span != null ? activateSpan(span) : noopScope()) {
       try {
         actual.handle(routingContext);
       } catch (final Throwable t) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -47,7 +47,7 @@ class TraceUtils {
     final AgentSpan span = inheritCurrent ? startSpan(rootOperationName) : startSpan(rootOperationName, null)
     DECORATOR.afterStart(span)
 
-    AgentScope scope = activateSpan(span, true)
+    AgentScope scope = activateSpan(span)
 
     try {
       return r.call()


### PR DESCRIPTION
`isAsyncPropagating` is always `true` by default now, so these calls can all be simplified.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-960]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-960]: https://datadoghq.atlassian.net/browse/APMAPI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ