### PR TITLE
Make the default config sources more robust when a security manager is installed

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -221,7 +221,11 @@ excludedClassesBranchCoverage = [
   'datadog.trace.util.stacktrace.HotSpotStackWalker',
   'datadog.trace.util.stacktrace.StackWalkerFactory'
 ]
-excludedClassesInstructionCoverage = ['datadog.trace.util.stacktrace.StackWalkerFactory']
+excludedClassesInstructionCoverage = [
+  'datadog.trace.bootstrap.config.provider.EnvironmentConfigSource',
+  'datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource',
+  'datadog.trace.util.stacktrace.StackWalkerFactory'
+]
 
 compileTestJava.dependsOn 'generateTestClassNameTries'
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/EnvironmentConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/EnvironmentConfigSource.java
@@ -8,7 +8,11 @@ final class EnvironmentConfigSource extends ConfigProvider.Source {
 
   @Override
   protected String get(String key) {
-    return System.getenv(propertyNameToEnvironmentVariableName(key));
+    try {
+      return System.getenv(propertyNameToEnvironmentVariableName(key));
+    } catch (SecurityException e) {
+      return null;
+    }
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
@@ -8,7 +8,11 @@ public final class SystemPropertiesConfigSource extends ConfigProvider.Source {
 
   @Override
   protected String get(String key) {
-    return System.getProperty(propertyNameToSystemPropertyName(key));
+    try {
+      return System.getProperty(propertyNameToSystemPropertyName(key));
+    } catch (SecurityException e) {
+      return null;
+    }
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

If we don't have permission to access system properties or the environment then fall back to defaults.

# Motivation

Supports installation of helpers, even when their target location is lacking permission to lookup configuration.  

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-14831]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-14831]: https://datadoghq.atlassian.net/browse/APMS-14831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ