### PR TITLE
Support common config sources for user-provided git info

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.civisibility.ci
 
 import datadog.trace.api.Config
-import datadog.trace.api.git.GitInfo
 import datadog.trace.api.git.GitInfoProvider
 import datadog.trace.api.git.UserSuppliedGitInfoBuilder
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -69,7 +68,7 @@ abstract class CITagsProviderTest extends Specification {
       environmentVariables.set(it.key, it.value)
     }
 
-    environmentVariables.set(GitInfo.DD_GIT_COMMIT_SHA, "1234567890123456789012345678901234567890")
+    environmentVariables.set(UserSuppliedGitInfoBuilder.DD_GIT_COMMIT_SHA, "1234567890123456789012345678901234567890")
 
     when:
     CIProviderInfoFactory ciProviderInfoFactory = new CIProviderInfoFactory(Config.get(), GIT_FOLDER_FOR_TESTS, new CiEnvironmentImpl(System.getenv()))
@@ -88,7 +87,7 @@ abstract class CITagsProviderTest extends Specification {
       environmentVariables.set(it.key, it.value)
     }
 
-    environmentVariables.set(GitInfo.DD_GIT_REPOSITORY_URL, "local supplied repo url")
+    environmentVariables.set(UserSuppliedGitInfoBuilder.DD_GIT_REPOSITORY_URL, "local supplied repo url")
 
     when:
     CIProviderInfoFactory ciProviderInfoFactory = new CIProviderInfoFactory(Config.get(), GIT_FOLDER_FOR_TESTS, new CiEnvironmentImpl(System.getenv()))

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.civisibility.ci.env.CiEnvironmentImpl
 import datadog.trace.civisibility.git.CILocalGitInfoBuilder
 import datadog.trace.civisibility.git.CIProviderGitInfoBuilder
 import datadog.trace.civisibility.git.tree.GitClient
+import datadog.trace.util.Strings
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
@@ -68,7 +69,7 @@ abstract class CITagsProviderTest extends Specification {
       environmentVariables.set(it.key, it.value)
     }
 
-    environmentVariables.set(UserSuppliedGitInfoBuilder.DD_GIT_COMMIT_SHA, "1234567890123456789012345678901234567890")
+    environmentVariables.set(Strings.propertyNameToEnvironmentVariableName(UserSuppliedGitInfoBuilder.DD_GIT_COMMIT_SHA), "1234567890123456789012345678901234567890")
 
     when:
     CIProviderInfoFactory ciProviderInfoFactory = new CIProviderInfoFactory(Config.get(), GIT_FOLDER_FOR_TESTS, new CiEnvironmentImpl(System.getenv()))
@@ -87,7 +88,7 @@ abstract class CITagsProviderTest extends Specification {
       environmentVariables.set(it.key, it.value)
     }
 
-    environmentVariables.set(UserSuppliedGitInfoBuilder.DD_GIT_REPOSITORY_URL, "local supplied repo url")
+    environmentVariables.set(Strings.propertyNameToEnvironmentVariableName(UserSuppliedGitInfoBuilder.DD_GIT_REPOSITORY_URL), "local supplied repo url")
 
     when:
     CIProviderInfoFactory ciProviderInfoFactory = new CIProviderInfoFactory(Config.get(), GIT_FOLDER_FOR_TESTS, new CiEnvironmentImpl(System.getenv()))

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfo.java
@@ -6,18 +6,6 @@ public class GitInfo {
 
   public static final GitInfo NOOP = new GitInfo(null, null, null, CommitInfo.NOOP);
 
-  public static final String DD_GIT_REPOSITORY_URL = "DD_GIT_REPOSITORY_URL";
-  public static final String DD_GIT_BRANCH = "DD_GIT_BRANCH";
-  public static final String DD_GIT_TAG = "DD_GIT_TAG";
-  public static final String DD_GIT_COMMIT_SHA = "DD_GIT_COMMIT_SHA";
-  public static final String DD_GIT_COMMIT_MESSAGE = "DD_GIT_COMMIT_MESSAGE";
-  public static final String DD_GIT_COMMIT_AUTHOR_NAME = "DD_GIT_COMMIT_AUTHOR_NAME";
-  public static final String DD_GIT_COMMIT_AUTHOR_EMAIL = "DD_GIT_COMMIT_AUTHOR_EMAIL";
-  public static final String DD_GIT_COMMIT_AUTHOR_DATE = "DD_GIT_COMMIT_AUTHOR_DATE";
-  public static final String DD_GIT_COMMIT_COMMITTER_NAME = "DD_GIT_COMMIT_COMMITTER_NAME";
-  public static final String DD_GIT_COMMIT_COMMITTER_EMAIL = "DD_GIT_COMMIT_COMMITTER_EMAIL";
-  public static final String DD_GIT_COMMIT_COMMITTER_DATE = "DD_GIT_COMMIT_COMMITTER_DATE";
-
   private final String repositoryURL;
   private final String branch;
   private final String tag;

--- a/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
@@ -1,33 +1,34 @@
 package datadog.trace.api.git;
 
-import static datadog.trace.api.git.GitInfo.DD_GIT_BRANCH;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_AUTHOR_DATE;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_AUTHOR_EMAIL;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_AUTHOR_NAME;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_COMMITTER_DATE;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_COMMITTER_EMAIL;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_COMMITTER_NAME;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_MESSAGE;
-import static datadog.trace.api.git.GitInfo.DD_GIT_COMMIT_SHA;
-import static datadog.trace.api.git.GitInfo.DD_GIT_REPOSITORY_URL;
-import static datadog.trace.api.git.GitInfo.DD_GIT_TAG;
-
 import datadog.trace.api.Config;
-import datadog.trace.api.ConfigCollector;
-import datadog.trace.api.ConfigOrigin;
 import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.util.Strings;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
 
+  public static final String DD_GIT_REPOSITORY_URL = "git.repository.url";
+  public static final String DD_GIT_BRANCH = "git.branch";
+  public static final String DD_GIT_TAG = "git.tag";
+  public static final String DD_GIT_COMMIT_SHA = "git.commit.sha";
+  public static final String DD_GIT_COMMIT_MESSAGE = "git.commit.message";
+  public static final String DD_GIT_COMMIT_AUTHOR_NAME = "git.commit.author.name";
+  public static final String DD_GIT_COMMIT_AUTHOR_EMAIL = "git.commit.author.email";
+  public static final String DD_GIT_COMMIT_AUTHOR_DATE = "git.commit.author.date";
+  public static final String DD_GIT_COMMIT_COMMITTER_NAME = "git.commit.committer.name";
+  public static final String DD_GIT_COMMIT_COMMITTER_EMAIL = "git.commit.committer.email";
+  public static final String DD_GIT_COMMIT_COMMITTER_DATE = "git.commit.committer.date";
   private static final Logger log = LoggerFactory.getLogger(UserSuppliedGitInfoBuilder.class);
 
   @Override
   public GitInfo build(@Nullable String repositoryPath) {
-    String gitRepositoryUrl = System.getenv(DD_GIT_REPOSITORY_URL);
+    ConfigProvider configProvider = ConfigProvider.getInstance();
+
+    String gitRepositoryUrl = configProvider.getString(DD_GIT_REPOSITORY_URL);
     if (gitRepositoryUrl == null) {
       gitRepositoryUrl = Config.get().getGlobalTags().get(Tags.GIT_REPOSITORY_URL);
     }
@@ -36,9 +37,9 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
     // using the value returned by the CI Provider, so
     // we need to normalize the value. Also, it can contain
     // the tag (e.g. origin/tags/0.1.0)
-    String gitTag = System.getenv(DD_GIT_TAG);
+    String gitTag = configProvider.getString(DD_GIT_TAG);
     String gitBranch = null;
-    final String gitBranchOrTag = System.getenv(DD_GIT_BRANCH);
+    final String gitBranchOrTag = configProvider.getString(DD_GIT_BRANCH);
     if (gitBranchOrTag != null) {
       if (!GitUtils.isTagReference(gitBranchOrTag)) {
         gitBranch = GitUtils.normalizeBranch(gitBranchOrTag);
@@ -47,21 +48,18 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
       }
     }
 
-    String gitCommitSha = System.getenv(DD_GIT_COMMIT_SHA);
+    String gitCommitSha = configProvider.getString(DD_GIT_COMMIT_SHA);
     if (gitCommitSha == null) {
       gitCommitSha = Config.get().getGlobalTags().get(Tags.GIT_COMMIT_SHA);
     }
 
-    ConfigCollector.get().put(DD_GIT_REPOSITORY_URL, gitRepositoryUrl, ConfigOrigin.ENV);
-    ConfigCollector.get().put(DD_GIT_COMMIT_SHA, gitCommitSha, ConfigOrigin.ENV);
-
-    final String gitCommitMessage = System.getenv(DD_GIT_COMMIT_MESSAGE);
-    final String gitCommitAuthorName = System.getenv(DD_GIT_COMMIT_AUTHOR_NAME);
-    final String gitCommitAuthorEmail = System.getenv(DD_GIT_COMMIT_AUTHOR_EMAIL);
-    final String gitCommitAuthorDate = System.getenv(DD_GIT_COMMIT_AUTHOR_DATE);
-    final String gitCommitCommitterName = System.getenv(DD_GIT_COMMIT_COMMITTER_NAME);
-    final String gitCommitCommitterEmail = System.getenv(DD_GIT_COMMIT_COMMITTER_EMAIL);
-    final String gitCommitCommitterDate = System.getenv(DD_GIT_COMMIT_COMMITTER_DATE);
+    final String gitCommitMessage = configProvider.getString(DD_GIT_COMMIT_MESSAGE);
+    final String gitCommitAuthorName = configProvider.getString(DD_GIT_COMMIT_AUTHOR_NAME);
+    final String gitCommitAuthorEmail = configProvider.getString(DD_GIT_COMMIT_AUTHOR_EMAIL);
+    final String gitCommitAuthorDate = configProvider.getString(DD_GIT_COMMIT_AUTHOR_DATE);
+    final String gitCommitCommitterName = configProvider.getString(DD_GIT_COMMIT_COMMITTER_NAME);
+    final String gitCommitCommitterEmail = configProvider.getString(DD_GIT_COMMIT_COMMITTER_EMAIL);
+    final String gitCommitCommitterDate = configProvider.getString(DD_GIT_COMMIT_COMMITTER_DATE);
 
     GitInfo gitInfo =
         new GitInfo(
@@ -82,8 +80,8 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
       if (repoUrl == null || repoUrl.isEmpty()) {
         log.error(
             "Could not resolve git repository URL (can be provided via "
-                + GitInfo.DD_GIT_REPOSITORY_URL
-                + " env var, "
+                + Strings.propertyNameToEnvironmentVariableName(DD_GIT_REPOSITORY_URL)
+                + " env var or corresponding system property, "
                 + GeneralConfig.TAGS
                 + " config property or by embedding git metadata at build time)");
       }
@@ -94,10 +92,10 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
             "Git commit SHA could not be resolved or is invalid: "
                 + commitSha
                 + " (can be provided via "
-                + GitInfo.DD_GIT_COMMIT_SHA
-                + " env var, "
+                + Strings.propertyNameToEnvironmentVariableName(DD_GIT_COMMIT_SHA)
+                + " env var or corresponding system property, "
                 + GeneralConfig.TAGS
-                + " config property or by embedding git metadata at build time; must be a full-length SHA_");
+                + " config property or by embedding git metadata at build time; must be a full-length SHA");
       }
     }
 


### PR DESCRIPTION
# What Does This Do

Updates the class that reads user-provided git metadata to use common config sources (env vars, system props, property files, etc).
Current implementation only uses the environment variables.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
