### PR TITLE
Prevent before callsites targeting constructors in super calls

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java
@@ -2,6 +2,7 @@ package datadog.trace.plugin.csi.impl;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static datadog.trace.plugin.csi.impl.CallSiteFactory.typeResolver;
+import static datadog.trace.plugin.csi.util.CallSiteConstants.ADVICE_TYPE_CLASS;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.AUTO_SERVICE_FQDN;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.CALL_SITES_CLASS;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.CALL_SITES_FQCN;
@@ -11,7 +12,6 @@ import static datadog.trace.plugin.csi.util.CallSiteConstants.HAS_ENABLED_PROPER
 import static datadog.trace.plugin.csi.util.CallSiteConstants.METHOD_HANDLER_CLASS;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.OPCODES_FQDN;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.STACK_DUP_MODE_CLASS;
-import static datadog.trace.plugin.csi.util.CallSiteConstants.TYPE_CLASS;
 import static datadog.trace.plugin.csi.util.CallSiteConstants.TYPE_RESOLVER;
 import static datadog.trace.plugin.csi.util.CallSiteUtils.deleteFile;
 import static datadog.trace.plugin.csi.util.JavaParserUtils.getPrimaryType;
@@ -213,7 +213,8 @@ public class AdviceGeneratorImpl implements AdviceGenerator {
             .setArguments(
                 new NodeList<>(
                     new FieldAccessExpr()
-                        .setScope(new TypeExpr(new ClassOrInterfaceType().setName(TYPE_CLASS)))
+                        .setScope(
+                            new TypeExpr(new ClassOrInterfaceType().setName(ADVICE_TYPE_CLASS)))
                         .setName(type),
                     new StringLiteralExpr(pointCut.getOwner().getInternalName()),
                     new StringLiteralExpr(pointCut.getMethodName()),

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/ext/IastExtension.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/ext/IastExtension.java
@@ -364,19 +364,19 @@ public class IastExtension implements Extension {
     final MethodType pointcut = spec.getPointcut();
     for (final MethodCallExpr add : addAdvices) {
       final NodeList<Expression> arguments = add.getArguments();
-      final String owner = arguments.get(0).asStringLiteralExpr().asString();
+      final String owner = arguments.get(1).asStringLiteralExpr().asString();
       if (!owner.equals(pointcut.getOwner().getInternalName())) {
         continue;
       }
-      final String method = arguments.get(1).asStringLiteralExpr().asString();
+      final String method = arguments.get(2).asStringLiteralExpr().asString();
       if (!method.equals(pointcut.getMethodName())) {
         continue;
       }
-      final String description = arguments.get(2).asStringLiteralExpr().asString();
+      final String description = arguments.get(3).asStringLiteralExpr().asString();
       if (!description.equals(pointcut.getMethodType().getDescriptor())) {
         continue;
       }
-      return arguments.get(3).asLambdaExpr();
+      return arguments.get(4).asLambdaExpr();
     }
     throw new IllegalArgumentException("Cannot find lambda expression for pointcut " + pointcut);
   }

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/CallSiteConstants.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/CallSiteConstants.java
@@ -30,6 +30,8 @@ public abstract class CallSiteConstants {
 
   public static final String HAS_ENABLED_PROPERTY_CLASS = CALL_SITES_CLASS + ".HasEnabledProperty";
 
+  public static final String TYPE_CLASS = "Type";
+
   public static final String STACK_DUP_MODE_CLASS = "StackDupMode";
 
   public static final String METHOD_HANDLER_CLASS = "MethodHandler";

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/CallSiteConstants.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/CallSiteConstants.java
@@ -30,7 +30,7 @@ public abstract class CallSiteConstants {
 
   public static final String HAS_ENABLED_PROPERTY_CLASS = CALL_SITES_CLASS + ".HasEnabledProperty";
 
-  public static final String TYPE_CLASS = "Type";
+  public static final String ADVICE_TYPE_CLASS = "AdviceType";
 
   public static final String STACK_DUP_MODE_CLASS = "StackDupMode";
 

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
@@ -44,6 +44,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       interfaces(CallSites)
       helpers(BeforeAdvice)
       advices(0) {
+        type("BEFORE")
         pointcut('java/security/MessageDigest', 'getInstance', '(Ljava/lang/String;)Ljava/security/MessageDigest;')
         statements(
           'handler.dupParameters(descriptor, StackDupMode.COPY);',
@@ -76,6 +77,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       interfaces(CallSites)
       helpers(AroundAdvice)
       advices(0) {
+        type("AROUND")
         pointcut('java/lang/String', 'replaceAll', '(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;')
         statements(
           'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AroundAdvice", "around", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");'
@@ -106,6 +108,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       interfaces(CallSites)
       helpers(AfterAdvice)
       advices(0) {
+        type("AFTER")
         pointcut('java/lang/String', 'concat', '(Ljava/lang/String;)Ljava/lang/String;')
         statements(
           'handler.dupInvoke(owner, descriptor, StackDupMode.COPY);',

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AdviceAssert.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AdviceAssert.groovy
@@ -1,10 +1,15 @@
 package datadog.trace.plugin.csi.impl.assertion
 
 class AdviceAssert {
+  protected String type
   protected String owner
   protected String method
   protected String descriptor
   protected Collection<String> statements
+
+  void type(String type) {
+    assert type == this.type
+  }
 
   void pointcut(String owner, String method, String descriptor) {
     assert owner == this.owner

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
@@ -83,10 +83,12 @@ class AssertBuilder<C extends CallSiteAssert> {
     return getMethodCalls(acceptMethod).findAll {
       it.nameAsString == 'addAdvice'
     }.collect {
-      def (owner, method, descriptor) = it.arguments.subList(0, 3)*.asStringLiteralExpr()*.asString()
-      final handlerLambda = it.arguments[3].asLambdaExpr()
+      final adviceType = it.arguments.get(0).asFieldAccessExpr().getName()
+      def (owner, method, descriptor) = it.arguments.subList(1, 4)*.asStringLiteralExpr()*.asString()
+      final handlerLambda = it.arguments[4].asLambdaExpr()
       final advice = handlerLambda.body.asBlockStmt().statements*.toString()
       return new AdviceAssert([
+        type      : adviceType,
         owner     : owner,
         method    : method,
         descriptor: descriptor,

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
@@ -217,8 +217,8 @@ class IastExtensionTest extends BaseCsiPluginTest {
       return getMethodCalls(acceptMethod).findAll {
         it.nameAsString == 'addAdvice'
       }.collect {
-        def (owner, method, descriptor) = it.arguments.subList(0, 3)*.asStringLiteralExpr()*.asString()
-        final handlerLambda = it.arguments[3].asLambdaExpr()
+        def (owner, method, descriptor) = it.arguments.subList(1, 4)*.asStringLiteralExpr()*.asString()
+        final handlerLambda = it.arguments[4].asLambdaExpr()
         final statements = handlerLambda.body.asBlockStmt().statements
         final instrumentedStmt = statements.get(0).asIfStmt()
         final executedStmt = statements.get(1).asIfStmt()

--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.csi;
 
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.AROUND;
+
 import datadog.trace.agent.tooling.csi.CallSites;
 import datadog.trace.agent.tooling.csi.InvokeAdvice;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
@@ -44,6 +46,7 @@ public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation {
       return Collections.singletonList(
           (container -> {
             container.addAdvice(
+                AROUND,
                 "javax/servlet/ServletRequest",
                 "getParameter",
                 "(Ljava/lang/String;)Ljava/lang/String;",

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -6,6 +6,8 @@ import static datadog.trace.agent.tooling.bytebuddy.csi.ConstantPool.CONSTANT_ME
 import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSites;
+import datadog.trace.agent.tooling.csi.InvokeAdvice;
+import datadog.trace.agent.tooling.csi.InvokeDynamicAdvice;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -141,6 +143,11 @@ public class Advices {
     return methodAdvices.get(descriptor);
   }
 
+  /** Gets the type of advice we are dealing with */
+  public byte typeOf(final CallSiteAdvice advice) {
+    return ((HasType) advice).getType();
+  }
+
   public String[] getHelpers() {
     return helpers;
   }
@@ -176,15 +183,17 @@ public class Advices {
 
     @Override
     public void addAdvice(
-        final String type,
+        final byte type,
+        final String owner,
         final String method,
         final String descriptor,
         final CallSiteAdvice advice) {
       final Map<String, Map<String, CallSiteAdvice>> typeAdvices =
-          advices.computeIfAbsent(type, k -> new HashMap<>());
+          advices.computeIfAbsent(owner, k -> new HashMap<>());
       final Map<String, CallSiteAdvice> methodAdvices =
           typeAdvices.computeIfAbsent(method, k -> new HashMap<>());
-      final CallSiteAdvice oldAdvice = methodAdvices.put(descriptor, advice);
+      final CallSiteAdvice oldAdvice =
+          methodAdvices.put(descriptor, HasType.withType(advice, type));
       if (oldAdvice != null) {
         throw new UnsupportedOperationException(
             String.format(
@@ -359,5 +368,68 @@ public class Advices {
   public interface Listener {
     void onConstantPool(
         @Nonnull TypeDescription type, @Nonnull ConstantPool pool, final byte[] classFile);
+  }
+
+  private interface HasType {
+    byte getType();
+
+    static CallSiteAdvice withType(final CallSiteAdvice advice, final byte type) {
+      if (advice instanceof InvokeAdvice) {
+        return new InvokeWithType((InvokeAdvice) advice, type);
+      } else {
+        return new InvokeDynamicWithType((InvokeDynamicAdvice) advice, type);
+      }
+    }
+  }
+
+  private static class InvokeWithType implements InvokeAdvice, HasType {
+    private final InvokeAdvice advice;
+    private final byte type;
+
+    private InvokeWithType(InvokeAdvice advice, byte type) {
+      this.advice = advice;
+      this.type = type;
+    }
+
+    @Override
+    public byte getType() {
+      return type;
+    }
+
+    @Override
+    public void apply(
+        final MethodHandler handler,
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface) {
+      advice.apply(handler, opcode, owner, name, descriptor, isInterface);
+    }
+  }
+
+  private static class InvokeDynamicWithType implements InvokeDynamicAdvice, HasType {
+    private final InvokeDynamicAdvice advice;
+    private final byte type;
+
+    private InvokeDynamicWithType(final InvokeDynamicAdvice advice, final byte type) {
+      this.advice = advice;
+      this.type = type;
+    }
+
+    @Override
+    public byte getType() {
+      return type;
+    }
+
+    @Override
+    public void apply(
+        final MethodHandler handler,
+        final String name,
+        final String descriptor,
+        final Handle bootstrapMethodHandle,
+        final Object... bootstrapMethodArguments) {
+      advice.apply(handler, name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+    }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -145,7 +145,7 @@ public class Advices {
 
   /** Gets the type of advice we are dealing with */
   public byte typeOf(final CallSiteAdvice advice) {
-    return ((HasType) advice).getType();
+    return ((TypedAdvice) advice).getType();
   }
 
   public String[] getHelpers() {
@@ -193,7 +193,7 @@ public class Advices {
       final Map<String, CallSiteAdvice> methodAdvices =
           typeAdvices.computeIfAbsent(method, k -> new HashMap<>());
       final CallSiteAdvice oldAdvice =
-          methodAdvices.put(descriptor, HasType.withType(advice, type));
+          methodAdvices.put(descriptor, TypedAdvice.withType(advice, type));
       if (oldAdvice != null) {
         throw new UnsupportedOperationException(
             String.format(
@@ -370,7 +370,7 @@ public class Advices {
         @Nonnull TypeDescription type, @Nonnull ConstantPool pool, final byte[] classFile);
   }
 
-  private interface HasType {
+  private interface TypedAdvice {
     byte getType();
 
     static CallSiteAdvice withType(final CallSiteAdvice advice, final byte type) {
@@ -382,7 +382,7 @@ public class Advices {
     }
   }
 
-  private static class InvokeWithType implements InvokeAdvice, HasType {
+  private static class InvokeWithType implements InvokeAdvice, TypedAdvice {
     private final InvokeAdvice advice;
     private final byte type;
 
@@ -408,7 +408,7 @@ public class Advices {
     }
   }
 
-  private static class InvokeDynamicWithType implements InvokeDynamicAdvice, HasType {
+  private static class InvokeDynamicWithType implements InvokeDynamicAdvice, TypedAdvice {
     private final InvokeDynamicAdvice advice;
     private final byte type;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.csi;
 
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static net.bytebuddy.jar.asm.ClassWriter.COMPUTE_MAXS;
 
@@ -126,7 +127,7 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
 
   private static class CallSiteMethodVisitor extends MethodVisitor
       implements CallSiteAdvice.MethodHandler {
-    private final Advices advices;
+    protected final Advices advices;
 
     private CallSiteMethodVisitor(
         @Nonnull final Advices advices, @Nonnull final MethodVisitor delegated) {
@@ -144,10 +145,20 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
 
       CallSiteAdvice advice = advices.findAdvice(owner, name, descriptor);
       if (advice instanceof InvokeAdvice) {
-        ((InvokeAdvice) advice).apply(this, opcode, owner, name, descriptor, isInterface);
+        invokeAdvice((InvokeAdvice) advice, opcode, owner, name, descriptor, isInterface);
       } else {
         mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
       }
+    }
+
+    protected void invokeAdvice(
+        final InvokeAdvice advice,
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface) {
+      advice.apply(this, opcode, owner, name, descriptor, isInterface);
     }
 
     @Override
@@ -158,12 +169,25 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
         final Object... bootstrapMethodArguments) {
       CallSiteAdvice advice = advices.findAdvice(bootstrapMethodHandle);
       if (advice instanceof InvokeDynamicAdvice) {
-        ((InvokeDynamicAdvice) advice)
-            .apply(this, name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+        invokeDynamicAdvice(
+            (InvokeDynamicAdvice) advice,
+            name,
+            descriptor,
+            bootstrapMethodHandle,
+            bootstrapMethodArguments);
       } else {
         mv.visitInvokeDynamicInsn(
             name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
       }
+    }
+
+    protected void invokeDynamicAdvice(
+        final InvokeDynamicAdvice advice,
+        final String name,
+        final String descriptor,
+        final Handle bootstrapMethodHandle,
+        final Object... bootstrapMethodArguments) {
+      advice.apply(this, name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
     }
 
     @Override
@@ -346,6 +370,23 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
     public void dupParameters(final String methodDescriptor, final StackDupMode mode) {
       super.dupParameters(
           methodDescriptor, isSuperCall ? StackDupMode.PREPEND_ARRAY_SUPER_CTOR : mode);
+    }
+
+    @Override
+    protected void invokeAdvice(
+        final InvokeAdvice advice,
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface) {
+      if (isSuperCall && advices.typeOf(advice) == BEFORE) {
+        // TODO APPSEC-57009 calls to super are not instrumented by before callsites
+        // just ignore the advice and keep on
+        mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+      } else {
+        super.invokeAdvice(advice, opcode, owner, name, descriptor, isInterface);
+      }
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.csi;
 
-import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.AFTER;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static net.bytebuddy.jar.asm.ClassWriter.COMPUTE_MAXS;
 
@@ -380,8 +380,8 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
         final String name,
         final String descriptor,
         final boolean isInterface) {
-      if (isSuperCall && advices.typeOf(advice) == BEFORE) {
-        // TODO APPSEC-57009 calls to super are not instrumented by before callsites
+      if (isSuperCall && advices.typeOf(advice) != AFTER) {
+        // TODO APPSEC-57009 calls to super are only instrumented by after call sites
         // just ignore the advice and keep on
         mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
       } else {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -73,9 +73,9 @@ public interface CallSiteAdvice {
     APPEND_ARRAY
   }
 
-  abstract class Type {
+  abstract class AdviceType {
 
-    private Type() {}
+    private AdviceType() {}
 
     public static final byte BEFORE = -1;
     public static final byte AROUND = 0;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -72,4 +72,13 @@ public interface CallSiteAdvice {
     /** Copies the parameters in an array and appends it */
     APPEND_ARRAY
   }
+
+  abstract class Type {
+
+    private Type() {}
+
+    public static final byte BEFORE = -1;
+    public static final byte AROUND = 0;
+    public static final byte AFTER = 1;
+  }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSites.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSites.java
@@ -6,22 +6,25 @@ public interface CallSites extends Consumer<CallSites.Container> {
 
   interface Container {
     default void addAdvice(
-        final String type,
+        final byte type,
+        final String owner,
         final String method,
         final String descriptor,
         final InvokeAdvice advice) {
-      addAdvice(type, method, descriptor, (CallSiteAdvice) advice);
+      addAdvice(type, owner, method, descriptor, (CallSiteAdvice) advice);
     }
 
     default void addAdvice(
-        final String type,
+        final byte type,
+        final String owner,
         final String method,
         final String descriptor,
         final InvokeDynamicAdvice advice) {
-      addAdvice(type, method, descriptor, (CallSiteAdvice) advice);
+      addAdvice(type, owner, method, descriptor, (CallSiteAdvice) advice);
     }
 
-    void addAdvice(String type, String method, String descriptor, CallSiteAdvice advice);
+    void addAdvice(
+        byte kind, String owner, String method, String descriptor, CallSiteAdvice advice);
 
     void addHelpers(String... helperClassNames);
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -9,6 +9,8 @@ import net.bytebuddy.jar.asm.Type
 import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.PREPEND_ARRAY_CTOR
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.AFTER
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.BEFORE
 
 class CallSiteInstrumentationTest extends BaseCallSiteTest {
 
@@ -84,7 +86,7 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
             )
         }
       }
-    final callSiteTransformer = new CallSiteTransformer(mockAdvices([mockCallSites(advice, pointcut)]))
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([mockCallSites(AFTER, advice, pointcut)]))
 
     when:
     final transformedClass = transformType(source, target, callSiteTransformer)
@@ -101,7 +103,7 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     @Override
     void accept(final Container container) {
       final pointcut = buildPointcut(String.getDeclaredMethod('concat', String))
-      container.addAdvice(pointcut.type, pointcut.method, pointcut.descriptor, new StringConcatAdvice())
+      container.addAdvice(BEFORE, pointcut.type, pointcut.method, pointcut.descriptor, new StringConcatAdvice())
     }
   }
 

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockCallSites.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockCallSites.java
@@ -1,3 +1,5 @@
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
+
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSites;
 import datadog.trace.api.iast.IastCallSites;
@@ -5,6 +7,6 @@ import datadog.trace.api.iast.IastCallSites;
 public class MockCallSites implements IastCallSites, CallSites {
   @Override
   public void accept(final Container container) {
-    container.addAdvice("type", "method", "descriptor", (CallSiteAdvice) null);
+    container.addAdvice(BEFORE, "type", "method", "descriptor", (CallSiteAdvice) null);
   }
 }

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockCallSites.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockCallSites.java
@@ -1,4 +1,4 @@
-import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.BEFORE;
 
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSites;

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockRaspCallSites.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockRaspCallSites.java
@@ -1,4 +1,4 @@
-import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.AdviceType.BEFORE;
 
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSites;

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockRaspCallSites.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/java/MockRaspCallSites.java
@@ -1,3 +1,5 @@
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.Type.BEFORE;
+
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSites;
 import datadog.trace.api.appsec.RaspCallSites;
@@ -5,6 +7,6 @@ import datadog.trace.api.appsec.RaspCallSites;
 public class MockRaspCallSites implements RaspCallSites, CallSites {
   @Override
   public void accept(final Container container) {
-    container.addAdvice("type", "method", "descriptor", (CallSiteAdvice) null);
+    container.addAdvice(BEFORE, "typeRasp", "methodRasp", "descriptorRasp", (CallSiteAdvice) null);
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
@@ -35,7 +35,7 @@ class ObjectInputStreamCallSiteTest extends AgentTestRunner {
     new TestCustomObjectInputStream(inputStream())
 
     then:
-    // TODO APPSEC-57009 calls to super are not instrumented by before callsites
+    // TODO APPSEC-57009 calls to super are only instrumented by after callsites
     0 * iastModule.onObject(_)
   }
 

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
@@ -5,6 +5,8 @@ import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.UntrustedDeserializationModule
 import foo.bar.TestObjectInputStreamSuite
 
+import foo.bar.TestCustomObjectInputStream
+
 class ObjectInputStreamCallSiteTest extends AgentTestRunner {
 
   @Override
@@ -17,12 +19,29 @@ class ObjectInputStreamCallSiteTest extends AgentTestRunner {
     final module = Mock(UntrustedDeserializationModule)
     InstrumentationBridge.registerIastModule(module)
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[0])
-
     when:
-    TestObjectInputStreamSuite.init(inputStream)
+    TestObjectInputStreamSuite.init(inputStream())
 
     then:
     1 * module.onObject(_)
+  }
+
+  void 'test super call to ObjectInputStream.<init>'() {
+    given:
+    final iastModule = Mock(UntrustedDeserializationModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestCustomObjectInputStream(inputStream())
+
+    then:
+    // TODO APPSEC-57009 calls to super are not instrumented by before callsites
+    0 * iastModule.onObject(_)
+  }
+
+  private static InputStream inputStream() {
+    final baos = new ByteArrayOutputStream()
+    new ObjectOutputStream(baos).writeObject([:])
+    return new ByteArrayInputStream(baos.toByteArray())
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomObjectInputStream.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomObjectInputStream.java
@@ -1,0 +1,12 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+
+public class TestCustomObjectInputStream extends ObjectInputStream {
+
+  public TestCustomObjectInputStream(final InputStream in) throws IOException {
+    super(in);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Disallows the usage of before call sites in calls to super in constructors which is not allowed by the JVM.

# Motivation

We got a report from a customer with an issue blocking the startup of a app due to:

```
java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    org/redisson/codec/CustomObjectInputStream.<init>(Ljava/lang/ClassLoader;Ljava/io/InputStream;Ljava/util/Set;)V @32: invokestatic
  Reason:
    Type uninitializedThis (current frame, stack[3]) is not assignable to 'java/io/InputStream'
  Current Frame:
    bci: @32
    flags: { flagThisUninit }
    locals: { uninitializedThis, 'java/lang/ClassLoader', 'java/io/InputStream', 'java/util/Set' }
    stack: { '[Ljava/lang/Object;', uninitializedThis, 'java/io/InputStream', uninitializedThis }
  Bytecode:
    0000000: 2a2c b200 8110 1e04 b800 8604 bd00 885a
    0000010: 5f10 005f 535a 5903 32c0 008a 5f57 1900
    0000020: b800 8fb7 0001 2a2b b500 072a 2db5 000d
    0000030: b1  
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56992]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56992]: https://datadoghq.atlassian.net/browse/APPSEC-56992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ