### PR TITLE
Remove unnecessary calls to setAsyncPropagationEnabled

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -2,7 +2,6 @@ package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -29,7 +28,6 @@ public class AdviceUtils {
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
         final AgentScope scope = continuation.activate();
-        setAsyncPropagationEnabled(true);
         // important - stop timing after the scope has been activated so the time in the queue can
         // be attributed to the correct context without duplicating the propagated information
         state.stopTiming();

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -16,8 +16,6 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 /**
  * Test executor instrumentation for Akka specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.
@@ -46,7 +44,6 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new AkkaAsyncChild())
           // this child won't
@@ -102,7 +99,6 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           dispatcher.execute(new AkkaAsyncChild())
           // this child won't
@@ -133,7 +129,6 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -37,7 +36,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         completeDelegate(result);
       }
     }
@@ -54,7 +52,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         failDelegate(ex);
       }
     }
@@ -70,7 +67,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -40,7 +39,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         completeDelegate(result);
       }
     }
@@ -57,7 +55,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         failDelegate(ex);
       }
     }
@@ -73,7 +70,6 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagationEnabled(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
@@ -11,7 +11,6 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 /**
  * Note: ideally this should live with the rest of ExecutorInstrumentationTest,
@@ -45,7 +44,6 @@ class CompletableFutureTest extends AgentTestRunner {
         @Trace(operationName = "parent")
         CompletableFuture<String> get() {
           try {
-            setAsyncPropagationEnabled(true)
             return CompletableFuture.supplyAsync(supplier, pool)
               .thenCompose({ s -> CompletableFuture.supplyAsync(new AppendingSupplier(s), differentPool) })
               .thenApply(function)

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
@@ -8,8 +8,6 @@ import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 class VirtualThreadTest extends AgentTestRunner {
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }
@@ -37,7 +35,6 @@ class VirtualThreadTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 abstract class ExecutorInstrumentationTest extends AgentTestRunner {
@@ -82,7 +81,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -256,7 +254,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           def future = m(pool, task)
           sleep(500)
           future.cancel(true)
@@ -317,7 +314,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           pool.execute(new JavaAsyncChild())
           // this child won't
@@ -368,7 +364,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           m(pool, w(child))
         }
       }.run()
@@ -406,7 +401,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
@@ -17,7 +17,6 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 class NettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -65,7 +64,6 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -213,7 +211,6 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
@@ -21,7 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class RejectedExecutionTest extends AgentTestRunner {
 
@@ -193,7 +192,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     when:
     runUnderTrace("parent") {
-      setAsyncPropagationEnabled(true)
       // must be rejected because the queue will be full until some
       // time after the first task is released
       executor.submit((Runnable) new JavaAsyncChild(true, false))
@@ -237,7 +235,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        setAsyncPropagationEnabled(true)
         pool.submit({})
       }
     }
@@ -261,7 +258,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        setAsyncPropagationEnabled(true)
         // must be rejected because the queue will be full until some
         // time after the first task is released
         def testTask = new JavaAsyncChild(true, false)

--- a/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
@@ -10,7 +10,6 @@ import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 class JettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -46,7 +45,6 @@ class JettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -19,8 +19,6 @@ import io.opentelemetry.trace.Status
 import io.opentelemetry.trace.TracingContextUtils
 import spock.lang.Subject
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 class OpenTelemetryTest extends AgentTestRunner {
   @Subject
   def tracer = OpenTelemetry.tracerProvider.get("test-inst")
@@ -234,7 +232,6 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def span = tracer.spanBuilder("some name").startSpan()
     TraceScope scope = tracer.withSpan(span)
-    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.currentSpan.delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -219,7 +219,6 @@ class OpenTracing31Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -234,7 +234,6 @@ class OpenTracing32Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play23;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -30,7 +29,6 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play24;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -29,7 +28,6 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play26;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -31,7 +30,6 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.playws1;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -55,7 +54,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -71,7 +69,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.playws21;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -60,7 +59,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -76,7 +74,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.playws2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -59,7 +58,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -75,7 +73,6 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -13,8 +13,6 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 /**
  * Test executor instrumentation for Scala specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.
@@ -43,7 +41,6 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new ScalaAsyncChild())
           // this child won't
@@ -94,7 +91,6 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.DECORATE;
 
@@ -119,7 +118,6 @@ public class Servlet2Advice {
     }
     DECORATE.beforeFinish(span);
 
-    setAsyncPropagationEnabled(false);
     scope.close();
     span.finish();
   }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 
@@ -44,7 +43,6 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithContinuation(CharSequence spanName) throws Throwable {
     try (AgentScope scope = continuation.activate()) {
-      setAsyncPropagationEnabled(true);
       return invokeWithSpan(spanName);
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -1,13 +1,10 @@
 package datadog.trace.core
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 class PendingTraceStrictWriteTest extends PendingTraceTestBase {
 
   def "trace is not reported until unfinished continuation is closed"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()
@@ -39,7 +36,6 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
   def "negative reference count throws an exception"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -10,8 +10,6 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
-
 class PendingTraceTest extends PendingTraceTestBase {
 
   @Override
@@ -51,7 +49,6 @@ class PendingTraceTest extends PendingTraceTestBase {
   def "trace is still reported when unfinished continuation discarded"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagationEnabled(true)
     tracer.captureActiveSpan()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -275,7 +275,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
 
     then:
@@ -293,7 +292,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
 
     then:
@@ -321,7 +319,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
 
     then:
@@ -354,7 +351,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     def parentScope = tracer.activateSpan(parentSpan)
     def childSpan = tracer.buildSpan("test", "child").start()
     def childScope = tracer.activateSpan(childSpan)
-    tracer.setAsyncPropagationEnabled(true)
 
     def continuation = tracer.captureActiveSpan()
     childScope.close()
@@ -408,7 +404,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "creating and activating a continuation"
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
@@ -694,7 +689,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
@@ -777,7 +771,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()
@@ -804,7 +797,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "completing another async scope lifecycle"
     def span2 = tracer.buildSpan("test", "test").start()
     def scope2 = tracer.activateSpan(span2)
-    tracer.setAsyncPropagationEnabled(true)
     def continuation2 = tracer.captureActiveSpan()
 
     then:
@@ -839,7 +831,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test", "test").start()
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
-    tracer.setAsyncPropagationEnabled(true)
     continuation = tracer.captureActiveSpan()
     scope.close()
     span.finish()


### PR DESCRIPTION
# What Does This Do

Most of these are calls after activating a continuation - but scopes created from continuations have async propagation enabled already: https://github.com/DataDog/dd-trace-java/blob/v1.47.0/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java#L160

The other non-test changes are a few places in the servlet / play instrumentations where we turned off async propagation for scopes that we've closed and are about to remove from the scope stack. Setting async propagation at this point has no affect.

The remaining cases are leftovers from refactoring in test code

# Motivation

Helps make it clearer where we really need/want to change the async propagation flag.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-981]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-981]: https://datadoghq.atlassian.net/browse/APMAPI-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ