### PR TITLE
Be consistent when deciding when to do async propagation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -54,7 +54,7 @@ public class AdviceUtils {
 
   public static <T> void capture(ContextStore<T, State> contextStore, T task) {
     AgentSpan span = activeSpan();
-    if (span != null && isAsyncPropagationEnabled()) {
+    if (span != null && span.isValid() && isAsyncPropagationEnabled()) {
       State state = contextStore.get(task);
       if (null == state) {
         state = State.FACTORY.create();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -1,12 +1,10 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,17 +17,17 @@ public final class ExecutorInstrumentationUtils {
    * Checks if given task should get state attached.
    *
    * @param task task object
-   * @param executor executor this task was scheduled on
+   * @param span active span
    * @return true iff given task object should be wrapped
    */
-  public static boolean shouldAttachStateToTask(final Object task, final Executor executor) {
+  public static boolean shouldAttachStateToTask(final Object task, final AgentSpan span) {
     if (task == null) {
       return false;
     }
     if (ExcludeFilter.exclude(ExcludeType.EXECUTOR, task)) {
       return false;
     }
-    return activeSpan() != null && isAsyncPropagationEnabled();
+    return span != null && span.isValid() && isAsyncPropagationEnabled();
   }
 
   /**
@@ -57,12 +55,10 @@ public final class ExecutorInstrumentationUtils {
   /**
    * Clean up after job submission method has exited.
    *
-   * @param executor the current executor
    * @param state task instrumentation state
    * @param throwable throwable that may have been thrown
    */
-  public static void cleanUpOnMethodExit(
-      final Executor executor, final State state, final Throwable throwable) {
+  public static void cleanUpOnMethodExit(final State state, final Throwable throwable) {
     if (null != state && null != throwable) {
       /*
       Note: this may potentially close somebody else's continuation if we didn't set it

--- a/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -29,7 +29,7 @@ public class PromiseHelper {
    */
   public static AgentSpan getSpan() {
     final AgentSpan span = activeSpan();
-    if (null != span && isAsyncPropagationEnabled()) {
+    if (null != span && span.isValid() && isAsyncPropagationEnabled()) {
       return span;
     }
     return null;


### PR DESCRIPTION
# Motivation

i.e. we should have a non-null, valid span and the async propagation flag should be set

(also remove some unused variables in the executor advice)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
