### PR TITLE
Simplify activateSpan API to not include async propagation flag

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
@@ -81,7 +81,7 @@ public class AkkaActorCellInstrumentation extends InstrumenterModule.Tracing
         return;
       }
       // Create an active scope with a noop span, and clean all the way to the previous scope
-      activateSpan(noopSpan(), false);
+      activateSpan(noopSpan());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
@@ -75,7 +75,7 @@ public class AkkaMailboxInstrumentation extends InstrumenterModule.Tracing
         return;
       }
       // Create an active scope with a noop span, and clean all the way to the previous scope
-      activateSpan(noopSpan(), false);
+      activateSpan(noopSpan());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/pekko-concurrent/src/main/java/datadog/trace/instrumentation/pekko/concurrent/PekkoActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-concurrent/src/main/java/datadog/trace/instrumentation/pekko/concurrent/PekkoActorCellInstrumentation.java
@@ -81,7 +81,7 @@ public class PekkoActorCellInstrumentation extends InstrumenterModule.Tracing
         return;
       }
       // Create an active scope with a noop span, and clean all the way to the previous scope
-      activateSpan(noopSpan(), false);
+      activateSpan(noopSpan());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/pekko-concurrent/src/main/java/datadog/trace/instrumentation/pekko/concurrent/PekkoMailboxInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-concurrent/src/main/java/datadog/trace/instrumentation/pekko/concurrent/PekkoMailboxInstrumentation.java
@@ -76,7 +76,7 @@ public class PekkoMailboxInstrumentation extends InstrumenterModule.Tracing
         return;
       }
       // Create an active scope with a noop span, and clean all the way to the previous scope
-      activateSpan(noopSpan(), false);
+      activateSpan(noopSpan());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -906,18 +906,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         .start();
   }
 
-  public AgentScope activateSpan(final AgentSpan span) {
-    return activateSpan(span, DEFAULT_ASYNC_PROPAGATING);
-  }
-
   @Override
-  public AgentScope activateSpan(AgentSpan span, boolean isAsyncPropagating) {
-    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
+  public AgentScope activateSpan(AgentSpan span) {
+    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION, DEFAULT_ASYNC_PROPAGATING);
   }
 
   @Override
   public AgentScope activateManualSpan(final AgentSpan span) {
-    return scopeManager.activate(span, ScopeSource.MANUAL);
+    return scopeManager.activate(span, ScopeSource.MANUAL /* inherit async propagation flag */);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1,7 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
-
 import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
@@ -86,11 +84,7 @@ public class AgentTracer {
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
-    return get().activateSpan(span, DEFAULT_ASYNC_PROPAGATING);
-  }
-
-  public static AgentScope activateSpan(final AgentSpan span, final boolean isAsyncPropagating) {
-    return get().activateSpan(span, isAsyncPropagating);
+    return get().activateSpan(span);
   }
 
   /**
@@ -339,7 +333,7 @@ public class AgentTracer {
         long startTimeMicros);
 
     /** Activate a span from inside auto-instrumentation. */
-    AgentScope activateSpan(AgentSpan span, boolean isAsyncPropagating);
+    AgentScope activateSpan(AgentSpan span);
 
     /** Activate a span from outside auto-instrumentation, i.e. a manual or custom span. */
     AgentScope activateManualSpan(AgentSpan span);
@@ -480,7 +474,7 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentScope activateSpan(final AgentSpan span, final boolean isAsyncPropagating) {
+    public AgentScope activateSpan(final AgentSpan span) {
       return NoopScope.INSTANCE;
     }
 


### PR DESCRIPTION
# Motivation

These remaining cases were no-op spans which are already not propagated

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-981]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-981]: https://datadoghq.atlassian.net/browse/APMAPI-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ