### PR TITLE
Mark tests as flaky

### DIFF
--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -3,11 +3,13 @@ package datadog.smoketest
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import datadog.trace.api.config.GeneralConfig
+import datadog.trace.test.util.Flaky
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_128_BIT_TRACEID_LOGGING_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_128_BIT_TRACEID_GENERATION_ENABLED
+import static datadog.trace.test.util.Predicates.IBM8
 import static java.util.concurrent.TimeUnit.SECONDS
 
 /**
@@ -254,6 +256,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     return unmangled.split(" ")[1..2]
   }
 
+  @Flaky(condition = IBM8)
   def "check raw file injection"() {
     when:
     def count = waitForTraceCount(2)

--- a/dd-smoke-tests/sample-trace/src/test/groovy/datadog/smoketest/SampleTraceSmokeTest.groovy
+++ b/dd-smoke-tests/sample-trace/src/test/groovy/datadog/smoketest/SampleTraceSmokeTest.groovy
@@ -1,5 +1,9 @@
 package datadog.smoketest
 
+import datadog.trace.test.util.Flaky
+
+import static datadog.trace.test.util.Predicates.IBM8
+
 class SampleTraceSmokeTest extends AbstractSmokeTest {
 
   @Override
@@ -21,6 +25,7 @@ class SampleTraceSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
+  @Flaky(condition = IBM8)
   def 'sample traces are sent'() {
     when:
     waitForTraceCount(10)


### PR DESCRIPTION
# What Does This Do

Mark the top flaky tests of the week as flaky.

# Motivation

Keep the CI as stable as possible

# Additional Notes

I can't find IBM8 JVM to setup locally so I didn't try to fix it in the first place.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-323]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-323]: https://datadoghq.atlassian.net/browse/LANGPLAT-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ