### PR TITLE
Expose Context.empty() as building block for creating custom root contexts

### DIFF
--- a/components/context/src/main/java/datadog/context/Context.java
+++ b/components/context/src/main/java/datadog/context/Context.java
@@ -37,6 +37,15 @@ import javax.annotation.Nullable;
  */
 public interface Context {
   /**
+   * Returns the empty context.
+   *
+   * @return the context containing no values at all.
+   */
+  static Context empty() {
+    return EmptyContext.INSTANCE;
+  }
+
+  /**
    * Returns the root context.
    *
    * @return the initial local context that all contexts extend.

--- a/components/context/src/test/java/datadog/context/ContextTest.java
+++ b/components/context/src/test/java/datadog/context/ContextTest.java
@@ -1,5 +1,6 @@
 package datadog.context;
 
+import static datadog.context.Context.empty;
 import static datadog.context.Context.root;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,6 +21,17 @@ class ContextTest {
   static final ContextKey<Boolean> BOOLEAN_KEY = ContextKey.named("boolean-key");
   static final ContextKey<Float> FLOAT_KEY = ContextKey.named("float-key");
   static final ContextKey<Long> LONG_KEY = ContextKey.named("long-key");
+
+  @Test
+  void testEmpty() {
+    // Test empty is always the same
+    Context empty = empty();
+    assertEquals(empty, empty(), "Empty context should be consistent");
+    // Test empty is not mutated
+    String stringValue = "value";
+    empty.with(STRING_KEY, stringValue);
+    assertEquals(empty, empty(), "Empty context should be immutable");
+  }
 
   @Test
   void testRoot() {


### PR DESCRIPTION
# Motivation

This supports custom `ContextManager`s that want to define their own root context without needing to expose all the different context implementations. They can start with `Context.empty()` and add any elements they want, storing the final context as a constant so it can be supplied as `Context.root()`

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-981]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
