### PR TITLE
Fix PlayNettySmokeTest logging config

### DIFF
--- a/dd-smoke-tests/play-2.4/conf/logback.xml
+++ b/dd-smoke-tests/play-2.4/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.5/conf/logback.xml
+++ b/dd-smoke-tests/play-2.5/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.6/conf/logback.xml
+++ b/dd-smoke-tests/play-2.6/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.7/conf/logback.xml
+++ b/dd-smoke-tests/play-2.7/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.8-otel/conf/logback.xml
+++ b/dd-smoke-tests/play-2.8-otel/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.8-split-routes/conf/logback.xml
+++ b/dd-smoke-tests/play-2.8-split-routes/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dd-smoke-tests/play-2.8/conf/logback.xml
+++ b/dd-smoke-tests/play-2.8/conf/logback.xml
@@ -1,11 +1,9 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%level %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
# What Does This Do
Simplify logging config for Play smoke tests.

# Motivation

In some modules (`play-2.4`) this led to errors, which were masked because the suite was marked as flaky;

```
Condition not satisfied:

errorLogs.isEmpty()
|         |
|         false
[16:23:12,038 |-ERROR in ch.qos.logback.core.pattern.parser.Compiler@b27b210 - Failed to instantiate converter class [play.api.libs.logback.ColoredLevel] for keyword [coloredLevel] ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type play.api.libs.logback.ColoredLevel, 16:23:12,039 |-ERROR in ch.qos.logback.core.pattern.parser.Compiler@b27b210 - [coloredLevel] is not a valid conversion word, 16:23:12,038 |-ERROR in ch.qos.logback.core.pattern.parser.Compiler@b27b210 - Failed to instantiate converter class [play.api.libs.logback.ColoredLevel] for keyword [coloredLevel] ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type play.api.libs.logback.ColoredLevel, 16:23:12,039
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
