### PR TITLE
Inherited decision maker is a meta

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
@@ -138,7 +138,7 @@ public class WebsocketDecorator extends BaseDecorator {
         if (useDedicatedTraces) {
           wsSpan = startSpan(WEBSOCKET.toString(), operationName, null);
           if (inheritSampling) {
-            wsSpan.setTag(DECISION_MAKER_INHERITED, 1);
+            wsSpan.setTag(DECISION_MAKER_INHERITED, "1");
             wsSpan.setTag(DECISION_MAKER_SERVICE, handshakeSpan.getServiceName());
             wsSpan.setTag(DECISION_MAKER_RESOURCE, handshakeSpan.getResourceName());
           }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2082,7 +2082,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         tag(Tags.COMPONENT, "websocket")
         if (traceStarter && Config.get().isWebsocketMessagesSeparateTraces()) {
           if (Config.get().isWebsocketMessagesInheritSampling()) {
-            tag(DDTags.DECISION_MAKER_INHERITED, 1)
+            tag(DDTags.DECISION_MAKER_INHERITED, "1")
             tag(DDTags.DECISION_MAKER_SERVICE, handshake.getServiceName())
             tag(DDTags.DECISION_MAKER_RESOURCE, handshake.getResourceName())
           }


### PR DESCRIPTION
# What Does This Do

As part of websocket tracing, the tag `_dd.dm.inherited` is a meta and not a metric. Hence let's stringify it

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
