### PR TITLE
Simplification: Context.root() is always empty

### DIFF
--- a/components/context/src/main/java/datadog/context/Context.java
+++ b/components/context/src/main/java/datadog/context/Context.java
@@ -37,21 +37,12 @@ import javax.annotation.Nullable;
  */
 public interface Context {
   /**
-   * Returns the empty context.
-   *
-   * @return the context containing no values at all.
-   */
-  static Context empty() {
-    return EmptyContext.INSTANCE;
-  }
-
-  /**
    * Returns the root context.
    *
    * @return the initial local context that all contexts extend.
    */
   static Context root() {
-    return manager().root();
+    return EmptyContext.INSTANCE;
   }
 
   /**

--- a/components/context/src/main/java/datadog/context/ContextManager.java
+++ b/components/context/src/main/java/datadog/context/ContextManager.java
@@ -3,16 +3,9 @@ package datadog.context;
 /** Manages context across execution units. */
 public interface ContextManager {
   /**
-   * Returns the root context.
-   *
-   * @return the initial local context that all contexts extend.
-   */
-  Context root();
-
-  /**
    * Returns the context attached to the current execution unit.
    *
-   * @return the attached context; {@link #root()} if there is none.
+   * @return the attached context; {@link Context#root()} if there is none.
    */
   Context current();
 
@@ -28,7 +21,7 @@ public interface ContextManager {
    * Swaps the given context with the one attached to current execution unit.
    *
    * @param context the context to swap.
-   * @return the previously attached context; {@link #root()} if there was none.
+   * @return the previously attached context; {@link Context#root()} if there was none.
    */
   Context swap(Context context);
 

--- a/components/context/src/main/java/datadog/context/ThreadLocalContextManager.java
+++ b/components/context/src/main/java/datadog/context/ThreadLocalContextManager.java
@@ -6,11 +6,6 @@ final class ThreadLocalContextManager implements ContextManager {
       ThreadLocal.withInitial(() -> new Context[] {EmptyContext.INSTANCE});
 
   @Override
-  public Context root() {
-    return EmptyContext.INSTANCE;
-  }
-
-  @Override
   public Context current() {
     return CURRENT_HOLDER.get()[0];
   }

--- a/components/context/src/test/java/datadog/context/ContextProviderForkedTest.java
+++ b/components/context/src/test/java/datadog/context/ContextProviderForkedTest.java
@@ -43,11 +43,6 @@ class ContextProviderForkedTest {
     ContextManager.register(
         new ContextManager() {
           @Override
-          public Context root() {
-            return EmptyContext.INSTANCE;
-          }
-
-          @Override
           public Context current() {
             return root();
           }

--- a/components/context/src/test/java/datadog/context/ContextTest.java
+++ b/components/context/src/test/java/datadog/context/ContextTest.java
@@ -1,6 +1,5 @@
 package datadog.context;
 
-import static datadog.context.Context.empty;
 import static datadog.context.Context.root;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,17 +20,6 @@ class ContextTest {
   static final ContextKey<Boolean> BOOLEAN_KEY = ContextKey.named("boolean-key");
   static final ContextKey<Float> FLOAT_KEY = ContextKey.named("float-key");
   static final ContextKey<Long> LONG_KEY = ContextKey.named("long-key");
-
-  @Test
-  void testEmpty() {
-    // Test empty is always the same
-    Context empty = empty();
-    assertEquals(empty, empty(), "Empty context should be consistent");
-    // Test empty is not mutated
-    String stringValue = "value";
-    empty.with(STRING_KEY, stringValue);
-    assertEquals(empty, empty(), "Empty context should be immutable");
-  }
 
   @Test
   void testRoot() {


### PR DESCRIPTION
# Motivation

We haven't needed a non-empty root context, and collapsing these concepts together simplifies the code.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-981]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-981]: https://datadoghq.atlassian.net/browse/APMAPI-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ