### PR TITLE
Mark tests as flaky

### DIFF
--- a/dd-smoke-tests/sample-trace/src/test/groovy/datadog/smoketest/SampleTraceSmokeTest.groovy
+++ b/dd-smoke-tests/sample-trace/src/test/groovy/datadog/smoketest/SampleTraceSmokeTest.groovy
@@ -2,7 +2,7 @@ package datadog.smoketest
 
 import datadog.trace.test.util.Flaky
 
-import static datadog.trace.test.util.Predicates.IBM8
+import static datadog.trace.test.util.Predicates.IBM
 
 class SampleTraceSmokeTest extends AbstractSmokeTest {
 
@@ -25,7 +25,7 @@ class SampleTraceSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
-  @Flaky(condition = IBM8)
+  @Flaky(condition = IBM)
   def 'sample traces are sent'() {
     when:
     waitForTraceCount(10)


### PR DESCRIPTION
# What Does This Do

This PR is a follow up of #8568 as it started to flake on Semeru 11 and 17 too.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
