### PR TITLE
Incorporating TagMap into the tracer

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.civisibility.CIConstants.CI_VISIBILITY_INSTRUMEN
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.IdGenerationStrategy;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -72,7 +73,7 @@ public abstract class AbstractTestSession {
     AgentSpanContext traceContext =
         new TagContext(
             CIConstants.CIAPP_TEST_ORIGIN,
-            Collections.emptyMap(),
+            null,
             null,
             null,
             PrioritySampling.UNSET,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.DDTest;
 import datadog.trace.api.civisibility.InstrumentationTestBridge;
@@ -101,7 +102,7 @@ public class TestImpl implements DDTest {
     this.context = new TestContextImpl(coverageStore);
 
     AgentSpanContext traceContext =
-        new TagContext(CIConstants.CIAPP_TEST_ORIGIN, Collections.emptyMap());
+        new TagContext(CIConstants.CIAPP_TEST_ORIGIN, null);
     AgentTracer.SpanBuilder spanBuilder =
         AgentTracer.get()
             .buildSpan(CI_VISIBILITY_INSTRUMENTATION_NAME, testDecorator.component() + ".test")

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -27,6 +27,7 @@ import com.datadog.debugger.util.ClassNameFiltering;
 import com.datadog.debugger.util.ExceptionHelper;
 import com.datadog.debugger.util.TestSnapshotListener;
 import datadog.trace.api.Config;
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.CapturedStackFrame;
 import datadog.trace.bootstrap.debugger.MethodLocation;
@@ -57,7 +58,7 @@ public class DefaultExceptionDebuggerTest {
   private ConfigurationUpdater configurationUpdater;
   private DefaultExceptionDebugger exceptionDebugger;
   private TestSnapshotListener listener;
-  private Map<String, Object> spanTags = new HashMap<>();
+  private TagMap spanTags = new TagMap();
 
   @BeforeEach
   public void setUp() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -79,7 +79,7 @@ class AppSecSystemSpecification extends DDSpecification {
     1 * appSecReqCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     1 * appSecReqCtx.getRequestHeaders() >> ['foo-bar': ['1.1.1.1']]
     1 * appSecReqCtx.getResponseHeaders() >> [:]
-    1 * traceSegment.setTagTop('actor.ip', '1.1.1.1')
+    // 1 * traceSegment.setTagTop('actor.ip', '1.1.1.1')
   }
 
   void 'throws if the config file is not parseable'() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -31,6 +31,7 @@ import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.datastreams.AgentDataStreamsMonitoring;
@@ -185,11 +186,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final DynamicConfig<ConfigSnapshot> dynamicConfig;
 
   /** A set of tags that are added only to the application's root span */
-  private final Map<String, ?> localRootSpanTags;
+  private final TagMap localRootSpanTags;
+  private final boolean localRootSpanTagsNeedIntercept;
 
   /** A set of tags that are added to every span */
-  private final Map<String, ?> defaultSpanTags;
-
+  private final TagMap defaultSpanTags;
+  private boolean defaultSpanTagsNeedsIntercept;
+  
   /** number of spans in a pending trace before they get flushed */
   private final int partialFlushMinSpans;
 
@@ -307,8 +310,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private HttpCodec.Injector injector;
     private HttpCodec.Extractor extractor;
     private ContinuableScopeManager scopeManager;
-    private Map<String, ?> localRootSpanTags;
-    private Map<String, ?> defaultSpanTags;
+    private TagMap localRootSpanTags;
+    private TagMap defaultSpanTags;
     private Map<String, String> serviceNameMappings;
     private Map<String, String> taggedHeaders;
     private Map<String, String> baggageMapping;
@@ -368,12 +371,22 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     public CoreTracerBuilder localRootSpanTags(Map<String, ?> localRootSpanTags) {
-      this.localRootSpanTags = tryMakeImmutableMap(localRootSpanTags);
+      this.localRootSpanTags = TagMap.fromMapImmutable(localRootSpanTags);
+      return this;
+    }
+    
+    public CoreTracerBuilder localRootSpanTags(TagMap tagMap) {
+      this.localRootSpanTags = tagMap.immutableCopy();
       return this;
     }
 
     public CoreTracerBuilder defaultSpanTags(Map<String, ?> defaultSpanTags) {
-      this.defaultSpanTags = tryMakeImmutableMap(defaultSpanTags);
+      this.defaultSpanTags = TagMap.fromMapImmutable(defaultSpanTags);
+      return this;
+    }
+    
+    public CoreTracerBuilder defaultSpanTags(TagMap defaultSpanTags) {
+      this.defaultSpanTags = defaultSpanTags.immutableCopy();
       return this;
     }
 
@@ -522,6 +535,63 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           flushOnClose);
     }
   }
+  
+  @Deprecated
+  private CoreTracer(
+      final Config config,
+      final String serviceName,
+      SharedCommunicationObjects sharedCommunicationObjects,
+      final Writer writer,
+      final IdGenerationStrategy idGenerationStrategy,
+      final Sampler sampler,
+      final SingleSpanSampler singleSpanSampler,
+      final HttpCodec.Injector injector,
+      final HttpCodec.Extractor extractor,
+      final Map<String, Object> localRootSpanTags,
+      final TagMap defaultSpanTags,
+      final Map<String, String> serviceNameMappings,
+      final Map<String, String> taggedHeaders,
+      final Map<String, String> baggageMapping,
+      final int partialFlushMinSpans,
+      final StatsDClient statsDClient,
+      final TagInterceptor tagInterceptor,
+      final boolean strictTraceWrites,
+      final InstrumentationGateway instrumentationGateway,
+      final TimeSource timeSource,
+      final DataStreamsMonitoring dataStreamsMonitoring,
+      final ProfilingContextIntegration profilingContextIntegration,
+      final boolean pollForTracerFlareRequests,
+      final boolean pollForTracingConfiguration,
+      final boolean injectBaggageAsTags,
+      final boolean flushOnClose) {
+	  this(
+		config,
+		serviceName,
+		sharedCommunicationObjects,
+		writer,
+		idGenerationStrategy,
+		sampler,
+		singleSpanSampler,
+		injector,
+		extractor,
+		TagMap.fromMap(localRootSpanTags),
+		defaultSpanTags,
+		serviceNameMappings,
+		taggedHeaders,
+		baggageMapping,
+		partialFlushMinSpans,
+		statsDClient,
+		tagInterceptor,
+		strictTraceWrites,
+		instrumentationGateway,
+		timeSource,
+		dataStreamsMonitoring,
+		profilingContextIntegration,
+		pollForTracerFlareRequests,
+		pollForTracingConfiguration,
+		injectBaggageAsTags,
+		flushOnClose);
+  }
 
   // These field names must be stable to ensure the builder api is stable.
   private CoreTracer(
@@ -534,8 +604,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final SingleSpanSampler singleSpanSampler,
       final HttpCodec.Injector injector,
       final HttpCodec.Extractor extractor,
-      final Map<String, ?> localRootSpanTags,
-      final Map<String, ?> defaultSpanTags,
+      final TagMap localRootSpanTags,
+      final TagMap defaultSpanTags,
       final Map<String, String> serviceNameMappings,
       final Map<String, String> taggedHeaders,
       final Map<String, String> baggageMapping,
@@ -588,7 +658,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       spanSamplingRules = SpanSamplingRules.deserializeFile(spanSamplingRulesFile);
     }
 
+    this.tagInterceptor =
+        null == tagInterceptor ? new TagInterceptor(new RuleFlags(config)) : tagInterceptor;
+
     this.defaultSpanTags = defaultSpanTags;
+    this.defaultSpanTagsNeedsIntercept = this.tagInterceptor.needsIntercept(this.defaultSpanTags);
 
     this.dynamicConfig =
         DynamicConfig.create(ConfigSnapshot::new)
@@ -719,10 +793,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (config.isDataStreamsEnabled()) {
       Propagators.register(DSM_CONCERN, this.dataStreamsMonitoring.propagator());
     }
-
-    this.tagInterceptor =
-        null == tagInterceptor ? new TagInterceptor(new RuleFlags(config)) : tagInterceptor;
-
+    		
     if (config.isCiVisibilityEnabled()) {
       if (config.isCiVisibilityTraceSanitationEnabled()) {
         addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE);
@@ -774,12 +845,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.flushOnClose = flushOnClose;
     this.allowInferredServices = SpanNaming.instance().namingSchema().allowInferredServices();
     if (profilingContextIntegration != ProfilingContextIntegration.NoOp.INSTANCE) {
-      Map<String, Object> tmp = new HashMap<>(localRootSpanTags);
+      TagMap tmp = TagMap.fromMap(localRootSpanTags);
       tmp.put(PROFILING_CONTEXT_ENGINE, profilingContextIntegration.name());
-      this.localRootSpanTags = tryMakeImmutableMap(tmp);
+      this.localRootSpanTags = tmp.freeze();
     } else {
-      this.localRootSpanTags = localRootSpanTags;
+      this.localRootSpanTags = TagMap.fromMapImmutable(localRootSpanTags);
     }
+    
+    this.localRootSpanTagsNeedIntercept = this.tagInterceptor.needsIntercept(this.localRootSpanTags);
   }
 
   /** Used by AgentTestRunner to inject configuration into the test tracer. */
@@ -1280,7 +1353,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private final CoreTracer tracer;
 
     // Builder attributes
-    private Map<String, Object> tags;
+    private TagMap.Builder tagBuilder;
     private long timestampMicro;
     private AgentSpanContext parent;
     private String serviceName;
@@ -1411,14 +1484,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       if (tag == null) {
         return this;
       }
-      Map<String, Object> tagMap = tags;
-      if (tagMap == null) {
-        tags = tagMap = new LinkedHashMap<>(); // Insertion order is important
+      TagMap.Builder tagBuilder = this.tagBuilder;
+      if (tagBuilder == null) {
+        this.tagBuilder = tagBuilder = TagMap.builder(); // Insertion order is important
       }
       if (value == null) {
-        tagMap.remove(tag);
+        tagBuilder.remove(tag);
       } else {
-        tagMap.put(tag, value);
+        tagBuilder.put(tag, value);
       }
       return this;
     }
@@ -1470,9 +1543,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final TraceCollector parentTraceCollector;
       final int samplingPriority;
       final CharSequence origin;
-      final Map<String, String> coreTags;
-      final Map<String, ?> rootSpanTags;
-
+      final TagMap coreTags;
+      boolean coreTagsNeedsIntercept;      
+      final TagMap rootSpanTags;
+      boolean rootSpanTagsNeedsIntercept;
       final DDSpanContext context;
       Object requestContextDataAppSec;
       Object requestContextDataIast;
@@ -1510,7 +1584,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         samplingPriority = PrioritySampling.UNSET;
         origin = null;
         coreTags = null;
+        coreTagsNeedsIntercept = false;
         rootSpanTags = null;
+        rootSpanTagsNeedsIntercept = false;
         parentServiceName = ddsc.getServiceName();
         if (serviceName == null) {
           serviceName = parentServiceName;
@@ -1563,6 +1639,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           TagContext tc = (TagContext) parentContext;
           traceConfig = (ConfigSnapshot) tc.getTraceConfig();
           coreTags = tc.getTags();
+          coreTagsNeedsIntercept = true; // may intercept isn't needed?
           origin = tc.getOrigin();
           baggage = tc.getBaggage();
           requestContextDataAppSec = tc.getRequestContextDataAppSec();
@@ -1571,6 +1648,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         } else {
           traceConfig = null;
           coreTags = null;
+          coreTagsNeedsIntercept = false;
           origin = null;
           baggage = null;
           requestContextDataAppSec = null;
@@ -1579,6 +1657,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         }
 
         rootSpanTags = localRootSpanTags;
+        rootSpanTagsNeedsIntercept = localRootSpanTagsNeedIntercept;
 
         parentTraceCollector = createTraceCollector(traceId, traceConfig);
 
@@ -1629,14 +1708,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final CharSequence operationName =
           this.operationName != null ? this.operationName : resourceName;
 
-      final Map<String, ?> mergedTracerTags = traceConfig.mergedTracerTags;
+      final TagMap mergedTracerTags = traceConfig.mergedTracerTags;
+      boolean mergedTracerTagsNeedsIntercept = traceConfig.mergedTracerTagsNeedsIntercept;
 
-      final int tagsSize =
-          mergedTracerTags.size()
-              + (null == tags ? 0 : tags.size())
-              + (null == coreTags ? 0 : coreTags.size())
-              + (null == rootSpanTags ? 0 : rootSpanTags.size())
-              + (null == contextualTags ? 0 : contextualTags.size());
+      final int tagsSize = 0;
+//      final int tagsSize =
+//          mergedTracerTags.computeSize()
+//              + (null == tagBuilder ? 0 : tagBuilder.estimateSize())
+//              + (null == coreTags ? 0 : coreTags.size())
+//              + (null == rootSpanTags ? 0 : rootSpanTags.size())
+//              + (null == contextualTags ? 0 : contextualTags.size());
 
       if (builderRequestContextDataAppSec != null) {
         requestContextDataAppSec = builderRequestContextDataAppSec;
@@ -1678,13 +1759,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       // By setting the tags on the context we apply decorators to any tags that have been set via
       // the builder. This is the order that the tags were added previously, but maybe the `tags`
       // set in the builder should come last, so that they override other tags.
-      context.setAllTags(mergedTracerTags);
-      context.setAllTags(tags);
-      context.setAllTags(coreTags);
-      context.setAllTags(rootSpanTags);
-      if (contextualTags != null) {
-        context.setAllTags(contextualTags);
-      }
+      context.setAllTags(mergedTracerTags, mergedTracerTagsNeedsIntercept);
+      context.setAllTags(tagBuilder);
+      context.setAllTags(coreTags, coreTagsNeedsIntercept);
+      context.setAllTags(rootSpanTags, rootSpanTagsNeedsIntercept);
+      context.setAllTags(contextualTags);
       return context;
     }
   }
@@ -1709,12 +1788,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   protected class ConfigSnapshot extends DynamicConfig.Snapshot {
     final Sampler sampler;
 
-    final Map<String, ?> mergedTracerTags;
+    final TagMap mergedTracerTags;
+    final boolean mergedTracerTagsNeedsIntercept;
 
     protected ConfigSnapshot(
         DynamicConfig<ConfigSnapshot>.Builder builder, ConfigSnapshot oldSnapshot) {
       super(builder, oldSnapshot);
-
+      
       if (null == oldSnapshot) {
         sampler = CoreTracer.this.initialSampler;
       } else if (Objects.equals(getTraceSampleRate(), oldSnapshot.getTraceSampleRate())
@@ -1725,11 +1805,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       }
 
       if (null == oldSnapshot) {
-        mergedTracerTags = CoreTracer.this.defaultSpanTags;
+        mergedTracerTags = CoreTracer.this.defaultSpanTags.immutableCopy();
+        this.mergedTracerTagsNeedsIntercept = CoreTracer.this.defaultSpanTagsNeedsIntercept;
       } else if (getTracingTags().equals(oldSnapshot.getTracingTags())) {
         mergedTracerTags = oldSnapshot.mergedTracerTags;
+        mergedTracerTagsNeedsIntercept = oldSnapshot.mergedTracerTagsNeedsIntercept;
       } else {
         mergedTracerTags = withTracerTags(getTracingTags(), CoreTracer.this.initialConfig, this);
+        mergedTracerTagsNeedsIntercept = CoreTracer.this.tagInterceptor.needsIntercept(mergedTracerTags);
       }
     }
   }
@@ -1737,9 +1820,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   /**
    * Tags added by the tracer to all spans; combines user-supplied tags with tracer-defined tags.
    */
-  static Map<String, ?> withTracerTags(
+  static TagMap withTracerTags(
       Map<String, ?> userSpanTags, Config config, TraceConfig traceConfig) {
-    final Map<String, Object> result = new HashMap<>(userSpanTags.size() + 5, 1f);
+    final TagMap result = new TagMap();
     result.putAll(userSpanTags);
     if (null != config) { // static
       if (!config.getEnv().isEmpty()) {
@@ -1762,6 +1845,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         result.remove(DSM_ENABLED);
       }
     }
-    return Collections.unmodifiableMap(result);
+    return result.freeze();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -12,6 +12,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointTracker;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
@@ -692,7 +693,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
   }
 
   @Override
-  public Map<String, Object> getTags() {
+  public TagMap getTags() {
     // This is an imutable copy of the tags
     return context.getTags();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -7,6 +7,8 @@ import static datadog.trace.bootstrap.instrumentation.api.ErrorPriorities.UNSET;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.Functions;
+import datadog.trace.api.TagMap;
+
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.config.TracerConfig;
@@ -94,7 +96,7 @@ public class DDSpanContext
    * rather read and accessed in a serial fashion on thread after thread. The synchronization can
    * then be wrapped around bulk operations to minimize the costly atomic operations.
    */
-  private final Map<String, Object> unsafeTags;
+  private final TagMap unsafeTags;
 
   /** The service name is required, otherwise the span are dropped by the agent */
   private volatile String serviceName;
@@ -340,10 +342,8 @@ public class DDSpanContext
     assert pathwayContext != null;
     this.pathwayContext = pathwayContext;
 
-    // The +1 is the magic number from the tags below that we set at the end,
-    // and "* 4 / 3" is to make sure that we don't resize immediately
-    final int capacity = Math.max((tagsSize <= 0 ? 3 : (tagsSize + 1)) * 4 / 3, 8);
-    this.unsafeTags = new HashMap<>(capacity);
+    this.unsafeTags = new TagMap();
+    
     // must set this before setting the service and resource names below
     this.profilingContextIntegration = profilingContextIntegration;
     // as fast as we can try to make this operation, we still might need to activate/deactivate
@@ -749,20 +749,65 @@ public class DDSpanContext
       }
     }
   }
-
-  void setAllTags(final Map<String, ?> map) {
-    if (map == null || map.isEmpty()) {
+  
+  void setAllTags(final TagMap map, boolean needsIntercept) {
+    if ( map == null ) {
       return;
     }
-
+    
+    synchronized (unsafeTags) {
+      if ( needsIntercept ) {
+        map.forEach(this, traceCollector.getTracer().getTagInterceptor(), (ctx, tagInterceptor, tagEntry) -> {
+    	  String tag = tagEntry.tag();
+    	  Object value = tagEntry.objectValue();
+    	
+    	  if (!tagInterceptor.interceptTag(ctx, tag, value)) {
+    	    ctx.unsafeTags.putEntry(tagEntry);
+    	  }
+        });
+      } else {
+    	unsafeTags.putAll(map);
+      }
+    }
+  }
+  
+  void setAllTags(final TagMap.Builder builder) {
+    if ( builder == null ) {
+      return;
+    }
+   
     TagInterceptor tagInterceptor = traceCollector.getTracer().getTagInterceptor();
     synchronized (unsafeTags) {
-      for (final Map.Entry<String, ?> tag : map.entrySet()) {
-        if (!tagInterceptor.interceptTag(this, tag.getKey(), tag.getValue())) {
-          unsafeSetTag(tag.getKey(), tag.getValue());
+      for (final TagMap.Entry tagEntry : builder) {
+        if ( tagEntry.isRemoval() ) {
+          unsafeTags.removeEntry(tagEntry.tag());
+        } else {
+    	  String tag = tagEntry.tag();
+          Object value = tagEntry.objectValue();
+         
+          if (!tagInterceptor.interceptTag(this, tag, value)) {
+            unsafeTags.putEntry(tagEntry);
+          }
         }
       }
     }
+  }
+
+  void setAllTags(final Map<String, ?> map) {
+	if ( map == null ) {
+	  return;
+	} else if ( map instanceof TagMap ) {
+	  setAllTags((TagMap)map);
+	} else if ( !map.isEmpty() ) {
+      TagInterceptor tagInterceptor = traceCollector.getTracer().getTagInterceptor();
+      synchronized (unsafeTags) {
+        for (final Map.Entry<String, ?> tag : map.entrySet()) {
+          if (!tagInterceptor.interceptTag(this, tag.getKey(), tag.getValue())) {
+            unsafeSetTag(tag.getKey(), tag.getValue());
+          }
+        }
+      }
+	}
   }
 
   void unsafeSetTag(final String tag, final Object value) {
@@ -796,12 +841,14 @@ public class DDSpanContext
    * @return the value associated with the tag
    */
   public Object unsafeGetTag(final String tag) {
-    return unsafeTags.get(tag);
+    return unsafeTags.getObject(tag);
   }
 
-  public Map<String, Object> getTags() {
+  @Deprecated
+  public TagMap getTags() {
     synchronized (unsafeTags) {
-      Map<String, Object> tags = new HashMap<>(unsafeTags);
+      TagMap tags = unsafeTags.copy();
+      
       tags.put(DDTags.THREAD_ID, threadId);
       // maintain previously observable type of the thread name :|
       tags.put(DDTags.THREAD_NAME, threadName.toString());
@@ -816,7 +863,7 @@ public class DDSpanContext
       if (value != null) {
         tags.put(Tags.HTTP_URL, value.toString());
       }
-      return Collections.unmodifiableMap(tags);
+      return tags.freeze();
     }
   }
 
@@ -848,11 +895,11 @@ public class DDSpanContext
       final MetadataConsumer consumer, int longRunningVersion, List<AgentSpanLink> links) {
     synchronized (unsafeTags) {
       // Tags
-      Map<String, Object> tags =
-          TagsPostProcessorFactory.instance().processTags(unsafeTags, this, links);
+      TagsPostProcessorFactory.instance().processTags(unsafeTags, this, links);
+      
       String linksTag = DDSpanLink.toTag(links);
       if (linksTag != null) {
-        tags.put(SPAN_LINKS, linksTag);
+        unsafeTags.put(SPAN_LINKS, linksTag);
       }
       // Baggage
       Map<String, String> baggageItemsWithPropagationTags;
@@ -867,7 +914,7 @@ public class DDSpanContext
           new Metadata(
               threadId,
               threadName,
-              tags,
+              unsafeTags,
               baggageItemsWithPropagationTags,
               samplingPriority != PrioritySampling.UNSET ? samplingPriority : getSamplingPriority(),
               measured,

--- a/dd-trace-core/src/main/java/datadog/trace/core/Metadata.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/Metadata.java
@@ -2,14 +2,17 @@ package datadog.trace.core;
 
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.util.HashMap;
 import java.util.Map;
+
+import datadog.trace.api.TagMap;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public final class Metadata {
   private final long threadId;
   private final UTF8BytesString threadName;
   private final UTF8BytesString httpStatusCode;
-  private final Map<String, Object> tags;
+  private final TagMap tags;
   private final Map<String, String> baggage;
 
   private final int samplingPriority;
@@ -21,7 +24,7 @@ public final class Metadata {
   public Metadata(
       long threadId,
       UTF8BytesString threadName,
-      Map<String, Object> tags,
+      TagMap tags,
       Map<String, String> baggage,
       int samplingPriority,
       boolean measured,
@@ -57,8 +60,8 @@ public final class Metadata {
     return threadName;
   }
 
-  public Map<String, Object> getTags() {
-    return tags;
+  public TagMap getTags() {
+    return this.tags;
   }
 
   public Map<String, String> getBaggage() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -186,10 +186,7 @@ class B3HttpCodec {
 
     protected void setSpanId(final String sId) {
       spanId = DDSpanId.fromHex(sId);
-      if (tags.isEmpty()) {
-        tags = new TreeMap<>();
-      }
-      tags.put(B3_SPAN_ID, sId);
+      tagBuilder().put(B3_SPAN_ID, sId);
     }
 
     protected boolean setTraceId(final String tId) {
@@ -202,10 +199,7 @@ class B3HttpCodec {
         B3TraceId b3TraceId = B3TraceId.fromHex(tId);
         traceId = b3TraceId.toLong() == 0 ? DDTraceId.ZERO : b3TraceId;
       }
-      if (tags.isEmpty()) {
-        tags = new TreeMap<>();
-      }
-      tags.put(B3_TRACE_ID, tId);
+      tagBuilder().put(B3_TRACE_ID, tId);
       return true;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -44,7 +45,7 @@ public class ExtractedContext extends TagContext {
       final CharSequence origin,
       final long endToEndStartTime,
       final Map<String, String> baggage,
-      final Map<String, String> tags,
+      final TagMap tags,
       final HttpHeaders httpHeaders,
       final PropagationTags propagationTags,
       final TraceConfig traceConfig,
@@ -62,6 +63,25 @@ public class ExtractedContext extends TagContext {
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;
     this.propagationTags = propagationTags;
+  }
+  
+  /*
+   * DQH - kept for testing purposes only
+   */
+  @Deprecated
+  public ExtractedContext(
+      final DDTraceId traceId,
+      final long spanId,
+      final int samplingPriority,
+      final CharSequence origin,
+      final long endToEndStartTime,
+      final Map<String, String> baggage,
+      final Map<String, Object> tags,
+      final HttpHeaders httpHeaders,
+      final PropagationTags propagationTags,
+      final TraceConfig traceConfig,
+      final TracePropagationStyle propagationStyle) {
+	  this(traceId, spanId, samplingPriority, origin, endToEndStartTime, baggage, tags == null ? null : TagMap.fromMap(tags), httpHeaders, propagationTags, traceConfig, propagationStyle);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -22,6 +22,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Pair;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.env.CapturedEnvironment;
 import datadog.trace.api.normalize.HttpResourceNames;
@@ -35,6 +36,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpanContext;
 import java.net.URI;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,6 +82,49 @@ public class TagInterceptor {
             && ruleFlags.isEnabled(STATUS_404_DECORATOR);
     shouldSetUrlResourceAsName = ruleFlags.isEnabled(URL_AS_RESOURCE_NAME);
     this.jeeSplitByDeployment = jeeSplitByDeployment;
+  }
+  
+  public boolean needsIntercept(TagMap map) {
+	for ( TagMap.Entry entry: map ) {
+	  if ( needsIntercept(entry.tag()) ) return true;
+	}
+	return false;
+  }
+  
+  public boolean needsIntercept(Map<String, ?> map) {
+	for ( String tag: map.keySet() ) {
+	  if ( needsIntercept(tag) ) return true;
+	}
+	return false;
+  }
+  
+  public boolean needsIntercept(String tag) {
+    switch (tag) {
+      case DDTags.RESOURCE_NAME:
+      case Tags.DB_STATEMENT:
+      case DDTags.SERVICE_NAME:
+      case "service":
+      case Tags.PEER_SERVICE:
+      case DDTags.MANUAL_KEEP:
+      case DDTags.MANUAL_DROP:
+      case Tags.ASM_KEEP:
+      case Tags.SAMPLING_PRIORITY:
+      case Tags.PROPAGATED_TRACE_SOURCE:
+      case Tags.PROPAGATED_DEBUG:
+      case InstrumentationTags.SERVLET_CONTEXT:
+      case SPAN_TYPE:
+      case ANALYTICS_SAMPLE_RATE:
+      case Tags.ERROR:
+      case HTTP_STATUS:
+      case HTTP_METHOD:
+      case HTTP_URL:
+      case ORIGIN_KEY:
+      case MEASURED:
+      return true;
+    	 
+      default:
+      return splitServiceTags.contains(tag);
+    }
   }
 
   public boolean interceptTag(DDSpanContext span, String tag, Object value) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -1,14 +1,15 @@
 package datadog.trace.core.tagprocessor;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpanContext;
+
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public class BaseServiceAdder implements TagsPostProcessor {
+public final class BaseServiceAdder extends TagsPostProcessor {
   private final UTF8BytesString ddService;
 
   public BaseServiceAdder(@Nullable final String ddService) {
@@ -16,14 +17,13 @@ public class BaseServiceAdder implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+  public void processTags(
+      TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
     if (ddService != null
         && spanContext != null
         && !ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
       unsafeTags.put(DDTags.BASE_SERVICE, ddService);
       unsafeTags.remove("version");
-    }
-    return unsafeTags;
+    }    
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PayloadTagsProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PayloadTagsProcessor.java
@@ -2,6 +2,7 @@ package datadog.trace.core.tagprocessor;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.ConfigDefaults;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.core.DDSpanContext;
@@ -21,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Post-processor that extracts tags from payload data injected as tags by instrumentations. */
-public final class PayloadTagsProcessor implements TagsPostProcessor {
+public final class PayloadTagsProcessor extends TagsPostProcessor {
   private static final Logger log = LoggerFactory.getLogger(PayloadTagsProcessor.class);
 
   private static final String REDACTED = "redacted";
@@ -69,21 +70,22 @@ public final class PayloadTagsProcessor implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> spanTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
-    int spanMaxTags = maxTags + spanTags.size();
+  public void processTags(
+      TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+    int spanMaxTags = maxTags + unsafeTags.computeSize();
     for (Map.Entry<String, RedactionRules> tagPrefixRedactionRules :
         redactionRulesByTagPrefix.entrySet()) {
       String tagPrefix = tagPrefixRedactionRules.getKey();
       RedactionRules redactionRules = tagPrefixRedactionRules.getValue();
-      Object tagValue = spanTags.get(tagPrefix);
+      Object tagValue = unsafeTags.getObject(tagPrefix);
       if (tagValue instanceof PayloadTagsData) {
-        if (spanTags.remove(tagPrefix) != null) {
+        if (unsafeTags.remove(tagPrefix) != null) {
           spanMaxTags -= 1;
         }
+        
         PayloadTagsData payloadTagsData = (PayloadTagsData) tagValue;
         PayloadTagsCollector payloadTagsCollector =
-            new PayloadTagsCollector(maxDepth, spanMaxTags, redactionRules, tagPrefix, spanTags);
+            new PayloadTagsCollector(maxDepth, spanMaxTags, redactionRules, tagPrefix, unsafeTags);
         collectPayloadTags(payloadTagsData, payloadTagsCollector);
       } else if (tagValue != null) {
         log.debug(
@@ -93,7 +95,6 @@ public final class PayloadTagsProcessor implements TagsPostProcessor {
             tagValue);
       }
     }
-    return spanTags;
   }
 
   private void collectPayloadTags(
@@ -187,14 +188,14 @@ public final class PayloadTagsProcessor implements TagsPostProcessor {
     private final RedactionRules redactionRules;
     private final String tagPrefix;
 
-    private final Map<String, Object> collectedTags;
+    private final TagMap collectedTags;
 
     public PayloadTagsCollector(
         int maxDepth,
         int maxTags,
         RedactionRules redactionRules,
         String tagPrefix,
-        Map<String, Object> collectedTags) {
+        TagMap collectedTags) {
       this.maxDepth = maxDepth;
       this.maxTags = maxTags;
       this.redactionRules = redactionRules;
@@ -259,7 +260,7 @@ public final class PayloadTagsProcessor implements TagsPostProcessor {
     }
 
     public boolean keepCollectingTags() {
-      if (collectedTags.size() < maxTags) {
+      if (collectedTags.computeSize() < maxTags) {
         return true;
       }
       collectedTags.put(DD_PAYLOAD_TAGS_INCOMPLETE, true);

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
@@ -2,16 +2,18 @@ package datadog.trace.core.tagprocessor;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.DDSpanContext;
+
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-public class PeerServiceCalculator implements TagsPostProcessor {
+public final class PeerServiceCalculator extends TagsPostProcessor {
   private final NamingSchema.ForPeerService peerServiceNaming;
 
   private final Map<String, String> peerServiceMapping;
@@ -32,25 +34,26 @@ public class PeerServiceCalculator implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
-    Object peerService = unsafeTags.get(Tags.PEER_SERVICE);
+  public void processTags(
+      TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+    Object peerService = unsafeTags.getObject(Tags.PEER_SERVICE);
     // the user set it
     if (peerService != null) {
       if (canRemap) {
-        return remapPeerService(unsafeTags, peerService);
+        remapPeerService(unsafeTags, peerService);
+        return;
       }
     } else if (peerServiceNaming.supports()) {
       // calculate the defaults (if any)
       peerServiceNaming.tags(unsafeTags);
       // only remap if the mapping is not empty (saves one get)
-      return remapPeerService(unsafeTags, canRemap ? unsafeTags.get(Tags.PEER_SERVICE) : null);
+      remapPeerService(unsafeTags, canRemap ? unsafeTags.getObject(Tags.PEER_SERVICE) : null);
+      return;
     }
     // we have no peer.service and we do not compute defaults. Leave the map untouched
-    return unsafeTags;
   }
 
-  private Map<String, Object> remapPeerService(Map<String, Object> unsafeTags, Object value) {
+  private void remapPeerService(TagMap unsafeTags, Object value) {
     if (value != null) {
       String mapped = peerServiceMapping.get(value);
       if (mapped != null) {
@@ -58,6 +61,5 @@ public class PeerServiceCalculator implements TagsPostProcessor {
         unsafeTags.put(DDTags.PEER_SERVICE_REMAPPED_FROM, value);
       }
     }
-    return unsafeTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
@@ -1,13 +1,15 @@
 package datadog.trace.core.tagprocessor;
 
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.core.DDSpanContext;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-public class PostProcessorChain implements TagsPostProcessor {
+public final class PostProcessorChain extends TagsPostProcessor {
   private final TagsPostProcessor[] chain;
 
   public PostProcessorChain(@Nonnull final TagsPostProcessor... processors) {
@@ -15,12 +17,9 @@ public class PostProcessorChain implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
-    Map<String, Object> currentTags = unsafeTags;
+  public void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
     for (final TagsPostProcessor tagsPostProcessor : chain) {
-      currentTags = tagsPostProcessor.processTags(currentTags, spanContext, spanLinks);
+      tagsPostProcessor.processTags(unsafeTags, spanContext, spanLinks);
     }
-    return currentTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
@@ -4,6 +4,7 @@ import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.DDSpanContext;
@@ -13,7 +14,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class QueryObfuscator implements TagsPostProcessor {
+public final class QueryObfuscator extends TagsPostProcessor {
 
   private static final Logger log = LoggerFactory.getLogger(QueryObfuscator.class);
 
@@ -58,20 +59,17 @@ public class QueryObfuscator implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
-    Object query = unsafeTags.get(DDTags.HTTP_QUERY);
+  public void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+    Object query = unsafeTags.getObject(DDTags.HTTP_QUERY);
     if (query instanceof CharSequence) {
       query = obfuscate(query.toString());
 
       unsafeTags.put(DDTags.HTTP_QUERY, query);
 
-      Object url = unsafeTags.get(Tags.HTTP_URL);
+      Object url = unsafeTags.getObject(Tags.HTTP_URL);
       if (url instanceof CharSequence) {
         unsafeTags.put(Tags.HTTP_URL, url + "?" + query);
       }
     }
-
-    return unsafeTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
@@ -1,13 +1,14 @@
 package datadog.trace.core.tagprocessor;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.core.DDSpanContext;
+
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
-public class RemoteHostnameAdder implements TagsPostProcessor {
+public final class RemoteHostnameAdder extends TagsPostProcessor {
   private final Supplier<String> hostnameSupplier;
 
   public RemoteHostnameAdder(Supplier<String> hostnameSupplier) {
@@ -15,11 +16,10 @@ public class RemoteHostnameAdder implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+  public void processTags(
+      TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
     if (spanContext.getSpanId() == spanContext.getRootSpanId()) {
       unsafeTags.put(DDTags.TRACER_HOST, hostnameSupplier.get());
     }
-    return unsafeTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
@@ -1,11 +1,27 @@
 package datadog.trace.core.tagprocessor;
 
+import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.core.DDSpanContext;
+
 import java.util.List;
 import java.util.Map;
 
-public interface TagsPostProcessor {
-  Map<String, Object> processTags(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks);
+public abstract class TagsPostProcessor {
+  /*
+   * DQH - For testing purposes only 
+   */
+  @Deprecated
+  final Map<String, Object> processTags(
+	Map<String, Object> unsafeTags,
+	DDSpanContext context,
+	List<AgentSpanLink> links)
+  {
+	TagMap map = TagMap.fromMap(unsafeTags);
+	this.processTags(map, context, links);
+	return map;
+  }
+
+  public abstract void processTags(
+      TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks);
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceGenerator.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.IdGenerationStrategy
+import datadog.trace.api.TagMap
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
@@ -176,7 +177,7 @@ class TraceGenerator {
       this.measured = measured
       this.samplingPriority = samplingPriority
       this.metadata = new Metadata(Thread.currentThread().getId(),
-        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage, samplingPriority, measured, topLevel,
+        UTF8BytesString.create(Thread.currentThread().getName()), TagMap.fromMap(tags), baggage, samplingPriority, measured, topLevel,
         statusCode == 0 ? null : UTF8BytesString.create(Integer.toString(statusCode)), origin, 0)
       this.httpStatusCode = (short) statusCode
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -8,6 +8,7 @@ import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
+import datadog.trace.api.TagMap
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.naming.SpanNaming
 import datadog.trace.api.sampling.PrioritySampling
@@ -361,9 +362,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     ] + productTags()
 
     where:
-    tagContext                                      | _
-    new TagContext(null, [:])                       | _
-    new TagContext("some-origin", ["asdf": "qwer"]) | _
+    tagContext                                                      | _
+    new TagContext(null, TagMap.fromMap([:]))                       | _
+    new TagContext("some-origin", TagMap.fromMap(["asdf": "qwer"])) | _
   }
 
   def "global span tags populated on each span"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.core
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
+import datadog.trace.api.TagMap
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
@@ -274,7 +275,7 @@ class DDSpanTest extends DDCoreSpecification {
 
     where:
     extractedContext                                                                                                              | _
-    new TagContext("some-origin", [:])                                                                                            | _
+    new TagContext("some-origin", TagMap.fromMap([:]))                                                                                            | _
     new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", propagationTagsFactory.empty(), DATADOG) | _
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.core.tagprocessor
 
+import datadog.trace.api.TagMap
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink
 import datadog.trace.core.DDSpanContext
 import datadog.trace.test.util.DDSpecification
@@ -9,55 +10,53 @@ class PostProcessorChainTest extends DDSpecification {
     setup:
     def processor1 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+        void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
           unsafeTags.put("key1", "processor1")
           unsafeTags.put("key2", "processor1")
-          return unsafeTags
         }
       }
     def processor2 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+        void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
           unsafeTags.put("key1", "processor2")
-          return unsafeTags
         }
       }
 
     def chain = new PostProcessorChain(processor1, processor2)
-    def tags = ["key1": "root", "key3": "root"]
+    def tags = TagMap.fromMap(["key1": "root", "key3": "root"])
 
     when:
-    def out = chain.processTags(tags, null, [])
+    chain.processTags(tags, null, [])
 
     then:
-    assert out == ["key1": "processor2", "key2": "processor1", "key3": "root"]
+    assert tags == ["key1": "processor2", "key2": "processor1", "key3": "root"]
   }
 
   def "processor can hide tags to next one()"() {
     setup:
     def processor1 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
-          return ["my": "tag"]
+        void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+          unsafeTags.clear()
+          unsafeTags.put("my", "tag")
         }
       }
     def processor2 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
+        void processTags(TagMap unsafeTags, DDSpanContext spanContext, List<AgentSpanLink> spanLinks) {
           if (unsafeTags.containsKey("test")) {
             unsafeTags.put("found", "true")
-          }
-          return unsafeTags
+          }          
         }
       }
 
     def chain = new PostProcessorChain(processor1, processor2)
-    def tags = ["test": "test"]
+    def tags = TagMap.fromMap(["test": "test"])
 
     when:
-    def out = chain.processTags(tags, null, [])
+    chain.processTags(tags, null, [])
 
     then:
-    assert out == ["my": "tag"]
+    assert tags == ["my": "tag"]
   }
 }

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -2,6 +2,7 @@ import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.IdGenerationStrategy
+import datadog.trace.api.TagMap
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.Metadata
@@ -155,7 +156,7 @@ class TraceGenerator {
       this.type = type
       this.measured = measured
       this.metadata = new Metadata(Thread.currentThread().getId(),
-        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage, UNSET, measured, topLevel, null, null, 0)
+        UTF8BytesString.create(Thread.currentThread().getName()), TagMap.fromMap(tags), baggage, UNSET, measured, topLevel, null, null, 0)
     }
 
     @Override
@@ -297,7 +298,7 @@ class TraceGenerator {
       return metadata.getBaggage()
     }
 
-    Map<String, Object> getTags() {
+    TagMap getTags() {
       return metadata.getTags()
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3467,10 +3467,12 @@ public class Config {
   }
 
   /** @return A map of tags to be applied only to the local application root span. */
-  public Map<String, Object> getLocalRootSpanTags() {
+  public TagMap getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
-    final Map<String, Object> result = new HashMap<>(runtimeTags.size() + 2);
+    
+    final TagMap result = new TagMap();
     result.putAll(runtimeTags);
+    
     result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     result.put(SCHEMA_VERSION_TAG_KEY, SpanNaming.instance().version());
     result.put(DDTags.PROFILING_ENABLED, isProfilingEnabled() ? 1 : 0);
@@ -3491,7 +3493,7 @@ public class Config {
 
     result.putAll(getProcessIdTag());
 
-    return Collections.unmodifiableMap(result);
+    return result.freeze();
   }
 
   public WellKnownTags getWellKnownTags() {

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -1,0 +1,2035 @@
+package datadog.trace.api;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import datadog.trace.api.function.TriConsumer;
+
+/**
+ * A super simple hash map designed for...
+ * - fast copy from one map to another
+ * - compatibility with Builder idioms
+ * - building small maps as fast as possible
+ * - storing primitives without boxing
+ * - minimal memory footprint
+ * 
+ * This is mainly accomplished by using immutable entry objects that can 
+ * reference an object or a primitive.  By using immutable entries, 
+ * the entry objects can be shared between builders & maps freely.
+ * 
+ * This map lacks some features of a regular java.util.Map...
+ * - Entry object mutation
+ * - size tracking - falls back to computeSize
+ * - manipulating Map through the entrySet() or values()
+ * 
+ * Also lacks features designed for handling large maps...
+ * - bucket array expansion
+ * - adaptive collision
+ */
+public final class TagMap implements Map<String, Object>, Iterable<TagMap.Entry> {
+  public static final TagMap EMPTY = createEmpty();
+  
+  static final TagMap createEmpty() {
+    return new TagMap().freeze();
+  }
+  
+  public static final Builder builder() {
+    return new Builder();
+  }
+  
+  public static final Builder builder(int size) {
+    return new Builder(size);
+  }
+  
+  public static final TagMap fromMap(Map<String, ?> map) {
+    TagMap tagMap = new TagMap();
+    tagMap.putAll(map);
+    return tagMap;
+  }
+  
+  public static final TagMap fromMapImmutable(Map<String, ?> map) {
+    if ( map.isEmpty() ) {
+      return TagMap.EMPTY;
+    } else {
+      return fromMap(map).freeze();
+    }
+  }
+  
+  private final Object[] buckets;
+  private boolean frozen;
+  
+  public TagMap() {
+    // needs to be a power of 2 for bucket masking calculation to work as intended
+    this.buckets = new Object[1 << 4];
+    this.frozen = false;
+  }
+  
+  /**
+   * Used for inexpensive immutable
+   */
+  private TagMap(Object[] buckets) {
+    this.buckets = buckets;
+    this.frozen = true;
+  }
+  
+  @Deprecated
+  @Override
+  public final int size() {
+    return this.computeSize();
+  }
+  
+  /**
+   * Computes the size of the TagMap
+   *  
+   * computeSize is fast but is an O(n) operation.
+   */
+  public final int computeSize() {
+    Object[] thisBuckets = this.buckets;
+    
+    int size = 0;
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object curBucket = thisBuckets[i];
+      
+      if ( curBucket instanceof Entry ) {
+        size += 1;
+      } else if ( curBucket instanceof BucketGroup ) {
+        BucketGroup curGroup = (BucketGroup)curBucket;
+        size += curGroup.sizeInChain();
+      }
+    }
+    return size;
+  }
+  
+  @Deprecated
+  @Override
+  public boolean isEmpty() {
+    return this.checkIfEmpty();
+  }
+  
+  public final boolean checkIfEmpty() {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object curBucket = thisBuckets[i];
+      
+      if ( curBucket instanceof Entry ) {
+        return false;
+      } else if ( curBucket instanceof BucketGroup ) {
+        BucketGroup curGroup = (BucketGroup)curBucket;
+        if ( !curGroup.isEmptyChain() ) return false;
+      }
+    }
+    
+    return true;
+  }
+  
+  @Override
+  public boolean containsKey(Object key) {
+    if ( !(key instanceof String) ) return false;
+    
+    return (this.getEntry((String)key) != null);
+  }
+  
+  @Override
+  public boolean containsValue(Object value) {
+    for ( Entry entry : this ) {
+      if ( entry.objectValue().equals(value) ) return true;
+    }
+    return false;
+  }
+  
+  @Deprecated
+  @Override
+  public Set<String> keySet() {
+    return new Keys(this);
+  }
+  
+  @Deprecated
+  @Override
+  public Collection<Object> values() {
+    return new Values(this);
+  }
+  
+  @Deprecated
+  @Override
+  public Set<java.util.Map.Entry<String, Object>> entrySet() {
+    return new Entries(this);
+  }
+  
+  @Deprecated
+  @Override
+  public final Object get(Object tag) {
+    if ( !(tag instanceof String) ) return null;
+    
+    return this.getObject((String)tag);
+  }
+  
+  public final Object getObject(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? null : entry.objectValue();
+  }
+  
+  public final String getString(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? null : entry.stringValue();
+  }
+  
+  public final boolean getBoolean(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? false : entry.booleanValue();
+  }
+
+  public final int getInt(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? 0 : entry.intValue();
+  }
+  
+  public final long getLong(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? 0L : entry.longValue();
+  }
+  
+  public final float getFloat(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? 0F : entry.floatValue();
+  }
+  
+  public final double getDouble(String tag) {
+    Entry entry = this.getEntry(tag);
+    return entry == null ? 0D : entry.doubleValue();
+  }
+  
+  public final Entry getEntry(String tag) {
+    Object[] thisBuckets = this.buckets;
+
+    int hash = _hash(tag);
+    int bucketIndex = hash & (thisBuckets.length - 1);
+
+    Object bucket = thisBuckets[bucketIndex];
+    if ( bucket == null ) {
+      return null;
+    } else if ( bucket instanceof Entry ) {
+      Entry tagEntry = (Entry)bucket;
+      if ( tagEntry.matches(tag) ) return tagEntry;
+    } else if ( bucket instanceof BucketGroup ) {
+      BucketGroup lastGroup = (BucketGroup)bucket;
+      
+      Entry tagEntry = lastGroup.findInChain(hash, tag);
+      if ( tagEntry != null ) return tagEntry;
+    }
+    return null;
+  }
+  
+  @Deprecated
+  public final Object put(String tag, Object value) {
+    TagMap.Entry entry = this.putEntry(Entry.newAnyEntry(tag, value));
+    return entry == null ? null : entry.objectValue();
+  }
+  
+  public final Entry set(String tag, Object value) {
+    return this.putEntry(Entry.newAnyEntry(tag, value));
+  }
+  
+  public final Entry set(String tag, CharSequence value) {
+    return this.putEntry(Entry.newObjectEntry(tag, value));
+  }
+  
+  public final Entry set(String tag, boolean value) {
+    return this.putEntry(Entry.newBooleanEntry(tag, value));
+  }  
+  
+  public final Entry set(String tag, int value) {
+    return this.putEntry(Entry.newIntEntry(tag, value));
+  }
+  
+  public final Entry set(String tag, long value) {
+    return this.putEntry(Entry.newLongEntry(tag, value));
+  }
+  
+  public final Entry set(String tag, float value) {
+    return this.putEntry(Entry.newFloatEntry(tag, value));
+  }
+  
+  public final Entry set(String tag, double value) {
+    return this.putEntry(Entry.newDoubleEntry(tag, value));
+  }
+  
+  public final Entry putEntry(Entry newEntry) {
+    this.checkWriteAccess();
+    
+    Object[] thisBuckets = this.buckets;
+
+    int newHash = newEntry.hash();
+    int bucketIndex = newHash & (thisBuckets.length - 1);
+    
+    Object bucket = thisBuckets[bucketIndex];
+    if ( bucket == null ) {
+      thisBuckets[bucketIndex] = newEntry;
+      
+      return null;
+    } else if ( bucket instanceof Entry ) {
+      Entry existingEntry = (Entry)bucket;
+      if ( existingEntry.matches(newEntry.tag) ) {
+        thisBuckets[bucketIndex] = newEntry;
+        
+        return existingEntry;
+      } else {
+        thisBuckets[bucketIndex] = new BucketGroup(
+          existingEntry.hash(), existingEntry,
+          newHash, newEntry);
+        
+        return null;
+      }
+    } else if ( bucket instanceof BucketGroup ){
+      BucketGroup lastGroup = (BucketGroup)bucket;
+      
+      BucketGroup containingGroup = lastGroup.findContainingGroupInChain(newHash, newEntry.tag);
+      if ( containingGroup != null ) {
+        return containingGroup._replace(newHash, newEntry);
+      }
+      
+      if ( !lastGroup.insertInChain(newHash, newEntry) ) {
+        thisBuckets[bucketIndex] = new BucketGroup(newHash, newEntry, lastGroup);
+      }
+      return null;
+    }
+    return null;
+  }
+  
+  public final void putAll(Iterable<? extends Entry> entries) {
+    this.checkWriteAccess();
+    
+    for ( Entry tagEntry: entries ) {
+      if ( tagEntry.isRemoval() ) {
+        this.remove(tagEntry.tag);
+      } else {
+        this.putEntry(tagEntry);
+      }
+    }
+  }
+  
+  public final void putAll(TagMap.Builder builder) {
+    putAll(builder.entries, builder.nextPos);
+  }
+  
+  private final void putAll(Entry[] tagEntries, int size) {
+    for ( int i = 0; i < size && i < tagEntries.length; ++i ) {
+      Entry tagEntry = tagEntries[i];
+      
+      if ( tagEntry.isRemoval() ) {
+        this.remove(tagEntry.tag);
+      } else {
+        this.putEntry(tagEntry);
+      }
+    }
+  }
+  
+  public final void putAll(TagMap that) {
+    this.checkWriteAccess();
+    
+    Object[] thisBuckets = this.buckets;
+    Object[] thatBuckets = that.buckets;
+
+    // Since TagMap-s don't support expansion, buckets are perfectly aligned
+    for ( int i = 0; i < thisBuckets.length && i < thatBuckets.length; ++i ) {
+      Object thatBucket = thatBuckets[i];
+
+      // nothing in the other hash, just skip this bucket
+      if ( thatBucket == null ) continue;
+
+      Object thisBucket = thisBuckets[i];
+
+      if ( thisBucket == null ) {
+        // This bucket is null, easy case
+        // Either copy over the sole entry or clone the BucketGroup chain
+
+        if ( thatBucket instanceof Entry ) {
+          thisBuckets[i] = thatBucket;
+        } else if ( thatBucket instanceof BucketGroup ) {
+          BucketGroup thatGroup = (BucketGroup)thatBucket;
+          
+          thisBuckets[i] = thatGroup.cloneChain();
+        }
+      } else if ( thisBucket instanceof Entry ) {
+        // This bucket is a single entry, medium complexity case
+        // If other side is an Entry - just merge the entries into a bucket
+        // If other side is a BucketGroup - then clone the group and insert the entry normally into the cloned group
+       
+        Entry thisEntry = (Entry)thisBucket;
+        int thisHash = thisEntry.hash();
+        
+        if ( thatBucket instanceof Entry ) {
+          Entry thatEntry = (Entry)thatBucket;
+          int thatHash = thatEntry.hash();
+          
+          if ( thisHash == thatHash && thisEntry.matches(thatEntry.tag())) {
+            thisBuckets[i] = thatEntry;
+          } else {
+            thisBuckets[i] = new BucketGroup(
+              thisHash, thisEntry,
+              thatHash, thatEntry);
+          }
+        } else if ( thatBucket instanceof BucketGroup ) {
+          BucketGroup thatGroup = (BucketGroup)thatBucket;
+          
+          // Clone the other group, then place this entry into that group
+          BucketGroup thisNewGroup = thatGroup.cloneChain();
+          
+          Entry incomingEntry = thisNewGroup.findInChain(thisHash, thisEntry.tag());
+          if ( incomingEntry != null ) {
+            // there's already an entry w/ the same tag from the incoming TagMap - done
+            thisBuckets[i] = thisNewGroup;
+          } else if ( thisNewGroup.insertInChain(thisHash, thisEntry) ) {
+            // able to add thisEntry into the existing groups
+            thisBuckets[i] = thisNewGroup;
+          } else {
+            // unable to add into the existing groups
+            thisBuckets[i] = new BucketGroup(thisHash, thisEntry, thisNewGroup);
+          }
+        }
+      } else if ( thisBucket instanceof BucketGroup ) {
+        // This bucket is a BucketGroup, medium to hard case
+        // If the other side is an entry, just normal insertion procedure - no cloning required
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+    
+        if ( thatBucket instanceof Entry ) {
+          Entry thatEntry = (Entry)thatBucket;
+          int thatHash = thatEntry.hash();
+          
+          if ( !thisGroup.replaceOrInsertInChain(thatHash, thatEntry) ) {
+            thisBuckets[i] = new BucketGroup(thatHash, thatEntry, thisGroup);
+          }
+        } else if ( thatBucket instanceof BucketGroup ) {
+          // Most complicated case - need to walk that bucket group chain and update this chain
+          BucketGroup thatGroup = (BucketGroup)thatBucket;
+        
+          thisBuckets[i] = thisGroup.replaceOrInsertAllInChain(thatGroup);
+        }
+      }
+    }
+  }
+  
+  public final void putAll(Map<? extends String, ? extends Object> map) {
+    this.checkWriteAccess();
+    
+    if ( map instanceof TagMap ) {
+      this.putAll((TagMap)map);
+    } else {
+      for ( Map.Entry<? extends String, ?> entry: map.entrySet() ) {
+        this.put(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+  
+  public final void fillMap(Map<? super String, Object> map) {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object thisBucket = thisBuckets[i];
+      
+      if ( thisBucket instanceof Entry ) {
+        Entry thisEntry = (Entry)thisBucket;
+        
+        map.put(thisEntry.tag, thisEntry.objectValue());
+      } else if ( thisBucket instanceof BucketGroup ) {
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+        
+        thisGroup.fillMapFromChain(map);
+      }
+    }
+  }
+  
+  public final void fillStringMap(Map<? super String, ? super String> stringMap) {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object thisBucket = thisBuckets[i];
+      
+      if ( thisBucket instanceof Entry ) {
+        Entry thisEntry = (Entry)thisBucket;
+        
+        stringMap.put(thisEntry.tag, thisEntry.stringValue());
+      } else if ( thisBucket instanceof BucketGroup ) {
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+        
+        thisGroup.fillStringMapFromChain(stringMap);
+      }
+    }
+  }
+  
+  @Deprecated
+  @Override
+  public final Object remove(Object tag) {
+    if ( !(tag instanceof String) ) return null;
+    
+    Entry entry = this.removeEntry((String)tag);
+    return entry == null ? null : entry.objectValue();
+  }
+  
+  public final Entry removeEntry(String tag) {
+    this.checkWriteAccess();
+    
+    Object[] thisBuckets = this.buckets;
+
+    int hash = _hash(tag);
+    int bucketIndex = hash & (thisBuckets.length - 1);
+    
+    Object bucket = thisBuckets[bucketIndex];
+    // null bucket case - do nothing
+    if ( bucket instanceof Entry ) {
+      Entry existingEntry = (Entry)bucket;
+      if (existingEntry.matches(tag)) {
+        thisBuckets[bucketIndex] = null;
+        return existingEntry;
+      } else {
+        return null;
+      }
+    } else if ( bucket instanceof BucketGroup) {
+      BucketGroup lastGroup = (BucketGroup)bucket;
+      
+      BucketGroup containingGroup = lastGroup.findContainingGroupInChain(hash, tag);
+      if ( containingGroup == null ) {
+        return null;
+      }
+      
+      Entry existingEntry = containingGroup._remove(hash, tag);
+      if ( containingGroup._isEmpty() ) {
+        this.buckets[bucketIndex] = lastGroup.removeGroupInChain(containingGroup);
+      }
+      
+      return existingEntry;
+    }
+    return null;
+  }
+  
+  public final TagMap copy() {
+    TagMap copy = new TagMap();
+    copy.putAll(this);
+    return copy;
+  }
+  
+  public final TagMap immutableCopy() {
+    if ( this.frozen ) {
+      return this;
+    } else {
+      return this.copy().freeze();
+    }
+  }
+  
+  public final TagMap immutable() {
+    // specialized constructor, freezes map immediately
+    return new TagMap(this.buckets);
+  }
+  
+  @Override
+  public final Iterator<Entry> iterator() {
+    return new EntryIterator(this);
+  }
+  
+  public final Stream<Entry> stream() {
+      return StreamSupport.stream(spliterator(), false);
+  }
+  
+  public final void forEach(Consumer<? super TagMap.Entry> consumer) {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object thisBucket = thisBuckets[i];
+      
+      if ( thisBucket instanceof Entry ) {
+        Entry thisEntry = (Entry)thisBucket;
+        
+        consumer.accept(thisEntry);
+      } else if ( thisBucket instanceof BucketGroup ) {
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+        
+        thisGroup.forEachInChain(consumer);
+      }
+    }
+  }
+  
+  public final <T> void forEach(T thisObj, BiConsumer<T, ? super TagMap.Entry> consumer) {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object thisBucket = thisBuckets[i];
+      
+      if ( thisBucket instanceof Entry ) {
+        Entry thisEntry = (Entry)thisBucket;
+        
+        consumer.accept(thisObj, thisEntry);
+      } else if ( thisBucket instanceof BucketGroup ) {
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+        
+        thisGroup.forEachInChain(thisObj, consumer);
+      }
+    }
+  }
+  
+  public final <T, U> void forEach(T thisObj, U otherObj, TriConsumer<T, U, ? super TagMap.Entry> consumer) {
+    Object[] thisBuckets = this.buckets;
+    
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      Object thisBucket = thisBuckets[i];
+      
+      if ( thisBucket instanceof Entry ) {
+        Entry thisEntry = (Entry)thisBucket;
+        
+        consumer.accept(thisObj, otherObj, thisEntry);
+      } else if ( thisBucket instanceof BucketGroup ) {
+        BucketGroup thisGroup = (BucketGroup)thisBucket;
+        
+        thisGroup.forEachInChain(thisObj, otherObj, consumer);
+      }
+    }
+  }
+  
+  public final void clear() {
+    this.checkWriteAccess();
+    
+    Arrays.fill(this.buckets, null);
+  }
+  
+  public final TagMap freeze() {
+    this.frozen = true;
+    
+    return this;
+  }
+  
+  public boolean isFrozen() {
+	return this.frozen;
+  }
+  
+//  final void check() {
+//    Object[] thisBuckets = this.buckets;
+//    
+//    for ( int i = 0; i < thisBuckets.length; ++i ) {
+//      Object thisBucket = thisBuckets[i];
+//      
+//      if ( thisBucket instanceof Entry ) {
+//        Entry thisEntry = (Entry)thisBucket;
+//        int thisHash = thisEntry.hash();
+//        
+//        int expectedBucket = thisHash & (thisBuckets.length - 1);
+//        assert expectedBucket == i;
+//      } else if ( thisBucket instanceof BucketGroup ) {
+//        BucketGroup thisGroup = (BucketGroup)thisBucket;
+//        
+//        for ( BucketGroup curGroup = thisGroup;
+//          curGroup != null;
+//          curGroup = curGroup.prev )
+//        {
+//          for ( int j = 0; j < BucketGroup.LEN; ++j ) {
+//            Entry thisEntry = curGroup._entryAt(i);
+//            if ( thisEntry == null ) continue;
+//            
+//            int thisHash = thisEntry.hash();
+//            assert curGroup._hashAt(i) == thisHash;
+//            
+//            int expectedBucket = thisHash & (thisBuckets.length - 1);
+//            assert expectedBucket == i;
+//          }
+//        }
+//      }
+//    }
+//  }
+  
+  @Override
+  public String toString() {
+    return toInternalString();
+  }
+  
+  String toPrettyString() {
+    boolean first = true;
+    
+    StringBuilder builder = new StringBuilder(128);
+    builder.append('{');
+    for ( Entry entry: this ) {
+      if ( first ) {
+        first = false;
+      } else {
+        builder.append(",");
+      }
+      
+      builder.append(entry.tag).append('=').append(entry.stringValue());
+    }
+    builder.append('}');
+    return builder.toString();
+  }
+  
+  String toInternalString() {
+    Object[] thisBuckets = this.buckets;
+    
+    StringBuilder builder = new StringBuilder(128);
+    for ( int i = 0; i < thisBuckets.length; ++i ) {
+      builder.append('[').append(i).append("] = ");
+      
+      Object thisBucket = thisBuckets[i];
+      if ( thisBucket == null ) {
+        builder.append("null");
+      } else if ( thisBucket instanceof Entry ) {
+        builder.append('{').append(thisBucket).append('}');
+      } else if ( thisBucket instanceof BucketGroup ) {
+        for ( BucketGroup curGroup = (BucketGroup)thisBucket; 
+          curGroup != null;
+          curGroup = curGroup.prev )
+        {
+          builder.append(curGroup).append(" -> ");
+        }
+      }
+      builder.append('\n');
+    }
+    return builder.toString();
+  }
+  
+  public final void checkWriteAccess() {
+    if ( this.frozen ) throw new IllegalStateException("TagMap frozen");
+  }
+  
+  static final int _hash(String tag) {
+    int hash = tag.hashCode();
+    return hash == 0 ? 0xDD06 : hash ^ (hash >>> 16);
+  }
+  
+  public static final class Entry implements Map.Entry<String, Object> {
+    /*
+     * Special value used to record removals in the builder
+     * Removal entries are never stored in the TagMap itself
+     */
+    private static final byte REMOVED = -1;
+
+    /*
+     * Special value used for Objects that haven't been type checked yet.
+     * These objects might be primitive box objects.
+     */
+    public static final byte ANY = 0;
+    public static final byte OBJECT = 1;
+    
+    /*
+     * Non-numeric primitive types
+     */
+    public static final byte BOOLEAN = 2;
+    public static final byte CHAR = 3;
+
+    /*
+     * Numeric constants - deliberately arranged to allow for checking by using type >= BYTE
+     */
+    public static final byte BYTE = 4;
+    public static final byte SHORT = 5;
+    public static final byte INT = 6;
+    public static final byte LONG = 7;
+    public static final byte FLOAT = 8;
+    public static final byte DOUBLE = 9;
+
+
+    static final Entry newAnyEntry(String tag, Object value) {
+      // DQH - To keep entry creation (e.g. map changes) as fast as possible, 
+      // the entry construction is kept as simple as possible.
+    
+      // Prior versions of this code did type detection on value to 
+      // recognize box types but that proved expensive.  So now, 
+      // the type is recorded as an ANY which is an indicator to do 
+      // type detection later if need be.
+      return new Entry(tag, ANY, 0L, value);
+    }
+
+    static final Entry newObjectEntry(String tag, Object value) {
+      return new Entry(tag, OBJECT, 0, value);
+    }    
+
+    static final Entry newBooleanEntry(String tag, boolean value) {
+      return new Entry(tag, BOOLEAN, boolean2Prim(value), Boolean.valueOf(value));
+    }
+    
+    static final Entry newBooleanEntry(String tag, Boolean box) {
+      return new Entry(tag, BOOLEAN, boolean2Prim(box.booleanValue()), box);
+    }
+
+    static final Entry newIntEntry(String tag, int value) {
+      return new Entry(tag, INT, int2Prim(value), null);
+    }
+    
+    static final Entry newIntEntry(String tag, Integer box) {
+      return new Entry(tag, INT, int2Prim(box.intValue()), box);
+    }
+
+    static final Entry newLongEntry(String tag, long value) {
+      return new Entry(tag, LONG, long2Prim(value), null);
+    }
+    
+    static final Entry newLongEntry(String tag, Long box) {
+      return new Entry(tag, LONG, long2Prim(box.longValue()), box);
+    }
+
+    static final Entry newFloatEntry(String tag, float value) {
+      return new Entry(tag, FLOAT, float2Prim(value), null);
+    }
+    
+    static final Entry newFloatEntry(String tag, Float box) {
+      return new Entry(tag, FLOAT, float2Prim(box.floatValue()), box);
+    }
+
+    static final Entry newDoubleEntry(String tag, double value) {
+      return new Entry(tag, DOUBLE, double2Prim(value), null);
+    }
+    
+    static final Entry newDoubleEntry(String tag, Double box) {
+      return new Entry(tag, DOUBLE, double2Prim(box.doubleValue()), box);
+    }
+
+    static final Entry newRemovalEntry(String tag) {
+      return new Entry(tag, REMOVED, 0, null);
+    }
+    
+    final String tag;
+    int hash;
+
+    // To optimize construction of Entry around boxed primitives and Object entries,
+    // no type checks are done during construction.
+    // Any Object entries are initially marked as type ANY, prim set to 0, and the Object put into obj
+    // If an ANY entry is later type checked or request as a primitive, then the ANY will be resolved
+    // to the correct type.
+    
+    // From the outside perspective, this object remains functionally immutable.
+    // However, internally, it is important to remember that this type must be thread safe.
+    // That includes multiple threads racing to resolve an ANY entry at the same time.
+    
+    volatile byte type;
+    volatile long prim;
+    volatile Object obj;
+    
+    volatile String strCache = null;
+
+    private Entry(String tag, byte type, long prim, Object obj) {
+      this.tag = tag;
+      this.hash = 0; // lazily computed
+      this.type = type;
+      this.prim = prim;
+      this.obj = obj;
+    }
+
+    public final String tag() {
+      return this.tag;
+    }
+    
+    int hash() {
+      int hash = this.hash;
+      if ( hash != 0 ) return hash;
+      
+      hash = _hash(this.tag);
+      this.hash = hash;
+      return hash;
+    }
+
+    public final byte type() {
+      return this.resolveAny();
+    }
+
+    public final boolean is(byte type) {
+      byte curType = this.type;
+      if ( curType == type ) {
+        return true;
+      } else if ( curType != ANY ) {
+        return false;
+      } else {
+        return (this.resolveAny() == type);
+      }
+    }
+
+    public final boolean isNumericPrimitive() {
+      byte curType = this.type;
+      if ( _isNumericPrimitive(curType) ) {
+        return true;
+      } else if ( curType != ANY ) {
+        return false;
+      } else {
+        return _isNumericPrimitive(this.resolveAny());
+      }
+    }
+    
+    public final boolean isNumber() {
+      byte curType = this.type;
+      return _isNumericPrimitive(curType) || (this.obj instanceof Number);
+    }
+    
+    private static final boolean _isNumericPrimitive(byte type) {
+      return (type >= BYTE);
+    }
+    
+    private final byte resolveAny() {
+      byte curType = this.type;
+      if ( curType != ANY ) return curType;
+      
+      Object value = this.obj;
+      long prim;
+      byte resolvedType;
+      
+      if (value instanceof Boolean) {
+        Boolean boolValue = (Boolean) value;
+        prim = boolean2Prim(boolValue);
+        resolvedType = BOOLEAN;
+      } else if (value instanceof Integer) {
+        Integer intValue = (Integer) value;
+        prim = int2Prim(intValue);
+        resolvedType = INT;
+      } else if (value instanceof Long) {
+        Long longValue = (Long) value;
+        prim = long2Prim(longValue);
+        resolvedType = LONG;
+      } else if (value instanceof Float) {
+        Float floatValue = (Float) value;
+        prim = float2Prim(floatValue);
+        resolvedType = FLOAT;
+      } else if (value instanceof Double) {
+        Double doubleValue = (Double) value;
+        prim = double2Prim(doubleValue);
+        resolvedType = DOUBLE;
+      } else {
+        prim = 0;
+        resolvedType = OBJECT;
+      }
+      
+      this._setPrim(resolvedType, prim);
+      
+      return resolvedType;
+    }
+    
+    private void _setPrim(byte type, long prim) {
+      // Order is important here, the contract is that prim must be set properly *before*
+      // type is set to a non-object type
+      
+      this.prim = prim;
+      this.type = type;
+    }
+
+    public final boolean isObject() {
+      return this.is(OBJECT);
+    }
+
+    public final boolean isRemoval() {
+      return this.is(REMOVED);
+    }
+    
+    public final boolean matches(String tag) {
+      return this.tag.equals(tag);
+    }
+
+    public final Object objectValue() {
+      if ( this.obj != null ) {
+        return this.obj;
+      }
+
+      // This code doesn't need to handle ANY-s.
+      // An entry that starts as an ANY will always have this.obj set
+      switch (this.type) {
+      case BOOLEAN:
+        this.obj = prim2Boolean(this.prim);
+        break;
+
+      case INT:
+        // Maybe use a wider cache that handles response code???
+        this.obj = prim2Int(this.prim);
+        break;
+
+      case LONG:
+        this.obj = prim2Long(this.prim);
+        break;
+
+      case FLOAT:
+        this.obj = prim2Float(this.prim);
+        break;
+
+      case DOUBLE:
+        this.obj = prim2Double(this.prim);
+        break;
+      }
+
+      if (this.is(REMOVED)) {
+        return null;
+      }
+
+      return this.obj;
+    }
+
+    public final boolean booleanValue() {
+      byte type = this.type;
+      
+      if (type == BOOLEAN) {
+        return prim2Boolean(this.prim);
+      } else if (type == ANY && this.obj instanceof Boolean) {
+        boolean boolValue = (Boolean)this.obj;
+        this._setPrim(BOOLEAN, boolean2Prim(boolValue));
+        return boolValue;
+      }
+      
+      // resolution will set prim if necessary
+      byte resolvedType = this.resolveAny();
+      long prim = this.prim;
+
+      switch (resolvedType) {
+      case INT:
+        return prim2Int(prim) != 0;
+
+      case LONG:
+        return prim2Long(prim) != 0L;
+
+      case FLOAT:
+        return prim2Float(prim) != 0F;
+
+      case DOUBLE:
+        return prim2Double(prim) != 0D;
+
+      case OBJECT:
+        return (this.obj != null);
+
+      case REMOVED:
+        return false;
+      }
+
+      return false;
+    }
+
+    public final int intValue() {
+      byte type = this.type;
+        
+      if (type == INT) {
+        return prim2Int(this.prim);
+      } else if (type == ANY && this.obj instanceof Integer) {
+        int intValue = (Integer)this.obj;
+        this._setPrim(INT, int2Prim(intValue));
+        return intValue;
+      }
+      
+      // resolution will set prim if necessary
+      byte resolvedType = this.resolveAny();
+      long prim = this.prim;
+
+      switch (resolvedType) {
+      case BOOLEAN:
+        return prim2Boolean(prim) ? 1 : 0;
+
+      case LONG:
+        return (int) prim2Long(prim);
+
+      case FLOAT:
+        return (int) prim2Float(prim);
+
+      case DOUBLE:
+        return (int) prim2Double(prim);
+
+      case OBJECT:
+        return 0;
+
+      case REMOVED:
+        return 0;
+      }
+
+      return 0;
+    }
+
+    public final long longValue() {
+      byte type = this.type;
+        
+      if (type == LONG) {
+        return prim2Long(this.prim);
+      } else if (type == ANY && this.obj instanceof Long) {
+        long longValue = (Long)this.obj;
+        this._setPrim(LONG, long2Prim(longValue));
+        return longValue;
+      }
+        
+      // resolution will set prim if necessary
+      byte resolvedType = this.resolveAny();
+      long prim = this.prim;
+
+      switch (resolvedType) {
+        case BOOLEAN:
+          return prim2Boolean(prim) ? 1L : 0L;
+
+        case INT:
+          return (long) prim2Int(prim);
+
+        case FLOAT:
+          return (long) prim2Float(prim);
+
+        case DOUBLE:
+          return (long) prim2Double(prim);
+
+        case OBJECT:
+          return 0;
+
+        case REMOVED:
+          return 0;
+      }
+
+      return 0;
+    }
+
+    public final float floatValue() {
+      byte type = this.type;
+        
+      if (type == FLOAT) {
+        return prim2Float(this.prim);
+      } else if (type == ANY && this.obj instanceof Float) {
+        float floatValue = (Float)this.obj;
+        this._setPrim(FLOAT, float2Prim(floatValue));
+        return floatValue;
+      }
+          
+      // resolution will set prim if necessary
+      byte resolvedType = this.resolveAny();
+      long prim = this.prim;
+
+      switch (resolvedType) {
+      case BOOLEAN:
+        return prim2Boolean(prim) ? 1F : 0F;
+
+      case INT:
+        return (float) prim2Int(prim);
+
+      case LONG:
+        return (float) prim2Long(prim);
+
+      case DOUBLE:
+        return (float) prim2Double(prim);
+
+      case OBJECT:
+        return 0F;
+
+      case REMOVED:
+        return 0F;
+      }
+
+      return 0F;
+    }
+
+    public final double doubleValue() {
+      byte type = this.type;
+        
+      if (type == DOUBLE) {
+        return prim2Double(this.prim);
+      } else if (type == ANY && this.obj instanceof Double) {
+        double doubleValue = (Double)this.obj;
+        this._setPrim(DOUBLE, double2Prim(doubleValue));
+        return doubleValue;
+      }
+      
+      // resolution will set prim if necessary
+      byte resolvedType = this.resolveAny();
+      long prim = this.prim;
+
+      switch (resolvedType) {
+      case BOOLEAN:
+        return prim2Boolean(prim) ? 1D : 0D;
+
+      case INT:
+        return (double) prim2Int(prim);
+
+      case LONG:
+        return (double) prim2Long(prim);
+
+      case FLOAT:
+        return (double) prim2Float(prim);
+
+      case OBJECT:
+        return 0D;
+
+      case REMOVED:
+        return 0D;
+      }
+
+      return 0D;
+    }
+
+    public final String stringValue() {
+      String strCache = this.strCache;
+      if ( strCache != null ) {
+      return strCache;
+      }
+      
+      String computeStr = this.computeStringValue();
+      this.strCache = computeStr;
+      return computeStr;
+    }
+    
+    private final String computeStringValue() {
+      // Could do type resolution here, 
+      // but decided to just fallback to this.obj.toString() for ANY case
+      switch (this.type) {
+      case BOOLEAN:
+        return Boolean.toString(prim2Boolean(this.prim));
+
+      case INT:
+        return Integer.toString(prim2Int(this.prim));
+
+      case LONG:
+        return Long.toString(prim2Long(this.prim));
+
+      case FLOAT:
+        return Float.toString(prim2Float(this.prim));
+
+      case DOUBLE:
+        return Double.toString(prim2Double(this.prim));
+
+      case REMOVED:
+        return null;
+
+      case OBJECT:
+      case ANY:
+        return this.obj.toString();
+      }
+
+      return null;
+    }
+    
+    @Override
+    public final String toString() {
+      return this.tag() + '=' + this.stringValue();
+    }
+    
+    @Deprecated
+    @Override
+    public String getKey() {
+      return this.tag();
+    }
+    
+    @Deprecated
+    @Override
+    public Object getValue() {
+      return this.objectValue();
+    }
+    
+    @Deprecated
+    @Override
+    public Object setValue(Object value) {
+      throw new UnsupportedOperationException();
+    }
+
+    private static final long boolean2Prim(boolean value) {
+      return value ? 1L : 0L;
+    }
+
+    private static final boolean prim2Boolean(long prim) {
+      return (prim != 0L);
+    }
+
+    private static final long int2Prim(int value) {
+      return (long) value;
+    }
+
+    private static final int prim2Int(long prim) {
+      return (int) prim;
+    }
+
+    private static final long long2Prim(long value) {
+      return value;
+    }
+
+    private static final long prim2Long(long prim) {
+      return prim;
+    }
+
+    private static final long float2Prim(float value) {
+      return (long) Float.floatToIntBits(value);
+    }
+
+    private static final float prim2Float(long prim) {
+      return Float.intBitsToFloat((int) prim);
+    }
+
+    private static final long double2Prim(double value) {
+      return Double.doubleToRawLongBits(value);
+    }
+
+    private static final double prim2Double(long prim) {
+      return Double.longBitsToDouble(prim);
+    }
+  }
+  
+  public static final class Builder implements Iterable<Entry> {
+    private Entry[] entries;
+    private int nextPos = 0;
+    
+    private Builder() {
+      this(8);
+    }
+    
+    private Builder(int size) {
+      this.entries = new Entry[size];
+    }
+    
+    public final boolean isDefinitelyEmpty() {
+      return (this.nextPos == 0);
+    }
+    
+    /**
+     * Provides the estimated size of the map created by the builder
+     * Doesn't account for overwritten entries or entry removal
+     * @return
+     */
+    public final int estimateSize() {
+      return this.nextPos;
+    }
+    
+    public final Builder put(String tag, Object value) {
+      return this.put(Entry.newAnyEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, CharSequence value) {
+      return this.put(Entry.newObjectEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, boolean value) {
+      return this.put(Entry.newBooleanEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, int value) {
+      return this.put(Entry.newIntEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, long value) {
+      return this.put(Entry.newLongEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, float value) {
+      return this.put(Entry.newFloatEntry(tag, value));
+    }
+    
+    public final Builder put(String tag, double value) {
+      return this.put(Entry.newDoubleEntry(tag, value));
+    }
+    
+    public final Builder remove(String tag) {
+      return this.put(Entry.newRemovalEntry(tag));
+    }
+    
+    public final Builder put(Entry entry) {
+      if ( this.nextPos >= this.entries.length ) {
+        this.entries = Arrays.copyOf(this.entries, this.entries.length << 1);
+      }
+      
+      this.entries[this.nextPos++] = entry;
+      return this;
+    }
+    
+    public final void reset() {
+      Arrays.fill(this.entries, null);
+      this.nextPos = 0;
+    }
+    
+    @Override
+    public final Iterator<Entry> iterator() {
+      return new BuilderIterator(this.entries, this.nextPos);
+    }
+    
+    public TagMap build() {
+      TagMap map = new TagMap();
+      if ( this.nextPos != 0 ) map.putAll(this.entries, this.nextPos);
+      return map;
+    }
+    
+    public TagMap buildImmutable() {
+      if ( this.nextPos == 0 ) {
+        return TagMap.EMPTY;
+      } else {
+        return this.build().freeze();
+      }
+    }
+  }
+  
+  private static final class BuilderIterator implements Iterator<Entry> {
+    private final Entry[] entries;
+    private final int size;
+    
+    private int pos;
+    
+    BuilderIterator(Entry[] entries, int size) {
+      this.entries = entries;
+      this.size = size;
+      
+      this.pos = -1;
+    }
+    
+    @Override
+    public final boolean hasNext() {
+      return ( this.pos + 1 < this.size );
+    }
+    
+    @Override
+    public Entry next() {
+      if ( !this.hasNext() ) throw new NoSuchElementException("no next");
+      
+      return this.entries[++this.pos];
+    }
+  }
+  
+  private static abstract class MapIterator<T> implements Iterator<T> {
+    private final Object[] buckets;
+    
+    private Entry nextEntry;
+
+    private int bucketIndex = -1;
+    
+    private BucketGroup group = null;
+    private int groupIndex = 0;
+    
+    MapIterator(TagMap map) {
+      this.buckets = map.buckets;
+    }
+    
+    @Override
+    public boolean hasNext() {
+      if ( this.nextEntry != null ) return true;
+      
+      while ( this.bucketIndex < this.buckets.length ) {
+        this.nextEntry = this.advance();
+        if ( this.nextEntry != null ) return true;
+      }
+      
+      return false;
+    }
+    
+    Entry nextEntry() {
+      if ( this.nextEntry != null ) {
+        Entry nextEntry = this.nextEntry;
+        this.nextEntry = null;
+        return nextEntry;
+      }
+      
+      if ( this.hasNext() ) {
+        return this.nextEntry;
+      } else {
+        throw new NoSuchElementException();
+      }
+    }
+    
+    private final Entry advance() {
+      while ( this.bucketIndex < this.buckets.length ) {
+        if ( this.group != null ) {
+          for ( ++this.groupIndex; this.groupIndex < BucketGroup.LEN; ++this.groupIndex ) {
+            Entry tagEntry = this.group._entryAt(this.groupIndex);
+            if ( tagEntry != null ) return tagEntry;
+          }
+        
+          // done processing - that group, go to next group
+          this.group = this.group.prev;
+          this.groupIndex = -1;
+        }
+
+        // if the group is null, then we've finished the current bucket - so advance the bucket
+        if ( this.group == null ) {
+          for ( ++this.bucketIndex; this.bucketIndex < this.buckets.length; ++this.bucketIndex ) {
+            Object bucket = this.buckets[this.bucketIndex];
+          
+            if ( bucket instanceof Entry ) {
+              return (Entry)bucket;
+            } else if ( bucket instanceof BucketGroup ) {
+              this.group = (BucketGroup)bucket;
+              this.groupIndex = -1;
+            
+              break;
+            }
+          }
+        }
+      };
+    
+      return null;
+    }
+  }
+  
+  static final class EntryIterator extends MapIterator<Entry> {
+    EntryIterator(TagMap map) {
+      super(map);
+    }
+    
+    @Override
+    public Entry next() {
+      return this.nextEntry();
+    }
+  }
+  
+  /**
+   * BucketGroup is compromise for performance over a linked list or array
+   * - linked list - would prevent TagEntry-s from being immutable and would limit sharing opportunities
+   * - array - wouldn't be able to store hashes close together
+   * - parallel arrays (one for hashes & another for entries) would require more allocation
+   */
+  static final class BucketGroup {
+    static final int LEN = 4;
+    
+    // int hashFilter = 0;
+    
+    // want the hashes together in the same cache line
+    int hash0 = 0;
+    int hash1 = 0;
+    int hash2 = 0;
+    int hash3 = 0;
+    
+    Entry entry0 = null;
+    Entry entry1 = null;
+    Entry entry2 = null;
+    Entry entry3 = null;
+    
+    BucketGroup prev = null;
+    
+    BucketGroup() {}
+    
+    /**
+     * New group with an entry pointing to existing BucketGroup
+     */
+    BucketGroup(int hash0, Entry entry0, BucketGroup prev) {
+      this.hash0 = hash0;
+      this.entry0 = entry0;
+      
+      this.prev = prev;
+      
+      // this.hashFilter = hash0;
+    }
+    
+    /**
+     * New group composed of two entries
+     */
+    BucketGroup(int hash0, Entry entry0, int hash1, Entry entry1) {
+      this.hash0 = hash0;
+      this.entry0 = entry0;
+      
+      this.hash1 = hash1;
+      this.entry1 = entry1;
+      
+      // this.hashFilter = hash0 | hash1;
+    }
+    
+    /**
+     * New group composed of 4 entries - used for cloning
+     */
+    BucketGroup(
+      int hash0, Entry entry0,
+      int hash1, Entry entry1,
+      int hash2, Entry entry2,
+      int hash3, Entry entry3)
+    {
+      this.hash0 = hash0;
+      this.entry0 = entry0;
+      
+      this.hash1 = hash1;
+      this.entry1 = entry1;
+      
+      this.hash2 = hash2;
+      this.entry2 = entry2;
+      
+      this.hash3 = hash3;
+      this.entry3 = entry3;
+      
+      // this.hashFilter = hash0 | hash1 | hash2 | hash3;
+    }
+    
+    Entry _entryAt(int index) {
+      switch ( index ) {
+        case 0:
+        return this.entry0;
+        
+        case 1:
+        return this.entry1;
+        
+        case 2:
+        return this.entry2;
+        
+        case 3:
+        return this.entry3;
+      }
+      
+      return null;
+    }
+    
+    int _hashAt(int index) {
+      switch ( index ) {
+        case 0:
+        return this.hash0;
+          
+        case 1:
+        return this.hash1;
+          
+        case 2:
+        return this.hash2;
+          
+        case 3:
+        return this.hash3;
+      }
+        
+      return 0;
+    }
+    
+    int sizeInChain() {
+      int size = 0;
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        size += curGroup._size();
+      }
+      return size;
+    }
+    
+    int _size() {
+      return ( this.hash0 == 0 ? 0 : 1 ) + 
+        ( this.hash1 == 0 ? 0 : 1 ) + 
+        ( this.hash2 == 0 ? 0 : 1 ) + 
+        ( this.hash3 == 0 ? 0 : 1 );
+    }
+    
+    boolean isEmptyChain() {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        if ( !curGroup._isEmpty() ) return false;
+      }
+      return true;
+    }
+    
+    boolean _isEmpty() {
+      return (this.hash0 | this.hash1 | this.hash2 | this.hash3) != 0;
+      // return (this.hashFilter == 0);
+    }
+    
+    BucketGroup findContainingGroupInChain(int hash, String tag) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        if ( curGroup._find(hash, tag) != null ) return curGroup;
+      }
+      return null;
+    }
+    
+//    boolean _mayContain(int hash) {
+//      return ((hash & this.hashFilter) == hash);
+//    }
+    
+    Entry findInChain(int hash, String tag) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        Entry curEntry = curGroup._find(hash, tag);
+        if ( curEntry != null ) return curEntry;
+      }
+      return null;
+    }
+
+    Entry _find(int hash, String tag) {
+      // if ( this._mayContain(hash) ) return null;
+      
+      if ( this.hash0 == hash && this.entry0.matches(tag)) {
+        return this.entry0;
+      } else if ( this.hash1 == hash && this.entry1.matches(tag)) {
+        return this.entry1;
+      } else if ( this.hash2 == hash && this.entry2.matches(tag)) {
+        return this.entry2;
+      } else if ( this.hash3 == hash && this.entry3.matches(tag)) {
+        return this.entry3;
+      }
+      return null;
+    }
+    
+    BucketGroup replaceOrInsertAllInChain(BucketGroup thatHeadGroup) {
+      BucketGroup thisOrigHeadGroup = this;
+      BucketGroup thisNewestHeadGroup = thisOrigHeadGroup;
+    
+      for ( BucketGroup thatCurGroup = thatHeadGroup;
+        thatCurGroup != null;
+        thatCurGroup = thatCurGroup.prev )
+      {
+        // First phase - tries to replace or insert each entry in the existing bucket chain
+        // Only need to search the original groups for replacements
+        // The whole chain is eligible for insertions
+        boolean handled0 = (thatCurGroup.hash0 == 0) ||
+          (thisOrigHeadGroup.replaceInChain(thatCurGroup.hash0, thatCurGroup.entry0) != null) ||
+          thisNewestHeadGroup.insertInChain(thatCurGroup.hash0, thatCurGroup.entry0);
+
+        boolean handled1 = (thatCurGroup.hash1 == 0) ||
+          (thisOrigHeadGroup.replaceInChain(thatCurGroup.hash1, thatCurGroup.entry1) != null) ||
+          thisNewestHeadGroup.insertInChain(thatCurGroup.hash1, thatCurGroup.entry1);
+        
+        boolean handled2 = (thatCurGroup.hash2 == 0) ||
+          (thisOrigHeadGroup.replaceInChain(thatCurGroup.hash2, thatCurGroup.entry2) != null) ||
+          thisNewestHeadGroup.insertInChain(thatCurGroup.hash2, thatCurGroup.entry2);
+        
+        boolean handled3 = (thatCurGroup.hash3 == 0) ||
+          (thisOrigHeadGroup.replaceInChain(thatCurGroup.hash3, thatCurGroup.entry3) != null) ||
+          thisNewestHeadGroup.insertInChain(thatCurGroup.hash3, thatCurGroup.entry3);
+        
+        // Second phase - takes any entries that weren't handled by phase 1 and puts them 
+        // into a new BucketGroup.  Since BucketGroups are fixed size, we know that the 
+        // left over entries from one BucketGroup will fit in the new BucketGroup.
+        if ( !handled0 || !handled1 || !handled2 || !handled3 ) {
+          // Rather than calling insert one time per entry
+          // Exploiting the fact that the new group is known to be empty
+          // And that BucketGroups are allowed to have holes in them (to allow for removal),
+          // so each unhandled entry from the source group is simply placed in 
+          // the same slot in the new group
+          BucketGroup thisNewHashGroup = new BucketGroup();
+          int hashFilter = 0;
+          if ( !handled0 ) {
+            thisNewHashGroup.hash0 = thatCurGroup.hash0;
+            thisNewHashGroup.entry0 = thatCurGroup.entry0;
+            hashFilter |= thatCurGroup.hash0;
+          }
+          if ( !handled1 ) {
+            thisNewHashGroup.hash1 = thatCurGroup.hash1;
+            thisNewHashGroup.entry1 = thatCurGroup.entry1;
+            hashFilter |= thatCurGroup.hash1;
+          }
+          if ( !handled2 ) {
+            thisNewHashGroup.hash2 = thatCurGroup.hash2;
+            thisNewHashGroup.entry2 = thatCurGroup.entry2;
+            hashFilter |= thatCurGroup.hash2;
+          }
+          if ( !handled3 ) {
+            thisNewHashGroup.hash3 = thatCurGroup.hash3;
+            thisNewHashGroup.entry3 = thatCurGroup.entry3;
+            hashFilter |= thatCurGroup.hash3;
+          }
+          // thisNewHashGroup.hashFilter = hashFilter;
+          thisNewHashGroup.prev = thisNewestHeadGroup;
+          
+          thisNewestHeadGroup = thisNewHashGroup;
+        }
+      }
+    
+      return thisNewestHeadGroup;
+    }
+    
+    boolean replaceOrInsertInChain(int hash, Entry entry) {
+       return (this.replaceInChain(hash, entry) != null) || this.insertInChain(hash, entry);
+    }
+    
+    Entry replaceInChain(int hash, Entry entry) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        Entry prevEntry = curGroup._replace(hash, entry);
+        if ( prevEntry != null ) return prevEntry;
+      }
+      return null;
+    }
+    
+    Entry _replace(int hash, Entry entry) {
+      // if ( this._mayContain(hash) ) return null;
+      
+      // first check to see if the item is already present
+      Entry prevEntry = null;
+      if ( this.hash0 == hash && this.entry0.matches(entry.tag) ) {
+        prevEntry = this.entry0;
+        this.entry0 = entry;
+      } else if ( this.hash1 == hash && this.entry1.matches(entry.tag) ) {
+        prevEntry = this.entry1;
+        this.entry1 = entry;
+      } else if ( this.hash2 == hash && this.entry2.matches(entry.tag) ) {
+        prevEntry = this.entry2;
+        this.entry2 = entry;
+      } else if ( this.hash3 == hash && this.entry3.matches(entry.tag) ) {
+        prevEntry = this.entry3;
+        this.entry3 = entry;
+      }
+      
+      // no need to update this.hashFilter, since the hash is already included
+      return prevEntry;
+    }
+    
+    boolean insertInChain(int hash, Entry entry) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        if ( curGroup._insert(hash, entry) ) return true;
+      }
+      return false;
+    }
+    
+    boolean _insert(int hash, Entry entry) {
+      boolean inserted = false;
+      if ( this.hash0 == 0 ) {
+        this.hash0 = hash;
+        this.entry0 = entry;
+        
+        // this.hashFilter |= hash;
+        inserted = true;
+      } else if ( this.hash1 == 0 ) {
+        this.hash1 = hash;
+        this.entry1 = entry;
+        
+        // this.hashFilter |= hash;
+        inserted = true;
+      } else if ( this.hash2 == 0 ) {
+        this.hash2 = hash;
+        this.entry2 = entry;
+        
+        // this.hashFilter |= hash;
+        inserted = true;
+      } else if ( this.hash3 == 0 ) {
+        this.hash3 = hash;
+        this.entry3 = entry;
+        
+        // this.hashFilter |= hash;
+        inserted = true;
+      }
+      return inserted;
+    }
+    
+    BucketGroup removeGroupInChain(BucketGroup removeGroup) {
+      BucketGroup firstGroup = this;
+      if ( firstGroup == removeGroup ) {
+        return firstGroup.prev;
+      }
+ 
+      for ( BucketGroup priorGroup = firstGroup, curGroup = priorGroup.prev; 
+        curGroup != null; 
+        priorGroup = curGroup, curGroup = priorGroup.prev ) {
+        if ( curGroup == removeGroup ) {
+          priorGroup.prev = curGroup.prev;
+        }
+      }
+      return firstGroup;
+    }
+
+    Entry _remove(int hash, String tag) {
+      Entry existingEntry = null;
+      if ( this.hash0 == hash && this.entry0.matches(tag)) {
+        existingEntry = this.entry0;
+        
+        this.hash0 = 0;
+        this.entry0 = null;
+      } else if ( this.hash1 == hash && this.entry1.matches(tag) ) {
+        existingEntry = this.entry1;
+        
+        this.hash1 = 0;
+        this.entry1 = null;
+      } else if ( this.hash2 == hash && this.entry2.matches(tag) ) {
+        existingEntry = this.entry2;
+        
+        this.hash2 = 0;
+        this.entry2 = null;
+      } else if ( this.hash3 == hash && this.entry3.matches(tag) ) {
+        existingEntry = this.entry3;
+        
+        this.hash3 = 0;
+        this.entry3 = null;
+      }
+      return existingEntry;
+    }
+    
+    void forEachInChain(Consumer<? super Entry> consumer) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        curGroup._forEach(consumer);
+      }
+    }
+    
+    void _forEach(Consumer<? super Entry> consumer) {
+      if ( this.entry0 != null ) consumer.accept(this.entry0);
+      if ( this.entry1 != null ) consumer.accept(this.entry1);
+      if ( this.entry2 != null ) consumer.accept(this.entry2);
+      if ( this.entry3 != null ) consumer.accept(this.entry3);
+    }
+    
+    <T> void forEachInChain(T thisObj, BiConsumer<T, ? super Entry> consumer) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        curGroup._forEach(thisObj, consumer);
+      }
+    }
+  
+    <T> void _forEach(T thisObj, BiConsumer<T, ? super Entry> consumer) {
+      if ( this.entry0 != null ) consumer.accept(thisObj, this.entry0);
+      if ( this.entry1 != null ) consumer.accept(thisObj, this.entry1);
+      if ( this.entry2 != null ) consumer.accept(thisObj, this.entry2);
+      if ( this.entry3 != null ) consumer.accept(thisObj, this.entry3);
+    }
+    
+    <T, U> void forEachInChain(T thisObj, U otherObj, TriConsumer<T, U, ? super Entry> consumer) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        curGroup._forEach(thisObj, otherObj, consumer);
+      }
+    }
+
+    <T, U> void _forEach(T thisObj, U otherObj, TriConsumer<T, U, ? super Entry> consumer) {
+      if ( this.entry0 != null ) consumer.accept(thisObj, otherObj, this.entry0);
+      if ( this.entry1 != null ) consumer.accept(thisObj, otherObj, this.entry1);
+      if ( this.entry2 != null ) consumer.accept(thisObj, otherObj, this.entry2);
+      if ( this.entry3 != null ) consumer.accept(thisObj, otherObj, this.entry3);
+    }
+  
+    void fillMapFromChain(Map<? super String, ? super Object> map) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        curGroup._fillMap(map);
+      }
+    }
+    
+    void _fillMap(Map<? super String, ? super Object> map) {
+      Entry entry0 = this.entry0;
+      if ( entry0 != null ) map.put(entry0.tag, entry0.objectValue());
+
+      Entry entry1 = this.entry1;
+      if ( entry1 != null ) map.put(entry1.tag, entry1.objectValue());
+      
+      Entry entry2 = this.entry2;
+      if ( entry2 != null ) map.put(entry2.tag, entry2.objectValue());
+      
+      Entry entry3 = this.entry3;
+      if ( entry3 != null ) map.put(entry3.tag, entry3.objectValue());
+    }
+    
+    void fillStringMapFromChain(Map<? super String, ? super String> map) {
+      for ( BucketGroup curGroup = this; curGroup != null; curGroup = curGroup.prev ) {
+        curGroup._fillStringMap(map);
+      }
+    }
+  
+    void _fillStringMap(Map<? super String, ? super String> map) {
+      Entry entry0 = this.entry0;
+      if ( entry0 != null ) map.put(entry0.tag, entry0.stringValue());
+
+      Entry entry1 = this.entry1;
+      if ( entry1 != null ) map.put(entry1.tag, entry1.stringValue());
+    
+      Entry entry2 = this.entry2;
+      if ( entry2 != null ) map.put(entry2.tag, entry2.stringValue());
+    
+      Entry entry3 = this.entry3;
+      if ( entry3 != null ) map.put(entry3.tag, entry3.stringValue());
+    }
+    
+    BucketGroup cloneChain() {
+      BucketGroup thisClone = this._cloneEntries();
+      
+      BucketGroup thisPriorClone = thisClone;
+      for ( BucketGroup curGroup = this.prev;
+        curGroup != null;
+        curGroup = curGroup.prev )
+      {
+        BucketGroup newClone = curGroup._cloneEntries();
+        thisPriorClone.prev = newClone;
+        
+        thisPriorClone = newClone;
+      }
+      
+      return thisClone;
+    }
+    
+    BucketGroup _cloneEntries() {
+      return new BucketGroup(
+        this.hash0, this.entry0,
+        this.hash1, this.entry1,
+        this.hash2, this.entry2,
+        this.hash3, this.entry3);
+    }
+    
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder(32);
+      builder.append('[');
+      for ( int i = 0; i < BucketGroup.LEN; ++i ) {
+        if ( builder.length() != 0 ) builder.append(", ");
+        
+        builder.append(this._entryAt(i));
+      }
+      builder.append(']');
+      return builder.toString();
+    }
+  }
+  
+  private static final class Entries extends AbstractSet<Map.Entry<String, Object>> {
+    private final TagMap map;
+    
+    Entries(TagMap map) {
+      this.map = map;
+    }
+    
+    @Override
+    public int size() {
+      return this.map.computeSize();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+      return this.map.checkIfEmpty();
+    }
+    
+    @Override
+    public Iterator<Map.Entry<String, Object>> iterator() {
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      Iterator<Map.Entry<String, Object>> iter = (Iterator)this.map.iterator();
+      return iter;
+    }
+  }
+  
+  private static final class Keys extends AbstractSet<String> {
+    private final TagMap map;
+    
+    Keys(TagMap map) {
+      this.map = map;
+    }
+    
+    @Override
+    public int size() {
+      return this.map.computeSize();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+      return this.map.checkIfEmpty();
+    }
+    
+    @Override
+    public boolean contains(Object o) {
+      return this.map.containsKey(o);
+    }
+    
+    @Override
+    public Iterator<String> iterator() {
+      return new KeysIterator(this.map);
+    }
+  }
+  
+  static final class KeysIterator extends MapIterator<String> {
+    KeysIterator(TagMap map) {
+      super(map);
+    }
+    
+    @Override
+    public String next() {
+      return this.nextEntry().tag();
+    }
+  }
+  
+  private static final class Values extends AbstractCollection<Object> {
+    private final TagMap map;
+    
+    Values(TagMap map) {
+      this.map = map;
+    }
+    
+    @Override
+    public int size() {
+      return this.map.computeSize();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+      return this.map.checkIfEmpty();
+    }
+    
+    @Override
+    public boolean contains(Object o) {
+      return this.map.containsValue(o);
+    }
+    
+    @Override
+    public Iterator<Object> iterator() {
+      return new ValuesIterator(this.map);
+    }
+  }
+  
+  static final class ValuesIterator extends MapIterator<Object> {
+    ValuesIterator(TagMap map) {
+      super(map);
+    }
+
+    @Override
+    public Object next() {
+      return this.nextEntry().objectValue();
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.gateway;
 
+import datadog.trace.api.TagMap;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -9,7 +10,7 @@ public interface IGSpanInfo {
 
   long getSpanId();
 
-  Map<String, Object> getTags();
+  TagMap getTags();
 
   AgentSpan setTag(String key, boolean value);
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.naming;
 
+import datadog.trace.api.TagMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
@@ -229,11 +230,10 @@ public interface NamingSchema {
     /**
      * Calculate the tags to be added to a span to represent the peer service
      *
-     * @param unsafeTags the span tags. Map che be mutated
-     * @return the input tags
+     * @param unsafeTags the span tags. Map to be mutated
      */
     @Nonnull
-    Map<String, Object> tags(@Nonnull Map<String, Object> unsafeTags);
+    void tags(@Nonnull TagMap unsafeTags);
   }
 
   interface ForServer {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/PeerServiceNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/PeerServiceNamingV0.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.naming.v0;
 
+import datadog.trace.api.TagMap;
 import datadog.trace.api.naming.NamingSchema;
 import java.util.Collections;
 import java.util.Map;
@@ -13,7 +14,6 @@ public class PeerServiceNamingV0 implements NamingSchema.ForPeerService {
 
   @Nonnull
   @Override
-  public Map<String, Object> tags(@Nonnull final Map<String, Object> unsafeTags) {
-    return Collections.emptyMap();
+  public void tags(@Nonnull final TagMap unsafeTags) {
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.naming.v1;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -52,8 +53,8 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
     return true;
   }
 
-  private void resolve(@Nonnull final Map<String, Object> unsafeTags) {
-    final Object component = unsafeTags.get(Tags.COMPONENT);
+  private void resolve(@Nonnull final TagMap unsafeTags) {
+    final Object component = unsafeTags.getObject(Tags.COMPONENT);
     // avoid issues with UTF8ByteString or others
     final String componentString = component == null ? null : component.toString();
     final String override = overridesByComponent.get(componentString);
@@ -71,14 +72,14 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
   }
 
   private boolean resolveBy(
-      @Nonnull final Map<String, Object> unsafeTags, @Nullable final String[] precursors) {
+      @Nonnull final TagMap unsafeTags, @Nullable final String[] precursors) {
     if (precursors == null) {
       return false;
     }
     Object value = null;
     String source = null;
     for (String precursor : precursors) {
-      value = unsafeTags.get(precursor);
+      value = unsafeTags.getObject(precursor);
       if (value != null) {
         // we have a match. Use the tag name for the source
         source = precursor;
@@ -90,7 +91,7 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
     return true;
   }
 
-  private void set(@Nonnull final Map<String, Object> unsafeTags, Object value, String source) {
+  private void set(@Nonnull final TagMap unsafeTags, Object value, String source) {
     if (value != null) {
       unsafeTags.put(Tags.PEER_SERVICE, value);
       unsafeTags.put(DDTags.PEER_SERVICE_SOURCE, source);
@@ -99,13 +100,12 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
 
   @Nonnull
   @Override
-  public Map<String, Object> tags(@Nonnull final Map<String, Object> unsafeTags) {
+  public void tags(@Nonnull final TagMap unsafeTags) {
     // check span.kind eligibility
-    final Object kind = unsafeTags.get(Tags.SPAN_KIND);
+    final Object kind = unsafeTags.getObject(Tags.SPAN_KIND);
     if (Tags.SPAN_KIND_CLIENT.equals(kind) || Tags.SPAN_KIND_PRODUCER.equals(kind)) {
       // we can calculate the peer service now
       resolve(unsafeTags);
     }
-    return unsafeTags;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import static datadog.trace.bootstrap.instrumentation.api.InternalContextKeys.SPAN_KEY;
 
+import datadog.trace.api.TagMap;
 import datadog.context.Context;
 import datadog.context.ContextKey;
 import datadog.context.ImplicitContextKeyed;
@@ -11,6 +12,8 @@ import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
+
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -91,6 +94,9 @@ public interface AgentSpan
   @Override
   AgentSpan setSpanType(final CharSequence type);
 
+  @Override
+  TagMap getTags();
+  
   Object getTag(String key);
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ExtractedSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ExtractedSpan.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.Flow.Action.RequestBlockingAction;
 import datadog.trace.api.gateway.RequestContext;
@@ -108,19 +109,18 @@ class ExtractedSpan extends ImmutableSpan {
   @Override
   public Object getTag(final String tag) {
     if (this.spanContext instanceof TagContext) {
-      return ((TagContext) this.spanContext).getTags().get(tag);
+      return ((TagContext) this.spanContext).getTags().getObject(tag);
     }
     return null;
   }
 
   @Override
-  public Map<String, Object> getTags() {
+  public TagMap getTags() {
     if (this.spanContext instanceof TagContext) {
-      Map<String, String> tags = ((TagContext) this.spanContext).getTags();
-      //noinspection unchecked,rawtypes
-      return (Map) tags;
+      return ((TagContext) this.spanContext).getTags();
+    } else {
+      return TagMap.EMPTY;
     }
-    return Collections.emptyMap();
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopSpan.java
@@ -1,9 +1,8 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-import static java.util.Collections.emptyMap;
-
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.Flow.Action.RequestBlockingAction;
 import datadog.trace.api.gateway.RequestContext;
@@ -79,10 +78,10 @@ class NoopSpan extends ImmutableSpan implements AgentSpan {
   public String getSpanType() {
     return null;
   }
-
+  
   @Override
-  public Map<String, Object> getTags() {
-    return emptyMap();
+  public TagMap getTags() {
+	return TagMap.EMPTY;
   }
 
   @Override

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/ExtractedSpanTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/ExtractedSpanTest.groovy
@@ -1,12 +1,13 @@
 package datadog.trace.bootstrap.instrumentation.api
 
 import datadog.trace.api.DDTraceId
+import datadog.trace.api.TagMap
 import spock.lang.Specification
 
 class ExtractedSpanTest extends Specification {
   def 'test extracted span from partial tracing context'() {
     given:
-    def tags = ['tag-1': 'value-1', 'tag-2': 'value-2']
+    def tags = TagMap.fromMap(['tag-1': 'value-1', 'tag-2': 'value-2'])
     def baggage = ['baggage-1': 'value-1', 'baggage-2': 'value-2']
     def traceId = DDTraceId.from(12345)
     def context = new TagContext('origin', tags, null, baggage, 0, null, null, traceId)


### PR DESCRIPTION
This change reduces the overhead from constructing spans both in terms of CPU and memory.

The biggest gains come when making use of SpanBuilders for both constructing the span and manipulating the Span.
Throughput with SpanBuilders improves by as much as 45%.

Gains when building Span and then manipulating via setTag are more modest, but still show a 10-20% improvement in throughput.

More importantly, these changes reduce the amount of memory consumed by each Span reducing allocation / garbage collection pressure.

# What Does This Do

These gains are accomplished by changing how tags are stored to use a new Map that excels at Map-to-Map copies.  Along with some work to skip interceptors when possible, these changes make the setting of common attributes on a Span nearly allocation free.

# Motivation

The tracer does some Map operations regularly that regular HashMaps aren't good at.

The primary operation of concern being copying Entry-s from Map to Map where every copied Entry requires allocating a new Entry object.

And secondarily, Builder patterns which use defensive copying but also require in-order processing in the Tracer.

TagMap solves both those problems by using immutable Entry objects.  By making the Entry objects immutable, the Entry objects can be freely shared between Map instances and between the Builder and a Map.

# Additional Notes

To get the benefit of this data structure, both the source Map and the destination Map need to be TagMaps and the transfer needs to happen through putAll or the TagMap specific putEntry.

Meaning - that to get a significant gain quite a few files had to be modified

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior
