### PR TITLE
Introduce constants to eliminate unnecessary calls to String.format()

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.codeorigin;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.CODE_ORIGIN;
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME;
-import static java.lang.String.format;
+import static datadog.trace.api.DDTags.*;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
 import com.datadog.debugger.exception.Fingerprinter;
@@ -172,10 +171,9 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
     @Override
     public void accept(Snapshot snapshot) {
       AgentSpan span = AgentTracer.get().activeSpan();
-      String snapshotId = format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id");
-      span.setTag(snapshotId, snapshot.getId());
+      span.setTag(DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID, snapshot.getId());
       if (entrySpanProbe) {
-        span.getLocalRootSpan().setTag(snapshotId, snapshot.getId());
+        span.getLocalRootSpan().setTag(DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID, snapshot.getId());
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.probe;
 
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME;
+import static datadog.trace.api.DDTags.*;
 import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE;
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -66,11 +65,11 @@ public class CodeOriginProbe extends ProbeDefinition {
     for (AgentSpan s : agentSpans) {
       if (s.getTag(DD_CODE_ORIGIN_TYPE) == null) {
         s.setTag(DD_CODE_ORIGIN_TYPE, entrySpanProbe ? "entry" : "exit");
-        s.setTag(format(DD_CODE_ORIGIN_FRAME, 0, "file"), location.getFile());
-        s.setTag(format(DD_CODE_ORIGIN_FRAME, 0, "method"), location.getMethod());
-        s.setTag(format(DD_CODE_ORIGIN_FRAME, 0, "line"), location.getLines().get(0));
-        s.setTag(format(DD_CODE_ORIGIN_FRAME, 0, "type"), location.getType());
-        s.setTag(format(DD_CODE_ORIGIN_FRAME, 0, "signature"), signature);
+        s.setTag(DD_CODE_ORIGIN_FRAME_FILE, location.getFile());
+        s.setTag(DD_CODE_ORIGIN_FRAME_METHOD, location.getMethod());
+        s.setTag(DD_CODE_ORIGIN_FRAME_LINE, location.getLines().get(0));
+        s.setTag(DD_CODE_ORIGIN_FRAME_TYPE, location.getType());
+        s.setTag(DD_CODE_ORIGIN_FRAME_SIGNATURE, signature);
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -1,8 +1,9 @@
 package com.datadog.debugger.origin;
 
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_LINE;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_METHOD;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID;
 import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_PREFIX;
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TASK_SCHEDULER;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -25,6 +26,7 @@ import com.datadog.debugger.util.TestSnapshotListener;
 import com.datadog.debugger.util.TestTraceInterceptor;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -140,7 +142,7 @@ public class CodeOriginTest extends CapturingTestBase {
     List<? extends MutableSpan> trace = traceInterceptor.getTrace();
     MutableSpan span = trace.get(0);
     // this should be entry but until we get the ordering resolved, it's this.
-    assertEquals("entry", span.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "method")));
+    assertEquals("entry", span.getTag(DD_CODE_ORIGIN_FRAME_METHOD));
   }
 
   @Test
@@ -232,7 +234,7 @@ public class CodeOriginTest extends CapturingTestBase {
             .collect(Collectors.toList());
 
     for (DDSpan span : list) {
-      checkEntrySpanTags(span, snapshotsExpected != 0);
+      checkCodeOriginTags(span, snapshotsExpected != 0);
     }
 
     assertEquals(
@@ -268,18 +270,16 @@ public class CodeOriginTest extends CapturingTestBase {
     return listener;
   }
 
-  private static void checkEntrySpanTags(DDSpan span, boolean includeSnapshot) {
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
-    assertNotEquals(-1, span.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "signature"));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
+  private static void checkCodeOriginTags(DDSpan span, boolean includeSnapshot) {
+    for (String tag : DDTags.REQUIRED_CODE_ORIGIN_TAGS) {
+      assertKeyPresent(span, tag);
+    }
+    assertNotEquals(-1, span.getTag(DD_CODE_ORIGIN_FRAME_LINE));
 
     if (includeSnapshot) {
-      assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
+      assertKeyPresent(span, DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID);
     } else {
-      assertKeyNotPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
+      assertKeyNotPresent(span, DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID);
     }
   }
 
@@ -298,27 +298,14 @@ public class CodeOriginTest extends CapturingTestBase {
   }
 
   private static void checkExitSpanTags(DDSpan span, boolean includeSnapshot) {
-    String keys =
-        format("Existing keys for %s: %s", span.getOperationName(), new TreeSet<>(ldKeys(span)));
-
-    assertKeyPresent(span, DD_CODE_ORIGIN_TYPE);
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
-    assertNotEquals(-1, span.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
-    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
-    if (includeSnapshot) {
-      assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
+    for (String tag : DDTags.REQUIRED_CODE_ORIGIN_TAGS) {
+      assertKeyPresent(span, tag);
     }
+    assertNotEquals(-1, span.getTag(DD_CODE_ORIGIN_FRAME_LINE));
 
-    MutableSpan rootSpan = span.getLocalRootSpan();
-    assertEquals(rootSpan.getTag(DD_CODE_ORIGIN_TYPE), "entry", keys);
-    Object file = rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "file"));
-    assertNotNull(file, rootSpan.getTags().toString());
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
-    assertNotEquals(-1, rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "method")));
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "type")));
+    if (includeSnapshot) {
+      assertKeyPresent(span, DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID);
+    }
   }
 
   private static Set<String> ldKeys(MutableSpan span) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -30,7 +30,6 @@ import datadog.trace.api.IdGenerationStrategy
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.TraceConfig
 import datadog.trace.api.WellKnownTags
-import datadog.trace.api.config.DebuggerConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.gateway.RequestContext
@@ -85,8 +84,6 @@ import static datadog.communication.http.OkHttpUtils.buildHttpClient
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT
-import static datadog.trace.api.config.DebuggerConfig.*
-import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious
@@ -310,12 +307,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
   def codeOriginSetup() {
     injectSysConfig(CODE_ORIGIN_FOR_SPANS_ENABLED, "true", true)
     injectSysConfig(DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE, "false", true)
+    rebuildConfig()
 
     def configuration = Configuration.builder()
     .setService("code origin test")
     .build()
 
-    rebuildConfig()
 
     def config = Config.get()
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -13,9 +13,6 @@ import groovy.transform.stc.SimpleType
 
 import java.util.regex.Pattern
 
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME
-import static java.lang.String.format
-
 class TagsAssert {
   private final long spanParentId
   private final Map<String, Object> tags
@@ -131,12 +128,9 @@ class TagsAssert {
   }
 
   def codeOriginTags() {
-    assert tags[DDTags.DD_CODE_ORIGIN_TYPE] != null
-    assert tags[format(DD_CODE_ORIGIN_FRAME, 0, "file")] != null
-    assert tags[format(DD_CODE_ORIGIN_FRAME, 0, "method")] != null
-    assert tags[format(DD_CODE_ORIGIN_FRAME, 0, "line")] != null
-    assert tags[format(DD_CODE_ORIGIN_FRAME, 0, "type")] != null
-    assert tags[format(DD_CODE_ORIGIN_FRAME, 0, "signature")] != null
+    DDTags.REQUIRED_CODE_ORIGIN_TAGS.each {
+      assert tags[it] != null
+    }
   }
 
   def errorTags(Throwable error) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
@@ -1,5 +1,9 @@
 package datadog.smoketest;
 
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_FILE;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_LINE;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_METHOD;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME_SIGNATURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import datadog.trace.api.DDTags;
@@ -11,15 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest {
-
-  private static final String DD_CODE_ORIGIN_FRAMES_0_FILE =
-      String.format(DDTags.DD_CODE_ORIGIN_FRAME, 0, "file");
-  private static final String DD_CODE_ORIGIN_FRAMES_0_METHOD =
-      String.format(DDTags.DD_CODE_ORIGIN_FRAME, 0, "method");
-  private static final String DD_CODE_ORIGIN_FRAMES_0_SIGNATURE =
-      String.format(DDTags.DD_CODE_ORIGIN_FRAME, 0, "signature");
-  private static final String DD_CODE_ORIGIN_FRAMES_0_LINE =
-      String.format(DDTags.DD_CODE_ORIGIN_FRAME, 0, "line");
 
   @Override
   protected ProcessBuilder createProcessBuilder(Path logFilePath, String... params) {
@@ -46,11 +41,11 @@ public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 assertEquals("entry", span.getMeta().get(DDTags.DD_CODE_ORIGIN_TYPE));
                 assertEquals(
                     "ServerDebuggerTestApplication.java",
-                    span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_FILE));
-                assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_METHOD));
+                    span.getMeta().get(DD_CODE_ORIGIN_FRAME_FILE));
+                assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAME_METHOD));
                 assertEquals(
-                    "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_SIGNATURE));
-                assertEquals("134", span.getMeta().get(DD_CODE_ORIGIN_FRAMES_0_LINE));
+                    "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAME_SIGNATURE));
+                assertEquals("134", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
                 codeOrigin.set(true);
               }
             }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -6,7 +6,25 @@ public class DDTags {
 
   public static final String DD_CODE_ORIGIN_TYPE = DD_CODE_ORIGIN_PREFIX + "type";
   // _dd.code_origin.frames.%d.file|line|method|type|snapshot_id
-  public static final String DD_CODE_ORIGIN_FRAME = DD_CODE_ORIGIN_PREFIX + "frames.%d.%s";
+  public static final String DD_CODE_ORIGIN_FRAME_FILE = DD_CODE_ORIGIN_PREFIX + "frames.0.file";
+  public static final String DD_CODE_ORIGIN_FRAME_TYPE = DD_CODE_ORIGIN_PREFIX + "frames.0.type";
+  public static final String DD_CODE_ORIGIN_FRAME_METHOD =
+      DD_CODE_ORIGIN_PREFIX + "frames.0.method";
+  public static final String DD_CODE_ORIGIN_FRAME_SIGNATURE =
+      DD_CODE_ORIGIN_PREFIX + "frames.0.signature";
+  public static final String DD_CODE_ORIGIN_FRAME_LINE = DD_CODE_ORIGIN_PREFIX + "frames.0.line";
+  public static final String DD_CODE_ORIGIN_FRAME_SNAPSHOT_ID =
+      DD_CODE_ORIGIN_PREFIX + "frames.0.snapshot_id";
+
+  public static final String[] REQUIRED_CODE_ORIGIN_TAGS =
+      new String[] {
+        DD_CODE_ORIGIN_TYPE,
+        DD_CODE_ORIGIN_FRAME_FILE,
+        DD_CODE_ORIGIN_FRAME_METHOD,
+        DD_CODE_ORIGIN_FRAME_LINE,
+        DD_CODE_ORIGIN_FRAME_TYPE,
+        DD_CODE_ORIGIN_FRAME_SIGNATURE,
+      };
 
   public static final String SPAN_TYPE = "span.type";
   public static final String SERVICE_NAME = "service.name";


### PR DESCRIPTION
# What Does This Do
Eliminates some unnecessary calls to String.format() so that they don't show up in the flamegraph when looking at traces.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
