### PR TITLE
Add instrumentation name to startSpan (A-J)

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -93,7 +93,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   public AgentSpan startAerospikeSpan(final String methodName) {
-    final AgentSpan span = startSpan(OPERATION_NAME);
+    final AgentSpan span = startSpan("aerospike", OPERATION_NAME);
     afterStart(span);
     withMethod(span, methodName);
     return span;

--- a/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/scala/AkkaActors.scala
@@ -130,7 +130,7 @@ class Greeter(message: String, receiverActor: ActorRef) extends Actor {
     case Greet =>
       receiverActor ! Greeting(greeting)
     case Leak(leak) =>
-      val span = startSpan(greeting)
+      val span = startSpan("akka-concurrent", greeting)
       span.setResourceName(leak)
       activateSpan(span)
       span.finish()

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
@@ -31,7 +31,7 @@ public class LinearTask extends RecursiveTask<Integer> {
       return parent;
     } else {
       int next = parent + 1;
-      AgentSpan span = startSpan(Integer.toString(next));
+      AgentSpan span = startSpan("akka-concurrent", Integer.toString(next));
       try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag$;
 
 public class AkkaHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, HttpRequest, HttpResponse, HttpRequest> {
-  private static final CharSequence AKKA_HTTP_SERVER = UTF8BytesString.create("akka-http-server");
+  public static final CharSequence AKKA_HTTP_SERVER = UTF8BytesString.create("akka-http-server");
 
   public static final AkkaHttpServerDecorator DECORATE = new AkkaHttpServerDecorator();
   public static final CharSequence AKKA_SERVER_REQUEST =

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -74,7 +74,8 @@ public final class AkkaHttpSingleRequestInstrumentation extends InstrumenterModu
         return null;
       }
 
-      final AgentSpan span = startSpan(AKKA_CLIENT_REQUEST);
+      final AgentSpan span =
+          startSpan(AkkaHttpClientDecorator.AKKA_HTTP_CLIENT.toString(), AKKA_CLIENT_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
 

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -12,7 +12,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 public class DatadogWrapperHelper {
   public static AgentScope createSpan(final HttpRequest request) {
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(request);
-    final AgentSpan span = DECORATE.startSpan(request, extractedContext);
+    final AgentSpan span =
+        DECORATE.startSpan(
+            AkkaHttpServerDecorator.AKKA_HTTP_SERVER.toString(), request, extractedContext);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
@@ -24,7 +24,10 @@ public class SingleRequestAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan(AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST);
+    final AgentSpan span =
+        startSpan(
+            AkkaHttpClientDecorator.AKKA_HTTP_CLIENT.toString(),
+            AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST);
     AkkaHttpClientDecorator.DECORATE.afterStart(span);
     AkkaHttpClientDecorator.DECORATE.onRequest(span, request);
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -91,7 +91,7 @@ public class ApacheHttpAsyncClientInstrumentation extends InstrumenterModule.Tra
         @Advice.Argument(value = 3, readOnly = false) FutureCallback<?> futureCallback) {
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan("apache-http-client", HTTP_REQUEST);
       DECORATE.afterStart(clientSpan);
 
       requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -37,7 +37,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpUriRequest request) {
-    final AgentSpan span = startSpan(HTTP_REQUEST);
+    final AgentSpan span = startSpan("apache-http-client", HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -97,7 +97,7 @@ public class ApacheHttpAsyncClientInstrumentation extends InstrumenterModule.Tra
         @Advice.Argument(value = 4, readOnly = false) FutureCallback<?> futureCallback) {
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan("apache-http-client", HTTP_REQUEST);
       final AgentScope clientScope = activateSpan(clientSpan);
       DECORATE.afterStart(clientSpan);
 

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -37,7 +37,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpRequest request) {
-    final AgentSpan span = startSpan(HTTP_REQUEST);
+    final AgentSpan span = startSpan("apache-http-client", HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -226,7 +226,8 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan(GRPC_MESSAGE).setTag("message.type", clientSpan.getTag("response.type"));
+            startSpan("armeria-grpc", GRPC_MESSAGE)
+                .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);
       }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -96,7 +96,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return null;
     }
     AgentSpan span =
-        startSpan(OPERATION_NAME)
+        startSpan("armeria-grpc", OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
@@ -67,8 +67,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     spanContext = callIGCallbackRequestStarted(tracer, spanContext);
 
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
-    final AgentSpan span =
-        startSpan(DECORATE.instrumentationNames()[0], GRPC_SERVER, spanContext).setMeasured(true);
+    final AgentSpan span = startSpan("armeria-grpc", GRPC_SERVER, spanContext).setMeasured(true);
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
@@ -144,7 +143,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onMessage(final ReqT message) {
       final AgentSpan msgSpan =
-          startSpan(DECORATE.instrumentationNames()[0], GRPC_MESSAGE, this.span.context())
+          startSpan("armeria-grpc", GRPC_MESSAGE, this.span.context())
               .setTag("message.type", message.getClass().getName());
       DECORATE.afterStart(msgSpan);
       try (AgentScope scope = activateSpan(msgSpan)) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -64,7 +64,7 @@ public class TracingRequestHandler extends RequestHandler2 {
         span.setOperationName(AwsNameCache.spanName(request));
       } else {
         // this is the most common code path
-        span = startSpan(AwsNameCache.spanName(request));
+        span = startSpan("aws-sdk", AwsNameCache.spanName(request));
       }
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -46,7 +46,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       return; // SQS messages spans are created by aws-java-sqs-2.0
     }
 
-    final AgentSpan span = startSpan(DECORATE.spanName(executionAttributes));
+    final AgentSpan span = startSpan("aws-sdk", DECORATE.spanName(executionAttributes));
     DECORATE.afterStart(span);
     executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
   }

--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -107,7 +107,7 @@ public class SnsInterceptor extends RequestHandler2 {
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {
-    final AgentSpan span = AgentTracer.startSpan("aws.sns.send");
+    final AgentSpan span = AgentTracer.startSpan("sns", "aws.sns.send");
     // pass the span to TracingRequestHandler in the sdk instrumentation where it'll be enriched &
     // activated
     contextStore.put(request, span);

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -76,6 +76,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
             if (timeInQueueStart > 0) {
               queueSpan =
                   startSpan(
+                      "sqs",
                       SQS_TIME_IN_QUEUE_OPERATION,
                       spanContext,
                       MILLISECONDS.toMicros(timeInQueueStart));
@@ -89,7 +90,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan(SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan("sqs", SQS_INBOUND_OPERATION, batchContext);
 
         LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
         sortedTags.put(DIRECTION_TAG, DIRECTION_IN);

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -89,9 +89,9 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
       AgentSpanContext lambdaContext = AgentTracer.get().notifyExtensionStart(event);
       final AgentSpan span;
       if (null == lambdaContext) {
-        span = startSpan(INVOCATION_SPAN_NAME);
+        span = startSpan("aws-lambda", INVOCATION_SPAN_NAME);
       } else {
-        span = startSpan(INVOCATION_SPAN_NAME, lambdaContext);
+        span = startSpan("aws-lambda", INVOCATION_SPAN_NAME, lambdaContext);
       }
       final AgentScope scope = activateSpan(span);
       return scope;

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisEngineInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisEngineInstrumentation.java
@@ -67,7 +67,7 @@ public final class AxisEngineInstrumentation extends InstrumenterModule.Tracing
         @Advice.Argument(0) final MessageContext message) {
       // only create a span if the message has a clear action and there's a surrounding request
       if (DECORATE.shouldTrace(message)) {
-        AgentSpan span = startSpan(AXIS2_MESSAGE);
+        AgentSpan span = startSpan(AxisMessageDecorator.AXIS2.toString(), AXIS2_MESSAGE);
         DECORATE.afterStart(span);
         DECORATE.onMessage(span, message);
         return activateSpan(span);
@@ -102,7 +102,7 @@ public final class AxisEngineInstrumentation extends InstrumenterModule.Tracing
         message.removeSelfManagedData(Tracer.class, AXIS2_CONTINUATION_KEY);
         // resuming is a distinct operation, so create a new span under the original request
         try (AgentScope parentScope = ((AgentScope.Continuation) continuation).activate()) {
-          AgentSpan span = startSpan(AXIS2_MESSAGE);
+          AgentSpan span = startSpan(AxisMessageDecorator.AXIS2.toString(), AXIS2_MESSAGE);
           DECORATE.afterStart(span);
           DECORATE.onMessage(span, message);
           return activateSpan(span);

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
@@ -64,7 +64,7 @@ public final class AxisTransportInstrumentation extends InstrumenterModule.Traci
     public static AgentScope beginTransport(@Advice.Argument(0) final MessageContext message) {
       // only create a span if the message has a clear action and there's a surrounding request
       if (DECORATE.shouldTrace(message)) {
-        AgentSpan span = startSpan(AXIS2_TRANSPORT);
+        AgentSpan span = startSpan(AxisMessageDecorator.AXIS2.toString(), AXIS2_TRANSPORT);
         DECORATE.afterStart(span);
         DECORATE.onTransport(span, message);
         DECORATE.onMessage(span, message);

--- a/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
+++ b/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
@@ -14,7 +14,7 @@ public class HTTPPluginAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Argument(value = 2) final Object serverTransaction) {
-    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("axway", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     // serverTransaction is like request + connection in one object:
     DECORATE.onRequest(span, serverTransaction, serverTransaction, null);

--- a/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/StateAdvice.java
+++ b/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/StateAdvice.java
@@ -19,7 +19,7 @@ import net.bytebuddy.asm.Advice;
 public class StateAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.This final Object stateInstance) {
-    final AgentSpan span = startSpan(AXWAY_TRY_TRANSACTION);
+    final AgentSpan span = startSpan("axway", AXWAY_TRY_TRANSACTION);
     final AgentScope scope = activateSpan(span);
     span.setMeasured(true);
     DECORATE.onTransaction(span, stateInstance);

--- a/dd-java-agent/instrumentation/azure-functions/src/main/java/datadog/trace/instrumentation/azure/functions/AzureFunctionsInstrumentation.java
+++ b/dd-java-agent/instrumentation/azure-functions/src/main/java/datadog/trace/instrumentation/azure/functions/AzureFunctionsInstrumentation.java
@@ -68,7 +68,7 @@ public class AzureFunctionsInstrumentation extends InstrumenterModule.Tracing
         @Advice.Argument(0) final HttpRequestMessage request,
         @Advice.Argument(1) final ExecutionContext context) {
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(request);
-      final AgentSpan span = DECORATE.startSpan(request, extractedContext);
+      final AgentSpan span = DECORATE.startSpan("azure-functions", request, extractedContext);
       DECORATE.afterStart(span, context.getFunctionName());
       DECORATE.onRequest(span, request, request, extractedContext);
       HTTP_RESOURCE_DECORATOR.withRoute(

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -64,7 +64,7 @@ public class CommonsHttpClientInstrumentation extends InstrumenterModule.Tracing
           return null;
         }
 
-        final AgentSpan span = startSpan(HTTP_REQUEST);
+        final AgentSpan span = startSpan("commons-http-client", HTTP_REQUEST);
         final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
@@ -88,7 +88,7 @@ public class ExecutionContextInstrumentation extends InstrumenterModule.Tracing
         @Advice.This final ExecutionContext executionContext,
         @Advice.Origin("datanucleus.#m") final String operationName) {
 
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -121,7 +121,7 @@ public class ExecutionContextInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -151,7 +151,7 @@ public class ExecutionContextInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan(DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -182,7 +182,7 @@ public class ExecutionContextInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan(DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
@@ -70,8 +70,8 @@ public class JDOQueryInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span =
           methodName.startsWith("execute")
-              ? startSpan(DATANUCLEUS_QUERY_EXECUTE)
-              : startSpan(DATANUCLEUS_QUERY_DELETE);
+              ? startSpan("datanucleus", DATANUCLEUS_QUERY_EXECUTE)
+              : startSpan("datanucleaus", DATANUCLEUS_QUERY_DELETE);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
@@ -44,7 +44,7 @@ public class JDOTransactionInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope start(
         @Advice.Origin("datanucleus.transaction.#m") final String operationName) {
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -252,7 +252,7 @@ public class TracingSession implements Session {
   }
 
   private AgentScope startSpanWithScope(final String query) {
-    final AgentSpan span = startSpan(OPERATION_NAME);
+    final AgentSpan span = startSpan("cassandra", OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, session);
     DECORATE.onStatement(span, query);

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
@@ -54,7 +54,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private ResultSet wrapSyncRequest(Statement request) {
-    AgentSpan span = startSpan(OPERATION_NAME);
+    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());
@@ -78,7 +78,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private CompletionStage<AsyncResultSet> wrapAsyncRequest(Statement request) {
-    AgentSpan span = startSpan(OPERATION_NAME);
+    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -69,7 +69,8 @@ public final class DropwizardViewInstrumentation extends InstrumenterModule.Trac
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span = startSpan("view.render").setTag(Tags.COMPONENT, "dropwizard-view");
+      final AgentSpan span =
+          startSpan("dropwizard", "view.render").setTag(Tags.COMPONENT, "dropwizard-view");
       span.setResourceName("View " + view.getTemplateName());
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -59,7 +59,7 @@ public class Elasticsearch5RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(1) final String endpoint,
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, method, endpoint, null, null);
 

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -57,7 +57,7 @@ public class Elasticsearch6RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
@@ -74,7 +74,7 @@ public class Elasticsearch7RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -63,7 +63,7 @@ public class Elasticsearch2TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -64,7 +64,7 @@ public class Elasticsearch53TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -63,7 +63,7 @@ public class Elasticsearch5TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -67,7 +67,7 @@ public class Elasticsearch6TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
@@ -74,7 +74,7 @@ public class Elasticsearch73TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -72,7 +72,7 @@ public class FinatraInstrumentation extends InstrumenterModule.Tracing
       parent.setTag(Tags.COMPONENT, "finatra");
       parent.setSpanName(DECORATE.spanName());
 
-      final AgentSpan span = startSpan(FINATRA_CONTROLLER);
+      final AgentSpan span = startSpan("finatra", FINATRA_CONTROLLER);
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.className(clazz));
 

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator.GOOGLE_HTTP_CLIENT;
 import static datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator.HTTP_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -72,7 +73,8 @@ public class GoogleHttpClientInstrumentation extends InstrumenterModule.Tracing
           return null;
         }
       }
-      return activateSpan(DECORATE.prepareSpan(startSpan(HTTP_REQUEST), request));
+      return activateSpan(
+          DECORATE.prepareSpan(startSpan(GOOGLE_HTTP_CLIENT.toString(), HTTP_REQUEST), request));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -100,7 +102,8 @@ public class GoogleHttpClientInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope methodEnter(@Advice.This HttpRequest request) {
-      return activateSpan(DECORATE.prepareSpan(startSpan(HTTP_REQUEST), request));
+      return activateSpan(
+          DECORATE.prepareSpan(startSpan(GOOGLE_HTTP_CLIENT.toString(), HTTP_REQUEST), request));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
@@ -48,7 +48,7 @@ public class PubSubDecorator extends MessagingClientDecorator {
     }
   }
 
-  private static final String PUBSUB = "google-pubsub";
+  public static final String PUBSUB = "google-pubsub";
   public static final CharSequence JAVA_PUBSUB = UTF8BytesString.create("java-google-pubsub");
   public static final CharSequence PUBSUB_CONSUME =
       UTF8BytesString.create(
@@ -131,7 +131,7 @@ public class PubSubDecorator extends MessagingClientDecorator {
   public AgentSpan onConsume(final PubsubMessage message, final String subscription) {
     final AgentSpanContext spanContext =
         extractContextAndGetSpanContext(message, TextMapExtractAdapter.GETTER);
-    final AgentSpan span = startSpan(PUBSUB_CONSUME, spanContext);
+    final AgentSpan span = startSpan(PUBSUB, PUBSUB_CONSUME, spanContext);
     final CharSequence parsedSubscription = extractSubscription(subscription);
     final LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>(3);
     sortedTags.put(DIRECTION_TAG, DIRECTION_IN);

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
@@ -10,6 +10,7 @@ import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.PUBSUB;
 import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.PUBSUB_PRODUCE;
 import static datadog.trace.instrumentation.googlepubsub.TextMapInjectAdapter.SETTER;
 import static java.util.Collections.singletonList;
@@ -69,7 +70,7 @@ public final class PublisherInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope before(
         @Advice.Argument(value = 0, readOnly = false) PubsubMessage msg,
         @Advice.This Publisher publisher) {
-      final AgentSpan span = startSpan(PUBSUB_PRODUCE);
+      final AgentSpan span = startSpan(PUBSUB, PUBSUB_PRODUCE);
 
       final CharSequence topicName = PRODUCER_DECORATE.extractTopic(publisher.getTopicNameString());
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
@@ -61,7 +61,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
   @Override
   public InstrumentationContext<ExecutionResult> beginExecution(
       InstrumentationExecutionParameters parameters) {
-    final AgentSpan requestSpan = startSpan(GRAPHQL_REQUEST);
+    final AgentSpan requestSpan = startSpan("graphql", GRAPHQL_REQUEST);
     DECORATE.afterStart(requestSpan);
 
     State state = parameters.getInstrumentationState();
@@ -100,7 +100,8 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
   public InstrumentationContext<Document> beginParse(
       InstrumentationExecutionParameters parameters) {
     State state = parameters.getInstrumentationState();
-    final AgentSpan parsingSpan = startSpan(GRAPHQL_PARSING, state.getRequestSpan().context());
+    final AgentSpan parsingSpan =
+        startSpan("graphql", GRAPHQL_PARSING, state.getRequestSpan().context());
     DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -111,7 +112,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
     State state = parameters.getInstrumentationState();
 
     final AgentSpan validationSpan =
-        startSpan(GRAPHQL_VALIDATION, state.getRequestSpan().context());
+        startSpan("graphql", GRAPHQL_VALIDATION, state.getRequestSpan().context());
     DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
@@ -65,7 +65,7 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
       return super.beginExecution(parameters, instrumentationState);
     }
     final State state = (State) instrumentationState;
-    final AgentSpan requestSpan = startSpan(GraphQLDecorator.GRAPHQL_REQUEST);
+    final AgentSpan requestSpan = startSpan("graphql", GraphQLDecorator.GRAPHQL_REQUEST);
     GraphQLDecorator.DECORATE.afterStart(requestSpan);
 
     state.setRequestSpan(requestSpan);
@@ -116,7 +116,8 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
     }
     final State state = (State) instrumentationState;
     final AgentSpan parsingSpan =
-        AgentTracer.startSpan(GraphQLDecorator.GRAPHQL_PARSING, state.getRequestSpan().context());
+        AgentTracer.startSpan(
+            "graphql", GraphQLDecorator.GRAPHQL_PARSING, state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -131,7 +132,7 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
 
     final AgentSpan validationSpan =
         AgentTracer.startSpan(
-            GraphQLDecorator.GRAPHQL_VALIDATION, state.getRequestSpan().context());
+            "graphql", GraphQLDecorator.GRAPHQL_VALIDATION, state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
@@ -34,7 +34,7 @@ public class InstrumentedDataFetcher implements DataFetcher<Object> {
         return dataFetcher.get(environment);
       }
     } else {
-      final AgentSpan fieldSpan = startSpan("graphql.field", this.requestSpan.context());
+      final AgentSpan fieldSpan = startSpan("graphql", "graphql.field", this.requestSpan.context());
       DECORATE.afterStart(fieldSpan);
       String parentType = GraphQLTypeUtil.simplePrint(environment.getParentType());
       String fieldName = environment.getField().getName();

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -74,7 +74,7 @@ public class GrizzlyHttpHandlerInstrumentation extends InstrumenterModule.Tracin
       }
 
       final AgentSpanContext.Extracted parentContext = DECORATE.extract(request);
-      final AgentSpan span = DECORATE.startSpan(request, parentContext);
+      final AgentSpan span = DECORATE.startSpan("grizzly-http-server", request, parentContext);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, parentContext);
 

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -66,7 +66,7 @@ public final class AsyncHttpClientInstrumentation extends InstrumenterModule.Tra
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler<?> handler) {
       AgentSpan parentSpan = activeSpan();
-      AgentSpan span = startSpan(HTTP_REQUEST);
+      AgentSpan span = startSpan("grizzly-http-client", HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -115,7 +115,7 @@ public class GrizzlyDecorator
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
     HttpResponsePacket httpResponse = httpRequest.getResponse();
     AgentSpanContext.Extracted context = DECORATE.extract(httpRequest);
-    AgentSpan span = DECORATE.startSpan(httpRequest, context);
+    AgentSpan span = DECORATE.startSpan("grizzly-http-server", httpRequest, context);
     AgentScope scope = activateSpan(span);
     DECORATE.afterStart(span);
     ctx.getAttributes().setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -96,7 +96,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return null;
     }
     AgentSpan span =
-        startSpan(OPERATION_NAME)
+        startSpan("grpc", OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
@@ -74,7 +74,8 @@ public final class MessagesAvailableInstrumentation extends InstrumenterModule.T
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan(GRPC_MESSAGE).setTag("message.type", clientSpan.getTag("response.type"));
+            startSpan("grpc", GRPC_MESSAGE)
+                .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);
       }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -67,7 +67,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     spanContext = callIGCallbackRequestStarted(tracer, spanContext);
 
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
-    final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
+    final AgentSpan span = startSpan("grpc", GRPC_SERVER, spanContext).setMeasured(true);
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
@@ -143,7 +143,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onMessage(final ReqT message) {
       final AgentSpan msgSpan =
-          startSpan(GRPC_MESSAGE, this.span.context())
+          startSpan("grpc", GRPC_MESSAGE, this.span.context())
               .setTag("message.type", message.getClass().getName());
       DECORATE.afterStart(msgSpan);
       try (AgentScope scope = activateSpan(msgSpan)) {

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
@@ -219,7 +219,7 @@ public class DistributedObjectInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
@@ -278,7 +278,7 @@ public class DistributedObjectInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
@@ -102,7 +102,7 @@ public class ClientInvocationInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast", SPAN_NAME);
       DECORATE.onHazelcastInstance(
           span, InstrumentationContext.get(ClientInvocation.class, String.class).get(that));
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
@@ -78,7 +78,7 @@ public class ClientListenerInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, operationName, null, correlationId);
 

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
@@ -36,7 +36,7 @@ public class InvocationAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan(HazelcastConstants.SPAN_NAME);
+    final AgentSpan span = startSpan("hazelcast", HazelcastConstants.SPAN_NAME);
 
     span.setTag(
         HazelcastConstants.HAZELCAST_INSTANCE,

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.DECORATOR;
+import static datadog.trace.instrumentation.hibernate.HibernateDecorator.HIBERNATE;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.HIBERNATE_SESSION;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -73,7 +74,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan(HIBERNATE, HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.DECORATOR;
+import static datadog.trace.instrumentation.hibernate.HibernateDecorator.HIBERNATE;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.HIBERNATE_SESSION;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -61,7 +62,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan(HIBERNATE, HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -11,11 +11,12 @@ import java.util.Set;
 public class HibernateDecorator extends OrmClientDecorator {
   public static final CharSequence HIBERNATE_SESSION = UTF8BytesString.create("hibernate.session");
   public static final HibernateDecorator DECORATOR = new HibernateDecorator();
+  public static final String HIBERNATE = "hibernate";
 
   @Override
   protected String service() {
-    return "hibernate";
-  }
+    return HIBERNATE;
+  } // FIXME: don't set service name in v1
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.hibernate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.DECORATOR;
+import static datadog.trace.instrumentation.hibernate.HibernateDecorator.HIBERNATE;
 
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.ContextStore;
@@ -41,7 +42,8 @@ public class SessionMethodUtils {
 
     final AgentScope scope;
     if (createSpan) {
-      final AgentSpan span = startSpan(operationName, sessionState.getSessionSpan().context());
+      final AgentSpan span =
+          startSpan(HIBERNATE, operationName, sessionState.getSessionSpan().context());
       DECORATOR.afterStart(span);
       DECORATOR.onOperation(span, entity);
       scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -53,7 +53,7 @@ public class UrlInstrumentation extends InstrumenterModule.Tracing
         String protocol = url.getProtocol();
         protocol = protocol != null ? protocol : "url";
 
-        final AgentSpan span = startSpan(DECORATE.operationName(protocol));
+        final AgentSpan span = startSpan("http-url-connection", DECORATE.operationName(protocol));
 
         try (final AgentScope scope = activateSpan(span)) {
           DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
@@ -85,7 +85,7 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -141,7 +141,7 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
@@ -93,7 +93,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -134,7 +134,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -174,7 +174,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
@@ -31,7 +31,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JakartaRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan(JAKARTA_RS_REQUEST_ABORT);
+        final AgentSpan span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JakartaRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -118,7 +118,7 @@ public final class JakartaRsAnnotationsInstrumentation extends InstrumenterModul
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAKARTA_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jakarta-rs", JAKARTA_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJakartaRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
@@ -26,7 +26,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan(JAKARTA_RS_REQUEST_ABORT);
+        span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/jakarta-ws-annotations/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-ws-annotations/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
@@ -75,7 +75,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan(JAKARTA_WS_REQUEST);
+      AgentSpan span = startSpan("jakarta-ws", JAKARTA_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJakartaWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAdvice.java
@@ -26,7 +26,7 @@ public class SendAdvice {
       if (callDepth > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(JavaNetClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("java-http-client", JavaNetClientDecorator.OPERATION_NAME);
       final AgentScope scope = activateSpan(span);
 
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
@@ -2,13 +2,13 @@ package datadog.trace.instrumentation.httpclient;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.httpclient.JavaNetClientDecorator.DECORATE;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -30,7 +30,7 @@ public class SendAsyncAdvice {
       if (callDepth > 0) {
         return null;
       }
-      final AgentSpan span = AgentTracer.startSpan(JavaNetClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("java-http-client", JavaNetClientDecorator.OPERATION_NAME);
       final AgentScope scope = activateSpan(span);
       if (bodyHandler != null) {
         bodyHandler = new BodyHandlerWrapper<>(bodyHandler, captureSpan(span));

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -95,7 +95,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -31,7 +31,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan(JAX_RS_REQUEST_ABORT);
+        final AgentSpan span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JaxRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -126,7 +126,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -25,7 +25,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan(JAX_RS_REQUEST_ABORT);
+        span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -71,7 +71,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
       // WARNING: this might be a chain...so we only have to trace the first in the chain.
       final boolean isRootClientHandler = null == request.getProperties().get(DD_SPAN_ATTRIBUTE);
       if (isRootClientHandler) {
-        final AgentSpan span = startSpan(JAX_RS_CLIENT_CALL);
+        final AgentSpan span = startSpan("jax-rs-client", JAX_RS_CLIENT_CALL);
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -24,7 +24,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
 
   @Override
   public void filter(final ClientRequestContext requestContext) {
-    final AgentSpan span = startSpan("jax-rs", JAX_RS_CLIENT_CALL);
+    final AgentSpan span = startSpan("jax-rs-client", JAX_RS_CLIENT_CALL);
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);

--- a/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
@@ -80,7 +80,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan(JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
@@ -74,7 +74,7 @@ public final class WebServiceProviderInstrumentation extends InstrumenterModule.
         return null;
       }
 
-      AgentSpan span = startSpan(JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -8,6 +8,7 @@ import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DBM_TRACE_PREPARED_STATEMENTS;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JDBC;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logMissingQueryInfo;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logSQLException;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -89,16 +90,16 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             span = AgentTracer.get().buildSpan(DATABASE_QUERY).withSpanId(spanID).start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan(JDBC, DATABASE_QUERY);
             DECORATE.setApplicationName(span, connection);
           } else if (DECORATE.isOracle(dbInfo)) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan(JDBC, DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan(JDBC, DATABASE_QUERY);
           }
         } else {
-          span = startSpan(DATABASE_QUERY);
+          span = startSpan(JDBC, DATABASE_QUERY);
         }
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.DATABASE_CONNECTION;
 import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.DECORATE;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JDBC;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -64,7 +65,7 @@ public final class DataSourceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(DATABASE_CONNECTION);
+      final AgentSpan span = startSpan(JDBC, DATABASE_CONNECTION);
       DECORATE.afterStart(span);
 
       span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -40,12 +40,13 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   public static final CharSequence JAVA_JDBC = UTF8BytesString.create("java-jdbc");
   public static final CharSequence DATABASE_QUERY = UTF8BytesString.create("database.query");
   private static final UTF8BytesString DB_QUERY = UTF8BytesString.create("DB Query");
+  public static final String JDBC = "jdbc";
   private static final UTF8BytesString JDBC_STATEMENT =
       UTF8BytesString.create("java-jdbc-statement");
   private static final UTF8BytesString JDBC_PREPARED_STATEMENT =
       UTF8BytesString.create("java-jdbc-prepared_statement");
   private static final String DEFAULT_SERVICE_NAME =
-      SpanNaming.instance().namingSchema().database().service("jdbc");
+      SpanNaming.instance().namingSchema().database().service(JDBC);
   public static final String DBM_PROPAGATION_MODE_STATIC = "service";
   public static final String DBM_PROPAGATION_MODE_FULL = "full";
 

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -9,6 +9,7 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DB
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JDBC;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -96,15 +97,15 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // The span ID is pre-determined so that we can reference it when setting the context
             final long spanID = DECORATE.setContextInfo(connection, dbInfo);
             // we then force that pre-determined span ID for the span covering the actual query
-            span = AgentTracer.get().buildSpan(DATABASE_QUERY).withSpanId(spanID).start();
+            span = AgentTracer.get().buildSpan(JDBC, DATABASE_QUERY).withSpanId(spanID).start();
           } else if (isOracle) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan(JDBC, DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan(JDBC, DATABASE_QUERY);
           }
         } else {
-          span = startSpan(DATABASE_QUERY);
+          span = startSpan(JDBC, DATABASE_QUERY);
         }
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jedis.JedisClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.jedis.JedisClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -64,7 +65,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
       DECORATE.onStatement(span, command.name());

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jedis30.JedisClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.jedis30.JedisClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -56,7 +57,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static redis.clients.jedis.JedisClientDecorator.DECORATE;
+import static redis.clients.jedis.JedisClientDecorator.OPERATION_NAME;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -16,7 +17,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.Connection;
-import redis.clients.jedis.JedisClientDecorator;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.ProtocolCommand;
 
@@ -56,7 +56,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope onEnter(
         @Advice.Argument(0) final CommandObject<?> commandObject,
         @Advice.This final Connection thiz) {
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
@@ -27,7 +27,7 @@ public class JettyServerAdvice {
       }
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
-      span = DECORATE.startSpan(req, extractedContext);
+      span = DECORATE.startSpan("jetty-server", req, extractedContext);
       final AgentScope scope = activateSpan(span);
       span.setMeasured(true);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
@@ -29,7 +29,8 @@ public class JettyServerAdvice {
       }
 
       final AgentSpanContext.Extracted extractedContext = JettyDecorator.DECORATE.extract(req);
-      final AgentSpan span = JettyDecorator.DECORATE.startSpan(req, extractedContext);
+      final AgentSpan span =
+          JettyDecorator.DECORATE.startSpan("jetty-server", req, extractedContext);
       try (final AgentScope scope = activateSpan(span)) {
         span.setMeasured(true);
         JettyDecorator.DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -157,7 +157,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
       }
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
-      span = DECORATE.startSpan(req, extractedContext);
+      span = DECORATE.startSpan("jetty-server", req, extractedContext);
       final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -158,7 +158,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
       }
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
-      span = DECORATE.startSpan(req, extractedContext);
+      span = DECORATE.startSpan("jetty-server", req, extractedContext);
       final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -172,7 +172,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
       }
 
       final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
-      span = DECORATE.startSpan(req, extractedContext);
+      span = DECORATE.startSpan("jetty-server", req, extractedContext);
       final AgentScope scope = activateSpan(span);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -26,7 +26,7 @@ public class HandleAdvice {
     }
 
     final AgentSpanContext.Extracted extractedContext = DECORATE.extract(req);
-    span = DECORATE.startSpan(req, extractedContext);
+    span = DECORATE.startSpan("jetty-server", req, extractedContext);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -9,6 +9,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevi
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_CONSUME;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_DELIVER;
 import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
@@ -124,13 +125,17 @@ public final class JMSMessageConsumerInstrumentation
       }
       long startMillis = GETTER.extractTimeInQueueStart(message);
       if (startMillis == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan(JMS_CONSUME, propagatedContext);
+        span = startSpan(JMS.toString(), JMS_CONSUME, propagatedContext);
       } else {
         long batchId = GETTER.extractMessageBatchId(message);
         AgentSpan timeInQueue = consumerState.getTimeInQueueSpan(batchId);
         if (null == timeInQueue) {
           timeInQueue =
-              startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
+              startSpan(
+                  JMS.toString(),
+                  JMS_DELIVER,
+                  propagatedContext,
+                  MILLISECONDS.toMicros(startMillis));
           BROKER_DECORATE.afterStart(timeInQueue);
           BROKER_DECORATE.onTimeInQueue(
               timeInQueue,
@@ -138,7 +143,7 @@ public final class JMSMessageConsumerInstrumentation
               consumerState.getBrokerServiceName());
           consumerState.setTimeInQueueSpan(batchId, timeInQueue);
         }
-        span = startSpan(JMS_CONSUME, timeInQueue.context());
+        span = startSpan(JMS.toString(), JMS_CONSUME, timeInQueue.context());
       }
 
       CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
@@ -88,7 +89,7 @@ public final class JMSMessageProducerInstrumentation
         }
       }
 
-      final AgentSpan span = startSpan(JMS_PRODUCE);
+      final AgentSpan span = startSpan(JMS.toString(), JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
       if (JMSDecorator.canInject(message)) {
@@ -135,7 +136,7 @@ public final class JMSMessageProducerInstrumentation
       String destinationName = PRODUCER_DECORATE.getDestinationName(destination);
       CharSequence resourceName = PRODUCER_DECORATE.toResourceName(destinationName, isQueue);
 
-      final AgentSpan span = startSpan(JMS_PRODUCE);
+      final AgentSpan span = startSpan(JMS.toString(), JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
       if (JMSDecorator.canInject(message)) {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MDBMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MDBMessageConsumerInstrumentation.java
@@ -8,6 +8,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_CONSUME;
 import static datadog.trace.instrumentation.jms.JMSDecorator.logJMSException;
 import static datadog.trace.instrumentation.jms.MessageExtractAdapter.GETTER;
@@ -68,7 +69,7 @@ public final class MDBMessageConsumerInstrumentation
         return null;
       }
       AgentSpanContext propagatedContext = extractContextAndGetSpanContext(message, GETTER);
-      AgentSpan span = startSpan(JMS_CONSUME, propagatedContext);
+      AgentSpan span = startSpan(JMS.toString(), JMS_CONSUME, propagatedContext);
       CONSUMER_DECORATE.afterStart(span);
       CharSequence consumerResourceName;
       try {

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -59,7 +59,8 @@ public final class JSPInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(
         @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
-      final AgentSpan span = startSpan(JSP_RENDER).setTag("servlet.context", req.getContextPath());
+      final AgentSpan span =
+          startSpan("jsp", JSP_RENDER).setTag("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);
       DECORATE.onRender(span, req);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -48,7 +48,7 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter() {
-      final AgentSpan span = startSpan(JSP_COMPILE);
+      final AgentSpan span = startSpan("jsp", JSP_COMPILE);
       DECORATE.afterStart(span);
       return activateSpan(span);
     }


### PR DESCRIPTION
# What Does This Do

Adds instrumentation name to `startSpan` in order to have proper telemetry

This is a partial change. Futher changes will happen for the rest of startSpan(k to z) and also to buildSpan(

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
