### PR TITLE
Most contexts won't have baggage, so this debug line is not that helpful

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
@@ -57,7 +57,6 @@ public class BaggagePropagator implements Propagator {
 
     Baggage baggage = Baggage.fromContext(context);
     if (baggage == null) {
-      LOG.debug("Baggage instance is missing from the following context {}", context);
       return;
     }
 


### PR DESCRIPTION
# Motivation

It also generates a large amount of log messages when tracer debug is on.
