### PR TITLE
Fix NPE in getMdcCopy of LoggingEventInstrumentation

### DIFF
--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -134,6 +134,10 @@ public class LoggingEventInstrumentation extends InstrumenterModule.Tracing
       if (!injectionRequired) {
         return;
       }
+      if (mdc == null) {
+        // this.mdcCopy can be null when MDC.getContext() returns null
+        return;
+      }
       // at this point the mdc has been shallow copied. No need to replace with a new hashtable.
       // Just add our info
       String serviceName = Config.get().getServiceName();

--- a/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
+++ b/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
@@ -16,8 +16,16 @@ class MdcTest extends AgentTestRunner {
     then:
     assert event.getMDC("data") == "dog"
     where:
-    injectionEnabled | _
-    "true"           | _
-    "false"          | _
+    injectionEnabled << ["true", "false"]
+  }
+
+  def "should prevent NPE when MDC context doesn't exist and getMDCCopy"() {
+    setup:
+    injectSysConfig("logs.injection", "true")
+    def event = new LoggingEvent("test", Category.getRoot(), Priority.INFO, "hello world", null)
+    when:
+    event.getMDCCopy()
+    then:
+    noExceptionThrown()
   }
 }


### PR DESCRIPTION
# What Does This Do

Fix NPE in getMdcCopy of LoggingEventInstrumentation

# Motivation

Even though the exception is caught, it adds overhead and noise to the telemetry data.

# Additional Notes

https://github.com/innoq/log4j/blob/master/src/main/java/org/apache/log4j/spi/LoggingEvent.java#L328-L339
```java
    public void getMDCCopy() {
        if (this.mdcCopyLookupRequired) {
            this.mdcCopyLookupRequired = false;
            Hashtable t = MDC.getContext();
            // If there is no context, it will be null, so this.mdcCopy will also be null.
            if (t != null) {
                this.mdcCopy = (Hashtable)t.clone();
            }
        }
    }
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15123]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15123]: https://datadoghq.atlassian.net/browse/APMS-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ