### PR TITLE
Introduce cache for peer.hostname lookup

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -6,6 +6,8 @@ import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -36,6 +38,8 @@ public abstract class BaseDecorator {
             }
           },
           Functions.PrefixJoin.of("."));
+
+  private static final DDCache<String, String> HOSTNAME_CACHE = DDCaches.newFixedSizeCache(64);
 
   protected final boolean traceAnalyticsEnabled;
   protected final Double traceAnalyticsSampleRate;
@@ -114,13 +118,14 @@ public abstract class BaseDecorator {
 
   public AgentSpan onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
+      String ip = remoteAddress.getHostAddress();
       if (resolved) {
-        span.setTag(Tags.PEER_HOSTNAME, remoteAddress.getHostName());
+        span.setTag(Tags.PEER_HOSTNAME, hostName(remoteAddress, ip));
       }
       if (remoteAddress instanceof Inet4Address) {
-        span.setTag(Tags.PEER_HOST_IPV4, remoteAddress.getHostAddress());
+        span.setTag(Tags.PEER_HOST_IPV4, ip);
       } else if (remoteAddress instanceof Inet6Address) {
-        span.setTag(Tags.PEER_HOST_IPV6, remoteAddress.getHostAddress());
+        span.setTag(Tags.PEER_HOST_IPV6, ip);
       }
     }
     return span;
@@ -186,5 +191,12 @@ public abstract class BaseDecorator {
   public CharSequence className(final Class<?> clazz) {
     String simpleName = clazz.getSimpleName();
     return simpleName.isEmpty() ? CLASS_NAMES.getClassName(clazz) : simpleName;
+  }
+
+  private static String hostName(InetAddress remoteAddress, String ip) {
+    if (null != ip) {
+      return HOSTNAME_CACHE.computeIfAbsent(ip, _ip -> remoteAddress.getHostName());
+    }
+    return remoteAddress.getHostName();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -119,7 +119,7 @@ public abstract class BaseDecorator {
   public AgentSpan onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
-      if (resolved) {
+      if (resolved && Config.get().isPeerHostNameEnabled()) {
         span.setTag(Tags.PEER_HOSTNAME, hostName(remoteAddress, ip));
       }
       if (remoteAddress instanceof Inet4Address) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -131,12 +131,13 @@ public final class TracerConfig {
       "trace.experimental.long-running.initial.flush.interval";
   public static final String TRACE_LONG_RUNNING_FLUSH_INTERVAL =
       "trace.experimental.long-running.flush.interval";
+
+  public static final String TRACE_PEER_HOSTNAME_ENABLED = "trace.peer.hostname.enabled";
+
   public static final String TRACE_PEER_SERVICE_DEFAULTS_ENABLED =
       "trace.peer.service.defaults.enabled";
-
   public static final String TRACE_PEER_SERVICE_COMPONENT_OVERRIDES =
       "trace.peer.service.component.overrides";
-
   public static final String TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED =
       "trace.remove.integration-service-names.enabled";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -146,6 +146,7 @@ public class Config {
   private final String prioritySamplingForce;
   private final boolean traceResolverEnabled;
   private final int spanAttributeSchemaVersion;
+  private final boolean peerHostNameEnabled;
   private final boolean peerServiceDefaultsEnabled;
   private final Map<String, String> peerServiceComponentOverrides;
   private final boolean removeIntegrationServiceNamesEnabled;
@@ -826,6 +827,8 @@ public class Config {
         getEnv("FUNCTIONS_WORKER_RUNTIME") != null && getEnv("FUNCTIONS_EXTENSION_VERSION") != null;
 
     spanAttributeSchemaVersion = schemaVersionFromConfig();
+
+    peerHostNameEnabled = configProvider.getBoolean(TRACE_PEER_HOSTNAME_ENABLED, true);
 
     // following two only used in v0.
     // in v1+ defaults are always calculated regardless this feature flag
@@ -2165,6 +2168,10 @@ public class Config {
 
   public int getSpanAttributeSchemaVersion() {
     return spanAttributeSchemaVersion;
+  }
+
+  public boolean isPeerHostNameEnabled() {
+    return peerHostNameEnabled;
   }
 
   public boolean isPeerServiceDefaultsEnabled() {
@@ -4820,6 +4827,8 @@ public class Config {
         + jaxRsExceptionAsErrorsEnabled
         + ", axisPromoteResourceName="
         + axisPromoteResourceName
+        + ", peerHostNameEnabled="
+        + peerHostNameEnabled
         + ", peerServiceDefaultsEnabled="
         + peerServiceDefaultsEnabled
         + ", peerServiceComponentOverrides="


### PR DESCRIPTION
# Motivation

Mitigates potential delays in mapping IP addresses back to their hostnames.

The `peer.hostname` tag feature can also be turned off completely by adding this JVM option:
```
-Ddd.trace.peer.hostname.enabled=false
```
or setting this environment variable:
```
DD_TRACE_PEER_HOSTNAME_ENABLED=false
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15123]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15123]: https://datadoghq.atlassian.net/browse/APMS-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ