### PR TITLE
Add scenario TRACING_CONFIG_NONDEFAULT in system-tests

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit c208feb5b40cca543670870b9601509d6a69c65e
+default_system_tests_commit: &default_system_tests_commit 69a5e874384dd256e2e3f42fc1c95807a67efbe6
 
 parameters:
   nightly:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -852,6 +852,9 @@ jobs:
             DEFAULT
             APM_TRACING_E2E
             APM_TRACING_E2E_SINGLE_SPAN
+            TRACING_CONFIG_NONDEFAULT
+            TRACING_CONFIG_NONDEFAULT_2
+            TRACING_CONFIG_NONDEFAULT_3
             "
             if ! [[ << parameters.weblog-variant >> =~ .*native ]]; then
               echo "


### PR DESCRIPTION
# What Does This Do

Add TRACING_CONFIG_NONDEFAULT, TRACING_CONFIG_NONDEFAULT_2 and TRACING_CONFIG_NONDEFAULT_3 in CI

# Motivation

Two days ago, a possible regression has been pushed to `master` ([nightly job](https://github.com/DataDog/system-tests-dashboard/actions/runs/13984998284/job/39157640605#step:33:50)). Those scenario will prevent this (and other) in the future.

# Additional Notes

Wait for DataDog/system-tests#4355 before merging this

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
