### PR TITLE
Ensure Propagators are still run when `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=ignore`

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1511,23 +1511,27 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       if (parentContext != null
           && parentContext.isRemote()
           && Config.get().getTracePropagationBehaviorExtract()
-              == TracePropagationBehaviorExtract.RESTART) {
-        SpanLink link;
-        if (parentContext instanceof ExtractedContext) {
-          ExtractedContext pc = (ExtractedContext) parentContext;
-          link =
-              DDSpanLink.from(
-                  pc,
-                  SpanAttributes.builder()
-                      .put("reason", "propagation_behavior_extract")
-                      .put("context_headers", pc.getPropagationStyle().toString())
-                      .build());
-        } else {
-          link = SpanLink.from(parentContext);
-        }
+              != TracePropagationBehaviorExtract.CONTINUE) {
         // reset links that may have come terminated span links
         links = new ArrayList<>();
-        links.add(link);
+
+        if(Config.get().getTracePropagationBehaviorExtract()
+            == TracePropagationBehaviorExtract.RESTART){
+          SpanLink link;
+          if (parentContext instanceof ExtractedContext) {
+            ExtractedContext pc = (ExtractedContext) parentContext;
+            link =
+                DDSpanLink.from(
+                    pc,
+                    SpanAttributes.builder()
+                        .put("reason", "propagation_behavior_extract")
+                        .put("context_headers", pc.getPropagationStyle().toString())
+                        .build());
+          } else {
+            link = SpanLink.from(parentContext);
+          }
+          links.add(link);
+        }
         parentContext = null;
       }
       // Propagate internal trace.

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1515,8 +1515,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         // reset links that may have come terminated span links
         links = new ArrayList<>();
 
-        if(Config.get().getTracePropagationBehaviorExtract()
-            == TracePropagationBehaviorExtract.RESTART){
+        if (Config.get().getTracePropagationBehaviorExtract()
+            == TracePropagationBehaviorExtract.RESTART) {
           SpanLink link;
           if (parentContext instanceof ExtractedContext) {
             ExtractedContext pc = (ExtractedContext) parentContext;

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -363,6 +363,22 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     link.traceState() == extractedContext.propagationTags.headerValue(PropagationTags.HeaderType.W3C)
   }
 
+  def "build context from ExtractedContext with TRACE_PROPAGATION_BEHAVIOR_EXTRACT=ignore"() {
+    setup:
+    injectSysConfig("trace.propagation.behavior.extract", "ignore")
+    def extractedContext = new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"), null, DATADOG)
+    final DDSpan span = tracer.buildSpan("test", "op name")
+      .asChildOf(extractedContext).start()
+
+    expect:
+    span.traceId != extractedContext.traceId
+    span.parentId != extractedContext.spanId
+    span.samplingPriority() == PrioritySampling.UNSET
+
+
+    assert span.links.size() == 0
+  }
+
   def "TagContext should populate default span details"() {
     setup:
     def thread = Thread.currentThread()

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1035,14 +1035,8 @@ public class Config {
       }
       // Now we can check if we should pick the default injection/extraction
 
-      if (extract.isEmpty()) {
-        extract = DEFAULT_TRACE_PROPAGATION_STYLE;
-      }
-
-      tracePropagationStylesToExtract =extract;
-//          tracePropagationBehaviorExtract == TracePropagationBehaviorExtract.IGNORE
-//              ? new HashSet<>()
-//              : extract;
+      tracePropagationStylesToExtract =
+          extract.isEmpty() ? DEFAULT_TRACE_PROPAGATION_STYLE : extract;
 
       tracePropagationStylesToInject = inject.isEmpty() ? DEFAULT_TRACE_PROPAGATION_STYLE : inject;
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1039,10 +1039,10 @@ public class Config {
         extract = DEFAULT_TRACE_PROPAGATION_STYLE;
       }
 
-      tracePropagationStylesToExtract =
-          tracePropagationBehaviorExtract == TracePropagationBehaviorExtract.IGNORE
-              ? new HashSet<>()
-              : extract;
+      tracePropagationStylesToExtract =extract;
+//          tracePropagationBehaviorExtract == TracePropagationBehaviorExtract.IGNORE
+//              ? new HashSet<>()
+//              : extract;
 
       tracePropagationStylesToInject = inject.isEmpty() ? DEFAULT_TRACE_PROPAGATION_STYLE : inject;
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -2666,20 +2666,6 @@ class ConfigTest extends DDSpecification {
     config.finalDebuggerSymDBUrl == "http://localhost:8126/symdb/v1/input"
   }
 
-  def "specify overrides for PROPAGATION_STYLE_EXTRACT when TRACE_PROPAGATION_BEHAVIOR_EXTRACT=ignore"() {
-    setup:
-    def prop = new Properties()
-    prop.setProperty(PROPAGATION_STYLE_EXTRACT, "Datadog, B3")
-    prop.setProperty(TRACE_PROPAGATION_BEHAVIOR_EXTRACT, "ignore")
-
-    when:
-    Config config = Config.get(prop)
-
-    then:
-    config.tracePropagationBehaviorExtract == TracePropagationBehaviorExtract.IGNORE
-    config.tracePropagationStylesToExtract.toList() == []
-  }
-
   def "verify try/catch behavior for invalid strings for TRACE_PROPAGATION_BEHAVIOR_EXTRACT"() {
     setup:
     def prop = new Properties()


### PR DESCRIPTION
# What Does This Do
Ensures that extraction still occurs for all incoming headers, and if `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=ignore`, then start a new tracecontext when it is being built from remote context in `CoreTracer`.
# Motivation
This PR is made to fix the following [failures](https://github.com/DataDog/system-tests-dashboard/actions/runs/13962317979/job/39092238354) from system-tests CI where other headers are not being seen as part of the span.
# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1251](https://datadoghq.atlassian.net/browse/APMAPI-1251)
<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
