### PR TITLE
Make TempLocationManager USER aware

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -295,7 +295,7 @@ public final class TempLocationManager {
 
     String pid = PidHelper.getPid();
 
-    baseTempDir = configuredTempDir.resolve("ddprof");
+    baseTempDir = configuredTempDir.resolve(getBaseTempDirName());
     baseTempDir.toFile().deleteOnExit();
 
     tempDir = baseTempDir.resolve(TEMPDIR_PREFIX + pid);
@@ -317,6 +317,17 @@ public final class TempLocationManager {
             },
             "Temp Location Manager Cleanup");
     Runtime.getRuntime().addShutdownHook(selfCleanup);
+  }
+
+  // @VisibleForTesting
+  static String getBaseTempDirName() {
+    String userName = System.getProperty("user.name");
+    // unlikely, but fall-back to system env based user name
+    userName = userName == null ? System.getenv("USER") : userName;
+    // make sure we do not have any illegal characters in the user name
+    userName =
+        userName != null ? userName.replace('.', '_').replace('/', '_').replace(' ', '_') : null;
+    return "ddprof" + (userName != null ? "_" + userName : "");
   }
 
   /**
@@ -396,7 +407,7 @@ public final class TempLocationManager {
   boolean cleanup(boolean cleanSelf, long timeout, TimeUnit unit) {
     try {
       if (!Files.exists(baseTempDir)) {
-        // not event the main temp location exists; nothing to clean up
+        // not even the main temp location exists; nothing to clean up
         return true;
       }
       try (Stream<Path> paths = Files.walk(baseTempDir)) {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
@@ -112,10 +112,10 @@ public class TempLocationManagerTest {
     Path tmpFile = Files.createFile(fakeTempDir.resolve("test.txt"));
     tmpFile.toFile().deleteOnExit(); // make sure this is deleted at exit
     fakeTempDir.toFile().deleteOnExit(); // also this one
-    tempLocationManager.cleanup(false);
+    boolean rslt = tempLocationManager.cleanup(false);
     // fake temp location should be deleted
     // real temp location should be kept
-    assertFalse(Files.exists(fakeTempDir));
+    assertFalse(rslt && Files.exists(fakeTempDir));
     assertTrue(Files.exists(tempDir));
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/TempLocationManagerTest.java
@@ -104,7 +104,7 @@ public class TempLocationManagerTest {
 
     // fake temp location
     Path fakeTempDir = tempDir.getParent();
-    while (fakeTempDir != null && !fakeTempDir.endsWith("ddprof")) {
+    while (fakeTempDir != null && !fakeTempDir.getFileName().toString().contains("ddprof")) {
       fakeTempDir = fakeTempDir.getParent();
     }
     fakeTempDir = fakeTempDir.resolve("pid_0000");
@@ -133,7 +133,8 @@ public class TempLocationManagerTest {
             "ddprof-test-",
             PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
 
-    Path fakeTempDir = baseDir.resolve("ddprof/pid_1234/scratch");
+    Path fakeTempDir =
+        baseDir.resolve(TempLocationManager.getBaseTempDirName() + "/pid_1234/scratch");
     Files.createDirectories(fakeTempDir);
     Path fakeTempFile = fakeTempDir.resolve("libxxx.so");
     Files.createFile(fakeTempFile);


### PR DESCRIPTION
# What Does This Do
It makes the temp location base dir to be 'username' specific.

# Motivation
Allow parallel runs of multiple services under multiple users without fighting for the ownership of the base dir.
Also, it is highly probably that the temporary artifacts created for one user will not be deletable by other user, so having the basedir per-user makes sense.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11529]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11529]: https://datadoghq.atlassian.net/browse/PROF-11529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ