### PR TITLE
🍒 8601 - Introduce cache for peer.hostname lookup

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -6,6 +6,8 @@ import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -36,6 +38,8 @@ public abstract class BaseDecorator {
             }
           },
           Functions.PrefixJoin.of("."));
+
+  private static final DDCache<String, String> HOSTNAME_CACHE = DDCaches.newFixedSizeCache(64);
 
   protected final boolean traceAnalyticsEnabled;
   protected final Double traceAnalyticsSampleRate;
@@ -114,13 +118,14 @@ public abstract class BaseDecorator {
 
   public AgentSpan onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
+      String ip = remoteAddress.getHostAddress();
       if (resolved) {
-        span.setTag(Tags.PEER_HOSTNAME, remoteAddress.getHostName());
+        span.setTag(Tags.PEER_HOSTNAME, hostName(remoteAddress, ip));
       }
       if (remoteAddress instanceof Inet4Address) {
-        span.setTag(Tags.PEER_HOST_IPV4, remoteAddress.getHostAddress());
+        span.setTag(Tags.PEER_HOST_IPV4, ip);
       } else if (remoteAddress instanceof Inet6Address) {
-        span.setTag(Tags.PEER_HOST_IPV6, remoteAddress.getHostAddress());
+        span.setTag(Tags.PEER_HOST_IPV6, ip);
       }
     }
     return span;
@@ -186,5 +191,12 @@ public abstract class BaseDecorator {
   public CharSequence className(final Class<?> clazz) {
     String simpleName = clazz.getSimpleName();
     return simpleName.isEmpty() ? CLASS_NAMES.getClassName(clazz) : simpleName;
+  }
+
+  private static String hostName(InetAddress remoteAddress, String ip) {
+    if (null != ip) {
+      return HOSTNAME_CACHE.computeIfAbsent(ip, _ip -> remoteAddress.getHostName());
+    }
+    return remoteAddress.getHostName();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -119,7 +119,7 @@ public abstract class BaseDecorator {
   public AgentSpan onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
-      if (resolved) {
+      if (resolved && Config.get().isPeerHostNameEnabled()) {
         span.setTag(Tags.PEER_HOSTNAME, hostName(remoteAddress, ip));
       }
       if (remoteAddress instanceof Inet4Address) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -126,12 +126,13 @@ public final class TracerConfig {
       "trace.experimental.long-running.initial.flush.interval";
   public static final String TRACE_LONG_RUNNING_FLUSH_INTERVAL =
       "trace.experimental.long-running.flush.interval";
+
+  public static final String TRACE_PEER_HOSTNAME_ENABLED = "trace.peer.hostname.enabled";
+
   public static final String TRACE_PEER_SERVICE_DEFAULTS_ENABLED =
       "trace.peer.service.defaults.enabled";
-
   public static final String TRACE_PEER_SERVICE_COMPONENT_OVERRIDES =
       "trace.peer.service.component.overrides";
-
   public static final String TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED =
       "trace.remove.integration-service-names.enabled";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -146,6 +146,7 @@ public class Config {
   private final String prioritySamplingForce;
   private final boolean traceResolverEnabled;
   private final int spanAttributeSchemaVersion;
+  private final boolean peerHostNameEnabled;
   private final boolean peerServiceDefaultsEnabled;
   private final Map<String, String> peerServiceComponentOverrides;
   private final boolean removeIntegrationServiceNamesEnabled;
@@ -799,6 +800,8 @@ public class Config {
     baggageMapping = configProvider.getMergedMapWithOptionalMappings(null, true, BAGGAGE_MAPPING);
 
     spanAttributeSchemaVersion = schemaVersionFromConfig();
+
+    peerHostNameEnabled = configProvider.getBoolean(TRACE_PEER_HOSTNAME_ENABLED, true);
 
     // following two only used in v0.
     // in v1+ defaults are always calculated regardless this feature flag
@@ -2092,6 +2095,10 @@ public class Config {
 
   public int getSpanAttributeSchemaVersion() {
     return spanAttributeSchemaVersion;
+  }
+
+  public boolean isPeerHostNameEnabled() {
+    return peerHostNameEnabled;
   }
 
   public boolean isPeerServiceDefaultsEnabled() {
@@ -4711,6 +4718,8 @@ public class Config {
         + jaxRsExceptionAsErrorsEnabled
         + ", axisPromoteResourceName="
         + axisPromoteResourceName
+        + ", peerHostNameEnabled="
+        + peerHostNameEnabled
         + ", peerServiceDefaultsEnabled="
         + peerServiceDefaultsEnabled
         + ", peerServiceComponentOverrides="


### PR DESCRIPTION
Backport #8601 to release/v1.47.x

# Motivation

Mitigates potential delays in mapping IP addresses back to their hostnames.

The `peer.hostname` tag feature can also be turned off completely by adding this JVM option:
```
-Ddd.trace.peer.hostname.enabled=false
```
or setting this environment variable:
```
DD_TRACE_PEER_HOSTNAME_ENABLED=false
```
