### PR TITLE
Add support for filtering shaded third-party libs

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ThirdPartyLibraries.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ThirdPartyLibraries.java
@@ -7,10 +7,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +24,20 @@ public class ThirdPartyLibraries {
   private static final JsonAdapter<InternalConfig> ADAPTER =
       new Moshi.Builder().build().adapter(InternalConfig.class);
   private static final String FILE_NAME = "/third_party_libraries.json";
+  private static final Set<String> DEFAULT_SHADING_IDENTIFIERS =
+      new HashSet<>(
+          Arrays.asList(
+              "shaded",
+              "thirdparty",
+              "dependencies",
+              "relocated",
+              "bundled",
+              "embedded",
+              "vendor",
+              "repackaged",
+              "shadow",
+              "shim",
+              "wrapper"));
 
   private ThirdPartyLibraries() {}
 
@@ -43,6 +59,13 @@ public class ThirdPartyLibraries {
   public Set<String> getThirdPartyExcludes(Config config) {
     return config.getThirdPartyExcludes().stream()
         .filter(s -> !s.isEmpty())
+        .collect(Collectors.toSet());
+  }
+
+  public Set<String> getShadingIdentifiers(Config config) {
+    Stream<String> configStream =
+        config.getThirdPartyShadingIdentifiers().stream().filter(s -> !s.isEmpty());
+    return Stream.concat(configStream, DEFAULT_SHADING_IDENTIFIERS.stream())
         .collect(Collectors.toSet());
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.symbol;
 
 import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
+import datadog.trace.util.Strings;
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
 import org.slf4j.Logger;
@@ -34,7 +35,7 @@ public class SymbolExtractionTransformer implements ClassFileTransformer {
         // Don't parse our own classes to avoid duplicate class definition
         return null;
       }
-      if (classNameFiltering.isExcluded(className)) {
+      if (classNameFiltering.isExcluded(Strings.getClassName(className))) {
         return null;
       }
       symbolAggregator.parseClass(className, classfileBuffer, protectionDomain);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
@@ -4,6 +4,7 @@ import com.datadog.debugger.agent.ThirdPartyLibraries;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
 import datadog.trace.util.ClassNameTrie;
+import datadog.trace.util.Strings;
 import java.util.Collections;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -14,36 +15,53 @@ public class ClassNameFiltering implements ClassNameFilter {
 
   private final ClassNameTrie includeTrie;
   private final ClassNameTrie excludeTrie;
+  private final Set<String> shadingIdentifiers;
 
   public ClassNameFiltering(Config config) {
     this(
         ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(config),
-        ThirdPartyLibraries.INSTANCE.getThirdPartyExcludes(config));
+        ThirdPartyLibraries.INSTANCE.getThirdPartyExcludes(config),
+        ThirdPartyLibraries.INSTANCE.getShadingIdentifiers(config));
   }
 
   public ClassNameFiltering(Set<String> excludes) {
-    this(excludes, Collections.emptySet());
+    this(excludes, Collections.emptySet(), Collections.emptySet());
   }
 
-  public ClassNameFiltering(Set<String> excludes, Set<String> includes) {
+  public ClassNameFiltering(
+      Set<String> excludes, Set<String> includes, Set<String> shadingIdentifiers) {
     ClassNameTrie.Builder excludeBuilder = new ClassNameTrie.Builder();
     excludes.forEach(s -> excludeBuilder.put(s + "*", 1));
     this.excludeTrie = excludeBuilder.buildTrie();
     ClassNameTrie.Builder includeBuilder = new ClassNameTrie.Builder();
     includes.forEach(s -> includeBuilder.put(s + "*", 1));
     this.includeTrie = includeBuilder.buildTrie();
+    this.shadingIdentifiers = shadingIdentifiers;
   }
 
+  // className is the fully qualified class name with '.' (Java type) notation
   public boolean isExcluded(String className) {
     return (includeTrie.apply(className) < 0 && excludeTrie.apply(className) > 0)
-        || isLambdaProxyClass(className);
+        || isLambdaProxyClass(className)
+        || isShaded(className);
   }
 
   static boolean isLambdaProxyClass(String className) {
     return LAMBDA_PROXY_CLASS_PATTERN.matcher(className).matches();
   }
 
+  boolean isShaded(String className) {
+    String packageName = Strings.getPackageName(className);
+    for (String shadingIdentifier : shadingIdentifiers) {
+      if (packageName.contains(shadingIdentifier)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static ClassNameFiltering allowAll() {
-    return new ClassNameFiltering(Collections.emptySet(), Collections.emptySet());
+    return new ClassNameFiltering(
+        Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
@@ -54,11 +54,10 @@ public class ClassNameFiltering implements ClassNameFilter {
   }
 
   int shadedIndexOf(String className) {
-    String current = className;
     int idx = 0;
     int previousIdx = 0;
-    while ((idx = current.indexOf('.', previousIdx)) > 0) {
-      if (shadingTrie.apply(current, previousIdx) > 0) {
+    while ((idx = className.indexOf('.', previousIdx)) > 0) {
+      if (shadingTrie.apply(className, previousIdx) > 0) {
         return idx + 1;
       }
       idx++;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ThirdPartyLibrariesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ThirdPartyLibrariesTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,6 +21,7 @@ class ThirdPartyLibrariesTest {
   void setUp() {
     when(mockConfig.getThirdPartyIncludes()).thenReturn(Collections.emptySet());
     when(mockConfig.getThirdPartyExcludes()).thenReturn(Collections.emptySet());
+    when(mockConfig.getThirdPartyShadingIdentifiers()).thenReturn(Collections.emptySet());
   }
 
   @Test
@@ -29,7 +31,6 @@ class ThirdPartyLibrariesTest {
 
   @Test
   void testGetExcludesWithExplicitExclude() {
-
     when(mockConfig.getThirdPartyIncludes())
         .thenReturn(Collections.singleton("com.datadog.debugger"));
     assertTrue(
@@ -71,5 +72,23 @@ class ThirdPartyLibrariesTest {
   void testGetExcludeAll() {
     Set<String> excludeAll = ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(null);
     for (char c : ThirdPartyLibraries.ALPHABET) assertTrue(excludeAll.contains(String.valueOf(c)));
+  }
+
+  @Test
+  void testEmptyStrings() {
+    int expectedIncludeDefaultSize =
+        ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(mockConfig).size();
+    int expectedShadingDefaultSize =
+        ThirdPartyLibraries.INSTANCE.getShadingIdentifiers(mockConfig).size();
+    when(mockConfig.getThirdPartyIncludes()).thenReturn(Collections.singleton(""));
+    when(mockConfig.getThirdPartyExcludes()).thenReturn(Collections.singleton(""));
+    when(mockConfig.getThirdPartyShadingIdentifiers()).thenReturn(Collections.singleton(""));
+    assertEquals(
+        expectedIncludeDefaultSize,
+        ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(mockConfig).size());
+    assertTrue(ThirdPartyLibraries.INSTANCE.getThirdPartyExcludes(mockConfig).isEmpty());
+    assertEquals(
+        expectedShadingDefaultSize,
+        ThirdPartyLibraries.INSTANCE.getShadingIdentifiers(mockConfig).size());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
@@ -169,7 +169,8 @@ class SymDBEnablementTest {
     ClassNameFiltering classNameFiltering =
         new ClassNameFiltering(
             Collections.singleton("org.springframework."),
-            Collections.singleton("com.datadog.debugger."));
+            Collections.singleton("com.datadog.debugger."),
+            Collections.emptySet());
     SymbolAggregator symbolAggregator = new SymbolAggregator(classNameFiltering, mockSymbolSink, 1);
     SymDBEnablement symDBEnablement =
         new SymDBEnablement(instr, config, symbolAggregator, classNameFiltering);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -982,7 +982,8 @@ class SymbolExtractionTransformerTest {
     return createTransformer(
         symbolSink,
         symbolFlushThreshold,
-        new ClassNameFiltering(TRANSFORMER_EXCLUDES, Collections.singleton(SYMBOL_PACKAGE)));
+        new ClassNameFiltering(
+            TRANSFORMER_EXCLUDES, Collections.singleton(SYMBOL_PACKAGE), Collections.emptySet()));
   }
 
   private SymbolExtractionTransformer createTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import datadog.trace.api.Config;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -85,8 +86,7 @@ class ClassNameFilteringTest {
         "akka.Actor",
         "cats.Functor",
         "org.junit.jupiter.api.Test",
-        "org.datadog.jmxfetch.FooBar",
-        "shaded.org.junit.Test"
+        "org.datadog.jmxfetch.FooBar"
       })
   public void testExcludeDefaults(String input) {
     Config config = mock(Config.class);
@@ -95,6 +95,20 @@ class ClassNameFilteringTest {
     when(config.getThirdPartyShadingIdentifiers()).thenReturn(Collections.emptySet());
     ClassNameFiltering classNameFiltering = new ClassNameFiltering(config);
     assertTrue(classNameFiltering.isExcluded(input));
+  }
+
+  @Test
+  public void testShaded() {
+    Config config = mock(Config.class);
+    when(config.getThirdPartyExcludes()).thenReturn(Collections.emptySet());
+    when(config.getThirdPartyIncludes())
+        .thenReturn(new HashSet<>(Arrays.asList("com.google", "org.junit")));
+    when(config.getThirdPartyShadingIdentifiers()).thenReturn(Collections.emptySet());
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(config);
+    assertTrue(classNameFiltering.isExcluded("com.google.FooBar"));
+    assertTrue(classNameFiltering.isExcluded("shaded.com.google.FooBar"));
+    assertFalse(classNameFiltering.isExcluded("com.example.shaded.com.example.FooBar"));
+    assertTrue(classNameFiltering.isExcluded("com.example.shaded.com.google.FooBar"));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.datadog.debugger.agent.ThirdPartyLibraries;
 import datadog.trace.api.Config;
 import java.util.Collections;
 import java.util.HashSet;
@@ -52,7 +51,8 @@ class ClassNameFilteringTest {
     ClassNameFiltering classNameFiltering =
         new ClassNameFiltering(
             Collections.singleton("com.datadog.debugger"),
-            Collections.singleton("com.datadog.debugger"));
+            Collections.singleton("com.datadog.debugger"),
+            Collections.emptySet());
     assertFalse(classNameFiltering.isExcluded("com.datadog.debugger.FooBar"));
   }
 
@@ -60,7 +60,9 @@ class ClassNameFilteringTest {
   public void testIncludePrefixOverridesExclude() {
     ClassNameFiltering classNameFiltering =
         new ClassNameFiltering(
-            Collections.singleton("com.datadog.debugger"), Collections.singleton("com.datadog"));
+            Collections.singleton("com.datadog.debugger"),
+            Collections.singleton("com.datadog"),
+            Collections.emptySet());
     assertFalse(classNameFiltering.isExcluded("com.datadog.debugger.FooBar"));
   }
 
@@ -69,7 +71,8 @@ class ClassNameFilteringTest {
     ClassNameFiltering classNameFiltering =
         new ClassNameFiltering(
             Stream.of("com.datadog.debugger", "org.junit").collect(Collectors.toSet()),
-            Collections.singleton("com.datadog.debugger"));
+            Collections.singleton("com.datadog.debugger"),
+            Collections.emptySet());
     assertFalse(classNameFiltering.isExcluded("com.datadog.debugger.FooBar"));
     assertTrue(classNameFiltering.isExcluded("org.junit.FooBar"));
   }
@@ -82,14 +85,15 @@ class ClassNameFilteringTest {
         "akka.Actor",
         "cats.Functor",
         "org.junit.jupiter.api.Test",
-        "org.datadog.jmxfetch.FooBar"
+        "org.datadog.jmxfetch.FooBar",
+        "shaded.org.junit.Test"
       })
   public void testExcludeDefaults(String input) {
     Config config = mock(Config.class);
     when(config.getThirdPartyExcludes()).thenReturn(Collections.emptySet());
     when(config.getThirdPartyIncludes()).thenReturn(Collections.emptySet());
-    ClassNameFiltering classNameFiltering =
-        new ClassNameFiltering(ThirdPartyLibraries.INSTANCE.getThirdPartyLibraries(config));
+    when(config.getThirdPartyShadingIdentifiers()).thenReturn(Collections.emptySet());
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(config);
     assertTrue(classNameFiltering.isExcluded(input));
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -61,6 +61,7 @@ public final class DebuggerConfig {
   public static final String DISTRIBUTED_DEBUGGER_ENABLED = "distributed.debugger.enabled";
   public static final String THIRD_PARTY_INCLUDES = "third.party.includes";
   public static final String THIRD_PARTY_EXCLUDES = "third.party.excludes";
+  public static final String THIRD_PARTY_SHADING_IDENTIFIERS = "third.party.shading.identifiers";
 
   private DebuggerConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -430,6 +430,7 @@ public class Config {
 
   private final Set<String> debuggerThirdPartyIncludes;
   private final Set<String> debuggerThirdPartyExcludes;
+  private final Set<String> debuggerShadingIdentifiers;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1734,6 +1735,8 @@ public class Config {
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
+    debuggerShadingIdentifiers =
+        tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_SHADING_IDENTIFIERS));
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -3297,6 +3300,10 @@ public class Config {
 
   public Set<String> getThirdPartyExcludes() {
     return debuggerThirdPartyExcludes;
+  }
+
+  public Set<String> getThirdPartyShadingIdentifiers() {
+    return debuggerShadingIdentifiers;
   }
 
   private String getFinalDebuggerBaseUrl() {

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -117,9 +117,17 @@ public final class ClassNameTrie {
     return apply(trieData, longJumps, key);
   }
 
+  public int apply(String key, int fromIndex) {
+    return apply(trieData, longJumps, key, fromIndex);
+  }
+
   public static int apply(char[] data, int[] longJumps, String key) {
+    return apply(data, longJumps, key, 0);
+  }
+
+  public static int apply(char[] data, int[] longJumps, String key, int fromIndex) {
     int keyLength = key.length();
-    int keyIndex = 0;
+    int keyIndex = fromIndex;
     int dataIndex = 0;
     int result = -1;
 
@@ -837,6 +845,14 @@ public final class ClassNameTrie {
         lines.add("    return ClassNameTrie.apply(TRIE_DATA, LONG_JUMPS, key);");
       } else {
         lines.add("    return ClassNameTrie.apply(TRIE_DATA, null, key);");
+      }
+      lines.add("  }");
+      lines.add("");
+      lines.add("  public static int apply(String key, int fromIndex) {");
+      if (hasLongJumps) {
+        lines.add("    return ClassNameTrie.apply(TRIE_DATA, LONG_JUMPS, key, fromIndex);");
+      } else {
+        lines.add("    return ClassNameTrie.apply(TRIE_DATA, null, key, fromIndex);");
       }
       lines.add("  }");
       lines.add("");

--- a/internal-api/src/test/groovy/datadog/trace/util/ClassNameTrieTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/ClassNameTrieTest.groovy
@@ -44,6 +44,45 @@ class ClassNameTrieTest extends DDSpecification {
     // spotless:on
   }
 
+  def 'test class name "#key" mapping with fromIndex'() {
+    when:
+    int value = TestClassNamesTrie.apply(key, "garbage.".length())
+    then:
+    value == expected
+    where:
+    // spotless:off
+    key                    | expected
+    'garbage.One'                  | 1
+    'garbage.com.Two'              | 2
+    'garbage.com.foo.Three'        | 3
+    'garbage.company.foo.Four'     | 4
+    'garbage.com.foobar.Five'      | 5
+    'garbage.company.foobar.Six'   | 6
+    'garbage.company.foobar.Sixty' | 60
+    'garbage.com.f'                | 7
+    'garbage.com.foo.a'            | 8
+    'garbage.com.foobar.b'         | 9
+    'garbage.company.f'            | 10
+    'garbage.company.foo.a'        | 11
+    'garbage.company.foobar.S'     | 12
+    'garbage.com.Two$f'            | 13
+    'garbage.foobar.Two$b'         | 14
+    'garbage.'                     | -1
+    'garbage.O'                    | -1
+    'garbage._'                    | -1
+    'garbage.On'                   | -1
+    'garbage.O_'                   | -1
+    'garbage.On_'                  | -1
+    'garbage.OneNoMatch'           | -1
+    'garbage.com.Twos'             | 7
+    'garbage.com.foo.Threes'       | 8
+    'garbage.com.foobar.Fives'     | 9
+    'garbage.foobar.Thre'          | -1
+    'garbage.foobar.Three'         | 15
+    'garbage.foobar.ThreeMore'     | 15
+    // spotless:on
+  }
+
   def 'test internal name "#key" mapping'() {
     when:
     int value = TestClassNamesTrie.apply(key)


### PR DESCRIPTION
# What Does This Do
Add filtering on shading identifiers
Add option to add more shading idententifiers

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3388]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3388]: https://datadoghq.atlassian.net/browse/DEBUG-3388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ