### PR TITLE
Set default Attempt to Fix retries if none provided from the backend

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TestManagementSettings.java
@@ -87,7 +87,7 @@ public class TestManagementSettings {
 
       return new TestManagementSettings(
           enabled != null ? enabled : false,
-          attemptToFixRetries != null ? attemptToFixRetries.intValue() : -1);
+          attemptToFixRetries != null ? attemptToFixRetries.intValue() : 20);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Fixes a bug where if the backend doesn't provide a number of retries for Attempt to Fix tests the test won't be retried at all, as it defaulted to -1. Now it defaults to 20 (the original number of retries planned in the RFC).

# Motivation

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: []

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
