### PR TITLE
Fix appsec.rasp.error and appsec.waf.error telemetry metrics

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -74,9 +74,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   public static final Set<String> RESPONSE_HEADERS_ALLOW_LIST =
       new TreeSet<>(
           Arrays.asList("content-length", "content-type", "content-encoding", "content-language"));
-  public static final int DD_WAF_RUN_INTERNAL_ERROR = -3;
-  public static final int DD_WAF_RUN_INVALID_OBJECT_ERROR = -2;
-  public static final int DD_WAF_RUN_INVALID_ARGUMENT_ERROR = -1;
 
   static {
     REQUEST_HEADERS_ALLOW_LIST.addAll(DEFAULT_REQUEST_HEADERS_ALLOW_LIST);
@@ -125,12 +122,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private volatile boolean blocked;
   private volatile int wafTimeouts;
   private volatile int raspTimeouts;
-  private volatile int raspInternalErrors;
-  private volatile int raspInvalidObjectErrors;
-  private volatile int raspInvalidArgumentErrors;
-  private volatile int wafInternalErrors;
-  private volatile int wafInvalidObjectErrors;
-  private volatile int wafInvalidArgumentErrors;
 
   // keep a reference to the last published usr.id
   private volatile String userId;
@@ -149,29 +140,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "wafTimeouts");
   private static final AtomicIntegerFieldUpdater<AppSecRequestContext> RASP_TIMEOUTS_UPDATER =
       AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "raspTimeouts");
-
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
-      RASP_INTERNAL_ERRORS_UPDATER =
-          AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "raspInternalErrors");
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
-      RASP_INVALID_OBJECT_ERRORS_UPDATER =
-          AtomicIntegerFieldUpdater.newUpdater(
-              AppSecRequestContext.class, "raspInvalidObjectErrors");
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
-      RASP_INVALID_ARGUMENT_ERRORS_UPDATER =
-          AtomicIntegerFieldUpdater.newUpdater(
-              AppSecRequestContext.class, "raspInvalidArgumentErrors");
-
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext> WAF_INTERNAL_ERRORS_UPDATER =
-      AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "wafInternalErrors");
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
-      WAF_INVALID_OBJECT_ERRORS_UPDATER =
-          AtomicIntegerFieldUpdater.newUpdater(
-              AppSecRequestContext.class, "wafInvalidObjectErrors");
-  private static final AtomicIntegerFieldUpdater<AppSecRequestContext>
-      WAF_INVALID_ARGUMENT_ERRORS_UPDATER =
-          AtomicIntegerFieldUpdater.newUpdater(
-              AppSecRequestContext.class, "wafInvalidArgumentErrors");
 
   // to be called by the Event Dispatcher
   public void addAll(DataBundle newData) {
@@ -222,70 +190,12 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     RASP_TIMEOUTS_UPDATER.incrementAndGet(this);
   }
 
-  public void increaseRaspErrorCode(int code) {
-    switch (code) {
-      case DD_WAF_RUN_INTERNAL_ERROR:
-        RASP_INTERNAL_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
-        RASP_INVALID_OBJECT_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
-        RASP_INVALID_ARGUMENT_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      default:
-        break;
-    }
-  }
-
-  public void increaseWafErrorCode(int code) {
-    switch (code) {
-      case DD_WAF_RUN_INTERNAL_ERROR:
-        WAF_INTERNAL_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
-        WAF_INVALID_OBJECT_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
-        WAF_INVALID_ARGUMENT_ERRORS_UPDATER.incrementAndGet(this);
-        break;
-      default:
-        break;
-    }
-  }
-
   public int getWafTimeouts() {
     return wafTimeouts;
   }
 
   public int getRaspTimeouts() {
     return raspTimeouts;
-  }
-
-  public int getRaspError(int code) {
-    switch (code) {
-      case DD_WAF_RUN_INTERNAL_ERROR:
-        return raspInternalErrors;
-      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
-        return raspInvalidObjectErrors;
-      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
-        return raspInvalidArgumentErrors;
-      default:
-        return 0;
-    }
-  }
-
-  public int getWafError(int code) {
-    switch (code) {
-      case DD_WAF_RUN_INTERNAL_ERROR:
-        return wafInternalErrors;
-      case DD_WAF_RUN_INVALID_OBJECT_ERROR:
-        return wafInvalidObjectErrors;
-      case DD_WAF_RUN_INVALID_ARGUMENT_ERROR:
-        return wafInvalidArgumentErrors;
-      default:
-        return 0;
-    }
   }
 
   public WafContext getOrCreateWafContext(WafHandle ctx, boolean createMetrics, boolean isRasp) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
@@ -1,5 +1,8 @@
 package com.datadog.appsec.ddwaf
 
+import com.datadog.ddwaf.WafErrorCode as LibWafErrorCode
+import datadog.trace.api.telemetry.WafMetricCollector.WafErrorCode as InternalWafErrorCode
+
 import com.datadog.appsec.AppSecModule
 import com.datadog.appsec.config.AppSecConfig
 import com.datadog.appsec.config.AppSecData
@@ -17,6 +20,11 @@ import com.datadog.appsec.event.data.MapDataBundle
 import com.datadog.appsec.gateway.AppSecRequestContext
 import com.datadog.appsec.gateway.GatewayContext
 import com.datadog.appsec.report.AppSecEvent
+import com.datadog.ddwaf.exception.AbstractWafException
+import com.datadog.ddwaf.exception.InternalWafException
+import com.datadog.ddwaf.exception.InvalidArgumentWafException
+import com.datadog.ddwaf.exception.InvalidObjectWafException
+import com.datadog.ddwaf.exception.UnclassifiedWafException
 import datadog.trace.api.telemetry.RuleType
 import datadog.trace.util.stacktrace.StackTraceEvent
 import com.datadog.appsec.test.StubAppSecConfigService
@@ -1753,6 +1761,94 @@ class WAFModuleSpecification extends DDSpecification {
     1 * wafMetricCollector.wafInit(Waf.LIB_VERSION, _, true)
     1 * wafMetricCollector.raspRuleSkipped(RuleType.SQL_INJECTION)
     0 * _
+  }
+
+  void 'test raspErrorCode metric is increased when waf  call throws #wafErrorCode '() {
+    setup:
+    ChangeableFlow flow = Mock()
+    GatewayContext gwCtxMock = new GatewayContext(false, RuleType.SQL_INJECTION)
+    WafContext wafContext = Mock()
+
+    when:
+    setupWithStubConfigService('rules_with_data_config.json')
+    dataListener = wafModule.dataSubscriptions.first()
+
+    def bundle = MapDataBundle.of(
+      KnownAddresses.USER_ID,
+      'legit-user'
+      )
+    dataListener.onDataAvailable(flow, ctx, bundle, gwCtxMock)
+
+    then:
+    (1..2) * ctx.isWafContextClosed() >> false // if UnclassifiedWafException it's called twice
+    1 * ctx.getOrCreateWafContext(_, true, true) >> wafContext
+    1 * wafMetricCollector.raspRuleEval(RuleType.SQL_INJECTION)
+    1 * wafContext.run(_, _, _) >> { throw createWafException(wafErrorCode) }
+    1 * wafMetricCollector.wafInit(Waf.LIB_VERSION, _, true)
+    1 * ctx.getRaspMetrics()
+    1 * ctx.getRaspMetricsCounter()
+    (0..1) * WafMetricCollector.get().wafRequestError() // TODO: remove this line when WAFModule is removed
+    1 * wafMetricCollector.raspErrorCode(RuleType.SQL_INJECTION, wafErrorCode.code)
+    0 * _
+
+    where:
+    wafErrorCode << LibWafErrorCode.values()
+  }
+
+  void 'test wafErrorCode metric is increased when waf  call throws #wafErrorCode '() {
+    setup:
+    ChangeableFlow flow = Mock()
+    WafContext wafContext = Mock()
+
+    when:
+    setupWithStubConfigService('rules_with_data_config.json')
+    dataListener = wafModule.dataSubscriptions.first()
+
+    def bundle = MapDataBundle.of(
+      KnownAddresses.USER_ID,
+      'legit-user'
+      )
+    dataListener.onDataAvailable(flow, ctx, bundle, gwCtx)
+
+    then:
+    (1..2) * ctx.isWafContextClosed() >> false // if UnclassifiedWafException it's called twice
+    1 * ctx.getOrCreateWafContext(_, true, false) >> wafContext
+    1 * wafContext.run(_, _, _) >> { throw createWafException(wafErrorCode) }
+    1 * wafMetricCollector.wafInit(Waf.LIB_VERSION, _, true)
+    2 * ctx.getWafMetrics()
+    (0..1) * WafMetricCollector.get().wafRequestError() // TODO: remove this line when WAFModule is removed
+    1 * wafMetricCollector.wafErrorCode(wafErrorCode.code)
+    0 * _
+
+    where:
+    wafErrorCode << LibWafErrorCode.values()
+  }
+
+  def 'internal-api WafErrorCode enum matches libddwaf-java by name and code'() {
+    given:
+    def libddwaf = com.datadog.ddwaf.WafErrorCode.values().collectEntries { [it.name(), it.code] }
+    def internal = datadog.trace.api.telemetry.WafMetricCollector.WafErrorCode.values().collectEntries { [it.name(), it.code] }
+
+    expect:
+    internal == libddwaf
+  }
+
+  /**
+   * Helper to return a concrete Waf exception for each WafErrorCode
+   */
+  static AbstractWafException createWafException(LibWafErrorCode code) {
+    switch (code) {
+      case LibWafErrorCode.INVALID_ARGUMENT:
+        return new InvalidArgumentWafException(code.code)
+      case LibWafErrorCode.INVALID_OBJECT:
+        return new InvalidObjectWafException(code.code)
+      case LibWafErrorCode.INTERNAL_ERROR:
+        return new InternalWafException(code.code)
+      case LibWafErrorCode.BINDING_ERROR:
+        return new UnclassifiedWafException(code.code)
+      default:
+        throw new IllegalStateException("Unhandled WafErrorCode: $code")
+    }
   }
 
   private Map<String, Object> getDefaultConfig() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
@@ -1826,8 +1826,8 @@ class WAFModuleSpecification extends DDSpecification {
 
   def 'internal-api WafErrorCode enum matches libddwaf-java by name and code'() {
     given:
-    def libddwaf = com.datadog.ddwaf.WafErrorCode.values().collectEntries { [it.name(), it.code] }
-    def internal = datadog.trace.api.telemetry.WafMetricCollector.WafErrorCode.values().collectEntries { [it.name(), it.code] }
+    def libddwaf = LibWafErrorCode.values().collectEntries { [it.name(), it.code] }
+    def internal = InternalWafErrorCode.values().collectEntries { [it.name(), it.code] }
 
     expect:
     internal == libddwaf

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -289,32 +289,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
     ctx.getRaspTimeouts() == 2
   }
 
-  def "test increase and get RaspErrors"() {
-    when:
-    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
-    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
-    ctx.increaseRaspErrorCode(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR)
-
-    then:
-    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR) == 2
-    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR) == 1
-    ctx.getRaspError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
-    ctx.getRaspError(0) == 0
-  }
-
-  def "test increase and get WafErrors"() {
-    when:
-    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
-    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR)
-    ctx.increaseWafErrorCode(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR)
-
-    then:
-    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INTERNAL_ERROR) == 2
-    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_OBJECT_ERROR) == 1
-    ctx.getWafError(AppSecRequestContext.DD_WAF_RUN_INVALID_ARGUMENT_ERROR) == 0
-    ctx.getWafError(0) == 0
-  }
-
   void 'close logs if request end was not called'() {
     given:
     TestLogCollector.enable()


### PR DESCRIPTION
# What Does This Do

- Remove counters from AppsecRequestContext as they are not used in the metrics
- Fix appsec.waf.error metric tags as they didn't match the RFC
- Fix that appsec.waf.error was created in the same loop using the rasp counter instead of using the waf counter
- Increment metrics if UnclassifiedPowerwafException is thrown
- Replace ConcurrentHashMap with AtomicLongArray for raspErrorCodeCounter to improve performance and memory efficiency
- Add test to cover WafModule implementation

# Motivation

# Additional Notes

[RFC](https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?tab=t.0#heading=h.6shrh2msb59g)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-da48a29c-7fff-7e4c-94ec-72d5ae20b262"><div dir="ltr" style="margin-left:0pt;" align="center">
appsec.waf.error | Count |   | Counts the number of times the WAF returned an error when evaluating WAF addresses through ddwaf_run.
-- | -- | -- | --
  | Version String | waf_version | Version of the libddwaf library
  | Version String | event_rules_version | Version of the ruleset
  | Int | waf_error | The numeric error returned by ddwaf_run or -127 If the error is caused by the WAF bindings rather than the call to ddwaf_run.

</div></b>


It's necessary to add more test to cover how metrics are incremented for errors in waf calls, right now the class used for that purpose (Additive) is final so there is no easy way to test this properly.
https://datadoghq.atlassian.net/browse/APPSEC-57082

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-57054]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-57054]: https://datadoghq.atlassian.net/browse/APPSEC-57054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ