### PR TITLE
Fix flaky InProduct enablement smoke test

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -172,6 +172,7 @@ public class DebuggerAgent {
     } else {
       LOGGER.debug("No configuration poller available from SharedCommunicationObjects");
     }
+    LOGGER.info("Started Dynamic Instrumentation");
   }
 
   public static void stopDynamicInstrumentation() {
@@ -205,6 +206,7 @@ public class DebuggerAgent {
             Duration.ofSeconds(config.getDebuggerExceptionCaptureInterval()),
             config.getDebuggerMaxExceptionPerSecond());
     DebuggerContext.initExceptionDebugger(exceptionDebugger);
+    LOGGER.info("Started Exception Replay");
   }
 
   public static void stopExceptionReplay() {
@@ -230,6 +232,7 @@ public class DebuggerAgent {
     initClassNameFilter();
     DebuggerContext.initClassNameFilter(classNameFilter);
     DebuggerContext.initCodeOrigin(new DefaultCodeOriginRecorder(config, configurationUpdater));
+    LOGGER.info("Started Code Origin for spans");
   }
 
   public static void stopCodeOriginForSpans() {

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -76,7 +76,7 @@ public class ServerDebuggerTestApplication {
   }
 
   protected void waitForInstrumentation(String className) {
-    System.out.println("waitForInstrumentation on " + className + " from: " + lastMatchedLine);
+    System.out.println("waitForInstrumentation on " + className);
     try {
       lastMatchedLine =
           TestApplicationHelper.waitForInstrumentation(LOG_FILENAME, className, lastMatchedLine);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -3,7 +3,6 @@ package datadog.smoketest;
 import static datadog.smoketest.debugger.TestApplicationHelper.waitForSpecificLine;
 
 import com.datadog.debugger.probe.LogProbe;
-import datadog.trace.test.util.Flaky;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -53,7 +52,6 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
     waitForSpecificLine(appUrl, "Feature dynamic.instrumentation.enabled is explicitly disabled");
   }
 
-  @Flaky
   @Test
   @DisplayName("testExceptionReplayEnablement")
   void testExceptionReplayEnablement() throws Exception {
@@ -70,7 +68,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   }
 
   private void waitForFeatureStarted(String appUrl, String feature) throws IOException {
-    String line = "INFO com.datadog.debugger.agent.DebuggerAgent - Starting " + feature;
+    String line = "INFO com.datadog.debugger.agent.DebuggerAgent - Started " + feature;
     waitForSpecificLine(appUrl, line);
     LOG.info("feature {} started", feature);
   }


### PR DESCRIPTION
# What Does This Do
Wait for feature started before sending request to avoid racy startup

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3653]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3653]: https://datadoghq.atlassian.net/browse/DEBUG-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ