### PR TITLE
Document when we manage a span's lifecycle without scopes

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -1,7 +1,7 @@
 package datadog.trace.civisibility.domain;
 
 import static datadog.json.JsonMapper.toJson;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpanWithoutScope;
 import static datadog.trace.civisibility.Constants.CI_VISIBILITY_INSTRUMENTATION_NAME;
 
 import datadog.trace.api.Config;
@@ -116,7 +116,7 @@ public class TestImpl implements DDTest {
 
     span = spanBuilder.start();
 
-    activateSpan(span);
+    activateSpanWithoutScope(span);
 
     span.setSpanType(InternalSpanTypes.TEST);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_TEST);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
@@ -1,7 +1,7 @@
 package datadog.trace.civisibility.domain;
 
 import static datadog.json.JsonMapper.toJson;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpanWithoutScope;
 import static datadog.trace.civisibility.Constants.CI_VISIBILITY_INSTRUMENTATION_NAME;
 
 import datadog.trace.api.Config;
@@ -130,7 +130,7 @@ public class TestSuiteImpl implements DDTestSuite {
     testDecorator.afterStart(span);
 
     if (!parallelized) {
-      activateSpan(span);
+      activateSpanWithoutScope(span);
     }
 
     metricCollector.add(CiVisibilityCountMetric.EVENT_CREATED, 1, instrumentation, EventType.SUITE);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.aws.v0;
 
 import static datadog.trace.api.datastreams.DataStreamsContext.create;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpanWithoutScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
@@ -55,7 +55,7 @@ public class TracingRequestHandler extends RequestHandler2 {
     if (!AWS_LEGACY_TRACING && isPollingRequest(request.getOriginalRequest())) {
       // SQS messages spans are created by aws-java-sqs-1.0 - replace client scope with no-op,
       // so we can tell when receive call is complete without affecting the rest of the trace
-      activateSpan(blackholeSpan());
+      activateSpanWithoutScope(blackholeSpan());
     } else {
       span = requestSpanStore.remove(request.getOriginalRequest());
       if (span != null) {
@@ -78,9 +78,9 @@ public class TracingRequestHandler extends RequestHandler2 {
       }
       // This scope will be closed by AwsHttpClientInstrumentation
       if (AWS_LEGACY_TRACING) {
-        activateSpan(span);
+        activateSpanWithoutScope(span);
       } else {
-        activateSpan(blackholeSpan());
+        activateSpanWithoutScope(blackholeSpan());
       }
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpanWithoutScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_LEGACY_TRACING;
@@ -93,7 +94,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
     if (span != null) {
       // This scope will be closed by AwsHttpClientInstrumentation since ExecutionInterceptor API
       // doesn't provide a way to run code in same thread after transmission has been scheduled.
-      activateSpan(span);
+      activateSpanWithoutScope(span);
     }
   }
 

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
@@ -22,7 +22,6 @@ import datadog.trace.api.civisibility.execution.TestExecutionHistory;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -198,7 +197,7 @@ public class KarateTracingHook implements RuntimeHook {
       return true;
     }
     AgentSpan span = AgentTracer.startSpan("karate", KARATE_STEP_SPAN_NAME);
-    AgentScope scope = AgentTracer.activateSpan(span);
+    AgentTracer.activateSpanWithoutScope(span);
     String stepName = step.getPrefix() + " " + step.getText();
     span.setResourceName(stepName);
     span.setTag(Tags.COMPONENT, "karate");

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpRequestParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpRequestParserInstrumentation.java
@@ -4,7 +4,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.ex
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closeActive;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -92,7 +91,7 @@ public class HttpRequestParserInstrumentation extends InstrumenterModule.Tracing
           if (scope != null) {
             scope.close();
           } else {
-            closeActive();
+            // span was already active, scope will be closed by HandlerInstrumentation
           }
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -917,6 +917,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  @SuppressWarnings("resource")
+  public void activateSpanWithoutScope(AgentSpan span) {
+    scopeManager.activateSpan(span);
+  }
+
+  @Override
   public AgentScope.Continuation captureActiveSpan() {
     return scopeManager.captureActiveSpan();
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -88,6 +88,16 @@ public class AgentTracer {
   }
 
   /**
+   * Activate a span which will be closed by {@link #closeActive()} instead of a scope.
+   *
+   * @deprecated This should only be used when the instrumented code doesn't align with a scope.
+   */
+  @Deprecated
+  public static void activateSpanWithoutScope(final AgentSpan span) {
+    get().activateSpanWithoutScope(span);
+  }
+
+  /**
    * When asynchronous propagation is enabled, prevent the currently active trace from reporting
    * until the returned Continuation is either activated (and the returned scope is closed) or the
    * continuation is canceled.
@@ -142,8 +152,8 @@ public class AgentTracer {
   /**
    * Closes the scope for the currently active span.
    *
-   * @deprecated This should only be used when an instrumentation does not have access to the
-   *     original scope returned by {@link #activateSpan}.
+   * @deprecated This should only be used when the span was previously activated with {@link
+   *     #activateSpanWithoutScope} because the instrumented code didn't align with a scope.
    */
   @Deprecated
   public static void closeActive() {
@@ -338,6 +348,9 @@ public class AgentTracer {
     /** Activate a span from outside auto-instrumentation, i.e. a manual or custom span. */
     AgentScope activateManualSpan(AgentSpan span);
 
+    /** Activate a span which will be closed by {@link #closeActive()} instead of a scope. */
+    void activateSpanWithoutScope(AgentSpan span);
+
     @Override
     AgentScope.Continuation captureActiveSpan();
 
@@ -482,6 +495,9 @@ public class AgentTracer {
     public AgentScope activateManualSpan(final AgentSpan span) {
       return NoopScope.INSTANCE;
     }
+
+    @Override
+    public void activateSpanWithoutScope(final AgentSpan span) {}
 
     @Override
     public AgentScope.Continuation captureActiveSpan() {


### PR DESCRIPTION
# What Does This Do

This PR adds an `activateSpanWithoutScope(span)` method to self-document this behaviour and explicitly tie it to the use of `closeActive()`.

# Motivation

There are a few instrumentations where the instrumented code does not align with scopes. In such situations the span is activated, but the scope is thrown away. The span is then closed in another section of code using `closeActive()`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-960]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-960]: https://datadoghq.atlassian.net/browse/APMAPI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ