### PR TITLE
Add buffer size customizability to JDK UDS support

### DIFF
--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -38,7 +38,7 @@ final class TunnelingJdkSocket extends Socket {
   // Indicate that the buffer size is not set by initializing to -1
   private int sendBufferSize = -1;
   private int receiveBufferSize = -1;
-  private int defaultBufferSize = 8192;
+  static final int DEFAULT_BUFFER_SIZE = 8192;
 
   TunnelingJdkSocket(final Path path) {
     this.unixSocketAddress = UnixDomainSocketAddress.of(path);

--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -35,10 +35,10 @@ final class TunnelingJdkSocket extends Socket {
   private boolean shutOut;
   private boolean closed;
 
-  // Indicate that the buffer size is not set by initializing to -1
+  protected static final int DEFAULT_BUFFER_SIZE = 8192;
+  // Initial buffer sizes to -1, meaning not set
   private int sendBufferSize = -1;
   private int receiveBufferSize = -1;
-  static final int DEFAULT_BUFFER_SIZE = 8192;
 
   TunnelingJdkSocket(final Path path) {
     this.unixSocketAddress = UnixDomainSocketAddress.of(path);
@@ -142,7 +142,7 @@ final class TunnelingJdkSocket extends Socket {
       throw new SocketException("Socket is closed");
     }
     if (sendBufferSize == -1) {
-      return defaultBufferSize;
+      return DEFAULT_BUFFER_SIZE;
     }
     return sendBufferSize;
   }
@@ -169,7 +169,7 @@ final class TunnelingJdkSocket extends Socket {
       throw new SocketException("Socket is closed");
     }
     if (receiveBufferSize == -1) {
-      return defaultBufferSize;
+      return DEFAULT_BUFFER_SIZE;
     }
     return receiveBufferSize;
   }
@@ -179,13 +179,9 @@ final class TunnelingJdkSocket extends Socket {
       throw new SocketException("Socket is closed");
     }
     if (sendBufferSize == -1 && receiveBufferSize == -1) {
-      return defaultBufferSize;
+      return DEFAULT_BUFFER_SIZE;
     }
     return Math.max(sendBufferSize, receiveBufferSize);
-  }
-
-  public int getDefaultBufferSize() {
-    return defaultBufferSize;
   }
 
   @Override

--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -36,7 +36,7 @@ final class TunnelingJdkSocket extends Socket {
   private boolean closed;
 
   protected static final int DEFAULT_BUFFER_SIZE = 8192;
-  // Initial buffer sizes to -1, meaning not set
+  // Indicate that the buffer size is not set by initializing to -1
   private int sendBufferSize = -1;
   private int receiveBufferSize = -1;
 

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -88,12 +88,11 @@ public class TunnelingJdkSocketTest {
     startServer(socketAddress);
     TunnelingJdkSocket clientSocket = createClient(socketPath);
 
-    int defaultBufferSize = clientSocket.getDefaultBufferSize();
-    assertEquals(defaultBufferSize, clientSocket.getSendBufferSize());
-    assertEquals(defaultBufferSize, clientSocket.getReceiveBufferSize());
-    assertEquals(defaultBufferSize, clientSocket.getStreamBufferSize());
+    assertEquals(TunnelingJdkSocket.DEFAULT_BUFFER_SIZE, clientSocket.getSendBufferSize());
+    assertEquals(TunnelingJdkSocket.DEFAULT_BUFFER_SIZE, clientSocket.getReceiveBufferSize());
+    assertEquals(TunnelingJdkSocket.DEFAULT_BUFFER_SIZE, clientSocket.getStreamBufferSize());
 
-    int newBufferSize = defaultBufferSize / 2;
+    int newBufferSize = TunnelingJdkSocket.DEFAULT_BUFFER_SIZE / 2;
     clientSocket.setSendBufferSize(newBufferSize);
     clientSocket.setReceiveBufferSize(newBufferSize / 2);
     assertEquals(newBufferSize, clientSocket.getSendBufferSize());
@@ -107,8 +106,12 @@ public class TunnelingJdkSocketTest {
         IllegalArgumentException.class, () -> clientSocket.setReceiveBufferSize(invalidBufferSize));
 
     clientSocket.close();
-    assertThrows(SocketException.class, () -> clientSocket.setSendBufferSize(defaultBufferSize));
-    assertThrows(SocketException.class, () -> clientSocket.setReceiveBufferSize(defaultBufferSize));
+    assertThrows(
+        SocketException.class,
+        () -> clientSocket.setSendBufferSize(TunnelingJdkSocket.DEFAULT_BUFFER_SIZE));
+    assertThrows(
+        SocketException.class,
+        () -> clientSocket.setReceiveBufferSize(TunnelingJdkSocket.DEFAULT_BUFFER_SIZE));
     assertThrows(SocketException.class, () -> clientSocket.getSendBufferSize());
     assertThrows(SocketException.class, () -> clientSocket.getReceiveBufferSize());
     assertThrows(SocketException.class, () -> clientSocket.getStreamBufferSize());

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -1,11 +1,13 @@
 package datadog.common.socket;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import datadog.trace.api.Config;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ServerSocketChannel;
@@ -28,32 +30,89 @@ public class TunnelingJdkSocketTest {
       return;
     }
 
-    int testTimeout = 3000;
+    Path socketPath = getSocketPath();
+    UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(socketPath);
+    startServer(socketAddress);
+    TunnelingJdkSocket clientSocket = createClient(socketPath);
+    InputStream inputStream = clientSocket.getInputStream();
+
+    int testTimeout = 1000;
+    clientSocket.setSoTimeout(testTimeout);
+    assertEquals(testTimeout, clientSocket.getSoTimeout());
+
+    long startTime = System.currentTimeMillis();
+    int readResult = inputStream.read();
+    long endTime = System.currentTimeMillis();
+    long readDuration = endTime - startTime;
+    int timeVariance = 100;
+    assertTrue(readDuration >= testTimeout && readDuration <= testTimeout + timeVariance);
+    assertEquals(0, readResult);
+
+    int newTimeout = testTimeout / 2;
+    clientSocket.setSoTimeout(newTimeout);
+    assertEquals(newTimeout, clientSocket.getSoTimeout());
+    assertTimeoutPreemptively(Duration.ofMillis(testTimeout), () -> inputStream.read());
+
+    // The socket should block indefinitely when timeout is set to 0, per
+    // https://docs.oracle.com/en/java/javase/16/docs/api//java.base/java/net/Socket.html#setSoTimeout(int).
+    int infiniteTimeout = 0;
+    clientSocket.setSoTimeout(infiniteTimeout);
+    assertEquals(infiniteTimeout, clientSocket.getSoTimeout());
+    try {
+      assertTimeoutPreemptively(Duration.ofMillis(testTimeout), () -> inputStream.read());
+      fail("Read should block indefinitely with infinite timeout");
+    } catch (AssertionError e) {
+      // Expected
+    }
+
+    int invalidTimeout = -1;
+    assertThrows(IllegalArgumentException.class, () -> clientSocket.setSoTimeout(invalidTimeout));
+
+    clientSocket.close();
+    assertThrows(SocketException.class, () -> clientSocket.setSoTimeout(testTimeout));
+    assertThrows(SocketException.class, () -> clientSocket.getSoTimeout());
+
+    isServerRunning.set(false);
+  }
+
+  @Test
+  public void testBufferSizes() throws Exception {
+    if (!Config.get().isJdkSocketEnabled()) {
+      System.out.println(
+          "TunnelingJdkSocket usage is disabled. Enable it by setting the property 'JDK_SOCKET_ENABLED' to 'true'.");
+      return;
+    }
+
     Path socketPath = getSocketPath();
     UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(socketPath);
     startServer(socketAddress);
     TunnelingJdkSocket clientSocket = createClient(socketPath);
 
-    // Test that the socket unblocks when timeout is set to >0
-    clientSocket.setSoTimeout(1000);
-    assertTimeoutPreemptively(
-        Duration.ofMillis(testTimeout), () -> clientSocket.getInputStream().read());
+    int defaultBufferSize = clientSocket.getDefaultBufferSize();
+    assertEquals(defaultBufferSize, clientSocket.getSendBufferSize());
+    assertEquals(defaultBufferSize, clientSocket.getReceiveBufferSize());
+    assertEquals(defaultBufferSize, clientSocket.getStreamBufferSize());
 
-    // Test that the socket blocks indefinitely when timeout is set to 0, per
-    // https://docs.oracle.com/en/java/javase/16/docs/api//java.base/java/net/Socket.html#setSoTimeout(int).
-    clientSocket.setSoTimeout(0);
-    boolean infiniteTimeOut = false;
-    try {
-      assertTimeoutPreemptively(
-          Duration.ofMillis(testTimeout), () -> clientSocket.getInputStream().read());
-    } catch (AssertionError e) {
-      infiniteTimeOut = true;
-    }
-    if (!infiniteTimeOut) {
-      fail("Test failed: Expected infinite blocking when timeout is set to 0.");
-    }
+    int newBufferSize = defaultBufferSize / 2;
+    clientSocket.setSendBufferSize(newBufferSize);
+    clientSocket.setReceiveBufferSize(newBufferSize / 2);
+    assertEquals(newBufferSize, clientSocket.getSendBufferSize());
+    assertEquals(newBufferSize / 2, clientSocket.getReceiveBufferSize());
+    assertEquals(newBufferSize, clientSocket.getStreamBufferSize());
+
+    int invalidBufferSize = -1;
+    assertThrows(
+        IllegalArgumentException.class, () -> clientSocket.setSendBufferSize(invalidBufferSize));
+    assertThrows(
+        IllegalArgumentException.class, () -> clientSocket.setReceiveBufferSize(invalidBufferSize));
 
     clientSocket.close();
+    assertThrows(SocketException.class, () -> clientSocket.setSendBufferSize(defaultBufferSize));
+    assertThrows(SocketException.class, () -> clientSocket.setReceiveBufferSize(defaultBufferSize));
+    assertThrows(SocketException.class, () -> clientSocket.getSendBufferSize());
+    assertThrows(SocketException.class, () -> clientSocket.getReceiveBufferSize());
+    assertThrows(SocketException.class, () -> clientSocket.getStreamBufferSize());
+
     isServerRunning.set(false);
   }
 


### PR DESCRIPTION
# What Does This Do
Following #8314, this PR allows users to set the send and receive buffer sizes by overriding the `setSendBufferSize` and `setReceiveBufferSize` `Socket` methods. The default size is set to `8192`.

# Motivation
Allow custom buffer sizes for the JDK support of UDS.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
