### PR TITLE
Upgrade to develocity plugin 3.19.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.gradle.develocity' version '3.18'
+  id 'com.gradle.develocity' version '3.19.2'
 }
 
 def isCI = System.getenv("CI") != null


### PR DESCRIPTION
# What Does This Do

Changelog since 3.18:

```
3.18.1:
- [NEW] Build Cache: Increase parallel remote build cache operation limit
- [FIX] Build Scan: Resource usage capturing causes excessive logging on Linux when udev is absent
- [FIX] Build Scan: Display name extraction for Java commands with multiple -jar arguments fails when resource usage capturing is enabled

3.18.2:
- [NEW] Test Retry: Add a `failOnSkippedAfterRetry` property to control whether the test task should fail if a failed test got skipped on retry
- [FIX] Build Scan: Resource usage capturing fails silently when the build uses an incompatible JNA version

3.19:
- [NEW] Build Cache: Support Edge discovery based on a Develocity user's location preference
- [NEW] Build Scan: Capture actual CPU load for the top 5 processes by CPU usage
- [NEW] Build Scan: The performance configuration page is now available when using the Isolated Projects feature of Gradle
- [NEW] Build Scan: Capture top 5 processes by memory usage
- [NEW] Build Scan: Maximum configured build cache artifact size is reported if remote store has been rejected due to exceeding this limit

3.19.1:
- [NEW] Build Scan: Do not capture output of Gradle's `:properties` task to avoid leaking sensitive information
- [NEW] Test Distribution: Fall back to local test execution if connection to Develocity times out instead of failing the build
- [FIX] Test Distribution: Performance statistics can be wrong when the build gets cancelled
- [FIX] Test Distribution: Build fails when starting the Kover coverage agent newer than version 0.8.0
- [FIX] Test Distribution: Test Distribution agent specific env variables are accessible from the test JVM
- [FIX] Test Distribution/Predictive Test Selection: Timestamps of test events can be wrong when the test task times out

3.19.2:
- [FIX] Test Distribution: File compression of huge input files can lead to connection timeouts
- [FIX] Test Distribution: Build fails when attempting to aggregate JaCoCo coverage reports produced by the Kover Gradle plugin
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
