### PR TITLE
Fix continuation metrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -264,7 +264,7 @@ public class PendingTrace extends TraceCollector implements PendingTraceBuffer.E
   }
 
   @Override
-  public void cancelContinuation(final AgentScope.Continuation continuation) {
+  public void removeContinuation(final AgentScope.Continuation continuation) {
     decrementRefAndMaybeWrite(false);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -266,7 +266,6 @@ public class PendingTrace extends TraceCollector implements PendingTraceBuffer.E
   @Override
   public void cancelContinuation(final AgentScope.Continuation continuation) {
     decrementRefAndMaybeWrite(false);
-    healthMetrics.onCancelContinuation();
   }
 
   private PublishState decrementRefAndMaybeWrite(boolean isRootSpan) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/StreamingTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StreamingTraceCollector.java
@@ -82,7 +82,7 @@ public class StreamingTraceCollector extends TraceCollector {
   }
 
   @Override
-  public void cancelContinuation(AgentScope.Continuation continuation) {
+  public void removeContinuation(AgentScope.Continuation continuation) {
     // do nothing
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -107,10 +107,7 @@ public final class ContinuableScopeManager implements ScopeStateAware {
   }
 
   private AgentScope.Continuation captureSpan(final AgentSpan span, byte source) {
-    ScopeContinuation continuation = new ScopeContinuation(this, span, source);
-    continuation.register();
-    healthMetrics.onCaptureContinuation();
-    return continuation;
+    return new ScopeContinuation(this, span, source).register();
   }
 
   private AgentScope activate(
@@ -207,7 +204,6 @@ public final class ContinuableScopeManager implements ScopeStateAware {
       scopeStack.cleanup();
       if (finishSpan) {
         top.span.finishWithEndToEnd();
-        healthMetrics.onFinishContinuation();
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
@@ -62,6 +62,7 @@ final class ScopeContinuation implements AgentScope.Continuation {
 
   ScopeContinuation register() {
     traceCollector.registerContinuation(this);
+    scopeManager.healthMetrics.onCaptureContinuation();
     return this;
   }
 
@@ -96,16 +97,19 @@ final class ScopeContinuation implements AgentScope.Continuation {
       // no outstanding activations and hold has been removed
       if (COUNT.compareAndSet(this, current, CANCELLED)) {
         traceCollector.cancelContinuation(this);
+        scopeManager.healthMetrics.onFinishContinuation();
         return;
       }
       current = count;
     }
+    scopeManager.healthMetrics.onCancelContinuation();
   }
 
   void cancelFromContinuedScopeClose() {
     if (COUNT.compareAndSet(this, 1, CANCELLED)) {
       // fast path: only one activation of the continuation (no hold)
       traceCollector.cancelContinuation(this);
+      scopeManager.healthMetrics.onFinishContinuation();
     } else if (COUNT.decrementAndGet(this) == 0) {
       // slow path: multiple activations, all have now closed (no hold)
       cancel();

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
@@ -96,7 +96,7 @@ final class ScopeContinuation implements AgentScope.Continuation {
     while (current == 0) {
       // no outstanding activations and hold has been removed
       if (COUNT.compareAndSet(this, current, CANCELLED)) {
-        traceCollector.cancelContinuation(this);
+        traceCollector.removeContinuation(this);
         scopeManager.healthMetrics.onFinishContinuation();
         return;
       }
@@ -108,7 +108,7 @@ final class ScopeContinuation implements AgentScope.Continuation {
   void cancelFromContinuedScopeClose() {
     if (COUNT.compareAndSet(this, 1, CANCELLED)) {
       // fast path: only one activation of the continuation (no hold)
-      traceCollector.cancelContinuation(this);
+      traceCollector.removeContinuation(this);
       scopeManager.healthMetrics.onFinishContinuation();
     } else if (COUNT.decrementAndGet(this) == 0) {
       // slow path: multiple activations, all have now closed (no hold)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -57,7 +57,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
     when: "continuation is finished the second time"
     // Yes this should be guarded by the used flag in the continuation,
     // so cancel it anyway to trigger the exception
-    traceCollector.cancelContinuation(continuation)
+    traceCollector.removeContinuation(continuation)
 
     then:
     thrown IllegalStateException

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -56,7 +56,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
 
     when: "continuation is finished the second time"
     // Yes this should be guarded by the used flag in the continuation,
-    // so cancel it anyway to trigger the exception
+    // so remove it anyway to trigger the exception
     traceCollector.removeContinuation(continuation)
 
     then:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTraceCollector.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTraceCollector.java
@@ -3,5 +3,5 @@ package datadog.trace.bootstrap.instrumentation.api;
 public interface AgentTraceCollector {
   void registerContinuation(AgentScope.Continuation continuation);
 
-  void cancelContinuation(AgentScope.Continuation continuation);
+  void removeContinuation(AgentScope.Continuation continuation);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -679,7 +679,7 @@ public class AgentTracer {
     public void registerContinuation(final AgentScope.Continuation continuation) {}
 
     @Override
-    public void cancelContinuation(final AgentScope.Continuation continuation) {}
+    public void removeContinuation(final AgentScope.Continuation continuation) {}
   }
 
   public static class NoopAgentHistogram implements AgentHistogram {


### PR DESCRIPTION
# What Does This Do

Move capture and canceled continuation metrics to the same class (previously we only recorded a canceled continuation metric when pending trace was enabled, not when streaming spans)

Fixed finished continuation metric (this was in the wrong place which meant it was only recorded when closing message spans)

# Motivation

More accurate metrics for continuations

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1271]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-1271]: https://datadoghq.atlassian.net/browse/APMAPI-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ