### PR TITLE
Fix the instrumentation to instrument at the exit line

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumentor.java
@@ -39,7 +39,7 @@ public class CodeOriginInstrumentor extends Instrumentor {
     CodeOriginProbe probe = (CodeOriginProbe) definition;
     List<String> lines = probe.getLocation().getLines();
     if (!probe.entrySpanProbe() && lines != null && !lines.isEmpty()) {
-      int line = Integer.valueOf(lines.get(0));
+      int line = Integer.parseInt(lines.get(0));
       for (AbstractInsnNode node : methodNode.instructions) {
         if (node instanceof LineNumberNode && ((LineNumberNode) node).line == line) {
           return node;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumentor.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.ldc;
 import static com.datadog.debugger.instrumentation.Types.DEBUGGER_CONTEXT_TYPE;
 import static com.datadog.debugger.instrumentation.Types.STRING_TYPE;
+import static java.lang.Integer.parseInt;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult.Status;
 import com.datadog.debugger.probe.CodeOriginProbe;
@@ -13,7 +14,7 @@ import java.util.List;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
-import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.LabelNode;
 
 public class CodeOriginInstrumentor extends Instrumentor {
   public CodeOriginInstrumentor(
@@ -39,11 +40,9 @@ public class CodeOriginInstrumentor extends Instrumentor {
     CodeOriginProbe probe = (CodeOriginProbe) definition;
     List<String> lines = probe.getLocation().getLines();
     if (!probe.entrySpanProbe() && lines != null && !lines.isEmpty()) {
-      int line = Integer.parseInt(lines.get(0));
-      for (AbstractInsnNode node : methodNode.instructions) {
-        if (node instanceof LineNumberNode && ((LineNumberNode) node).line == line) {
-          return node;
-        }
+      LabelNode lineLabel = classFileLines.getLineLabel(parseInt(lines.get(0)));
+      if (lineLabel != null) {
+        return lineLabel.getNext();
       }
     }
     return methodEnterLabel;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -62,6 +62,7 @@ public class CodeOriginProbe extends ProbeDefinition {
       LOGGER.debug("Code origin probe {} has no location", id);
       return;
     }
+    System.out.println("****** CodeOriginProbe.commit entrySpanProbe = " + entrySpanProbe);
     for (AgentSpan s : agentSpans) {
       if (s.getTag(DD_CODE_ORIGIN_TYPE) == null) {
         s.setTag(DD_CODE_ORIGIN_TYPE, entrySpanProbe ? "entry" : "exit");
@@ -82,14 +83,14 @@ public class CodeOriginProbe extends ProbeDefinition {
   public void buildLocation(MethodInfo methodInfo) {
     String type = where.getTypeName();
     String method = where.getMethodName();
-    List<String> lines = null;
+    List<String> lines = where.getLines() != null ? asList(where.getLines()) : null;
 
     String file = where.getSourceFile();
 
     if (methodInfo != null) {
       type = methodInfo.getTypeName();
       method = methodInfo.getMethodName();
-      if (methodInfo.getMethodStart() != -1) {
+      if (entrySpanProbe || where.getLines() == null) {
         lines = singletonList(String.valueOf(methodInfo.getMethodStart()));
       }
       if (file == null) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -62,7 +62,6 @@ public class CodeOriginProbe extends ProbeDefinition {
       LOGGER.debug("Code origin probe {} has no location", id);
       return;
     }
-    System.out.println("****** CodeOriginProbe.commit entrySpanProbe = " + entrySpanProbe);
     for (AgentSpan s : agentSpans) {
       if (s.getTag(DD_CODE_ORIGIN_TYPE) == null) {
         s.setTag(DD_CODE_ORIGIN_TYPE, entrySpanProbe ? "entry" : "exit");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
+import static utils.InstrumentationTestHelper.getLineForLineProbe;
 import static utils.TestHelper.setFieldInConfig;
 
 import com.datadog.debugger.agent.CapturingTestBase;
@@ -130,12 +131,34 @@ public class CodeOriginTest extends CapturingTestBase {
     final String className = "com.datadog.debugger.CodeOrigin05";
 
     installProbes(
-        new CodeOriginProbe(CODE_ORIGIN_ID1, true, Where.of(className, "entry", "()", "53"), true),
-        new CodeOriginProbe(CODE_ORIGIN_ID2, false, Where.of(className, "exit", "()", "62"), true),
+        new CodeOriginProbe(
+            CODE_ORIGIN_ID1,
+            true,
+            Where.of(
+                className,
+                "entry",
+                "()",
+                "" + getLineForLineProbe("com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_ID1)),
+            true),
+        new CodeOriginProbe(
+            CODE_ORIGIN_ID2,
+            false,
+            Where.of(
+                className,
+                "exit",
+                "()",
+                "" + getLineForLineProbe("com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_ID2)),
+            true),
         new CodeOriginProbe(
             CODE_ORIGIN_DOUBLE_ENTRY_ID,
             true,
-            Where.of(className, "doubleEntry", "()", "66"),
+            Where.of(
+                className,
+                "doubleEntry",
+                "()",
+                ""
+                    + getLineForLineProbe(
+                        "com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_DOUBLE_ENTRY_ID)),
             true));
     final Class<?> testClass = compileAndLoadClass(className);
     checkResults(testClass, "fullTrace", 0);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -135,19 +135,12 @@ public class CodeOriginTest extends CapturingTestBase {
             CODE_ORIGIN_ID1,
             true,
             Where.of(
-                className,
-                "entry",
-                "()",
-                "" + getLineForLineProbe("com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_ID1)),
+                className, "entry", "()", "" + getLineForLineProbe(className, CODE_ORIGIN_ID1)),
             true),
         new CodeOriginProbe(
             CODE_ORIGIN_ID2,
             false,
-            Where.of(
-                className,
-                "exit",
-                "()",
-                "" + getLineForLineProbe("com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_ID2)),
+            Where.of(className, "exit", "()", "" + getLineForLineProbe(className, CODE_ORIGIN_ID2)),
             true),
         new CodeOriginProbe(
             CODE_ORIGIN_DOUBLE_ENTRY_ID,
@@ -156,9 +149,7 @@ public class CodeOriginTest extends CapturingTestBase {
                 className,
                 "doubleEntry",
                 "()",
-                ""
-                    + getLineForLineProbe(
-                        "com.datadog.debugger.CodeOrigin05", CODE_ORIGIN_DOUBLE_ENTRY_ID)),
+                "" + getLineForLineProbe(className, CODE_ORIGIN_DOUBLE_ENTRY_ID)),
             true));
     final Class<?> testClass = compileAndLoadClass(className);
     checkResults(testClass, "fullTrace", 0);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
@@ -49,7 +49,7 @@ public class CodeOrigin05 {
 
   public static void entry() throws NoSuchMethodException {
     // just to fill out the method body
-    boolean dummyCode = true;
+    boolean dummyCode = true; // code origin 1
     if (!dummyCode) {
       dummyCode = false;
     }
@@ -57,13 +57,13 @@ public class CodeOrigin05 {
   }
 
   private static void exit() {
-    int x = 47 / 3;
+    int x = 47 / 3; // code origin 2
   }
 
   public static void doubleEntry() throws NoSuchMethodException {
     // just to fill out the method body
     boolean dummyCode = true;
-    if (!dummyCode) {
+    if (!dummyCode) { // double entry code origin
       dummyCode = false;
     }
   }


### PR DESCRIPTION
# What Does This Do
With the changes to how code origins are instrumented and the deferral of exit span support, the application of the instrumentation for these exit spans ended up at the beginning of the method rather than the line itself.  Largely, i think is also a side effect of these probes starting off as context capturing probes which would always get instrumented at the method start for $reasons.  This PR moves the exit span instrumentation down to the exact line where it "should" be.
 
