### PR TITLE
Reduce number of jobs running in Circle CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1333,6 +1333,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *test_matrix
 
+{% if ssi_smoke %}
   - tests:
       requires:
         - ok_to_test
@@ -1346,6 +1347,7 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 3
       matrix:
         <<: *test_matrix
+{% endif %}
 
   - tests:
       requires:
@@ -1389,6 +1391,7 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 3
       testJvm: "8"
 
+{% if ssi_smoke %}
   - tests:
       requires:
         - ok_to_test
@@ -1401,13 +1404,16 @@ build_test_jobs: &build_test_jobs
       parallelism: 4
       maxWorkers: 3
       testJvm: "8"
+{% endif %}
 
   - fan_in:
       requires:
         - z_test_<< matrix.testJvm >>_base
         - z_test_<< matrix.testJvm >>_inst
         - z_test_<< matrix.testJvm >>_smoke
+{% if ssi_smoke %}
         - z_test_<< matrix.testJvm >>_ssi_smoke
+{% endif %}
       name: test_<< matrix.testJvm >>
       stage: tracing
       matrix:
@@ -1418,7 +1424,9 @@ build_test_jobs: &build_test_jobs
         - z_test_8_base
         - z_test_8_inst
         - z_test_8_smoke
+{% if ssi_smoke %}
         - z_test_8_ssi_smoke
+{% endif %}
       name: test_8
       stage: tracing
       testJvm: "8"

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1512,6 +1512,14 @@ build_test_jobs: &build_test_jobs
       stage: required
 
 workflows:
+{% if skip_circleci %}
+  build_test:
+    jobs:
+      # Just a "required" job to make GitHub PR checks happy, and run nothing else.
+      - fan_in:
+          name: required
+          stage: required
+{% else %}
 {% if is_regular %}
   build_test:
     jobs:
@@ -1551,4 +1559,5 @@ workflows:
           name: build_cache_profiling
           gradleTarget: :profilingTest
           cacheType: profiling
+{% endif %}
 {% endif %}

--- a/.circleci/no_circleci_changes.sh
+++ b/.circleci/no_circleci_changes.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -eu
+git diff --name-only "$1" | grep --invert-match --quiet -E '^(.gitlab-ci.yml|.gitlab)'

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -15,9 +15,10 @@ OUT_FILENAME = "config.continue.yml"
 GENERATED_CONFIG_PATH = os.path.join(SCRIPT_DIR, OUT_FILENAME)
 
 # JDKs that will run on every pipeline.
-ALWAYS_ON_JDKS = {"8", "11", "17", "21"}
+ALWAYS_ON_JDKS = {"8", "17", "21"}
 # And these will run only in master and release/ branches.
 MASTER_ONLY_JDKS = {
+    "11",
     "ibm8",
     "oracle8",
     "semeru8",

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -107,7 +107,7 @@ vars = {
     "all_jdks": all_jdks,
     "all_debugger_jdks": all_debugger_jdks,
     "nocov_jdks": nocov_jdks,
-    "flaky": branch == "master" or "flaky" in labels or "all" in labels,
+    "flaky": "flaky" in labels or "all" in labels,
     "docker_image_prefix": "" if is_nightly else f"{DOCKER_IMAGE_VERSION}-",
     "use_git_changes": use_git_changes,
     "pr_base_ref": pr_base_ref,

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path
+import subprocess
 import time
 
 import jinja2
@@ -74,6 +75,13 @@ branch = os.environ.get("CIRCLE_BRANCH", "")
 run_all = "all" in labels
 is_master_or_release = branch == "master" or branch.startswith("release/v")
 
+skip_circleci = False
+if pr_base_ref:
+   ret = subprocess.call([".circleci/no_circleci_changes.sh", f"{pr_base_ref}..HEAD"], shell=False)
+   if ret == 1:
+       # Only GitLab-related files have changed, just skip Circle CI jobs.
+       skip_circleci = True
+
 if is_master_or_release or run_all:
     all_jdks = ALWAYS_ON_JDKS | MASTER_ONLY_JDKS
 else:
@@ -103,6 +111,7 @@ vars = {
     "docker_image_prefix": "" if is_nightly else f"{DOCKER_IMAGE_VERSION}-",
     "use_git_changes": use_git_changes,
     "pr_base_ref": pr_base_ref,
+    "skip_circleci": skip_circleci,
 }
 
 print(f"Variables for this build: {vars}")

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -113,6 +113,7 @@ vars = {
     "use_git_changes": use_git_changes,
     "pr_base_ref": pr_base_ref,
     "skip_circleci": skip_circleci,
+    "ssi_smoke": is_regular and is_master_or_release
 }
 
 print(f"Variables for this build: {vars}")


### PR DESCRIPTION
# What Does This Do
* Skip Circle CI if only GitLab files change
* Disable flaky jobs in master
* Move jdk 11 jobs to master-only in Circle CI
* Move ssi_smoke tests to master-only in Circle CI

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
