### PR TITLE
When activating a span merge it with any non-span context

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.core.scopemanager
 
+import datadog.context.Context
+import datadog.context.ContextKey
 import datadog.trace.agent.test.utils.ThreadUtils
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.Stateful
@@ -1031,6 +1033,46 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     cleanup:
     executor.shutdown()
+  }
+
+  def "activating a span merges it with existing context"() {
+    when:
+    def span = tracer.buildSpan("test", "test").start()
+    def testKey = ContextKey.named("test")
+    def context = Context.root().with(testKey, "test-value")
+    def contextScope = scopeManager.attach(context)
+
+    then:
+    scopeManager.active() == contextScope
+    scopeManager.current() == context
+    scopeManager.activeSpan() == null
+    scopeManager.current().get(testKey) == "test-value"
+
+    when:
+    def scope = tracer.activateSpan(span)
+
+    then:
+    scopeManager.active() == scope
+    scopeManager.current() != context
+    scopeManager.activeSpan() == span
+    scopeManager.current().get(testKey) == "test-value"
+
+    when:
+    scope.close()
+
+    then:
+    scopeManager.active() == contextScope
+    scopeManager.current() == context
+    scopeManager.activeSpan() == null
+    scopeManager.current().get(testKey) == "test-value"
+
+    when:
+    contextScope.close()
+
+    then:
+    scopeManager.active() == null
+    scopeManager.current() == Context.root()
+    scopeManager.activeSpan() == null
   }
 
   boolean spanFinished(AgentSpan span) {


### PR DESCRIPTION
# Motivation

Follow-up to #8636 to handle the edge case where non-span context is already active when activating a span.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-960]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-960]: https://datadoghq.atlassian.net/browse/APMAPI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ