### PR TITLE
Avoid disconnected traces when using Kotlin flowOn

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.kotlin.coroutines.AbstractKotlinCoroutineInstrumentationTest
 import kotlinx.coroutines.CoroutineDispatcher
-import spock.lang.Ignore
 
 class KotlinCoroutineInstrumentationTest extends AbstractKotlinCoroutineInstrumentationTest<KotlinCoroutineTests> {
 
@@ -44,7 +43,6 @@ class KotlinCoroutineInstrumentationTest extends AbstractKotlinCoroutineInstrume
     [dispatcherName, dispatcher] << dispatchersToTest
   }
 
-  @Ignore("Not working: disconnected trace")
   def "kotlin trace consistent after flow"() {
     setup:
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
@@ -46,7 +46,7 @@ class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutin
       emit(1)
     }.flowOn(Dispatchers.IO)
     val ff = f.single()
-    // FIXME: This span is detached
+
     childSpan("outside-flow").activateAndUse {
       println("hello $ff")
     }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
@@ -1,8 +1,14 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.AbstractCoroutine;
+import kotlinx.coroutines.ChildHandle;
 import kotlinx.coroutines.Job;
+import kotlinx.coroutines.JobNode;
+import kotlinx.coroutines.JobSupport;
 import org.jetbrains.annotations.Nullable;
 
 public class CoroutineContextHelper {
@@ -40,7 +46,55 @@ public class CoroutineContextHelper {
     final ScopeStateCoroutineContext scopeStackContext =
         getScopeStateContext(coroutine.getContext());
     if (scopeStackContext != null) {
-      scopeStackContext.maybeCloseScopeAndCancelContinuation(coroutine);
+      scopeStackContext.maybeCloseScopeAndCancelContinuation(coroutine, getParentJob(coroutine));
     }
+  }
+
+  private static final MethodHandle PARENT_HANDLE_METHOD;
+  private static final MethodHandle PARENT_HANDLE_FIELD;
+  private static final MethodHandle JOB_FIELD;
+
+  static {
+    MethodHandle parentHandleMethod = null;
+    MethodHandle parentHandleField = null;
+    MethodHandle jobField = null;
+
+    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+    try {
+      // Kotlin coroutines 1.5+
+      parentHandleMethod =
+          lookup.findVirtual(
+              JobSupport.class,
+              "getParentHandle$kotlinx_coroutines_core",
+              MethodType.methodType(ChildHandle.class));
+      jobField = lookup.findGetter(JobNode.class, "job", JobSupport.class);
+    } catch (Throwable ignore) {
+      try {
+        // Kotlin coroutines 1.3
+        parentHandleField = lookup.findGetter(JobSupport.class, "parentHandle", ChildHandle.class);
+        jobField = lookup.findGetter(JobNode.class, "job", Job.class);
+      } catch (Throwable ignored) {
+      }
+    }
+
+    PARENT_HANDLE_METHOD = parentHandleMethod;
+    PARENT_HANDLE_FIELD = parentHandleField;
+    JOB_FIELD = jobField;
+  }
+
+  private static Job getParentJob(JobSupport coroutine) {
+    try {
+      Object parentHandle = null;
+      if (null != PARENT_HANDLE_METHOD) {
+        parentHandle = PARENT_HANDLE_METHOD.invoke(coroutine);
+      } else if (null != PARENT_HANDLE_FIELD) {
+        parentHandle = PARENT_HANDLE_FIELD.invoke(coroutine);
+      }
+      if (parentHandle instanceof JobNode) {
+        return (Job) JOB_FIELD.invoke((JobNode) parentHandle);
+      }
+    } catch (Throwable ignore) {
+    }
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
@@ -10,12 +10,15 @@ import kotlinx.coroutines.Job;
 import kotlinx.coroutines.JobNode;
 import kotlinx.coroutines.JobSupport;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CoroutineContextHelper {
+  private static final Logger log = LoggerFactory.getLogger(CoroutineContextHelper.class);
+
   /*
   IntelliJ shows a warning here for Job being out of bounds, but that's not true, the class compiles.
    */
-
   @Nullable
   @SuppressWarnings("unchecked")
   public static Job getJob(final CoroutineContext context) {
@@ -73,7 +76,8 @@ public class CoroutineContextHelper {
         // Kotlin coroutines 1.3
         parentHandleField = lookup.findGetter(JobSupport.class, "parentHandle", ChildHandle.class);
         jobField = lookup.findGetter(JobNode.class, "job", Job.class);
-      } catch (Throwable ignored) {
+      } catch (Throwable e) {
+        log.debug("Unable to access parent handle", e);
       }
     }
 
@@ -93,7 +97,8 @@ public class CoroutineContextHelper {
       if (parentHandle instanceof JobNode) {
         return (Job) JOB_FIELD.invoke((JobNode) parentHandle);
       }
-    } catch (Throwable ignore) {
+    } catch (Throwable e) {
+      log.debug("Unable to extract parent job", e);
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.core.DDSpan
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ThreadPoolDispatcherKt
-import spock.lang.Ignore
 import spock.lang.Shared
 
 abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCoroutineTests> extends AgentTestRunner {
@@ -366,7 +365,6 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
     [dispatcherName, dispatcher] << dispatchersToTest
   }
 
-  @Ignore("Not working: disconnected trace")
   def "kotlin trace consistent with timeout"() {
     setup:
     CoreKotlinCoroutineTests kotlinTest = getCoreKotlinCoroutineTestsInstance(dispatcher)
@@ -389,7 +387,7 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
         }
         span(2) {
           operationName "3-after-timeout"
-          childOf span(5)
+          childOf span(1)
         }
         span(3) {
           operationName "4-after-timeout-2"
@@ -406,7 +404,6 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
     [dispatcherName, dispatcher] << dispatchersToTest
   }
 
-  @Ignore("Not working: disconnected trace")
   def "kotlin trace consistent after delay"() {
     setup:
     CoreKotlinCoroutineTests kotlinTest = getCoreKotlinCoroutineTestsInstance(dispatcher)

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -320,7 +320,6 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
         delay(10)
       }
     }
-    // FIXME: This span is detached
     childSpan("3-after-timeout").activateAndUse {
       delay(10)
     }
@@ -351,7 +350,6 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
       }
     }
 
-    // FIXME: This span is detached
     tracedChild("after-process")
 
     6


### PR DESCRIPTION
# What Does This Do

Restore parent scope stack after completing coroutines

# Additional Notes

Uses method handles to extract the parent for different versions of Kotlin coroutines. We could avoid this by moving the helpers into the version specific instrumentations and specializing them, but then we'd need to duplicate several classes.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-963]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-963]: https://datadoghq.atlassian.net/browse/APMAPI-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ