### PR TITLE
Support CompletableFuture on spring webmvc controllers

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AsyncResultExtensions.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AsyncResultExtensions.java
@@ -61,17 +61,17 @@ public final class AsyncResultExtensions {
       }
       return null;
     }
+  }
 
-    private <T> BiConsumer<T, Throwable> finishSpan(AgentSpan span) {
-      return (o, throwable) -> {
-        if (throwable != null) {
-          span.addThrowable(
-              throwable instanceof ExecutionException || throwable instanceof CompletionException
-                  ? throwable.getCause()
-                  : throwable);
-        }
-        span.finish();
-      };
-    }
+  public static <T> BiConsumer<T, Throwable> finishSpan(AgentSpan span) {
+    return (o, throwable) -> {
+      if (throwable != null) {
+        span.addThrowable(
+            throwable instanceof ExecutionException || throwable instanceof CompletionException
+                ? throwable.getCause()
+                : throwable);
+      }
+      span.finish();
+    };
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -357,6 +357,7 @@
 0 org.springframework.util.StreamUtils
 # Included for IAST Spring mvc unvalidated redirect and xss vulnerability
 0 org.springframework.web.method.support.HandlerMethodReturnValueHandlerComposite
+0 org.springframework.web.method.support.InvocableHandlerMethod
 2 org.xml.*
 2 org.yaml.snakeyaml.*
 # Need for IAST sink

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/build.gradle
@@ -3,26 +3,7 @@ muzzle {
     group = 'org.springframework'
     module = 'spring-webmvc'
     versions = "[3.1.0.RELEASE,6)"
-    skipVersions += [
-      '1.2.1',
-      '1.2.2',
-      '1.2.3',
-      '1.2.4'] // broken releases... missing dependencies
     skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-    // assertInverse = true
-  }
-
-  // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
-  fail {
-    group = 'org.springframework'
-    module = 'spring-web'
-    versions = "[,]"
-    skipVersions += [
-      '1.2.1',
-      '1.2.2',
-      '1.2.3',
-      '1.2.4'] // broken releases... missing dependencies
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/AppConfig.groovy
@@ -8,6 +8,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer
 import org.springframework.boot.web.servlet.filter.OrderedRequestContextFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.core.Ordered
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.web.filter.RequestContextFilter
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
@@ -15,6 +16,7 @@ import org.springframework.web.util.UrlPathHelper
 
 // Component scan defeats the purpose of configuring with specific classes
 @SpringBootApplication(scanBasePackages = "doesnotexist")
+@EnableAsync
 class AppConfig extends WebMvcConfigurerAdapter {
 
   @Bean

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootBasedTest.groovy
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.MATRIX_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -290,7 +291,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   boolean hasResponseSpan(ServerEndpoint endpoint) {
-    return endpoint == REDIRECT || endpoint == NOT_FOUND || endpoint == LOGIN
+    return endpoint == REDIRECT || endpoint == NOT_FOUND || endpoint == LOGIN || endpoint == FORWARDED
   }
 
   @Override
@@ -338,6 +339,18 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         childOfPrevious()
         tags {
           "component" "java-web-servlet-response"
+          defaultTags()
+        }
+      }
+    } else if (endpoint == FORWARDED) {
+      trace.span {
+        serviceName expectedServiceName()
+        operationName 'servlet.dispatch'
+        resourceName 'servlet.dispatch'
+        tags {
+          "$Tags.COMPONENT" 'java-web-servlet-async-dispatcher'
+          'servlet.context' "/$servletContext"
+          'servlet.path' '/forwarded'
           defaultTags()
         }
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/TestController.groovy
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.view.RedirectView
 
 import javax.servlet.http.HttpServletRequest
+import java.util.concurrent.CompletableFuture
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
@@ -48,9 +49,11 @@ class TestController {
 
   @RequestMapping("/forwarded")
   @ResponseBody
-  String forwarded(HttpServletRequest request) {
-    HttpServerTest.controller(FORWARDED) {
-      request.getHeader("x-forwarded-for")
+  CompletableFuture<String> forwarded(HttpServletRequest request) {
+    CompletableFuture.supplyAsync {
+      HttpServerTest.controller(FORWARDED) {
+        request.getHeader("x-forwarded-for")
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -7,6 +7,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_CONTINUE_SUFFIX;
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_PREFIX_KEY;
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -22,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.web.method.HandlerMethod;
 
 @AutoService(InstrumenterModule.class)
 public final class HandlerAdapterInstrumentation extends InstrumenterModule.Tracing
@@ -64,7 +67,10 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope nameResourceAndStartSpan(
         @Advice.Argument(0) final HttpServletRequest request,
-        @Advice.Argument(2) final Object handler) {
+        @Advice.Argument(2) final Object handler,
+        @Advice.Local("handlerSpanKey") String handlerSpanKey) {
+      handlerSpanKey = "";
+
       // Name the parent span based on the matching pattern
       Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
       if (parentSpan instanceof AgentSpan) {
@@ -77,24 +83,47 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
 
       // Now create a span for handler/controller execution.
 
+      final String handlerKey;
+      if (handler instanceof HandlerMethod) {
+        handlerKey = ((HandlerMethod) handler).getBean().getClass().getName();
+      } else {
+        handlerKey = handler.getClass().getName();
+      }
+      handlerSpanKey = DD_HANDLER_SPAN_PREFIX_KEY + handlerKey;
+      final Object existingSpan = request.getAttribute(handlerSpanKey);
+      if (existingSpan instanceof AgentSpan) {
+        return activateSpan((AgentSpan) existingSpan);
+      }
+
       final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
-
+      request.setAttribute(handlerSpanKey, span);
       return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Argument(0) final HttpServletRequest request,
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable,
+        @Advice.Local("handlerSpanKey") String handlerSpanKey) {
       if (scope == null) {
         return;
       }
-
-      DECORATE.onError(scope, throwable);
-      DECORATE.beforeFinish(scope);
+      boolean finish =
+          !Boolean.TRUE.equals(
+              request.getAttribute(handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX));
+      final AgentSpan span = scope.span();
       scope.close();
-      scope.span().finish();
+      if (throwable != null) {
+        DECORATE.onError(span, throwable);
+        finish = true;
+      }
+      if (finish) {
+        DECORATE.beforeFinish(span);
+        span.finish();
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
@@ -1,0 +1,69 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_CONTINUE_SUFFIX;
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_PREFIX_KEY;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AsyncResultExtensions;
+import java.util.concurrent.CompletionStage;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.InvocableHandlerMethod;
+
+@AutoService(InstrumenterModule.class)
+public class InvocableHandlerMethodInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  public InvocableHandlerMethodInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.web.method.support.InvocableHandlerMethod";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("invokeForRequest"), getClass().getName() + "$WrapContinuableResultAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SpringWebHttpServerDecorator", packageName + ".ServletRequestURIAdapter",
+    };
+  }
+
+  public static class WrapContinuableResultAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void after(
+        @Advice.Argument(value = 0, typing = Assigner.Typing.DYNAMIC)
+            final NativeWebRequest nativeWebRequest,
+        @Advice.Return(readOnly = false) Object result,
+        @Advice.This final InvocableHandlerMethod self) {
+      if (!(nativeWebRequest instanceof ServletWebRequest)
+          || !(result instanceof CompletionStage)) {
+        return;
+      }
+      ServletWebRequest servletWebRequest = (ServletWebRequest) nativeWebRequest;
+      final String handlerSpanKey =
+          DD_HANDLER_SPAN_PREFIX_KEY + self.getBean().getClass().getName();
+      Object span = servletWebRequest.getAttribute(handlerSpanKey, ServletWebRequest.SCOPE_REQUEST);
+      if (!(span instanceof AgentSpan)) {
+        return;
+      }
+      servletWebRequest.setAttribute(
+          handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX, true, ServletWebRequest.SCOPE_REQUEST);
+      result =
+          ((CompletionStage<?>) result)
+              .whenComplete(AsyncResultExtensions.finishSpan((AgentSpan) span));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
@@ -55,6 +55,13 @@ public class InvocableHandlerMethodInstrumentation extends InstrumenterModule.Tr
       ServletWebRequest servletWebRequest = (ServletWebRequest) nativeWebRequest;
       final String handlerSpanKey =
           DD_HANDLER_SPAN_PREFIX_KEY + self.getBean().getClass().getName();
+
+      if (Boolean.TRUE.equals(
+          servletWebRequest.getAttribute(
+              handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX, ServletWebRequest.SCOPE_REQUEST))) {
+        return;
+      }
+
       Object span = servletWebRequest.getAttribute(handlerSpanKey, ServletWebRequest.SCOPE_REQUEST);
       if (!(span instanceof AgentSpan)) {
         return;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -30,6 +30,8 @@ public class SpringWebHttpServerDecorator
       new SpringWebHttpServerDecorator(UTF8BytesString.create("spring-web-controller"));
   public static final SpringWebHttpServerDecorator DECORATE_RENDER =
       new SpringWebHttpServerDecorator(UTF8BytesString.create("spring-webmvc"));
+  public static final String DD_HANDLER_SPAN_PREFIX_KEY = "dd.handler.span.";
+  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".suffix";
 
   public SpringWebHttpServerDecorator(CharSequence component) {
     this.component = component;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -31,7 +31,7 @@ public class SpringWebHttpServerDecorator
   public static final SpringWebHttpServerDecorator DECORATE_RENDER =
       new SpringWebHttpServerDecorator(UTF8BytesString.create("spring-webmvc"));
   public static final String DD_HANDLER_SPAN_PREFIX_KEY = "dd.handler.span.";
-  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".suffix";
+  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".continue";
 
   public SpringWebHttpServerDecorator(CharSequence component) {
     this.component = component;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.MATRIX_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -348,7 +349,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   boolean hasResponseSpan(ServerEndpoint endpoint) {
-    return endpoint == REDIRECT || endpoint == NOT_FOUND || endpoint == LOGIN
+    return endpoint == REDIRECT || endpoint == NOT_FOUND || endpoint == LOGIN || endpoint == FORWARDED
   }
 
   @Override
@@ -396,6 +397,18 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         childOfPrevious()
         tags {
           "component" "java-web-servlet-response"
+          defaultTags()
+        }
+      }
+    }  else if (endpoint == FORWARDED) {
+      trace.span {
+        serviceName expectedServiceName()
+        operationName 'servlet.dispatch'
+        resourceName 'servlet.dispatch'
+        tags {
+          "$Tags.COMPONENT" 'java-web-servlet-async-dispatcher'
+          'servlet.context' "/$servletContext"
+          'servlet.path' '/forwarded'
           defaultTags()
         }
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/TestController.groovy
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.view.RedirectView
 
 import javax.servlet.http.HttpServletRequest
+import java.util.concurrent.CompletableFuture
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
@@ -49,9 +50,11 @@ class TestController {
 
   @RequestMapping("/forwarded")
   @ResponseBody
-  String forwarded(HttpServletRequest request) {
-    HttpServerTest.controller(FORWARDED) {
-      request.getHeader("x-forwarded-for")
+  CompletableFuture<String> forwarded(HttpServletRequest request) {
+    CompletableFuture.supplyAsync {
+      HttpServerTest.controller(FORWARDED) {
+        request.getHeader("x-forwarded-for")
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/InvocableHandlerMethodInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/InvocableHandlerMethodInstrumentation.java
@@ -1,0 +1,33 @@
+package datadog.trace.instrumentation.springweb6;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+
+@AutoService(InstrumenterModule.class)
+public class InvocableHandlerMethodInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  public InvocableHandlerMethodInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.web.method.support.InvocableHandlerMethod";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("invokeForRequest"), packageName + ".WrapContinuableResultAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SpringWebHttpServerDecorator", packageName + ".ServletRequestURIAdapter",
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
@@ -4,23 +4,28 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_CONTINUE_SUFFIX;
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_PREFIX_KEY;
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import jakarta.servlet.http.HttpServletRequest;
 import net.bytebuddy.asm.Advice;
+import org.springframework.web.method.HandlerMethod;
 
 public class ControllerAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope nameResourceAndStartSpan(
       @Advice.Argument(0) final HttpServletRequest request,
-      @Advice.Argument(2) final Object handler) {
+      @Advice.Argument(2) final Object handler,
+      @Advice.Local("handlerSpanKey") String handlerSpanKey) {
+    handlerSpanKey = "";
     // Name the parent span based on the matching pattern
     Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
     if (parentSpan instanceof AgentSpan) {
-      SpringWebHttpServerDecorator.DECORATE.onRequest(
-          (AgentSpan) parentSpan, request, request, null);
+      DECORATE.onRequest((AgentSpan) parentSpan, request, request, null);
     }
 
     if (activeSpan() == null) {
@@ -29,24 +34,46 @@ public class ControllerAdvice {
 
     // Now create a span for handler/controller execution.
 
-    final AgentSpan span =
-        startSpan(SpringWebHttpServerDecorator.DECORATE.spanName()).setMeasured(true);
-    SpringWebHttpServerDecorator.DECORATE.afterStart(span);
-    SpringWebHttpServerDecorator.DECORATE.onHandle(span, handler);
+    final String handlerKey;
+    if (handler instanceof HandlerMethod) {
+      handlerKey = ((HandlerMethod) handler).getBean().getClass().getName();
+    } else {
+      handlerKey = handler.getClass().getName();
+    }
+    handlerSpanKey = DD_HANDLER_SPAN_PREFIX_KEY + handlerKey;
+    final Object existingSpan = request.getAttribute(handlerSpanKey);
+    if (existingSpan instanceof AgentSpan) {
+      return activateSpan((AgentSpan) existingSpan);
+    }
 
+    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    DECORATE.afterStart(span);
+    DECORATE.onHandle(span, handler);
+    request.setAttribute(handlerSpanKey, span);
     return activateSpan(span);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
-      @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      @Advice.Enter final AgentScope scope,
+      @Advice.Argument(0) final HttpServletRequest request,
+      @Advice.Thrown final Throwable throwable,
+      @Advice.Local("handlerSpanKey") String handlerSpanKey) {
     if (scope == null) {
       return;
     }
-
-    SpringWebHttpServerDecorator.DECORATE.onError(scope, throwable);
-    SpringWebHttpServerDecorator.DECORATE.beforeFinish(scope);
+    boolean finish =
+        !Boolean.TRUE.equals(
+            request.getAttribute(handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX));
+    final AgentSpan span = scope.span();
     scope.close();
-    scope.span().finish();
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+      finish = true;
+    }
+    if (finish) {
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -35,7 +35,7 @@ public class SpringWebHttpServerDecorator
       new SpringWebHttpServerDecorator(UTF8BytesString.create("spring-webmvc"));
 
   public static final String DD_HANDLER_SPAN_PREFIX_KEY = "dd.handler.span.";
-  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".suffix";
+  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".continue";
 
   public SpringWebHttpServerDecorator(CharSequence component) {
     this.component = component;

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -34,6 +34,9 @@ public class SpringWebHttpServerDecorator
   public static final SpringWebHttpServerDecorator DECORATE_RENDER =
       new SpringWebHttpServerDecorator(UTF8BytesString.create("spring-webmvc"));
 
+  public static final String DD_HANDLER_SPAN_PREFIX_KEY = "dd.handler.span.";
+  public static final String DD_HANDLER_SPAN_CONTINUE_SUFFIX = ".suffix";
+
   public SpringWebHttpServerDecorator(CharSequence component) {
     this.component = component;
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/WrapContinuableResultAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/WrapContinuableResultAdvice.java
@@ -1,0 +1,44 @@
+package datadog.trace.instrumentation.springweb6;
+
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_CONTINUE_SUFFIX;
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DD_HANDLER_SPAN_PREFIX_KEY;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AsyncResultExtensions;
+import java.util.concurrent.CompletionStage;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.InvocableHandlerMethod;
+
+public class WrapContinuableResultAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void after(
+      @Advice.Argument(value = 0, typing = Assigner.Typing.DYNAMIC)
+          final NativeWebRequest nativeWebRequest,
+      @Advice.Return(readOnly = false) Object result,
+      @Advice.This final InvocableHandlerMethod self) {
+    if (!(nativeWebRequest instanceof ServletWebRequest) || !(result instanceof CompletionStage)) {
+      return;
+    }
+
+    ServletWebRequest servletWebRequest = (ServletWebRequest) nativeWebRequest;
+    final String handlerSpanKey = DD_HANDLER_SPAN_PREFIX_KEY + self.getBean().getClass().getName();
+
+    if (Boolean.TRUE.equals(
+        servletWebRequest.getAttribute(
+            handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX, ServletWebRequest.SCOPE_REQUEST))) {
+      return;
+    }
+    Object span = servletWebRequest.getAttribute(handlerSpanKey, ServletWebRequest.SCOPE_REQUEST);
+    if (!(span instanceof AgentSpan)) {
+      return;
+    }
+    servletWebRequest.setAttribute(
+        handlerSpanKey + DD_HANDLER_SPAN_CONTINUE_SUFFIX, true, ServletWebRequest.SCOPE_REQUEST);
+    result =
+        ((CompletionStage<?>) result)
+            .whenComplete(AsyncResultExtensions.finishSpan((AgentSpan) span));
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/TestController.groovy
@@ -12,6 +12,8 @@ import org.springframework.web.servlet.view.RedirectView
 
 import jakarta.servlet.http.HttpServletRequest
 
+import java.util.concurrent.CompletableFuture
+
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.*
 
 @Controller
@@ -27,9 +29,11 @@ class TestController {
 
   @RequestMapping("/forwarded")
   @ResponseBody
-  String forwarded(HttpServletRequest request) {
-    HttpServerTest.controller(FORWARDED) {
-      request.getHeader("x-forwarded-for")
+  CompletableFuture<String> forwarded(HttpServletRequest request) {
+    CompletableFuture.supplyAsync {
+      HttpServerTest.controller(FORWARDED) {
+        request.getHeader("x-forwarded-for")
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

This PR allows tracking the right span duration when `CompletableFuture` are returned on spring controllers. 
In fact, we were just finishing the span right after the controller calls returned instead of waiting that the future completed.

It also avoids async controllers to be traced twice since the advices was kicking in the first time when the handler was called and the second time when the future is resolved. (see the linked issue below in which we can see that the controller span twice).

Note: this PR will then change the duration of impacted controller span hence also their metrics. However, those spans are not entry point hence service RED metrics will not be impacted.


Now the duration looks more realistic. 
Given that code:

```
@RestController
public class TestController {
  @GetMapping
  public CompletableFuture<String> test() {
    return CompletableFuture.supplyAsync(() -> {
        try {
            Thread.sleep(new Random().nextInt(3000));
        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
        }
        return "Hello World";
    });
  }
}
```

Before was producing that trace with wrong duration and double logged span:
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/b8a4f2fe-a4c9-4335-949f-a87334e57c9c" />

Now it produces:

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/5f111fa1-7ce1-4314-a263-e418b9fe1f90" />


# Motivation

# Additional Notes

Solves #7825 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
