### PR TITLE
Don't use strict trace writing for vertx sql tests

### DIFF
--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/test/groovy/VertxSqlClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/test/groovy/VertxSqlClientForkedTest.groovy
@@ -37,6 +37,13 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
   @Shared
   def vertx = Vertx.vertx(new VertxOptions())
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // given how the test without parent is done, we cannot guarantee that the handler callback finishes always
+    // after the sql span since things are going asynchronously. Indeed we should not enforce that unbuffered write.
+    false
+  }
+
   def "test #type"() {
     when:
     AsyncResult<RowSet<Row>> asyncResult = runUnderTrace("parent") {

--- a/dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/test/groovy/VertxSqlClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/test/groovy/VertxSqlClientForkedTest.groovy
@@ -39,6 +39,13 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
   @Shared
   def vertx = Vertx.vertx(new VertxOptions())
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // given how the test without parent is done, we cannot guarantee that the handler callback finishes always
+    // after the sql span since things are going asynchronously. Indeed we should not enforce that unbuffered write.
+    false
+  }
+
   def "test #type"() {
     when:
     AsyncResult<RowSet<Row>> asyncResult = runUnderTrace("parent") {


### PR DESCRIPTION
# What Does This Do

Removes strict trace buffering since, when the root span is missing, the handler span (the result callback) is not guaranteed to finish before the sql call span (there can be wait when the CPU is busy especially in CI)

Relates to `test #type without parent` from `VertxSqlClientForkedTest` flakiness

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
