### PR TITLE
Remove error log when source path resolution fails on isModified check

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -210,7 +210,7 @@ public class ExecutionStrategy {
           .contains(sourcePath, lines.getStartLineNumber(), lines.getEndLineNumber());
 
     } catch (Exception e) {
-      LOGGER.error("Could not determine if {} was modified, assuming false", testSourceData, e);
+      LOGGER.debug("Could not determine if {} was modified, assuming false", testSourceData, e);
       return false;
     }
   }


### PR DESCRIPTION
# What Does This Do

Lowers the level of the log from `error` to `debug` when the source path resolution fails on a `isModified` check.

# Motivation

Got feedback and questions from customers regarding the error log they were finding in their runs when having duplicate class names in their projects. Lowering it to debug level as it is not actionable on their side.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
