### PR TITLE
Fix lettuce tests

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
@@ -1,0 +1,82 @@
+import com.lambdaworks.redis.ClientOptions
+import com.lambdaworks.redis.RedisClient
+import com.lambdaworks.redis.api.StatefulConnection
+import com.lambdaworks.redis.api.sync.RedisCommands
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.agent.test.utils.PortUtils
+import redis.embedded.RedisServer
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+abstract class Lettuce4ClientTestBase extends VersionedNamingTestBase {
+  public static final String HOST = "127.0.0.1"
+  public static final int DB_INDEX = 0
+  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
+  public static final ClientOptions CLIENT_OPTIONS = new ClientOptions.Builder().autoReconnect(false).build()
+
+  @Shared
+  int port
+  @Shared
+  int incorrectPort
+  @Shared
+  String dbAddr
+  @Shared
+  String dbAddrNonExistent
+  @Shared
+  String dbUriNonExistent
+  @Shared
+  String embeddedDbUri
+
+  @Shared
+  RedisServer redisServer
+
+  @Shared
+  Map<String, String> testHashMap = [
+    firstname: "John",
+    lastname : "Doe",
+    age      : "53"
+  ]
+
+  RedisClient redisClient
+  StatefulConnection connection
+  RedisCommands<String, ?> syncCommands
+
+  def setupSpec() {
+    port = PortUtils.randomOpenPort()
+    incorrectPort = PortUtils.randomOpenPort()
+    dbAddr = HOST + ":" + port + "/" + DB_INDEX
+    dbAddrNonExistent = HOST + ":" + incorrectPort + "/" + DB_INDEX
+    dbUriNonExistent = "redis://" + dbAddrNonExistent
+    embeddedDbUri = "redis://" + dbAddr
+
+    redisServer = RedisServer.builder()
+    // bind to localhost to avoid firewall popup
+      .setting("bind " + HOST)
+    // set max memory to avoid problems in CI
+      .setting("maxmemory 128M")
+      .port(port).build()
+  }
+
+  def setup() {
+    redisServer.start()
+
+    redisClient = RedisClient.create(embeddedDbUri)
+    redisClient.setOptions(CLIENT_OPTIONS)
+
+    runUnderTrace("setup") {
+      connection = redisClient.connect()
+      syncCommands = connection.sync()
+
+      syncCommands.set("TESTKEY", "TESTVAL")
+      syncCommands.hmset("TESTHM", testHashMap)
+    }
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
+  }
+
+  def cleanup() {
+    connection.close()
+    redisServer.stop()
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
@@ -1,6 +1,7 @@
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.api.StatefulConnection
+import com.lambdaworks.redis.api.async.RedisAsyncCommands
 import com.lambdaworks.redis.api.sync.RedisCommands
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
@@ -41,6 +42,7 @@ abstract class Lettuce4ClientTestBase extends VersionedNamingTestBase {
   RedisClient redisClient
   StatefulConnection connection
   RedisCommands<String, ?> syncCommands
+  RedisAsyncCommands<String, ?> asyncCommands
 
   def setupSpec() {
     port = PortUtils.randomOpenPort()
@@ -67,6 +69,7 @@ abstract class Lettuce4ClientTestBase extends VersionedNamingTestBase {
     runUnderTrace("setup") {
       connection = redisClient.connect()
       syncCommands = connection.sync()
+      asyncCommands = connection.async()
 
       syncCommands.set("TESTKEY", "TESTVAL")
       syncCommands.hmset("TESTHM", testHashMap)

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
@@ -51,9 +51,9 @@ abstract class Lettuce4ClientTestBase extends VersionedNamingTestBase {
     embeddedDbUri = "redis://" + dbAddr
 
     redisServer = RedisServer.builder()
-    // bind to localhost to avoid firewall popup
+      // bind to localhost to avoid firewall popup
       .setting("bind " + HOST)
-    // set max memory to avoid problems in CI
+      // set max memory to avoid problems in CI
       .setting("maxmemory 128M")
       .port(port).build()
   }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -1,21 +1,13 @@
-import com.redis.testcontainers.RedisContainer
-import datadog.trace.agent.test.naming.VersionedNamingTestBase
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.RedisURI
 import io.lettuce.core.api.StatefulConnection
-import io.lettuce.core.api.async.RedisAsyncCommands
-import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
 import io.lettuce.core.protocol.AsyncCommand
-import org.testcontainers.containers.wait.strategy.Wait
-import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
 import java.time.Duration
@@ -28,7 +20,6 @@ import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
 
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
 abstract class Lettuce5AsyncClientTest extends Lettuce5ClientTestBase {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -28,76 +28,10 @@ import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
 
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
-abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
-  public static final int DB_INDEX = 0
-  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
-  public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
-
-  @Shared
-  int port
-  @Shared
-  int incorrectPort
-  @Shared
-  String dbAddr
-  @Shared
-  String dbAddrNonExistent
-  @Shared
-  String dbUriNonExistent
-  @Shared
-  String embeddedDbUri
-
-  @Shared
-  RedisContainer redisServer = new RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME)
-  .waitingFor(Wait.forListeningPort())
-
-  @Shared
-  Map<String, String> testHashMap = [
-    firstname: "John",
-    lastname : "Doe",
-    age      : "53"
-  ]
-
-  RedisClient redisClient
-  StatefulConnection connection
-  RedisAsyncCommands<String, ?> asyncCommands
-  RedisCommands<String, ?> syncCommands
-
-  def setupSpec() {
-    redisServer.start()
-    println "Using redis: $redisServer.redisURI"
-    port = redisServer.firstMappedPort
-    incorrectPort = PortUtils.randomOpenPort()
-    dbAddr = redisServer.getHost() + ":" + port + "/" + DB_INDEX
-    dbAddrNonExistent = redisServer.getHost() + ":" + incorrectPort + "/" + DB_INDEX
-    dbUriNonExistent = "redis://" + dbAddrNonExistent
-    embeddedDbUri = "redis://" + dbAddr
-  }
-
-  def setup() {
-    redisClient = RedisClient.create(embeddedDbUri)
-    redisClient.setOptions(CLIENT_OPTIONS)
-
-    connection = redisClient.connect()
-    asyncCommands = connection.async()
-    syncCommands = connection.sync()
-
-    syncCommands.set("TESTKEY", "TESTVAL")
-
-    // 1 set + 1 connect trace
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
-  }
-
-  def cleanup() {
-    connection.close()
-  }
-
-  def cleanupSpec() {
-    redisServer.stop()
-  }
-
+abstract class Lettuce5AsyncClientTest extends Lettuce5ClientTestBase {
   def "connect using get on ConnectionFuture"() {
     setup:
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
@@ -582,7 +516,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Lettuce5SyncClientV0Test extends Lettuce5AsyncClientTest {
+class Lettuce5AsyncClientV0Test extends Lettuce5AsyncClientTest {
 
   @Override
   int version() {
@@ -600,7 +534,7 @@ class Lettuce5SyncClientV0Test extends Lettuce5AsyncClientTest {
   }
 }
 
-class Lettuce5SyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
+class Lettuce5AsyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
   int version() {
@@ -619,7 +553,7 @@ class Lettuce5SyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 }
 
 
-class Lettuce5AsyncProfilingForkedTest extends Lettuce5AsyncClientTest {
+class Lettuce5AsyncClientProfilingForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
   protected void configurePreAgent() {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
@@ -1,0 +1,78 @@
+import com.redis.testcontainers.RedisContainer
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.agent.test.utils.PortUtils
+import io.lettuce.core.ClientOptions
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisAsyncCommands
+import io.lettuce.core.api.reactive.RedisReactiveCommands
+import io.lettuce.core.api.sync.RedisCommands
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import spock.util.concurrent.PollingConditions
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+abstract class Lettuce5ClientTestBase extends VersionedNamingTestBase {
+  public static final int DB_INDEX = 0
+  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
+  public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
+
+  public static final Map<String, String> testHashMap = [
+    firstname: "John",
+    lastname : "Doe",
+    age      : "53"
+  ]
+
+  int port
+  int incorrectPort
+  String dbAddr
+  String dbAddrNonExistent
+  String dbUriNonExistent
+  String embeddedDbUri
+
+  RedisContainer redisServer = new RedisContainer(DockerImageName.parse("redis:6.2.6"))
+    .waitingFor(Wait.forListeningPort())
+
+  RedisClient redisClient
+  StatefulRedisConnection connection
+  RedisReactiveCommands<String, ?> reactiveCommands
+  RedisAsyncCommands<String, ?> asyncCommands
+  RedisCommands<String, ?> syncCommands
+
+  def setup() {
+    redisServer.start()
+    println "Using redis: $redisServer.redisURI"
+
+    port = redisServer.firstMappedPort
+    incorrectPort = PortUtils.randomOpenPort()
+    dbAddr = redisServer.getHost() + ":" + port + "/" + DB_INDEX
+    dbAddrNonExistent = redisServer.getHost() + ":" + incorrectPort + "/" + DB_INDEX
+    dbUriNonExistent = "redis://" + dbAddrNonExistent
+    embeddedDbUri = "redis://" + dbAddr
+
+    redisClient = RedisClient.create(embeddedDbUri)
+    redisClient.setOptions(CLIENT_OPTIONS)
+
+    runUnderTrace("setup") {
+      new PollingConditions(delay: 3, timeout: 15).eventually {
+        (connection = redisClient.connect()) != null
+      }
+      reactiveCommands = connection.reactive()
+      asyncCommands = connection.async()
+      syncCommands = connection.sync()
+
+      syncCommands.set("TESTKEY", "TESTVAL")
+      syncCommands.hmset("TESTHM", testHashMap)
+    }
+
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
+  }
+
+  def cleanup() {
+    connection.close()
+    redisClient.shutdown()
+    redisServer.stop()
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
@@ -32,7 +32,7 @@ abstract class Lettuce5ClientTestBase extends VersionedNamingTestBase {
   String embeddedDbUri
 
   RedisContainer redisServer = new RedisContainer(DockerImageName.parse("redis:6.2.6"))
-    .waitingFor(Wait.forListeningPort())
+  .waitingFor(Wait.forListeningPort())
 
   RedisClient redisClient
   StatefulRedisConnection connection

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -1,22 +1,11 @@
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
-import com.redis.testcontainers.RedisContainer
-import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import io.lettuce.core.ClientOptions
-import io.lettuce.core.RedisClient
-import io.lettuce.core.api.StatefulRedisConnection
-import io.lettuce.core.api.reactive.RedisReactiveCommands
-import io.lettuce.core.api.sync.RedisCommands
-import org.testcontainers.containers.wait.strategy.Wait
 import reactor.core.scheduler.Schedulers
-import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
-import spock.util.concurrent.PollingConditions
 
 import java.util.function.Consumer
 
@@ -69,7 +58,11 @@ abstract class Lettuce5ReactiveClientTest extends Lettuce5ClientTestBase {
     def conds = new AsyncConditions()
 
     when:
-    reactiveCommands.get("TESTKEY").subscribe { res -> conds.evaluate { assert res == "TESTVAL" } }
+    reactiveCommands.get("TESTKEY").subscribe { res ->
+      conds.evaluate {
+        assert res == "TESTVAL"
+      }
+    }
 
     then:
     conds.await()

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -1,4 +1,5 @@
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
 import com.redis.testcontainers.RedisContainer
@@ -19,61 +20,7 @@ import spock.util.concurrent.PollingConditions
 
 import java.util.function.Consumer
 
-abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
-  public static final int DB_INDEX = 0
-  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
-  public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
-
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
-  @Shared
-  String embeddedDbUri
-
-  @Shared
-  int port
-
-  @Shared
-  RedisContainer redisServer = new RedisContainer(RedisContainer.DEFAULT_TAG)
-  .waitingFor(Wait.forListeningPort())
-
-  RedisClient redisClient
-  StatefulRedisConnection connection
-  RedisReactiveCommands<String, ?> reactiveCommands
-  RedisCommands<String, ?> syncCommands
-
-  def setup() {
-    redisServer.start()
-    println "Using redis: $redisServer.redisURI"
-    port = redisServer.firstMappedPort
-    String dbAddr = redisServer.getHost() + ":" + port + "/" + DB_INDEX
-    embeddedDbUri = "redis://" + dbAddr
-    redisClient = RedisClient.create(embeddedDbUri)
-
-    redisClient.setOptions(CLIENT_OPTIONS)
-
-    new PollingConditions(delay: 3, timeout: 15).eventually {
-      (connection = redisClient.connect()) != null
-    }
-    reactiveCommands = connection.reactive()
-    syncCommands = connection.sync()
-
-    syncCommands.set("TESTKEY", "TESTVAL")
-
-    // 1 set + 1 connect trace
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
-  }
-
-  def cleanup() {
-    connection.close()
-    redisClient.shutdown()
-    redisServer.stop()
-  }
-
+abstract class Lettuce5ReactiveClientTest extends Lettuce5ClientTestBase {
   def "set command with subscribe on a defined consumer"() {
 
     def conds = new AsyncConditions()
@@ -198,7 +145,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
     when:
     reactiveCommands.randomkey().subscribe { res ->
       conds.evaluate {
-        assert res == "TESTKEY"
+        assert res == "TESTKEY" || res == "TESTHM"
       }
     }
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -1,21 +1,11 @@
-import org.testcontainers.utility.DockerImageName
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
-import com.redis.testcontainers.RedisContainer
-import datadog.trace.agent.test.naming.VersionedNamingTestBase
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.api.StatefulConnection
-import io.lettuce.core.api.sync.RedisCommands
-import org.testcontainers.containers.wait.strategy.Wait
-import spock.lang.Shared
 
 import java.util.concurrent.CompletionException
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -1,3 +1,6 @@
+import org.testcontainers.utility.DockerImageName
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.AGENT_CRASHING_COMMAND_PREFIX
 
 import com.redis.testcontainers.RedisContainer
@@ -16,71 +19,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.CompletionException
 
-abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
-  public static final int DB_INDEX = 0
-  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
-  public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
-
-  @Shared
-  int port
-  @Shared
-  int incorrectPort
-  @Shared
-  String dbAddr
-  @Shared
-  String dbAddrNonExistent
-  @Shared
-  String dbUriNonExistent
-  @Shared
-  String embeddedDbUri
-
-  @Shared
-  RedisContainer redisServer = new RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME)
-  .waitingFor(Wait.forListeningPort())
-
-  @Shared
-  Map<String, String> testHashMap = [
-    firstname: "John",
-    lastname : "Doe",
-    age      : "53"
-  ]
-
-  RedisClient redisClient
-  StatefulConnection connection
-  RedisCommands<String, ?> syncCommands
-
-  def setupSpec() {
-    redisServer.start()
-    println "Using redis: $redisServer.redisURI"
-    port = redisServer.firstMappedPort
-    incorrectPort = PortUtils.randomOpenPort()
-    dbAddr = redisServer.getHost() + ":" + port + "/" + DB_INDEX
-    dbAddrNonExistent = redisServer.getHost() + ":" + incorrectPort + "/" + DB_INDEX
-    dbUriNonExistent = "redis://" + dbAddrNonExistent
-    embeddedDbUri = "redis://" + dbAddr
-  }
-
-  def setup() {
-    redisClient = RedisClient.create(embeddedDbUri)
-    connection = redisClient.connect()
-    syncCommands = connection.sync()
-
-    syncCommands.set("TESTKEY", "TESTVAL")
-    syncCommands.hmset("TESTHM", testHashMap)
-
-    // 2 sets + 1 connect trace
-    TEST_WRITER.waitForTraces(3)
-    TEST_WRITER.clear()
-  }
-
-  def cleanup() {
-    connection.close()
-  }
-
-  def cleanupSpec() {
-    redisServer.stop()
-  }
-
+abstract class Lettuce5SyncClientTest extends Lettuce5ClientTestBase {
   def "connect"() {
     setup:
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
@@ -230,7 +169,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" redisServer.getHost()
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
@@ -417,7 +359,8 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
     }
   }
 }
-class Lettuce5AsyncClientV0Test extends Lettuce5AsyncClientTest {
+
+class Lettuce5SyncClientV0Test extends Lettuce5SyncClientTest {
 
   @Override
   int version() {
@@ -435,7 +378,7 @@ class Lettuce5AsyncClientV0Test extends Lettuce5AsyncClientTest {
   }
 }
 
-class Lettuce5AsyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
+class Lettuce5SyncClientV1ForkedTest extends Lettuce5SyncClientTest {
 
   @Override
   int version() {
@@ -450,5 +393,30 @@ class Lettuce5AsyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
   @Override
   String operation() {
     return "redis.command"
+  }
+}
+
+class Lettuce5SyncClientProfilingForkedTest extends Lettuce5SyncClientTest {
+
+  @Override
+  protected void configurePreAgent() {
+
+    super.configurePreAgent()
+    injectSysConfig('dd.profiling.enabled', 'true')
+  }
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return "redis"
+  }
+
+  @Override
+  String operation() {
+    return "redis.query"
   }
 }


### PR DESCRIPTION
Lettuce tests were flawed in a few ways:

* They were order dependent. An innocuous change like modifying a constant can cause them all to fail. This is most evident with the `shutdown()` test which shuts down the server and breaks all tests after it
* The lettuce-5 `Sync` tests were not run at all. The inner classes in `Lettuce5SyncClientTest` were extending the *`Async`* flavor
* Much of the setup code was repeated leading to slightly different behavior between tests

This PR fixes all of those issues. The setup code has been moved into a base class and the and the server is restarted between tests to prevent order dependence.

# Motivation
I stumbled upon the broken tests while migrating to Gitlab. Gitlab has a different test order so it always broke.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
