### PR TITLE
Fix In-Product when config is empty

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultProductConfigUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultProductConfigUpdater.java
@@ -70,10 +70,12 @@ class DefaultProductConfigUpdater implements DebuggerContext.ProductConfigUpdate
       LOGGER.debug("Feature {} is explicitly disabled", booleanKey);
       return;
     }
-    if (currentStatus != null && currentStatus) {
-      start.run();
-    } else {
-      stop.run();
+    if (currentStatus != null) {
+      if (currentStatus) {
+        start.run();
+      } else {
+        stop.run();
+      }
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultProductConfigUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultProductConfigUpdaterTest.java
@@ -24,6 +24,11 @@ class DefaultProductConfigUpdaterTest {
     assertTrue(productConfigUpdater.isExceptionReplayEnabled());
     assertTrue(productConfigUpdater.isCodeOriginEnabled());
     assertTrue(productConfigUpdater.isDistributedDebuggerEnabled());
+    productConfigUpdater.updateConfig(null, null, null, null);
+    assertTrue(productConfigUpdater.isDynamicInstrumentationEnabled());
+    assertTrue(productConfigUpdater.isExceptionReplayEnabled());
+    assertTrue(productConfigUpdater.isCodeOriginEnabled());
+    assertTrue(productConfigUpdater.isDistributedDebuggerEnabled());
     productConfigUpdater.updateConfig(false, false, false, false);
     assertFalse(productConfigUpdater.isDynamicInstrumentationEnabled());
     assertFalse(productConfigUpdater.isExceptionReplayEnabled());


### PR DESCRIPTION
# What Does This Do
should not stop the product with empty config

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
