### PR TITLE
[Debugger] Allow double interval for diagnostics uploads

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -56,7 +56,7 @@ public class ProbeStatusSink {
     this.useMultiPart = useMultiPart;
     this.messageBuilder = new Builder(config);
     this.interval =
-      Duration.ofMillis((long) (config.getDynamicInstrumentationDiagnosticsInterval() * 1000));
+        Duration.ofMillis((long) (config.getDynamicInstrumentationDiagnosticsInterval() * 1000));
     this.batchSize = config.getDynamicInstrumentationUploadBatchSize();
     this.queue = new ArrayBlockingQueue<>(2 * this.batchSize);
     this.isInstrumentTheWorld = config.isDynamicInstrumentationInstrumentTheWorld();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -55,7 +55,8 @@ public class ProbeStatusSink {
     this.diagnosticUploader = diagnosticUploader;
     this.useMultiPart = useMultiPart;
     this.messageBuilder = new Builder(config);
-    this.interval = Duration.ofMillis((long) (config.getDynamicInstrumentationDiagnosticsInterval() * 1000));
+    this.interval =
+      Duration.ofMillis((long) (config.getDynamicInstrumentationDiagnosticsInterval() * 1000));
     this.batchSize = config.getDynamicInstrumentationUploadBatchSize();
     this.queue = new ArrayBlockingQueue<>(2 * this.batchSize);
     this.isInstrumentTheWorld = config.isDynamicInstrumentationInstrumentTheWorld();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -55,7 +55,7 @@ public class ProbeStatusSink {
     this.diagnosticUploader = diagnosticUploader;
     this.useMultiPart = useMultiPart;
     this.messageBuilder = new Builder(config);
-    this.interval = Duration.ofSeconds(config.getDynamicInstrumentationDiagnosticsInterval());
+    this.interval = Duration.ofMillis((long) (config.getDynamicInstrumentationDiagnosticsInterval() * 1000));
     this.batchSize = config.getDynamicInstrumentationUploadBatchSize();
     this.queue = new ArrayBlockingQueue<>(2 * this.batchSize);
     this.isInstrumentTheWorld = config.isDynamicInstrumentationInstrumentTheWorld();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -33,11 +33,11 @@ class ProbeStatusSinkTest {
   private static final ProbeId PROBE_ID_NEW_VERSION = new ProbeId(PROBE_ID.getId(), 21);
   private static final ProbeId PROBE_ID2 = new ProbeId(UUID.randomUUID().toString(), 21);
   private static final String MESSAGE = "Foo";
-  private static final int DIAGNOSTICS_INTERVAL = 60 * 60; // in seconds = 1h
+  private static final double DIAGNOSTICS_INTERVAL = 60 * 60; // in seconds = 1h
   private static final Instant AFTER_INTERVAL_HAS_PASSED =
-      Instant.now().plus(Duration.ofSeconds(DIAGNOSTICS_INTERVAL + 5));
+      Instant.now().plus(Duration.ofSeconds((int) DIAGNOSTICS_INTERVAL + 5));
   private static final Instant BEFORE_INTERVAL_HAS_PASSED =
-      Instant.now().plus(Duration.ofSeconds(DIAGNOSTICS_INTERVAL - 5));
+      Instant.now().plus(Duration.ofSeconds((int) DIAGNOSTICS_INTERVAL - 5));
 
   @Mock private Config config;
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -402,7 +402,7 @@ public class Config {
   private final int dynamicInstrumentationUploadFlushInterval;
   private final boolean dynamicInstrumentationClassFileDumpEnabled;
   private final int dynamicInstrumentationPollInterval;
-  private final int dynamicInstrumentationDiagnosticsInterval;
+  private final double dynamicInstrumentationDiagnosticsInterval;
   private final boolean dynamicInstrumentationMetricEnabled;
   private final String dynamicInstrumentationProbeFile;
   private final int dynamicInstrumentationUploadBatchSize;
@@ -1653,7 +1653,7 @@ public class Config {
         configProvider.getInteger(
             DYNAMIC_INSTRUMENTATION_POLL_INTERVAL, DEFAULT_DYNAMIC_INSTRUMENTATION_POLL_INTERVAL);
     dynamicInstrumentationDiagnosticsInterval =
-        configProvider.getInteger(
+        configProvider.getDouble(
             DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_INTERVAL,
             DEFAULT_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_INTERVAL);
     dynamicInstrumentationMetricEnabled =
@@ -3222,7 +3222,7 @@ public class Config {
     return dynamicInstrumentationPollInterval;
   }
 
-  public int getDynamicInstrumentationDiagnosticsInterval() {
+  public double getDynamicInstrumentationDiagnosticsInterval() {
     return dynamicInstrumentationDiagnosticsInterval;
   }
 


### PR DESCRIPTION
# What Does This Do
Updated `DynamicInstrumentationDiagnosticsInterval` to support double values instead of integers.

# Motivation
Allowing sub-second intervals can significantly improve system testing by enabling more frequent diagnostics. Rather than introducing a new variable or renaming the existing one, this change maintains compatibility while extending functionality in a simple and effective way.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
