### PR TITLE
Prevent double reporting of Scalatest events when using SBT with test forking

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 2799fa982318da14c9d3e5f722abdc670d2802c3
+default_system_tests_commit: &default_system_tests_commit 761b9e7a82ffb136c4653a4d1623d120d67b005b
 
 parameters:
   nightly:
@@ -932,7 +932,7 @@ jobs:
           command: |
             cd system-tests
             DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh INTEGRATIONS
-        
+
       - run:
           name: Run IDM Crossed Tracing Libraries propagation tests for messaging
           environment:
@@ -975,7 +975,7 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
-            export DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY 
+            export DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY
             ./run.sh DEBUGGER_SCENARIOS
 
       - run:

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/DatadogReporter.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/DatadogReporter.java
@@ -86,14 +86,17 @@ public class DatadogReporter {
 
   private static void onSuiteStart(SuiteStarting event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
     Collection<String> categories = Collections.emptyList();
     boolean parallelized = true;
 
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestSuiteStart(
         new TestSuiteDescriptor(testSuiteName, testClass),
         testSuiteName,
@@ -108,30 +111,40 @@ public class DatadogReporter {
 
   private static void onSuiteFinish(SuiteCompleted event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
+
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestSuiteFinish(new TestSuiteDescriptor(testSuiteName, testClass), null);
   }
 
   private static void onSuiteAbort(SuiteAborted event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
     Throwable throwable = event.throwable().getOrElse(null);
+
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestSuiteFailure(new TestSuiteDescriptor(testSuiteName, testClass), throwable);
     eventHandler.onTestSuiteFinish(new TestSuiteDescriptor(testSuiteName, testClass), null);
   }
 
   private static void onTestStart(TestStarting event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     String testName = event.testName();
@@ -146,6 +159,7 @@ public class DatadogReporter {
     }
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
 
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestStart(
         new TestSuiteDescriptor(testSuiteName, testClass),
         new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier),
@@ -161,8 +175,10 @@ public class DatadogReporter {
 
   private static void onTestSuccess(TestSucceeded event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
@@ -175,13 +191,16 @@ public class DatadogReporter {
     TestIdentifier testIdentifier = new TestIdentifier(testSuiteName, testName, null);
     TestExecutionHistory executionHistory = context.popExecutionHistory(testIdentifier);
 
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestFinish(testDescriptor, null, executionHistory);
   }
 
   private static void onTestFailure(TestFailed event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     Class<?> testClass = ScalatestUtils.getClass(event.suiteClassName());
@@ -195,14 +214,17 @@ public class DatadogReporter {
     TestIdentifier testIdentifier = new TestIdentifier(testSuiteName, testName, null);
     TestExecutionHistory executionHistory = context.popExecutionHistory(testIdentifier);
 
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestFailure(testDescriptor, throwable);
     eventHandler.onTestFinish(testDescriptor, null, executionHistory);
   }
 
   private static void onTestIgnore(TestIgnored event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     String testName = event.testName();
@@ -214,6 +236,7 @@ public class DatadogReporter {
     TestIdentifier skippableTest = new TestIdentifier(testSuiteName, testName, null);
     SkipReason reason = context.getSkipReason(skippableTest);
 
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestIgnore(
         new TestSuiteDescriptor(testSuiteName, testClass),
         new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier),
@@ -228,8 +251,10 @@ public class DatadogReporter {
 
   private static void onTestCancel(TestCanceled event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     String testName = event.testName();
@@ -241,6 +266,7 @@ public class DatadogReporter {
 
     TestDescriptor testDescriptor =
         new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     if (throwable instanceof SuppressedTestFailedException) {
       eventHandler.onTestFailure(testDescriptor, throwable.getCause());
     } else {
@@ -255,8 +281,10 @@ public class DatadogReporter {
 
   private static void onTestPending(TestPending event) {
     int runStamp = event.ordinal().runStamp();
-    RunContext context = RunContext.getOrCreate(runStamp);
-    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
+    RunContext context = RunContext.get(runStamp);
+    if (context == null) {
+      return;
+    }
 
     String testSuiteName = event.suiteId();
     String testName = event.testName();
@@ -267,6 +295,7 @@ public class DatadogReporter {
 
     TestDescriptor testDescriptor =
         new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
+    TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler = context.getEventHandler();
     eventHandler.onTestSkip(testDescriptor, reason);
 
     TestIdentifier testIdentifier = new TestIdentifier(testSuiteName, testName, null);

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
@@ -31,9 +31,15 @@ public class RunContext {
     return CONTEXTS.computeIfAbsent(runStamp, RunContext::new);
   }
 
+  public static RunContext get(int runStamp) {
+    return CONTEXTS.get(runStamp);
+  }
+
   public static void destroy(int runStamp) {
     RunContext context = CONTEXTS.remove(runStamp);
-    context.destroy();
+    if (context != null) {
+      context.destroy();
+    }
   }
 
   private final int runStamp;

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestForkInstrumentation.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestForkInstrumentation.java
@@ -55,6 +55,12 @@ public class ScalatestForkInstrumentation extends InstrumenterModule.CiVisibilit
    * the tests) and not the parent one. The way to distinguish between the two is by examining the
    * "remoteArgs" passed to the runner method: the args are non-empty in the child process, and
    * empty in the parent one.
+   *
+   * <p>The instrumentation works by increasing the Reporter.class counter in the call depth thread
+   * local map. The counter is decreased when the runner method exits.
+   *
+   * <p>Since the tracing instrumentation is checking the counter value to avoid nested calls,
+   * increasing it here results in effectively disabling the tracing.
    */
   public static class RunnerAdvice {
     @Advice.OnMethodEnter

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestForkInstrumentation.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestForkInstrumentation.java
@@ -1,0 +1,74 @@
+package datadog.trace.instrumentation.scalatest;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.Config;
+import datadog.trace.api.config.CiVisibilityConfig;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import org.scalatest.Reporter;
+
+@AutoService(InstrumenterModule.class)
+public class ScalatestForkInstrumentation extends InstrumenterModule.CiVisibility
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public ScalatestForkInstrumentation() {
+    super("ci-visibility", "scalatest");
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    return super.isApplicable(enabledSystems)
+        && Config.get().isCiVisibilityScalatestForkMonitorEnabled();
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.scalatest.tools.Framework";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {};
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("runner").and(takesArgument(1, String[].class)),
+        ScalatestForkInstrumentation.class.getName() + "$RunnerAdvice");
+  }
+
+  /**
+   * This instrumentation is needed to prevent double-reporting of Scalatest events when using SBT
+   * and Test/fork. Current version of the code cannot detect such cases automatically, so it has to
+   * be activated explicitly by setting {@link
+   * CiVisibilityConfig#CIVISIBILITY_SCALATEST_FORK_MONITOR_ENABLED}.
+   *
+   * <p>When using SBT with test forking, Scalatest reporter is activated both in the parent and in
+   * the child process. We only want to instrument the child process (since it is actually executing
+   * the tests) and not the parent one. The way to distinguish between the two is by examining the
+   * "remoteArgs" passed to the runner method: the args are non-empty in the child process, and
+   * empty in the parent one.
+   */
+  public static class RunnerAdvice {
+    @Advice.OnMethodEnter
+    public static void beforeRunnerStart(@Advice.Argument(value = 1) String[] remoteArgs) {
+      if (remoteArgs.length == 0) {
+        CallDepthThreadLocalMap.incrementCallDepth(Reporter.class);
+      }
+    }
+
+    @Advice.OnMethodExit
+    public static void afterRunnerStart(@Advice.Argument(value = 1) String[] remoteArgs) {
+      if (remoteArgs.length == 0) {
+        CallDepthThreadLocalMap.decrementCallDepth(Reporter.class);
+      }
+    }
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -79,6 +79,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_REMOTE_ENV_VARS_PROVIDER_KEY =
       "civisibility.remote.env.vars.provider.key";
   public static final String CIVISIBILITY_TEST_ORDER = "civisibility.test.order";
+  public static final String CIVISIBILITY_SCALATEST_FORK_MONITOR_ENABLED =
+      "civisibility.scalatest.fork.monitor.enabled";
   public static final String TEST_MANAGEMENT_ENABLED = "test.management.enabled";
   public static final String TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES =
       "test.management.attempt.to.fix.retries";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -383,6 +383,7 @@ public class Config {
   private final String ciVisibilityTestOrder;
   private final boolean ciVisibilityTestManagementEnabled;
   private final Integer ciVisibilityTestManagementAttemptToFixRetries;
+  private final boolean ciVisibilityScalatestForkMonitorEnabled;
 
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
@@ -1607,6 +1608,8 @@ public class Config {
     ciVisibilityTestManagementEnabled = configProvider.getBoolean(TEST_MANAGEMENT_ENABLED, true);
     ciVisibilityTestManagementAttemptToFixRetries =
         configProvider.getInteger(TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES);
+    ciVisibilityScalatestForkMonitorEnabled =
+        configProvider.getBoolean(CIVISIBILITY_SCALATEST_FORK_MONITOR_ENABLED, false);
 
     remoteConfigEnabled =
         configProvider.getBoolean(
@@ -3112,6 +3115,10 @@ public class Config {
     return ciVisibilityFlakyRetryEnabled
         || ciVisibilityEarlyFlakeDetectionEnabled
         || ciVisibilityTestManagementEnabled;
+  }
+
+  public boolean isCiVisibilityScalatestForkMonitorEnabled() {
+    return ciVisibilityScalatestForkMonitorEnabled;
   }
 
   public int getCiVisibilityFlakyRetryCount() {


### PR DESCRIPTION
# What Does This Do

Prevents double reporting of Scalatest events when using SBT with test forking.


When running an SBT build with Test/fork set to true, Scalatest reporter that we instrument is initialised both in the parent process and in the child process.
We only want to instrument the one in the child process, since the child process is where the tests are actually executed.

We distinguish the child process from the parent process by examining the "remote arguments" of the Scalatest runner: in the child process the remote arguments are not empty (as they define how to interact with the parent).

# Additional Notes

I could not find a way to determine SBT + Test/fork + Scalatest case automatically, so for the time being the instrumentation has to be activated manually with the `DD_CIVISIBILITY_SCALATEST_FORK_MONITOR_ENABLED` env variable (or corresponding system property).

We only have a handful of Scalatest users and if they happen to use SBT and forking we will advise them to activate the property.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
