### PR TITLE
Expand MUnit runners filter to catch munit.MUnitRunner in JUnit 4 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -57,7 +57,7 @@ public class JUnit4Instrumentation extends InstrumenterModule.CiVisibility
         .and(not(extendsClass(named("com.intuit.karate.junit4.Karate"))))
         // do not instrument MUnit-JUnit 4 interface runner
         // since MUnit has a dedicated instrumentation
-        .and(not(extendsClass(nameStartsWith("munit.internal.junitinterface."))))
+        .and(not(extendsClass(nameStartsWith("munit"))))
         // PowerMock runner is being instrumented,
         // so do not instrument its internal delegates
         .and(

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -348,7 +348,7 @@ public abstract class JUnit4Utils {
       return TestFrameworkInstrumentation.KARATE;
     } else if (runnerClassName.startsWith("io.cucumber")) {
       return TestFrameworkInstrumentation.CUCUMBER;
-    } else if (runnerClassName.startsWith("munit.internal.junitinterface")) {
+    } else if (runnerClassName.startsWith("munit")) {
       return TestFrameworkInstrumentation.MUNIT;
     } else {
       return TestFrameworkInstrumentation.JUNIT4;


### PR DESCRIPTION
# What Does This Do

Expanding on the work done in https://github.com/DataDog/dd-trace-java/pull/8675, the filter is expanded to also catch `munit.MUnitRunner` and not create two test sessions and modules.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
