### PR TITLE
Make source file tracking asynchronous

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -74,10 +74,7 @@ public class DebuggerAgent {
     Config config = Config.get();
     DebuggerContext.initProductConfigUpdater(new DefaultProductConfigUpdater());
     classesToRetransformFinder = new ClassesToRetransformFinder();
-    if (config.isDynamicInstrumentationEnabled() || config.isDebuggerExceptionEnabled()) {
-      // only activate Source File Tracking if DI or ER is enabled from the start
-      setupSourceFileTracking(instrumentation, classesToRetransformFinder);
-    }
+    setupSourceFileTracking(instrumentation, classesToRetransformFinder);
     if (config.isDebuggerCodeOriginEnabled()) {
       startCodeOriginForSpans();
     }
@@ -314,7 +311,10 @@ public class DebuggerAgent {
 
   private static void setupSourceFileTracking(
       Instrumentation instrumentation, ClassesToRetransformFinder finder) {
-    instrumentation.addTransformer(new SourceFileTrackingTransformer(finder));
+    SourceFileTrackingTransformer sourceFileTrackingTransformer =
+        new SourceFileTrackingTransformer(finder);
+    sourceFileTrackingTransformer.start();
+    instrumentation.addTransformer(sourceFileTrackingTransformer);
   }
 
   private static void loadFromFile(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
@@ -4,9 +4,15 @@ import static com.datadog.debugger.util.ClassFileHelper.removeExtension;
 import static com.datadog.debugger.util.ClassFileHelper.stripPackagePath;
 
 import com.datadog.debugger.util.ClassFileHelper;
+import datadog.trace.util.AgentTaskScheduler;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Permanent Transformer to track all Inner or Top-Level classes associated with the same SourceFile
@@ -14,10 +20,39 @@ import java.security.ProtectionDomain;
  * trigger {@link java.lang.instrument.Instrumentation#retransformClasses(Class[])} on them
  */
 public class SourceFileTrackingTransformer implements ClassFileTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SourceFileTrackingTransformer.class);
+
   private final ClassesToRetransformFinder finder;
+  private final Queue<SourceFileItem> queue = new ConcurrentLinkedQueue<>();
+  private final AgentTaskScheduler scheduler = AgentTaskScheduler.INSTANCE;
+  private AgentTaskScheduler.Scheduled<Runnable> scheduled;
 
   public SourceFileTrackingTransformer(ClassesToRetransformFinder finder) {
     this.finder = finder;
+  }
+
+  public void start() {
+    scheduled = scheduler.scheduleAtFixedRate(this::flush, 0, 1, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    if (scheduled != null) {
+      scheduled.cancel();
+    }
+  }
+
+  void flush() {
+    if (queue.isEmpty()) {
+      return;
+    }
+    int size = queue.size();
+    long start = System.nanoTime();
+    SourceFileItem item;
+    while ((item = queue.poll()) != null) {
+      registerSourceFile(item.className, item.classfileBuffer);
+    }
+    LOGGER.debug(
+        "flushing {} source file items in {}ms", size, (System.nanoTime() - start) / 1_000_000);
   }
 
   @Override
@@ -31,16 +66,30 @@ public class SourceFileTrackingTransformer implements ClassFileTransformer {
     if (className == null) {
       return null;
     }
+    queue.add(new SourceFileItem(className, classfileBuffer));
+    return null;
+  }
+
+  private void registerSourceFile(String className, byte[] classfileBuffer) {
     String sourceFile = ClassFileHelper.extractSourceFile(classfileBuffer);
     if (sourceFile == null) {
-      return null;
+      return;
     }
     String simpleClassName = stripPackagePath(className);
     String simpleSourceFile = removeExtension(sourceFile);
     if (simpleClassName.equals(simpleSourceFile)) {
-      return null;
+      return;
     }
     finder.register(sourceFile, className);
-    return null;
+  }
+
+  private static class SourceFileItem {
+    final String className;
+    final byte[] classfileBuffer;
+
+    public SourceFileItem(String className, byte[] classfileBuffer) {
+      this.className = className;
+      this.classfileBuffer = classfileBuffer;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -32,6 +32,7 @@ class SourceFileTrackingTransformerTest {
         null,
         null,
         getClassFileBytes(MyTopLevelClass.class));
+    sourceFileTrackingTransformer.flush();
     changedClasses =
         finder.getAllLoadedChangedClasses(
             new Class[] {TopLevelHelper.class, MyTopLevelClass.class}, comparer);
@@ -48,6 +49,7 @@ class SourceFileTrackingTransformerTest {
     ConfigurationComparer comparer = createComparer("InnerHelper.java");
     sourceFileTrackingTransformer.transform(
         null, getInternalName(InnerHelper.class), null, null, getClassFileBytes(InnerHelper.class));
+    sourceFileTrackingTransformer.flush();
     List<Class<?>> changedClasses =
         finder.getAllLoadedChangedClasses(new Class[] {InnerHelper.class}, comparer);
     assertEquals(1, changedClasses.size());
@@ -64,6 +66,7 @@ class SourceFileTrackingTransformerTest {
         null,
         null,
         getClassFileBytes(InnerHelper.MySecondInner.class));
+    sourceFileTrackingTransformer.flush();
     changedClasses =
         finder.getAllLoadedChangedClasses(
             new Class[] {

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -43,6 +43,7 @@ public class ServerDebuggerTestApplication {
     methodsByName.put("tracedMethod", ServerDebuggerTestApplication::runTracedMethod);
     methodsByName.put("loopingFullMethod", ServerDebuggerTestApplication::runLoopingFullMethod);
     methodsByName.put("loopingTracedMethod", ServerDebuggerTestApplication::runLoopingTracedMethod);
+    methodsByName.put("topLevelMethod", ServerDebuggerTestApplication::runTopLevelMethod);
   }
 
   public ServerDebuggerTestApplication(String controlServerUrl) {
@@ -161,6 +162,10 @@ public class ServerDebuggerTestApplication {
     for (int i = 0; i < Integer.parseInt(arg); i++) {
       runTracedMethod(arg);
     }
+  }
+
+  private static String runTopLevelMethod(String arg) {
+    return TopLevel.process(arg);
   }
 
   private static String fullMethod(
@@ -288,5 +293,11 @@ public class ServerDebuggerTestApplication {
       }
       return EMPTY_HTTP_200;
     }
+  }
+}
+
+class TopLevel {
+  public static String process(String arg) {
+    return "TopLevel.process: " + arg;
   }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
@@ -45,7 +45,7 @@ public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAME_METHOD));
                 assertEquals(
                     "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAME_SIGNATURE));
-                assertEquals("145", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
+                assertEquals("146", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
                 codeOrigin.set(true);
               }
             }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -40,6 +40,28 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   }
 
   @Test
+  @DisplayName("testDynamicInstrumentationEnablementWithLineProbe")
+  void testDynamicInstrumentationEnablementWithLineProbe() throws Exception {
+    appUrl = startAppAndAndGetUrl();
+    setConfigOverrides(createConfigOverrides(true, false));
+    LogProbe probe =
+        LogProbe.builder()
+            .probeId(LINE_PROBE_ID1)
+            .where("ServerDebuggerTestApplication.java", 301)
+            .build();
+    setCurrentConfiguration(createConfig(probe));
+    waitForFeatureStarted(appUrl, "Dynamic Instrumentation");
+    execute(appUrl, "topLevelMethod", "");
+    waitForInstrumentation(appUrl, "datadog.smoketest.debugger.TopLevel");
+    // disable DI
+    setConfigOverrides(createConfigOverrides(false, false));
+    waitForFeatureStopped(appUrl, "Dynamic Instrumentation");
+    waitForReTransformation(
+        appUrl,
+        "datadog.smoketest.debugger.TopLevel"); // wait for retransformation of removed probe
+  }
+
+  @Test
   @DisplayName("testDynamicInstrumentationEnablementStaticallyDisabled")
   void testDynamicInstrumentationEnablementStaticallyDisabled() throws Exception {
     // explicitly disable dynamic instrumentation, preventing enablement

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
@@ -31,7 +31,8 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
       "datadog.smoketest.debugger.ServerDebuggerTestApplication";
   protected static final String CONTROL_URL = "/control";
   protected static final ProbeId PROBE_ID = new ProbeId("123356536", 0);
-  protected static final ProbeId PROBE_ID2 = new ProbeId("1233565367", 12);
+  protected static final ProbeId LINE_PROBE_ID1 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000001", 0);
   protected static final String TEST_APP_CLASS_NAME = "ServerDebuggerTestApplication";
   protected static final String FULL_METHOD_NAME = "fullMethod";
   protected static final String TRACED_METHOD_NAME = "tracedMethod";
@@ -106,9 +107,11 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   protected void waitForInstrumentation(String appUrl) throws Exception {
-    String url =
-        String.format(
-            appUrl + "/waitForInstrumentation?classname=%s", SERVER_DEBUGGER_TEST_APP_CLASS);
+    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS);
+  }
+
+  protected void waitForInstrumentation(String appUrl, String className) throws Exception {
+    String url = String.format(appUrl + "/waitForInstrumentation?classname=%s", className);
     LOG.info("waitForInstrumentation with url={}", url);
     sendRequest(url);
     AtomicBoolean received = new AtomicBoolean();
@@ -136,9 +139,11 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   protected void waitForReTransformation(String appUrl) throws IOException {
-    String url =
-        String.format(
-            appUrl + "/waitForReTransformation?classname=%s", SERVER_DEBUGGER_TEST_APP_CLASS);
+    waitForReTransformation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS);
+  }
+
+  protected void waitForReTransformation(String appUrl, String className) throws IOException {
+    String url = String.format(appUrl + "/waitForReTransformation?classname=%s", className);
     sendRequest(url);
     LOG.info("re-transformation done");
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SimpleAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SimpleAppDebuggerIntegrationTest.java
@@ -11,7 +11,8 @@ public class SimpleAppDebuggerIntegrationTest extends BaseIntegrationTest {
   protected static final String DEBUGGER_TEST_APP_CLASS =
       "datadog.smoketest.debugger.DebuggerTestApplication";
   protected static final ProbeId PROBE_ID = new ProbeId("123356536", 0);
-  protected static final ProbeId PROBE_ID2 = new ProbeId("1233565368", 12);
+  protected static final ProbeId LINE_PROBE_ID1 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000001", 0);
   protected static final String MAIN_CLASS_NAME = "Main";
 
   @Override


### PR DESCRIPTION
# What Does This Do
Source file tracking is enqueueing classfile buffer to be processed by a background thread avoiding startup delay.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3649]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3649]: https://datadoghq.atlassian.net/browse/DEBUG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ