### PR TITLE
Allow dogstatsd port to be configurable with DD_DOGSTATSD_PORT

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClientManager.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClientManager.java
@@ -21,7 +21,8 @@ public final class DDAgentStatsDClientManager implements StatsDClientManager {
     return INSTANCE;
   }
 
-  private static final AtomicInteger defaultStatsDPort = new AtomicInteger(Config.get().getDogsStatsDPort());
+  private static final AtomicInteger defaultStatsDPort =
+      new AtomicInteger(Config.get().getDogsStatsDPort());
 
   public static void setDefaultStatsDPort(final int newPort) {
     if (newPort > 0 && defaultStatsDPort.getAndSet(newPort) != newPort) {

--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClientManager.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClientManager.java
@@ -1,6 +1,5 @@
 package datadog.communication.monitor;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_PORT;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.LOGGING_WRITER_TYPE;
 
 import datadog.trace.api.Config;
@@ -22,7 +21,7 @@ public final class DDAgentStatsDClientManager implements StatsDClientManager {
     return INSTANCE;
   }
 
-  private static final AtomicInteger defaultStatsDPort = new AtomicInteger(DEFAULT_DOGSTATSD_PORT);
+  private static final AtomicInteger defaultStatsDPort = new AtomicInteger(Config.get().getDogsStatsDPort());
 
   public static void setDefaultStatsDPort(final int newPort) {
     if (newPort > 0 && defaultStatsDPort.getAndSet(newPort) != newPort) {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -527,6 +527,7 @@ public class Config {
   private final List<String> traceAgentArgs;
   private final String dogStatsDPath;
   private final List<String> dogStatsDArgs;
+  private final int dogStatsDPort;
 
   private String env;
   private String version;
@@ -1083,6 +1084,8 @@ public class Config {
     dogStatsDStartDelay =
         configProvider.getInteger(
             DOGSTATSD_START_DELAY, DEFAULT_DOGSTATSD_START_DELAY, JMX_FETCH_START_DELAY);
+
+    dogStatsDPort = configProvider.getInteger(DOGSTATSD_PORT, DEFAULT_DOGSTATSD_PORT);
 
     statsDClientQueueSize = configProvider.getInteger(STATSD_CLIENT_QUEUE_SIZE);
     statsDClientSocketBuffer = configProvider.getInteger(STATSD_CLIENT_SOCKET_BUFFER);
@@ -3526,6 +3529,10 @@ public class Config {
 
   public List<String> getDogStatsDArgs() {
     return dogStatsDArgs;
+  }
+
+  public int getDogsStatsDPort() {
+    return dogStatsDPort;
   }
 
   public String getConfigFileStatus() {


### PR DESCRIPTION
# What Does This Do
Currently, the `DD_DOGSTATSD_PORT` environment variable and `dd.dogstatsd.port` system property only affect the dogstatsd port used by the embedded JMXFetch client. With this change, the configured port is also used by the tracer's dogstatsd client unless overridden by the agent.

# Motivation
With Crashtracking tests, it was impossible to supply another port. Additionally, respecting the environment variable makes the tracer more consistent.

# Additional Notes
It's impossible to test this change directly because `DDAgentStatsDClientManager` makes heavy use of `static` fields and methods. It's tested indirectly in #8685

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
