### PR TITLE
Add system property to force injection of the tracing library even though multiple javaagents have been detected

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap;
 
+import static datadog.trace.bootstrap.SystemUtils.getPropertyOrEnvVar;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.cli.CLIHelper;
@@ -45,7 +46,7 @@ import java.util.jar.JarFile;
  */
 public final class AgentBootstrap {
   static final String LIB_INJECTION_ENABLED_FLAG = "DD_INJECTION_ENABLED";
-  static final String LIB_INJECTION_FORCE_FLAG = "DD_INJECT_FORCE";
+  static final String LIB_INJECTION_FORCE_FLAG = "dd.inject.force";
 
   private static final Class<?> thisClass = AgentBootstrap.class;
   private static final int MAX_EXCEPTION_CHAIN_LENGTH = 99;
@@ -158,8 +159,10 @@ public final class AgentBootstrap {
       case LIB_INJECTION_ENABLED_FLAG:
         return System.getenv(LIB_INJECTION_ENABLED_FLAG) != null;
       case LIB_INJECTION_FORCE_FLAG:
-        String libInjectionForceFlag = System.getenv(LIB_INJECTION_FORCE_FLAG);
-        return "true".equalsIgnoreCase(libInjectionForceFlag) || "1".equals(libInjectionForceFlag);
+        {
+          String injectionForceFlag = getPropertyOrEnvVar(LIB_INJECTION_FORCE_FLAG);
+          return "true".equalsIgnoreCase(injectionForceFlag) || "1".equals(injectionForceFlag);
+        }
       default:
         return false;
     }
@@ -285,6 +288,7 @@ public final class AgentBootstrap {
 
   static boolean shouldAbortDueToOtherJavaAgents() {
     // Simply considering having multiple agents
+
     if (getConfig(LIB_INJECTION_ENABLED_FLAG)
         && !getConfig(LIB_INJECTION_FORCE_FLAG)
         && getAgentFilesFromVMArguments().size() > 1) {
@@ -305,7 +309,7 @@ public final class AgentBootstrap {
           "Info: multiple JVM agents detected, found "
               + agentFiles
               + ". Loading multiple APM/Tracing agent is not a recommended or supported configuration."
-              + "Please set the DD_INJECT_FORCE configuration to TRUE to load Datadog APM/Tracing agent.");
+              + "Please set the environment variable DD_INJECT_FORCE or the system property dd.inject.force to TRUE to load Datadog APM/Tracing agent.");
       return true;
     }
     return false;

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -45,8 +45,8 @@ import java.util.jar.JarFile;
  * </ul>
  */
 public final class AgentBootstrap {
-  static final String LIB_INJECTION_ENABLED_FLAG = "DD_INJECTION_ENABLED";
-  static final String LIB_INJECTION_FORCE_FLAG = "dd.inject.force";
+  static final String LIB_INJECTION_ENABLED_ENV_VAR = "DD_INJECTION_ENABLED";
+  static final String LIB_INJECTION_FORCE_SYS_PROP = "dd.inject.force";
 
   private static final Class<?> thisClass = AgentBootstrap.class;
   private static final int MAX_EXCEPTION_CHAIN_LENGTH = 99;
@@ -156,11 +156,11 @@ public final class AgentBootstrap {
 
   static boolean getConfig(String configName) {
     switch (configName) {
-      case LIB_INJECTION_ENABLED_FLAG:
-        return System.getenv(LIB_INJECTION_ENABLED_FLAG) != null;
-      case LIB_INJECTION_FORCE_FLAG:
+      case LIB_INJECTION_ENABLED_ENV_VAR:
+        return System.getenv(LIB_INJECTION_ENABLED_ENV_VAR) != null;
+      case LIB_INJECTION_FORCE_SYS_PROP:
         {
-          String injectionForceFlag = getPropertyOrEnvVar(LIB_INJECTION_FORCE_FLAG);
+          String injectionForceFlag = getPropertyOrEnvVar(LIB_INJECTION_FORCE_SYS_PROP);
           return "true".equalsIgnoreCase(injectionForceFlag) || "1".equals(injectionForceFlag);
         }
       default:
@@ -289,8 +289,8 @@ public final class AgentBootstrap {
   static boolean shouldAbortDueToOtherJavaAgents() {
     // Simply considering having multiple agents
 
-    if (getConfig(LIB_INJECTION_ENABLED_FLAG)
-        && !getConfig(LIB_INJECTION_FORCE_FLAG)
+    if (getConfig(LIB_INJECTION_ENABLED_ENV_VAR)
+        && !getConfig(LIB_INJECTION_FORCE_SYS_PROP)
         && getAgentFilesFromVMArguments().size() > 1) {
       // Formatting agent file list, Java 7 style
       StringBuilder agentFiles = new StringBuilder();

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/SystemUtils.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/SystemUtils.java
@@ -30,4 +30,16 @@ public final class SystemUtils {
       return defaultValue;
     }
   }
+
+  private static String toEnvVar(String string) {
+    return string.replace('.', '_').replace('-', '_').toUpperCase();
+  }
+
+  public static String getPropertyOrEnvVar(String property) {
+    String envVarValue = System.getenv(toEnvVar(property));
+    if (envVarValue != null) {
+      return envVarValue;
+    }
+    return System.getProperty(property);
+  }
 }


### PR DESCRIPTION
# What Does This Do
Add the possibility to use a system property to force injection of the tracing library even though multiple javaagents have been detected.

Forcing the library injection can now be done:
- by setting the env variable `DD_INJECT_FORCE` to 1 or true
- by setting the system property `dd.inject.force` to 1 or true

# Motivation
[APMS-15377](https://datadoghq.atlassian.net/browse/APMS-15377)

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15377]: https://datadoghq.atlassian.net/browse/APMS-15377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ