### PR TITLE
setup.sh should check for JAVA_HOME if  version is not 1.8

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ function check-jvm() {
 }
 
 echo "ℹ️ Checking required JVM:"
-if [ -e "$JAVA_HOME" ]; then
+if [ -e "$JAVA_HOME" ] || [ $(java -version | grep -c "1.8") -eq 0 ]; then
     check-jvm "JAVA_HOME" "1.8"
 fi
 check-jvm "JAVA_8_HOME" "1.8"

--- a/setup.sh
+++ b/setup.sh
@@ -18,9 +18,19 @@ function check-jvm() {
     fi
 }
 
-echo "ℹ️ Checking required JVM:"
-if [ -e "$JAVA_HOME" ] || [ $(java -version | grep -c "1.8") -eq 0 ]; then
+function check-jvm-from-path() {
+    local EXPECTED_JAVA_VERSION=$1
+    if java -version 2>&1 | grep version | grep -q -v "version \"$EXPECTED_JAVA_VERSION"; then
+        echo "❌ The java command from path is not $EXPECTED_JAVA_VERSION. Please set JAVA_HOME environment varible to a JDK $EXPECTED_JAVA_VERSION." >&2
+        exit 1
+    fi
+}
+
+echo "ℹ️ Checking required JVMs:"
+if [ -e "$JAVA_HOME" ]; then
     check-jvm "JAVA_HOME" "1.8"
+elif command -v java &> /dev/null; then
+    check-jvm-from-path "1.8"
 fi
 check-jvm "JAVA_8_HOME" "1.8"
 check-jvm "JAVA_11_HOME" "11"


### PR DESCRIPTION
# What Does This Do

The setup.sh check needs an additional condition if `java` binary is not Java 8. Else, gradle fails:

```
./gradlew clean spotlessApply shadowJar --rerun-tasks

(...)

> Task :dd-smoke-tests:iast-propagation:compileKotlin FAILED
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dd-smoke-tests:iast-propagation:compileKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileJava' (1.8) and 'compileKotlin' (17).
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
