### PR TITLE
Remove muzzle from CircleCI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -744,79 +744,6 @@ jobs:
           path: ./reports
 
       - display_memory_usage
-  muzzle-dep-report:
-    <<: *defaults
-    resource_class: medium
-    steps:
-      - setup_code
-      - skip_unless_matching_files_changed:
-          pattern: "dd-java-agent/instrumentation"
-      - restore_dependency_cache:
-          cacheType: inst
-      - restore_build_cache:
-          cacheType: inst
-      - run:
-          name: Generate muzzle dep report
-          command: >-
-            SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew generateMuzzleReport muzzleInstrumentationReport
-      - run:
-          name: Collect Reports
-          command: .circleci/collect_muzzle_deps.sh
-      - store_artifacts:
-          path: ./reports
-
-  muzzle:
-    <<: *defaults
-    resource_class: medium+
-    parallelism: 4
-    steps:
-      - setup_code
-
-      - skip_unless_matching_files_changed:
-          pattern: "dd-java-agent/instrumentation"
-
-      # We are not running with a separate cache of all muzzle artifacts here because it gets very big and
-      # ends up taking more time restoring/saving than the actual increase in time it takes just
-      # downloading the artifacts each time.
-      #
-      # Let's at least restore the build cache to have something to start from.
-      - restore_dependency_cache:
-          cacheType: inst
-      - restore_build_cache:
-          cacheType: inst
-
-      - run:
-          name: Gather muzzle tasks
-          command: >-
-            SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew writeMuzzleTasksToFile
-            << pipeline.parameters.gradle_flags >>
-            --max-workers=3
-
-      - run:
-          name: Verify Muzzle
-          command: >-
-            SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx3G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew `circleci tests split --split-by=timings workspace/build/muzzleTasks | xargs`
-            << pipeline.parameters.gradle_flags >>
-            --max-workers=4
-
-      - run:
-          name: Collect Reports
-          when: on_fail
-          command: .circleci/collect_reports.sh
-
-      - store_artifacts:
-          path: ./reports
-
-      - store_test_results:
-          path: workspace/build/muzzle-test-results
-
-      - display_memory_usage
 
   system-tests:
     machine:
@@ -1451,20 +1378,6 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
 
-  - muzzle:
-      requires:
-        - ok_to_test
-      filters:
-        branches:
-          ignore:
-            - master
-            - project/*
-            - release/*
-
-  - muzzle-dep-report:
-      requires:
-        - ok_to_test
-
   - system-tests:
       requires:
         - ok_to_test
@@ -1512,7 +1425,6 @@ build_test_jobs: &build_test_jobs
         - "test_{{ jdk }}"
 {% endfor %}
         - test_inst_latest
-        - muzzle
         - profiling
         - debugger
         - system-tests


### PR DESCRIPTION
# What Does This Do
Removes muzzle jobs from CircleCI

# Motivation
Eventually, all jobs will be migrated from CircleCI to GitLab. Muzzle jobs in Gitlab have comparable failure rates of 1-3% with a flakyness of 0%. The flakyness indicates that these failures were actual failures and not issues with the CI system.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
