### PR TITLE
Add process tags to client stats payload

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.common.metrics
 
+import datadog.trace.api.Config
+import datadog.trace.api.ProcessTags
 import datadog.trace.api.WellKnownTags
 import datadog.trace.api.Pair
 import datadog.trace.test.util.DDSpecification
@@ -9,13 +11,18 @@ import org.msgpack.core.MessageUnpacker
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLongArray
 
+import static datadog.trace.api.config.GeneralConfig.EXPERIMENTAL_COLLECT_PROCESS_TAGS_ENABLED
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class SerializingMetricWriterTest extends DDSpecification {
 
-  def "should produce correct message #iterationIndex" () {
+  def "should produce correct message #iterationIndex with process tags enabled #withProcessTags" () {
     setup:
+    if (withProcessTags) {
+      injectSysConfig(EXPERIMENTAL_COLLECT_PROCESS_TAGS_ENABLED, "true")
+    }
+    ProcessTags.reset()
     long startTime = MILLISECONDS.toNanos(System.currentTimeMillis())
     long duration = SECONDS.toNanos(10)
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version","language")
@@ -43,6 +50,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         Pair.of(new MetricKey("resource" + i, "service" + i, "operation" + i, "type", 0, false), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L)))
       })
     ]
+    withProcessTags << [true, false]
   }
 
 
@@ -70,7 +78,7 @@ class SerializingMetricWriterTest extends DDSpecification {
     void accept(int messageCount, ByteBuffer buffer) {
       MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
       int mapSize = unpacker.unpackMapHeader()
-      assert mapSize == 6
+      assert mapSize == (6 + (Config.get().isExperimentalCollectProcessTagsEnabled() ? 1 : 0))
       assert unpacker.unpackString() == "RuntimeId"
       assert unpacker.unpackString() == wellKnownTags.getRuntimeId() as String
       assert unpacker.unpackString() == "Seq"
@@ -81,6 +89,10 @@ class SerializingMetricWriterTest extends DDSpecification {
       assert unpacker.unpackString() == wellKnownTags.getEnv() as String
       assert unpacker.unpackString() == "Version"
       assert unpacker.unpackString() == wellKnownTags.getVersion() as String
+      if (Config.get().isExperimentalCollectProcessTagsEnabled()) {
+        assert unpacker.unpackString() == "ProcessTags"
+        assert unpacker.unpackString() == ProcessTags.tagsForSerialization as String
+      }
       assert unpacker.unpackString() == "Stats"
       int outerLength = unpacker.unpackArrayHeader()
       assert outerLength == 1


### PR DESCRIPTION
# What Does This Do

Adds process tags to stats client payload. 

See https://github.com/DataDog/datadog-agent/pull/35746 and https://github.com/DataDog/dd-trace-java/pull/8698

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
