### PR TITLE
Add process tags as list to remote config payload

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
@@ -72,6 +72,7 @@ class ProcessTagsForkedTest extends DDSpecification {
     ProcessTags.addTag("test", "value")
     then:
     assert ProcessTags.tagsForSerialization == null
+    assert ProcessTags.tagsAsList == null
   }
 
   def 'should lazily recalculate when a tag is added'() {
@@ -80,12 +81,18 @@ class ProcessTagsForkedTest extends DDSpecification {
     ProcessTags.reset()
     when:
     def processTags = ProcessTags.tagsForSerialization
+    def tagsAsList = ProcessTags.tagsAsList
     then:
     assert ProcessTags.enabled
     assert processTags != null
+    assert tagsAsList != null
+    assert tagsAsList.size() > 0
     when:
     ProcessTags.addTag("test", "value")
     then:
     assert ProcessTags.tagsForSerialization.toString() == "$processTags,test:value"
+    def size = ProcessTags.tagsAsList.size()
+    assert size == tagsAsList.size() + 1
+    assert ProcessTags.tagsAsList[size - 1] == "test:value"
   }
 }

--- a/remote-config/remote-config-core/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
+++ b/remote-config/remote-config-core/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
@@ -1,6 +1,7 @@
 package datadog.remoteconfig.tuf;
 
 import com.squareup.moshi.Json;
+import datadog.trace.api.ProcessTags;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,7 +27,14 @@ public class RemoteConfigRequest {
 
     ClientInfo.TracerInfo tracerInfo =
         new RemoteConfigRequest.ClientInfo.TracerInfo(
-            runtimeId, tracerVersion, serviceName, extraServices, serviceEnv, serviceVersion, tags);
+            runtimeId,
+            tracerVersion,
+            serviceName,
+            extraServices,
+            serviceEnv,
+            serviceVersion,
+            tags,
+            ProcessTags.getTagsAsList());
 
     ClientInfo clientInfo =
         new RemoteConfigRequest.ClientInfo(
@@ -174,6 +182,9 @@ public class RemoteConfigRequest {
       @Json(name = "app_version")
       private final String serviceVersion;
 
+      @Json(name = "process_tags")
+      private final List<String> processTags;
+
       public TracerInfo(
           String runtimeId,
           String tracerVersion,
@@ -181,7 +192,8 @@ public class RemoteConfigRequest {
           List<String> extraServices,
           String serviceEnv,
           String serviceVersion,
-          List<String> tags) {
+          List<String> tags,
+          List<String> processTags) {
         this.runtimeId = runtimeId;
         this.tracerVersion = tracerVersion;
         this.serviceName = serviceName;
@@ -189,6 +201,7 @@ public class RemoteConfigRequest {
         this.serviceEnv = serviceEnv;
         this.serviceVersion = serviceVersion;
         this.tags = tags;
+        this.processTags = processTags;
       }
 
       public String getServiceName() {
@@ -209,6 +222,10 @@ public class RemoteConfigRequest {
 
       public List<String> getTags() {
         return tags;
+      }
+
+      public List<String> getProcessTags() {
+        return processTags;
       }
     }
 


### PR DESCRIPTION
# What Does This Do

Adds Process tags in the remote config payload under `client_tracer.process_tags`

See also https://github.com/DataDog/datadog-agent/pull/36049/files and https://github.com/DataDog/dd-trace-java/pull/8698

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-628]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-628]: https://datadoghq.atlassian.net/browse/AIDM-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ