### PR TITLE
feat: update byte buddy to 1.15.x

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,15 +30,15 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.18")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.15.11")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")
   implementation("org.apache.maven", "maven-aether-provider", "3.3.9")
 
   implementation("com.google.guava", "guava", "20.0")
-  implementation("org.ow2.asm", "asm", "9.7.1")
-  implementation("org.ow2.asm", "asm-tree", "9.7.1")
+  implementation("org.ow2.asm", "asm", "9.8")
+  implementation("org.ow2.asm", "asm-tree", "9.8")
 
   testImplementation("org.spockframework", "spock-core", "2.2-groovy-3.0")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -27,7 +27,7 @@ class CallSiteInstrumentationPluginTest extends Specification {
     }
     
     dependencies {
-      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.18'
+      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.15.11'
       implementation group: 'com.google.auto.service', name: 'auto-service-annotations', version: '1.0-rc7'
     }
   '''

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.18' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.15.11' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ spock = "2.3-groovy-3.0"
 groovy = "3.0.17"
 junit5 = "5.9.2"
 logback = "1.2.3"
-bytebuddy = "1.14.18"
+bytebuddy = "1.15.11"
 scala = "2.11.12" # Last version to support Java 7 (2.12+ require Java 8+)
 scala211 = "2.11.12"
 scala212 = "2.12.18"
@@ -30,7 +30,7 @@ testcontainers = '1.20.1'
 jmc = "8.1.0"
 autoservice = "1.0-rc7"
 ddprof = "1.23.0"
-asm = "9.7.1"
+asm = "9.8"
 cafe_crypto = "0.1.0"
 lz4 = "1.7.1"
 


### PR DESCRIPTION
# What Does This Do
This updates byte buddy to 1.15.x to resolve the java 24 issue. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
