### PR TITLE
Update config line to account for large binary files

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -167,7 +167,8 @@ commands:
               if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != "release/*" ]]; then
                 # We know that we have checked out the PR merge branch, so the HEAD commit is a merge
                 # As a backup, if anything goes wrong with the diff, the build will fail
-                CHANGED_FILES=$(git show HEAD | grep -e "^Merge:" | cut -d ' ' -f 2- | sed 's/ /.../' | xargs git diff --name-only)
+                # Get list of changed files directly using git diff-tree to avoid issues with large binary files
+                CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)
                 # Count the number of matches, and ignore if the grep doesn't match anything
                 MATCH_COUNT=$(echo "$CHANGED_FILES" | grep -c -E "<< pipeline.parameters.global_pattern >>|<< parameters.pattern >>") || true
                 if [[ "$MATCH_COUNT" -eq "0" ]]; then


### PR DESCRIPTION
# What Does This Do

This PR changes the way we retrieve the list of changed files in the merge commit by replacing the original `git diff` command with a `git diff-tree` command.

# Motivation

#8657 tries to upgrade the byte-buddy version to 1.17.5 which requires the agent jar size to be increased. This increase was causing the original `git diff` command to fail due to the large binary file size. By using `git diff-tree`, we can compare the tree objects directly and avoid problems with large binary files.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
