### PR TITLE
Improve error reporting on profiler startup

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/CompositeController.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/CompositeController.java
@@ -1,5 +1,7 @@
 package com.datadog.profiling.agent;
 
+import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
+
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.ControllerContext;
 import com.datadog.profiling.controller.OngoingRecording;
@@ -140,15 +142,17 @@ public class CompositeController implements Controller {
     List<Controller> controllers = new ArrayList<>();
     boolean isOracleJDK8 = Platform.isOracleJDK8();
     boolean isDatadogProfilerEnabled = Config.get().isDatadogProfilerEnabled();
-    if (provider.getBoolean(ProfilingConfig.PROFILING_DEBUG_JFR_DISABLED, false)) {
-      log.warn("JFR is disabled by configuration");
+    boolean isJfrEnabled =
+        !provider.getBoolean(ProfilingConfig.PROFILING_DEBUG_JFR_DISABLED, false);
+    if (!isJfrEnabled) {
+      log.warn(SEND_TELEMETRY, "JFR is disabled by configuration");
     } else {
       if (isOracleJDK8 && !isDatadogProfilerEnabled) {
         try {
           Class.forName("com.oracle.jrockit.jfr.Producer");
           controllers.add(OracleJdkController.instance(provider));
-        } catch (Throwable ignored) {
-          log.debug("Failed to load oracle profiler", ignored);
+        } catch (Throwable t) {
+          log.debug(SEND_TELEMETRY, "Failed to load oracle profiler: " + t.getMessage(), t);
         }
       }
       if (!isOracleJDK8) {
@@ -156,10 +160,15 @@ public class CompositeController implements Controller {
           if (Platform.hasJfr()) {
             controllers.add(OpenJdkController.instance(provider));
           } else {
-            log.debug("JFR is not available on this platform");
+            log.debug(
+                SEND_TELEMETRY,
+                "JFR is not available on this platform: "
+                    + OperatingSystem.current()
+                    + ", "
+                    + Arch.current());
           }
-        } catch (Throwable ignored) {
-          log.debug("Failed to load openjdk profiler", ignored);
+        } catch (Throwable t) {
+          log.debug(SEND_TELEMETRY, "Failed to load openjdk profiler: " + t.getMessage(), t);
         }
       }
     }
@@ -175,16 +184,20 @@ public class CompositeController implements Controller {
         context.setDatadogProfilerUnavailableReason(rootCause.getMessage());
         OperatingSystem os = OperatingSystem.current();
         if (os != OperatingSystem.linux) {
-          log.debug("Datadog profiler only supported on Linux", rootCause);
-        } else if (log.isDebugEnabled()) {
-          log.warn(
-              "failed to instantiate Datadog profiler on {} {}", os, Arch.current(), rootCause);
-        } else {
+          log.debug(SEND_TELEMETRY, "Datadog profiler only supported on Linux", rootCause);
+        } else if (!log.isDebugEnabled()) {
           log.warn(
               "failed to instantiate Datadog profiler on {} {} because: {}",
               os,
               Arch.current(),
               rootCause.getMessage());
+        } else {
+          log.debug(
+              SEND_TELEMETRY,
+              "failed to instantiate Datadog profiler on {} {}",
+              os,
+              Arch.current(),
+              rootCause);
         }
       }
     } else {
@@ -202,14 +215,18 @@ public class CompositeController implements Controller {
     }
     controllers.forEach(controller -> controller.configure(context));
     if (controllers.isEmpty()) {
-      throw new UnsupportedEnvironmentException(getFixProposalMessage());
+      throw new UnsupportedEnvironmentException(
+          getFixProposalMessage(isDatadogProfilerEnabled, isJfrEnabled));
     } else if (controllers.size() == 1) {
       return controllers.get(0);
     }
     return new CompositeController(controllers);
   }
 
-  private static String getFixProposalMessage() {
+  private static String getFixProposalMessage(boolean datadogProfilerEnabled, boolean jfrEnabled) {
+    if (!datadogProfilerEnabled && !jfrEnabled) {
+      return "Profiling is disabled by configuration. Please, make sure that your configuration is correct.";
+    }
     final String javaVendor = System.getProperty("java.vendor");
     final String javaVersion = System.getProperty("java.version");
     final String javaRuntimeName = System.getProperty("java.runtime.name");

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -109,7 +109,7 @@ public class ProfilingAgent {
         return;
       }
       if (!config.isProfilingEnabled()) {
-        log.debug("Profiling: disabled");
+        log.debug(SEND_TELEMETRY, "Profiling: disabled");
         return;
       }
       if (config.getApiKey() != null && !API_KEY_REGEX.test(config.getApiKey())) {
@@ -167,7 +167,8 @@ public class ProfilingAgent {
         }
       } catch (final UnsupportedEnvironmentException e) {
         log.warn(e.getMessage());
-        log.debug(SEND_TELEMETRY, "Unsupported environment for Datadog profiler", e);
+        // no need to send telemetry for this aggregate message
+        //   a detailed telemetry message has been sent from the attempts to enable the controllers
       } catch (final ConfigurationException e) {
         log.warn("Failed to initialize profiling agent! {}", e.getMessage());
         log.debug(SEND_TELEMETRY, "Failed to initialize profiling agent!", e);


### PR DESCRIPTION
# What Does This Do
This modifies the way how we report the failures to initialize profiler components to DD telemetry and enhances the visibility to why the expected temporary directory structure may not get properly created.

# Motivation
Improve the supportability of the profiler configuration issues

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11667]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11667]: https://datadoghq.atlassian.net/browse/PROF-11667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ