### PR TITLE
Do not set the hibernate or datanucleus span service name when disabled

### DIFF
--- a/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/DatanucleusDecorator.java
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/DatanucleusDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.datanucleus;
 
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -16,7 +17,8 @@ public class DatanucleusDecorator extends OrmClientDecorator {
   public static final CharSequence DATANUCLEUS_QUERY_DELETE =
       UTF8BytesString.create("datanucleus.query.delete");
   public static final CharSequence JAVA_DATANUCLEUS = UTF8BytesString.create("java-datanucleus");
-
+  private static final String SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("datanucleus");
   public static final DatanucleusDecorator DECORATE = new DatanucleusDecorator();
 
   @Override
@@ -36,7 +38,7 @@ public class DatanucleusDecorator extends OrmClientDecorator {
 
   @Override
   protected String service() {
-    return "datanucleus";
+    return SERVICE_NAME;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.hibernate;
 
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.OrmClientDecorator;
@@ -10,11 +11,13 @@ import java.util.Set;
 
 public class HibernateDecorator extends OrmClientDecorator {
   public static final CharSequence HIBERNATE_SESSION = UTF8BytesString.create("hibernate.session");
+  private static final String SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("hibernate");
   public static final HibernateDecorator DECORATOR = new HibernateDecorator();
 
   @Override
   protected String service() {
-    return "hibernate";
+    return SERVICE_NAME;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Do not set the hibernate or datanucleus span service name if `dd.trace.remove.integration-service-names.enabled` is `true` or the naming scheme version is `v1`

# Motivation

It's currently impossible to disable and results in an unwanted service name `hibernate`.

# Additional Notes

This may have been an oversight, because of the many DatabaseClientDecorator implementations, only Hibernate and Datanucleus were not updated.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15546]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15546]: https://datadoghq.atlassian.net/browse/APMS-15546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ