### PR TITLE
Ensure net.bytebuddy.raw is set to true when ConfigTransformSpockExtension is installed

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactoryForkedTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactoryForkedTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.agent.tooling.bytebuddy.outline
 
 import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers
+import net.bytebuddy.description.type.TypeDescription
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -28,6 +29,9 @@ class TypeFactoryForkedTest extends Specification {
   def hasContextField = declaresContextField('java.lang.Runnable', 'java.lang.String')
 
   def "can mix full types with outlines"() {
+    expect:
+    TypeDescription.AbstractBase.RAW_TYPES // this test relies on raw-types
+
     when:
     def systemLoader = ClassLoader.systemClassLoader
     def systemLocator = ClassFileLocators.classFileLocator(systemLoader)

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/ConfigTransformSpockExtension.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/ConfigTransformSpockExtension.groovy
@@ -18,6 +18,11 @@ import static net.bytebuddy.matcher.ElementMatchers.none
  * Transforms the Config class to make its INSTANCE field non-final and volatile.
  */
 class ConfigTransformSpockExtension implements IGlobalExtension {
+  static {
+    // same setting as AgentInstaller to avoid spurious agent-tooling test failures
+    System.setProperty("net.bytebuddy.raw", "true")
+  }
+
   static final String INST_CONFIG = "datadog.trace.api.InstrumenterConfig"
   static final String CONFIG = "datadog.trace.api.Config"
 


### PR DESCRIPTION
# What Does This Do

This matches the same setting used by AgentInstaller which avoids spurious test failures in agent-tooling, specifically TypeFactoryForkedTest. This requires raw-types enabled to match the behaviour when installing the tracer with -javaagent. Without this byte-buddy will use dufferent code paths involving generic checks, which can lead to test failures using recent versions of byte-buddy (specifically going between full and outline types, where outlines are always raw-types by their nature.)

# Motivation

These failures would not happen when using -javaagent because AgentInstaller forces the use of the raw-types setting. ConfigTransformSpockExtension should therefore do the same.

# Additional Notes

Note we can't set this property in TypeFactoryForkedTest because by then it is too late, byte-buddy is already confgured by ConfigTransformSpockExtension and the raw-types value cannot be changed.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
