### PR TITLE
Revert "Update config line to account for large binary files"

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -167,8 +167,7 @@ commands:
               if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != "release/*" ]]; then
                 # We know that we have checked out the PR merge branch, so the HEAD commit is a merge
                 # As a backup, if anything goes wrong with the diff, the build will fail
-                # Get list of changed files directly using git diff-tree to avoid issues with large binary files
-                CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)
+                CHANGED_FILES=$(git show HEAD | grep -e "^Merge:" | cut -d ' ' -f 2- | sed 's/ /.../' | xargs git diff --name-only)
                 # Count the number of matches, and ignore if the grep doesn't match anything
                 MATCH_COUNT=$(echo "$CHANGED_FILES" | grep -c -E "<< pipeline.parameters.global_pattern >>|<< parameters.pattern >>") || true
                 if [[ "$MATCH_COUNT" -eq "0" ]]; then

--- a/dd-java-agent/instrumentation/mule-4/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4/build.gradle
@@ -78,6 +78,9 @@ configurations.all {
     // avoid bringing in logback based on java 11
     force libs.logback.classic
     force libs.logback.core
+
+    // force specific version of byte-buddy for all configurations
+    force 'net.bytebuddy:byte-buddy:1.14.18'
   }
 }
 
@@ -146,7 +149,6 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:caffeine')
   testImplementation project(':dd-java-agent:instrumentation:quartz-2')
 
-
   testImplementation group: 'org.mule.runtime', name: 'mule-module-launcher', version: muleVersion
   testImplementation group: 'org.mule.runtime', name: 'mule-core', version: muleVersion
   //testImplementation group: 'org.mule.runtime', name: 'mule-module-extensions-spring-support', version: muleVersion
@@ -174,7 +176,6 @@ dependencies {
   latestDepForkedTestImplementation group: 'org.mule.runtime', name: 'mule-module-extensions-spring-support', version: '4.8.+'
   latestDepForkedTestImplementation group: 'org.mule.runtime', name: 'mule-module-service', version: '4.8.+'
   latestDepForkedTestImplementation group: 'org.mule.runtime', name: 'mule-module-javaee', version: '4.8.+'
-
 
   //TODO: 4.9.0 is not yet out but it looks like using 4.+ instead of above 4.8.+ brings in 4.9.0-SNAPSHOT artifacts.
   /*


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#8709

This change is unnecessary given our excluding extra classes in the latest byte-buddy upgrade. It also caused us to miss some testing on PRs, namely with #8720 (resolved by #8728).