### PR TITLE
Limit net.bytebuddy.raw fix to agent-tooling…

### DIFF
--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -89,3 +89,9 @@ project.tasks.compileTest_java11Java.configure {
 final jmh = project.tasks.jmh
 jmh.outputs.upToDateWhen { false }
 jmh.dependsOn(compileTestJava)
+
+tasks.withType(Test).configureEach {
+  // same setting as AgentInstaller to avoid spurious agent-tooling test failures
+  // caused by ConfigTransformSpockExtension installing byte-buddy during testing
+  jvmArgs += ["-Dnet.bytebuddy.raw=true"]
+}

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/ConfigTransformSpockExtension.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/ConfigTransformSpockExtension.groovy
@@ -18,11 +18,6 @@ import static net.bytebuddy.matcher.ElementMatchers.none
  * Transforms the Config class to make its INSTANCE field non-final and volatile.
  */
 class ConfigTransformSpockExtension implements IGlobalExtension {
-  static {
-    // same setting as AgentInstaller to avoid spurious agent-tooling test failures
-    System.setProperty("net.bytebuddy.raw", "true")
-  }
-
   static final String INST_CONFIG = "datadog.trace.api.InstrumenterConfig"
   static final String CONFIG = "datadog.trace.api.Config"
 


### PR DESCRIPTION
# Motivation

…to avoid the fix in  #8728 causing test side-effects elsewhere

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
