### PR TITLE
Update trace sampling formula

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -49,7 +49,7 @@ public abstract class DeterministicSampler implements RateSampler {
   @Override
   public <T extends CoreSpan<T>> boolean sample(final T span) {
     // unsigned 64 bit comparison with cutoff/threshold
-    return getSamplingId(span) * KNUTH_FACTOR + Long.MIN_VALUE < threshold;
+    return getSamplingId(span) * KNUTH_FACTOR + Long.MIN_VALUE <= threshold;
   }
 
   protected abstract <T extends CoreSpan<T>> long getSamplingId(T span);

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/DeterministicTraceSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/DeterministicTraceSamplerTest.groovy
@@ -121,6 +121,7 @@ class DeterministicTraceSamplerTest extends DDSpecification {
     true     | "9828766684487745566"
     true     | "9908585559158765387"
     true     | "9956202364908137547"
+    true     | "9223372036854775808"
   }
 
   def "test sampling none: #traceId"() {


### PR DESCRIPTION
# What Does This Do

The sampling formula has changed a bit to have an consistent one across all tracers. The change is relatively small in Java as it only require a change from `<` to `<=`

# Motivation


We are aiming to have consistent sampling over all tracers.

# Additional Notes

I added a new TraceID to the unit test that lands exactly on `0.5 * (2^64 -1)` when multiplicated by the knuth

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1262]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-1262]: https://datadoghq.atlassian.net/browse/APMAPI-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ