### PR TITLE
Use byte-buddy classes optimized for Java8+

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -99,6 +99,16 @@ def includeShadowJar(TaskProvider<ShadowJar> shadowJarTask, String jarname) {
       rename '(^.*)\\.class$', '$1.classdata'
       // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
       rename '^LICENSE$', 'LICENSE.renamed'
+      if (jarname == 'inst') {
+        // byte-buddy now ships classes optimized for Java8+ under META-INF/versions/9
+        // since we target Java8+ we can promote these classes over the pre-Java8 ones
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        eachFile {
+          if (it.path.contains('META-INF/versions/9/net/bytebuddy')) {
+            it.path = it.path.replace('META-INF/versions/9/', '')
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

byte-buddy now ships classes optimized for Java8+ under `META-INF/versions/9`

since we target Java8+ we can promote these classes over the pre-Java8 ones

# Motivation

these classes should allow for [faster class file validation and CDS support](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.15.6) on JDK 8 and later

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
