### PR TITLE
Introduce Java 8 bytecode bridge for instrumentation API

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Java8BytecodeBridge.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Java8BytecodeBridge.java
@@ -1,0 +1,32 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.context.Context;
+
+/**
+ * A helper for accessing methods that rely on new Java 8 bytecode features such as calling a static
+ * interface methods. In instrumentation, we may need to call these methods in code that is inlined
+ * into an instrumented class, however many times the instrumented class has been compiled to a
+ * previous version of bytecode, and so we cannot inline calls to static interface methods, as those
+ * were not supported prior to Java 8 and will lead to a class verification error.
+ */
+public class Java8BytecodeBridge {
+  /** @see Context#root() */
+  public static Context getRootContext() {
+    return Context.root();
+  }
+
+  /** @see Context#current() */
+  public static Context getCurrentContext() {
+    return Context.current();
+  }
+
+  /** @see Context#from(Object) */
+  public static Context getContextFrom(Object carrier) {
+    return Context.from(carrier);
+  }
+
+  /** @see Context#detachFrom(Object) */
+  public static Context detachContextFrom(Object carrier) {
+    return Context.detachFrom(carrier);
+  }
+}


### PR DESCRIPTION
# What Does This Do

Introduce Java 8 bytecode bride.

> In instrumentation, we may need to call these methods in code that is inlined into an instrumented class, however many times the instrumented class has been compiled to a previous version of bytecode, and so we cannot inline calls to static interface methods, as those were not supported prior to Java 8 and will lead to a class verification error.

# Motivation

Add has context API helpers

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-457]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-457]: https://datadoghq.atlassian.net/browse/LANGPLAT-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ