### PR TITLE
Add Java 24 tests to CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1237,6 +1237,20 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 3
       testJvm: "21"
 
+  - xlarge_tests:
+      requires:
+        - ok_to_test
+        - build_latestdep
+      name: test_24_inst_latest
+      gradleTarget: ":instrumentationLatestDepTest"
+      gradleParameters: "-PskipFlakyTests"
+      triggeredBy: *instrumentation_modules
+      stage: instrumentation
+      cacheType: latestdep
+      parallelism: 12
+      maxWorkers: 3
+      testJvm: "24"
+
 {% if flaky %}
   - tests:
       requires:

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -15,7 +15,7 @@ OUT_FILENAME = "config.continue.yml"
 GENERATED_CONFIG_PATH = os.path.join(SCRIPT_DIR, OUT_FILENAME)
 
 # JDKs that will run on every pipeline.
-ALWAYS_ON_JDKS = {"8", "17", "21"}
+ALWAYS_ON_JDKS = {"8", "17", "21", "24"}
 # And these will run only in master and release/ branches.
 MASTER_ONLY_JDKS = {
     "11",


### PR DESCRIPTION
# What Does This Do

Add minimum Java 24 tests to CI

# Motivation

Test Java 24

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
