### PR TITLE
Fix exclude identifiers normalization

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
@@ -117,7 +117,10 @@ public class Redaction {
      * based on sentry list: https://github.com/getsentry/sentry-python/blob/fefb454287b771ac31db4e30fa459d9be2f977b8/sentry_sdk/scrubber.py#L17-L58
      */
     KEYWORDS.addAll(PREDEFINED_KEYWORDS);
-    KEYWORDS.removeAll(Config.get().getDynamicInstrumentationRedactionExcludedIdentifiers());
+    // Exclude user defined keywords
+    for (String keyword : Config.get().getDynamicInstrumentationRedactionExcludedIdentifiers()) {
+      KEYWORDS.remove(normalize(keyword));
+    }
   }
 
   public static void addUserDefinedKeywords(Config config) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
@@ -58,10 +58,11 @@ class RedactionTest {
     setFieldInConfig(
         config,
         "dynamicInstrumentationRedactionExcludedIdentifiers",
-        new HashSet<>(Arrays.asList("password")));
+        new HashSet<>(Arrays.asList("password", "_2FA")));
     Redaction.initKeywords();
     try {
       assertFalse(Redaction.isRedactedKeyword("password"));
+      assertFalse(Redaction.isRedactedKeyword("_2fa"));
     } finally {
       setFieldInConfig(
           config, "dynamicInstrumentationRedactionExcludedIdentifiers", Collections.emptySet());


### PR DESCRIPTION
# What Does This Do

exclude identifiers provided by configuration were not normalized

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3745]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3745]: https://datadoghq.atlassian.net/browse/DEBUG-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ