### PR TITLE
Do not run JFR specific tests on J9

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -12,14 +12,16 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRI
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.datadog.profiling.controller.ControllerContext;
 import com.datadog.profiling.controller.jfr.JfpUtilsTest;
+import datadog.trace.api.Platform;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.util.Properties;
 import jdk.jfr.Recording;
-import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +30,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class OpenJdkControllerTest {
 
   private static final String TEST_NAME = "recording name";
+
+  @BeforeAll
+  static void setupSpec() {
+    assumeFalse(Platform.isJ9());
+  }
 
   @Test
   public void testCreateContinuousRecording() throws Exception {
@@ -194,7 +201,7 @@ public class OpenJdkControllerTest {
 
   @Test
   public void testNativeProfilerIsDisabledOnUnsupportedVersion() throws Exception {
-    Assumptions.assumeFalse(isNativeMethodSampleAvailable());
+    assumeFalse(isNativeMethodSampleAvailable());
     Properties props = getConfigProperties();
 
     ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
@@ -1,11 +1,13 @@
 package com.datadog.profiling.controller.openjdk;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datadog.profiling.controller.ControllerContext;
+import datadog.trace.api.Platform;
 import datadog.trace.api.profiling.RecordingData;
 import java.time.Instant;
 import jdk.jfr.Recording;
@@ -34,6 +36,7 @@ public class OpenJdkOngoingRecordingTest {
 
   @BeforeEach
   public void setup() {
+    assumeFalse(Platform.isJ9());
     when(recording.getState()).thenReturn(RecordingState.RUNNING);
     when(recording.getName()).thenReturn(TEST_NAME);
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
@@ -4,9 +4,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import datadog.trace.api.Platform;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +44,7 @@ public class OpenJdkRecordingDataTest {
 
   @BeforeEach
   public void setup() throws IOException {
+    assumeFalse(Platform.isJ9());
     when(recording.getStream(start, end)).thenReturn(stream);
     when(recording.getStream(customStart, customEnd)).thenReturn(customStream);
     when(recording.getStartTime()).thenReturn(start);

--- a/dd-java-agent/instrumentation/exception-profiling/src/test/groovy/datadog/trace/bootstrap/instrumentation/jfr/exceptions/KnownExcludesForkedTest.groovy
+++ b/dd-java-agent/instrumentation/exception-profiling/src/test/groovy/datadog/trace/bootstrap/instrumentation/jfr/exceptions/KnownExcludesForkedTest.groovy
@@ -1,5 +1,6 @@
 import com.zaxxer.hikari.pool.ProxyLeakTask
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling
 import jdk.jfr.Recording
 import org.openjdk.jmc.common.item.Attribute
@@ -7,10 +8,14 @@ import org.openjdk.jmc.common.item.IAttribute
 import org.openjdk.jmc.common.item.ItemFilters
 import org.openjdk.jmc.common.unit.UnitLookup
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit
+import spock.lang.Requires
 import spock.lang.Shared
 
 import java.nio.file.Files
 
+@Requires({
+  !Platform.isJ9()
+})
 class KnownExcludesForkedTest extends AgentTestRunner {
   private static final IAttribute<String> TYPE =
   Attribute.attr("type", "type", "Exception type", UnitLookup.PLAIN_TEXT)

--- a/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionHistogramTest.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionHistogramTest.java
@@ -5,10 +5,12 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import datadog.trace.api.Config;
+import datadog.trace.api.Platform;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Comparator;
@@ -60,6 +62,7 @@ public class ExceptionHistogramTest {
 
   @BeforeEach
   public void setup() {
+    assumeFalse(Platform.isJ9());
     recording = new Recording();
     recording.enable("datadog.ExceptionCount");
     recording.start();

--- a/dd-java-agent/instrumentation/java-directbytebuffer/src/test/groovy/DirectAllocationTrackingTest.groovy
+++ b/dd-java-agent/instrumentation/java-directbytebuffer/src/test/groovy/DirectAllocationTrackingTest.groovy
@@ -1,9 +1,11 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling
 import jdk.jfr.FlightRecorder
 import jdk.jfr.Recording
 import jdk.jfr.consumer.RecordingFile
+import spock.lang.Requires
 
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
@@ -14,6 +16,9 @@ import java.util.stream.Collectors
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
+@Requires({
+  !Platform.isJ9()
+})
 class DirectAllocationTrackingTest extends AgentTestRunner {
 
   Recording recording


### PR DESCRIPTION
It does what it says - it will prevent unexpected test failures on J9 with JFR stub implementation.