### PR TITLE
Do not inspect reactor context when not needed

### DIFF
--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ContextSpanHelper.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ContextSpanHelper.java
@@ -4,16 +4,37 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
 import javax.annotation.Nullable;
 import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
 public class ContextSpanHelper {
+
+  private static final Class<?> MONO_WITH_CONTEXT_CLASS = findMonoWithContextClass();
+
   private static final String DD_SPAN_KEY = "dd.span";
+
+  private static Class<?> findMonoWithContextClass() {
+    final ClassLoader classLoader = Mono.class.getClassLoader();
+    // 3.4+
+    try {
+      return Class.forName(
+          "reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber", false, classLoader);
+    } catch (Throwable ignored) {
+    }
+    // < 3.4
+    try {
+      return Class.forName(
+          "reactor.core.publisher.FluxContextStart$ContextStartSubscriber", false, classLoader);
+    } catch (Throwable ignored) {
+    }
+    return null;
+  }
 
   private ContextSpanHelper() {}
 
   @Nullable
   public static AgentSpan extractSpanFromSubscriberContext(final CoreSubscriber<?> subscriber) {
-    if (subscriber == null) {
+    if (MONO_WITH_CONTEXT_CLASS == null || !MONO_WITH_CONTEXT_CLASS.isInstance(subscriber)) {
       return null;
     }
     Context context = null;


### PR DESCRIPTION
# What Does This Do

Our reactor-core instrumentation needs to access to the `currentContext()` in order to _eventually_ propagate the active span the user can provide under the `dd.span` key.
The issue, raised by one customer, is that access can eat a lot of cpu time because of the way reactor is working.
In fact, the reactor operators, are nested and for InnerOperators (https://github.com/reactor/reactor-core/blob/718cc691dc3610e6a46636b2e90f1a37bb434669/reactor-core/src/main/java/reactor/core/publisher/InnerOperator.java#L33) the call is delegating to the enclosed one.

This means that on each subscribe and onNext we're calling a lot of method wasting time and causing performance issue.
That PR is addressing the issue by limiting that context access only when needed

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-611]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-611]: https://datadoghq.atlassian.net/browse/AIDM-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ