### PR TITLE
Exclude jackson afterburner dynamic classes from instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/proxy_ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/proxy_ignored_class_name.trie
@@ -31,4 +31,7 @@
 1 $Access4JacksonDeserializer*
 1 $Access4JacksonSerializer*
 1 $Creator4JacksonDeserializer*
-1 $Creator4JacksonSerializer*
+# Hibernate
+1 $HibernateInstantiator$*
+1 $HibernateProxy$*
+1 $HibernateAccessOptimizer$*

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/proxy_ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/proxy_ignored_class_name.trie
@@ -27,3 +27,8 @@
 1 $$_Weld*
 1 $$_jvst*
 1 $$SpringCGLIB$$*
+# Jackson afterburner
+1 $Access4JacksonDeserializer*
+1 $Access4JacksonSerializer*
+1 $Creator4JacksonDeserializer*
+1 $Creator4JacksonSerializer*


### PR DESCRIPTION
# What Does This Do

Excludes jackson afterburner classes from instrumentations. See https://github.com/search?q=org%3AFasterXML+4Jackson+repo%3AFasterXML%2Fjackson-module-afterburner&type=code

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
