### PR TITLE
Take defensive copy of parent scope stack when closing nested coroutines

### DIFF
--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
@@ -52,8 +52,7 @@ public class FiberContext {
   }
 
   public void onResume() {
-    this.oldState = AgentTracer.get().newScopeState();
-    this.oldState.fetchFromActive();
+    this.oldState = AgentTracer.get().oldScopeState();
 
     this.state.activate();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -295,6 +295,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public ScopeState oldScopeState() {
+    return scopeManager.oldScopeState();
+  }
+
+  @Override
   public ScopeState newScopeState() {
     return scopeManager.newScopeState();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -350,8 +350,13 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
   }
 
   @Override
+  public ScopeState oldScopeState() {
+    return new ContinuableScopeState(tlsScopeStack.get());
+  }
+
+  @Override
   public ScopeState newScopeState() {
-    return new ContinuableScopeState();
+    return new ContinuableScopeState(tlsScopeStack.initialValue());
   }
 
   @Override
@@ -371,8 +376,11 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
   }
 
   private class ContinuableScopeState implements ScopeState {
+    private final ScopeStack localScopeStack;
 
-    private ScopeStack localScopeStack = tlsScopeStack.initialValue();
+    ContinuableScopeState(ScopeStack scopeStack) {
+      this.localScopeStack = scopeStack;
+    }
 
     @Override
     public void activate() {
@@ -380,8 +388,8 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
     }
 
     @Override
-    public void fetchFromActive() {
-      localScopeStack = tlsScopeStack.get();
+    public ScopeState copy() {
+      return new ContinuableScopeState(localScopeStack.copy());
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
@@ -24,6 +24,14 @@ final class ScopeStack {
     this.profilingContextIntegration = profilingContextIntegration;
   }
 
+  ScopeStack copy() {
+    ScopeStack copy = new ScopeStack(profilingContextIntegration);
+    copy.stack.addAll(stack);
+    copy.top = top;
+    copy.overdueRootScope = overdueRootScope;
+    return copy;
+  }
+
   ContinuableScope active() {
     // avoid attaching further spans to the root scope when it's been marked as overdue
     return top != overdueRootScope ? top : null;

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -72,8 +72,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "scope state should be able to fetch and activate state when there is no active span"() {
     when:
-    def initialScopeState = scopeManager.newScopeState()
-    initialScopeState.fetchFromActive()
+    def initialScopeState = scopeManager.oldScopeState()
 
     then:
     scopeManager.active() == null
@@ -125,8 +124,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    def initialScopeState = scopeManager.newScopeState()
-    initialScopeState.fetchFromActive()
+    def initialScopeState = scopeManager.oldScopeState()
 
     then:
     scope.span() == span

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -639,6 +639,11 @@ public class AgentTracer {
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
 
     @Override
+    public ScopeState oldScopeState() {
+      return null;
+    }
+
+    @Override
     public ScopeState newScopeState() {
       return null;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
@@ -3,5 +3,5 @@ package datadog.trace.bootstrap.instrumentation.api;
 public interface ScopeState {
   void activate();
 
-  void fetchFromActive();
+  ScopeState copy();
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
@@ -1,5 +1,9 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 public interface ScopeStateAware {
+  /** @return The old connected scope stack */
+  ScopeState oldScopeState();
+
+  /** @return A new disconnected scope stack */
   ScopeState newScopeState();
 }


### PR DESCRIPTION
# What Does This Do

This PR applies some short-term defensive fixes:
* Remove `newScopeState().fetchFromActive()` code path in favour of `oldScopeState()` which does both
* Remove the cached coroutine context item when we first start closing the coroutine, not at the end
* Take defensive copy of parent scope stack when closing nested child coroutines

# Motivation

The parent coroutine scope stack is only used for cleanup purposes in certain situations and using a defensive copy avoids potential concurrent modification issues when different child coroutines are closed at the same time across multiple threads.

# Additional Notes

This code is being refactored as part of further context improvements, so these defensive fixes are only needed in the short-term.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15615]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15615]: https://datadoghq.atlassian.net/browse/APMS-15615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ