### PR TITLE
Fix incorrect use of Path.getRoot()

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -465,7 +465,9 @@ public final class TempLocationManager {
       // we will find the first offender not having the expected permissions and fail the check
       if (isPosixFs) {
         // take the first subfolder below the base temp dir
-        Path root = baseTempDir.resolve(baseTempDir.relativize(tempDir).getRoot());
+        // we can wave the checks for tempDir being a subdir of baseTempDir because that's how it is
+        // created
+        Path root = baseTempDir.resolve(baseTempDir.relativize(tempDir).getName(0));
         try {
           AtomicReference<Path> failed = new AtomicReference<>();
           Files.walkFileTree(


### PR DESCRIPTION
# What Does This Do
After #8714 the profiling tests started failing. The reason is that the `Path.getRoot()` will return `null` for a single element path because it considers it not having a root 🤷 

# Notes
As a part of this change I removed the `testShortCircuit` test - because the base temp directory is now created eagerly and not lazily so it can not happen that it will not exist, and this test was asserting that exact 'short-circuit' to avoid scanning the dir structure when there is guaranteed nothing in there.

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
