### PR TITLE
Solve file leakage and turn JDK socket support on by default

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2022,7 +2022,7 @@ public class Config {
 
     this.apmTracingEnabled = configProvider.getBoolean(GeneralConfig.APM_TRACING_ENABLED, true);
 
-    this.jdkSocketEnabled = configProvider.getBoolean(JDK_SOCKET_ENABLED, false);
+    this.jdkSocketEnabled = configProvider.getBoolean(JDK_SOCKET_ENABLED, true);
 
     log.debug("New instance: {}", this);
   }

--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -142,7 +142,9 @@ final class TunnelingJdkSocket extends Socket {
     try {
       unixSocketChannel.setOption(java.net.StandardSocketOptions.SO_SNDBUF, size);
     } catch (IOException e) {
-      throw new SocketException("Failed to set send buffer size socket option");
+      SocketException se = new SocketException("Failed to set send buffer size socket option");
+      se.initCause(e);
+      throw se;
     }
   }
 
@@ -169,7 +171,9 @@ final class TunnelingJdkSocket extends Socket {
     try {
       unixSocketChannel.setOption(java.net.StandardSocketOptions.SO_RCVBUF, size);
     } catch (IOException e) {
-      throw new SocketException("Failed to set receive buffer size socket option");
+      SocketException se = new SocketException("Failed to set receive buffer size socket option");
+      se.initCause(e);
+      throw se;
     }
   }
 
@@ -339,18 +343,31 @@ final class TunnelingJdkSocket extends Socket {
     if (isClosed()) {
       return;
     }
-    if (!isInputShutdown()) {
-      shutdownInput();
+    // Ignore possible exceptions so that we continue closing the socket
+    try {
+      if (!isInputShutdown()) {
+        shutdownInput();
+      }
+    } catch (IOException e) {
     }
-    if (!isOutputShutdown()) {
-      shutdownOutput();
+    try {
+      if (!isOutputShutdown()) {
+        shutdownOutput();
+      }
+    } catch (IOException e) {
     }
-    if (selector != null) {
-      selector.close();
-      selector = null;
+    try {
+      if (selector != null) {
+        selector.close();
+        selector = null;
+      }
+    } catch (IOException e) {
     }
-    if (unixSocketChannel != null) {
-      unixSocketChannel.close();
+    try {
+      if (unixSocketChannel != null) {
+        unixSocketChannel.close();
+      }
+    } catch (IOException e) {
     }
     closed = true;
   }

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -25,7 +25,7 @@ public class TunnelingJdkSocketTest {
   private static final AtomicBoolean isServerRunning = new AtomicBoolean(false);
 
   @Test
-  public void testSocketConnect() throws Exception {
+  public void testSocketConnectAndClose() throws Exception {
     if (!Config.get().isJdkSocketEnabled()) {
       System.out.println(
           "TunnelingJdkSocket usage is disabled. Enable it by setting the property 'JDK_SOCKET_ENABLED' to 'true'.");
@@ -39,45 +39,25 @@ public class TunnelingJdkSocketTest {
 
     assertFalse(clientSocket.isConnected());
     assertFalse(clientSocket.isClosed());
+
     clientSocket.connect(new InetSocketAddress("localhost", 0));
+    InputStream inputStream = clientSocket.getInputStream();
+    OutputStream outputStream = clientSocket.getOutputStream();
+
     assertTrue(clientSocket.isConnected());
     assertFalse(clientSocket.isClosed());
     assertFalse(clientSocket.isInputShutdown());
     assertFalse(clientSocket.isOutputShutdown());
     assertThrows(
         SocketException.class, () -> clientSocket.connect(new InetSocketAddress("localhost", 0)));
-    clientSocket.close();
-    assertFalse(clientSocket.isConnected());
-    assertTrue(clientSocket.isClosed());
-    assertTrue(clientSocket.isInputShutdown());
-    assertTrue(clientSocket.isOutputShutdown());
+
     clientSocket.close();
 
-    isServerRunning.set(false);
-  }
-
-  @Test
-  public void testSocketClose() throws Exception {
-    if (!Config.get().isJdkSocketEnabled()) {
-      System.out.println(
-          "TunnelingJdkSocket usage is disabled. Enable it by setting the property 'JDK_SOCKET_ENABLED' to 'true'.");
-      return;
-    }
-
-    TunnelingJdkSocket clientSocket = createClient();
-    InputStream inputStream = clientSocket.getInputStream();
-    OutputStream outputStream = clientSocket.getOutputStream();
-
-    assertFalse(clientSocket.isClosed());
-    assertFalse(clientSocket.isInputShutdown());
-    assertFalse(clientSocket.isOutputShutdown());
     assertTrue(clientSocket.isConnected());
-    clientSocket.close();
     assertTrue(clientSocket.isClosed());
     assertTrue(clientSocket.isInputShutdown());
     assertTrue(clientSocket.isOutputShutdown());
-    assertFalse(clientSocket.isConnected());
-    assertThrows(IOException.class, () -> inputStream.read());
+    assertEquals(-1, inputStream.read());
     assertThrows(IOException.class, () -> outputStream.write(1));
     assertThrows(SocketException.class, () -> clientSocket.getInputStream());
     assertThrows(SocketException.class, () -> clientSocket.getOutputStream());
@@ -101,11 +81,13 @@ public class TunnelingJdkSocketTest {
     assertFalse(clientSocket.isClosed());
     assertFalse(clientSocket.isInputShutdown());
     assertFalse(clientSocket.isOutputShutdown());
+
     inputStream.close();
+
     assertTrue(clientSocket.isClosed());
     assertTrue(clientSocket.isInputShutdown());
     assertTrue(clientSocket.isOutputShutdown());
-    assertThrows(IOException.class, () -> inputStream.read());
+    assertEquals(-1, inputStream.read());
     assertThrows(IOException.class, () -> outputStream.write(1));
     assertThrows(SocketException.class, () -> clientSocket.getInputStream());
     assertThrows(SocketException.class, () -> clientSocket.getOutputStream());
@@ -128,11 +110,13 @@ public class TunnelingJdkSocketTest {
     assertFalse(clientSocket.isClosed());
     assertFalse(clientSocket.isInputShutdown());
     assertFalse(clientSocket.isOutputShutdown());
+
     outputStream.close();
+
     assertTrue(clientSocket.isClosed());
     assertTrue(clientSocket.isInputShutdown());
     assertTrue(clientSocket.isOutputShutdown());
-    assertThrows(IOException.class, () -> inputStream.read());
+    assertEquals(-1, inputStream.read());
     assertThrows(IOException.class, () -> outputStream.write(1));
     assertThrows(SocketException.class, () -> clientSocket.getInputStream());
     assertThrows(SocketException.class, () -> clientSocket.getOutputStream());

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -229,14 +229,14 @@ public class TunnelingJdkSocketTest {
     for (int i = 0; i < 100; i++) {
       InputStream inputStream = clientSocket.getInputStream();
       long currentCount = getFileDescriptorCount();
-      assertTrue(currentCount <= initialCount + 7); // why +7?
+      assertTrue(currentCount <= initialCount + 7);
     }
 
     clientSocket.close();
     isServerRunning.set(false);
 
     long finalCount = getFileDescriptorCount();
-    assertTrue(finalCount <= initialCount + 3); // why +3?
+    assertTrue(finalCount <= initialCount + 3);
   }
 
   private long getFileDescriptorCount() {


### PR DESCRIPTION
# What Does This Do

Address file leakage issue with the native UDS implementation.

Update closing technique such that when the input stream, output stream, or socket is closed, all resources (i.e. input stream, output stream, channel, selector, and socket) are closed. This better matches expected socket behavior.

Turn JDK socket support by default back on.

# Motivation

Resolve issue: https://github.com/DataDog/dd-trace-java/issues/8696

Update closing technique to match expected behavior - [closing the input stream should close the socket](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/Socket.java#L922-L923), [closing the output stream should close the socket](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/Socket.java#L1040-L1041), and [closing the socket should close both streams and the associated channel](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/Socket.java#L1613-L1618).

# Additional Notes

OpenJDK Socket class for reference: https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/Socket.java

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-459

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
