### PR TITLE
Clean up old CI reports

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -78,24 +78,6 @@ jobs:
       - name: Perform CodeQL Analysis and upload results to GitHub Security tab
         uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
 
-      # For now, CodeQL SARIF results are not supported by Datadog CI
-      # - name: Upload results to Datadog CI Static Analysis
-      #   run: |
-      #     wget --no-verbose https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 -O datadog-ci
-      #     chmod +x datadog-ci
-      #     ./datadog-ci sarif upload /home/runner/work/dd-trace-java/results/java.sarif --service dd-trace-java --env ci
-      #   env:
-      #     DD_API_KEY: ${{ secrets.DATADOG_APP_KEY_PROD }}
-      #     DD_SITE: datadoghq.com
-
-      # For now, CodeQL SARIF results are not supported by Datadog CI
-      # - name: Upload results to Datadog Staging CI Static Analysis
-      #   run: |
-      #     ./datadog-ci sarif upload /home/runner/work/dd-trace-java/results/java.sarif --service dd-trace-java --env ci
-      #   env:
-      #     DD_API_KEY: ${{ secrets.DATADOG_API_KEY_STAGING }}
-      #     DD_SITE: datad0g.com
-
   trivy:
     name: Analyze changes with Trivy
     runs-on: ubuntu-latest
@@ -170,10 +152,3 @@ jobs:
         env:
           DD_API_KEY: ${{ secrets.DATADOG_API_KEY_PROD }}
           DD_SITE: datadoghq.com
-
-      - name: Upload results to Datadog Staging CI Static Analysis
-        run: |
-          ./datadog-ci sarif upload trivy-results.sarif --service dd-trace-java --env ci
-        env:
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_STAGING }}
-          DD_SITE: datad0g.com


### PR DESCRIPTION
# What Does This Do

Clean up old reporting to staging environment.

# Motivation

No more used as moved to production environment.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
