### PR TITLE
Preserve old logic to extract jar file name

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/internal-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -103,9 +103,9 @@ public class CapturedEnvironment {
       return siteName;
     }
 
-    if (processInfo.jarFile != null) {
-      final String jarName = processInfo.jarFile.getName();
-      return jarName.substring(0, jarName.length() - 4); // strip .jar
+    // preserve the original logic that is case sensitive on the .jar extension
+    if (processInfo.jarFile != null && processInfo.jarFile.getName().endsWith(".jar")) {
+      return processInfo.jarFile.getName().replace(".jar", "");
     } else {
       return processInfo.mainClass;
     }


### PR DESCRIPTION
# What Does This Do

During #8698 the `CapturedEnvironment` has been refactored to expose the jar file info. However, some logic has been improved (like matching case-insensitive filename extension or stripping the extension with substring instead of using replace).
To avoid risks of changes in the default service naming algorithm, this PR uses the exact code that we had before

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
