### PR TITLE
Remove top-level maven pom.properties of vendored packages

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -35,7 +35,10 @@ ext.generalShadowJarConfig = {
 
   // Remove some cruft from the final jar.
   // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
-  // used to report our own dependencies.
+  // used to report our own dependencies, but we should remove the top-level metadata
+  // of vendored packages because those could trigger unwanted framework checks.
+  exclude '/META-INF/maven/org.slf4j/**'
+  exclude '/META-INF/maven/org.yaml/**'
   exclude '**/META-INF/maven/**/pom.xml'
   exclude '**/META-INF/proguard/'
   exclude '**/META-INF/*.kotlin_module'
@@ -43,6 +46,7 @@ ext.generalShadowJarConfig = {
   exclude '**/liblz4-java.so'
   exclude '**/liblz4-java.dylib'
   exclude '**/inst/META-INF/versions/**'
+  exclude '**/META-INF/versions/*/org/yaml/**'
 
   // Replaced by 'instrumenter.index', no need to include original service file
   exclude '**/META-INF/services/datadog.trace.agent.tooling.InstrumenterModule'


### PR DESCRIPTION
# Motivation

Remove top-level maven `pom.properties` of vendored packages as they could trigger unwanted framework checks. See APMS-15680 for an example of such a check.

# Additional Notes

Also remove some empty `META-INF/versions` directories leftover from vendoring SnakeYaml

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15680]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15680]: https://datadoghq.atlassian.net/browse/APMS-15680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ