### PR TITLE
Make Akka's ForkJoin pool instrumented class names configurable

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -25,7 +26,9 @@ import net.bytebuddy.asm.Advice;
  */
 @AutoService(InstrumenterModule.class)
 public final class AkkaForkJoinExecutorTaskInstrumentation extends InstrumenterModule.Tracing
-    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForSingleType,
+        Instrumenter.ForConfiguredType,
+        Instrumenter.HasMethodAdvice {
   public AkkaForkJoinExecutorTaskInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
@@ -36,11 +39,13 @@ public final class AkkaForkJoinExecutorTaskInstrumentation extends InstrumenterM
   }
 
   @Override
-  public String[] knownMatchingTypes() {
-    return new String[] {
-      "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask",
-      "com.dd.logs.concurrent.akka.AkkaForkJoinTask", // logs-backend fork
-    };
+  public String instrumentedType() {
+    return "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask";
+  }
+
+  @Override
+  public String configuredMatchingType() {
+    return InstrumenterConfig.get().getAkkaForkJoinExecutorTaskName();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.asm.Advice;
  */
 @AutoService(InstrumenterModule.class)
 public final class AkkaForkJoinExecutorTaskInstrumentation extends InstrumenterModule.Tracing
-    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
   public AkkaForkJoinExecutorTaskInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
@@ -36,8 +36,11 @@ public final class AkkaForkJoinExecutorTaskInstrumentation extends InstrumenterM
   }
 
   @Override
-  public String instrumentedType() {
-    return "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask";
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask",
+      "com.dd.logs.concurrent.akka.AkkaForkJoinTask", // logs-backend fork
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
@@ -12,6 +12,7 @@ import akka.dispatch.forkjoin.ForkJoinTask;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Map;
@@ -19,18 +20,22 @@ import net.bytebuddy.asm.Advice;
 
 @AutoService(InstrumenterModule.class)
 public final class AkkaForkJoinPoolInstrumentation extends InstrumenterModule.Tracing
-    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForSingleType,
+        Instrumenter.ForConfiguredType,
+        Instrumenter.HasMethodAdvice {
 
   public AkkaForkJoinPoolInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
 
   @Override
-  public String[] knownMatchingTypes() {
-    return new String[] {
-      "akka.dispatch.forkjoin.ForkJoinPool",
-      "com.dd.logs.concurrent.akka.forkjoin.ForkJoinPool" // logs-backend fork
-    };
+  public String instrumentedType() {
+    return "akka.dispatch.forkjoin.ForkJoinPool";
+  }
+
+  @Override
+  public String configuredMatchingType() {
+    return InstrumenterConfig.get().getAkkaForkJoinPoolName();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
@@ -19,15 +19,18 @@ import net.bytebuddy.asm.Advice;
 
 @AutoService(InstrumenterModule.class)
 public final class AkkaForkJoinPoolInstrumentation extends InstrumenterModule.Tracing
-    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
 
   public AkkaForkJoinPoolInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
 
   @Override
-  public String instrumentedType() {
-    return "akka.dispatch.forkjoin.ForkJoinPool";
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "akka.dispatch.forkjoin.ForkJoinPool",
+      "com.dd.logs.concurrent.akka.forkjoin.ForkJoinPool" // logs-backend fork
+    };
   }
 
   @Override
@@ -43,6 +46,7 @@ public final class AkkaForkJoinPoolInstrumentation extends InstrumenterModule.Tr
   }
 
   public static final class ExternalPush {
+
     @Advice.OnMethodEnter
     public static <T> void externalPush(@Advice.Argument(0) ForkJoinTask<T> task) {
       if (!exclude(FORK_JOIN_TASK, task)) {

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -52,14 +52,17 @@ public final class AkkaForkJoinTaskInstrumentation extends InstrumenterModule.Tr
 
   @Override
   public String hierarchyMarkerType() {
-    return "akka.dispatch.forkjoin.ForkJoinTask";
+    return "org.apache.pekko.dispatch.ExecutorServiceConfigurator";
   }
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return notExcludedByName(FORK_JOIN_TASK)
         .and(declaresMethod(namedOneOf("exec", "fork", "cancel")))
-        .and(extendsClass(named(hierarchyMarkerType())));
+        .and(
+            extendsClass(named("akka.dispatch.forkjoin.ForkJoinTask"))
+                // logs-backend fork
+                .or(extendsClass(named("com.dd.logs.concurrent.akka.forkjoin.ForkJoinTask"))));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -19,6 +19,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
@@ -52,17 +53,26 @@ public final class AkkaForkJoinTaskInstrumentation extends InstrumenterModule.Tr
 
   @Override
   public String hierarchyMarkerType() {
-    return "org.apache.pekko.dispatch.ExecutorServiceConfigurator";
+    String akkaForkJoinTaskName = InstrumenterConfig.get().getAkkaForkJoinTaskName();
+    return akkaForkJoinTaskName != null && !akkaForkJoinTaskName.isEmpty()
+        ? null // bypass the hint if custom class is configured
+        : "akka.dispatch.forkjoin.ForkJoinTask";
   }
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return notExcludedByName(FORK_JOIN_TASK)
         .and(declaresMethod(namedOneOf("exec", "fork", "cancel")))
-        .and(
-            extendsClass(named("akka.dispatch.forkjoin.ForkJoinTask"))
-                // logs-backend fork
-                .or(extendsClass(named("com.dd.logs.concurrent.akka.forkjoin.ForkJoinTask"))));
+        .and(isForkJoinTaskSubclass());
+  }
+
+  private ElementMatcher<TypeDescription> isForkJoinTaskSubclass() {
+    ElementMatcher.Junction<TypeDescription> forkJoinTaskSubclass =
+        extendsClass(named("akka.dispatch.forkjoin.ForkJoinTask"));
+    String akkaForkJoinTaskName = InstrumenterConfig.get().getAkkaForkJoinTaskName();
+    return akkaForkJoinTaskName != null && !akkaForkJoinTaskName.isEmpty()
+        ? forkJoinTaskSubclass.or(extendsClass(named(akkaForkJoinTaskName)))
+        : forkJoinTaskSubclass;
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -72,6 +72,11 @@ public final class TraceInstrumentationConfig {
 
   public static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
 
+  public static final String AKKA_FORK_JOIN_TASK_NAME = "trace.akka.fork.join.task.name";
+  public static final String AKKA_FORK_JOIN_EXECUTOR_TASK_NAME =
+      "trace.akka.fork.join.executor.task.name";
+  public static final String AKKA_FORK_JOIN_POOL_NAME = "trace.akka.fork.join.pool.name";
+
   public static final String EXPERIMENTATAL_JEE_SPLIT_BY_DEPLOYMENT =
       "trace.experimental.jee.split-by-deployment";
 

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -32,6 +32,9 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATI
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
+import static datadog.trace.api.config.TraceInstrumentationConfig.AKKA_FORK_JOIN_EXECUTOR_TASK_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.AKKA_FORK_JOIN_POOL_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.AKKA_FORK_JOIN_TASK_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.AXIS_TRANSPORT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.EXPERIMENTAL_DEFER_INTEGRATIONS_UNTIL;
@@ -126,6 +129,10 @@ public class InstrumenterConfig {
   private final String httpURLConnectionClassName;
   private final String axisTransportClassName;
   private final boolean websocketTracingEnabled;
+
+  private final String akkaForkJoinTaskName;
+  private final String akkaForkJoinExecutorTaskName;
+  private final String akkaForkJoinPoolName;
 
   private final boolean directAllocationProfilingEnabled;
 
@@ -225,6 +232,10 @@ public class InstrumenterConfig {
 
     httpURLConnectionClassName = configProvider.getString(HTTP_URL_CONNECTION_CLASS_NAME, "");
     axisTransportClassName = configProvider.getString(AXIS_TRANSPORT_CLASS_NAME, "");
+
+    akkaForkJoinTaskName = configProvider.getString(AKKA_FORK_JOIN_TASK_NAME, "");
+    akkaForkJoinExecutorTaskName = configProvider.getString(AKKA_FORK_JOIN_EXECUTOR_TASK_NAME, "");
+    akkaForkJoinPoolName = configProvider.getString(AKKA_FORK_JOIN_POOL_NAME, "");
 
     directAllocationProfilingEnabled =
         configProvider.getBoolean(
@@ -399,6 +410,18 @@ public class InstrumenterConfig {
 
   public String getAxisTransportClassName() {
     return axisTransportClassName;
+  }
+
+  public String getAkkaForkJoinTaskName() {
+    return akkaForkJoinTaskName;
+  }
+
+  public String getAkkaForkJoinExecutorTaskName() {
+    return akkaForkJoinExecutorTaskName;
+  }
+
+  public String getAkkaForkJoinPoolName() {
+    return akkaForkJoinPoolName;
   }
 
   public boolean isDirectAllocationProfilingEnabled() {


### PR DESCRIPTION
# What Does This Do

Update Akka's ForkJoinPool instrumentations to also instrument backported fork of the pool that is used by logs-backend (existing instrumentations can now be configured to instrument custom class names; logs-backend-specific class names will be provided in logs-backend tracer config).

# Motivation

CI Visibility's per-test code coverage relies on spans propagation to capture coverage data from different threads.
Without this instrumentation coverage data for test cases that use Akka is incomplete.

# Additional Notes

More context as to why logs-backend has its own ForkJoinPool implementation can be found in [this PR](https://github.com/DataDog/logs-backend/pull/74238).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1957]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1957]: https://datadoghq.atlassian.net/browse/SDTEST-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ