### PR TITLE
Add context API support OTel propagators

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/OtelContext.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/OtelContext.java
@@ -89,6 +89,15 @@ public class OtelContext implements Context {
     return "OtelContext{" + "delegate=" + delegate + '}';
   }
 
+  /**
+   * Returns the underlying context.
+   *
+   * @return The underlying context.
+   */
+  public datadog.context.Context asContext() {
+    return this.delegate;
+  }
+
   private static datadog.context.ContextKey delegateKey(ContextKey key) {
     return DELEGATE_KEYS.computeIfAbsent(key, OtelContext::mapByKeyName);
   }

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
@@ -1,9 +1,7 @@
 package datadog.opentelemetry.shim.context.propagation;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
-import static datadog.opentelemetry.shim.trace.OtelSpanContext.fromRemote;
 import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
-import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extractContextAndGetSpanContext;
 
 import datadog.opentelemetry.shim.context.OtelContext;
 import datadog.opentelemetry.shim.trace.OtelExtractedContext;
@@ -13,8 +11,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext.Extracted;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.util.PropagationUtils;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
@@ -45,27 +41,25 @@ public class AgentTextMapPropagator implements TextMapPropagator {
     if (carrier == null) {
       return context;
     }
-    Extracted extracted =
-        extractContextAndGetSpanContext(
-            carrier,
-            (carrier1, classifier) -> {
-              for (String key : getter.keys(carrier1)) {
-                classifier.accept(key, getter.get(carrier1, key));
-              }
-            });
-    if (extracted == null) {
-      return context;
-    } else {
-      TraceState traceState = extractTraceState(extracted, carrier, getter);
-      SpanContext spanContext = fromRemote(extracted, traceState);
-      return Span.wrap(spanContext).storeInContext(OtelContext.ROOT);
-    }
+    datadog.context.Context extracted =
+        defaultPropagator()
+            .extract(
+                convertContext(context),
+                carrier,
+                (carrier1, classifier) -> {
+                  for (String key : getter.keys(carrier1)) {
+                    classifier.accept(key, getter.get(carrier1, key));
+                  }
+                });
+    return new OtelContext(extracted);
   }
 
   private static datadog.context.Context convertContext(Context context) {
-    // TODO Extract baggage too
-    // TODO Create fast path from OtelSpan --> AgentSpan delegate --> with() to inflate as full
-    // context if baggage
+    // Try to get the underlying context when injecting a Datadog context
+    if (context instanceof OtelContext) {
+      return ((OtelContext) context).asContext();
+    }
+    // Otherwise, fallback to extracting limited tracing context and recreating an OTel context from
     AgentSpanContext extract = OtelExtractedContext.extract(context);
     return AgentSpan.fromSpanContext(extract);
   }


### PR DESCRIPTION
# What Does This Do

This PR adds context API support to OTel propagators

# Motivation

This will propagate the full internal Datadog context using OTel propagator, not only the tracing one.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
