### PR TITLE
Add a gatekeeper job for PR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -137,6 +137,13 @@ _Action:_ Build the Java Client Library and runs [the system tests](https://gith
 
 _Recovery:_ Manually trigger the action on the desired branch.
 
+### all-green [🔗](all-green.yaml)
+
+_Trigger:_ Any pull request.
+
+_Action:_ This action will check all other jobs (Github action, Gitlab, CircleCi), and will fail if any of them fails. This action got an `ignored` paraemters to exclude some jobs if they are temprorary failing. The purpose of this job is to be required for merges, achieving Green CI Policy.
+
+_Recovery:_ Manually trigger the action on the desired branch.
 
 ## Maintenance
 

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -21,14 +21,12 @@ jobs:
           initial-delay-seconds: "1000"
           max-retries: "60"
           ignored-name-patterns: |
-            ci/circleci: .*
             dd-gitlab/default-pipeline
             dd-gitlab/check_inst 4/4
             dd-gitlab/muzzle .*
 
 # ignored jobs : 
 #
-# * ci/circleci: .*  => will be decommisionned soon
 # * dd-gitlab/default-pipeline => success rate of 70% (needs an owner)
 # * dd-gitlab/check_inst 4/4   => success rate of 78% (needs an owner)
-# * dd-gitlab/muzzle 3/8       => success rate of ~85% (needs an owner)
+# * dd-gitlab/muzzle .*        => success rate of ~85% (needs an owner)

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   checks: read
   statuses: read

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,0 +1,34 @@
+name: Check Pull Request CI Status
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  checks: read
+  statuses: read
+
+jobs:
+  all-jobs-are-green:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Ensure CI Success
+        uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
+        with:
+          initial-delay-seconds: "1000"
+          max-retries: "60"
+          ignored-name-patterns: |
+            ci/circleci: .*
+            dd-gitlab/default-pipeline
+            dd-gitlab/check_inst 4/4
+            dd-gitlab/muzzle .*
+
+# ignored jobs : 
+#
+# * ci/circleci: .*  => will be decommisionned soon
+# * dd-gitlab/default-pipeline => success rate of 70% (needs an owner)
+# * dd-gitlab/check_inst 4/4   => success rate of 78% (needs an owner)
+# * dd-gitlab/muzzle 3/8       => success rate of ~85% (needs an owner)


### PR DESCRIPTION
# What Does This Do

Add a job in the CI that runs in PR. The job will be a success if all other jobs are skipped/success, and fails otherwise

### Motivation

While it's possible to enforce a green CI policy using GitHub's native "required status checks" feature, doing so requires explicitly listing all job names under branch protection rules. This approach has two key drawbacks:

- It does not support optional jobs
- It introduces ongoing maintenance overhead as the job list evolves

This jobs will check ALL other job, and we'll be able to set this as a requirement. The action used offers a `ignored-name-patterns` parameters`, I added few job that failed more than 10% over the last 60 days on merges.

The plan is to merge this PR, wait few days to be sure that everything is fine. Then add it as a requirement.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
