### PR TITLE
Have muzzle checks use internal artifact proxy

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -62,7 +62,7 @@ class MuzzlePlugin implements Plugin<Project> {
       MUZZLE_REPOS = Collections.singletonList(central)
     } else {
       RemoteRepository proxy = new RemoteRepository.Builder("central-proxy", "default", mavenProxyUrl).build()
-      MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(proxy))
+      MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(proxy, central))
     }
   }
 

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -55,11 +55,15 @@ class MuzzlePlugin implements Plugin<Project> {
 
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build()
-    // Only needed for restlet
-    RemoteRepository restlet = new RemoteRepository.Builder("restlet", "default", "https://maven.restlet.talend.com/").build()
-    // Only needed  for play-2.3
-    RemoteRepository typesafe = new RemoteRepository.Builder("typesafe", "default", "https://repo.typesafe.com/typesafe/maven-releases/").build()
-    MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(central, restlet, typesafe))
+
+    String mavenProxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+
+    if (mavenProxyUrl == null) {
+      MUZZLE_REPOS = Collections.singletonList(central)
+    } else {
+      RemoteRepository proxy = new RemoteRepository.Builder("central-proxy", "default", mavenProxyUrl).build()
+      MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(proxy))
+    }
   }
 
   static class TestedArtifact {

--- a/dd-java-agent/instrumentation/play-2.3/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.3/build.gradle
@@ -4,6 +4,8 @@ ext {
 }
 
 muzzle {
+  extraRepository("typesafe", "https://repo.typesafe.com/typesafe/maven-releases/")
+
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.11'

--- a/dd-java-agent/instrumentation/play-2.4/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.4/build.gradle
@@ -4,6 +4,8 @@ ext {
 }
 
 muzzle {
+  extraRepository("typesafe", "https://repo.typesafe.com/typesafe/maven-releases/")
+
   pass {
     name = "play24and25"
     group = 'com.typesafe.play'

--- a/dd-java-agent/instrumentation/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/build.gradle
@@ -7,6 +7,8 @@ def scalaVersion = '2.11'
 def playVersion = '2.6.0'
 
 muzzle {
+  extraRepository("typesafe", "https://repo.typesafe.com/typesafe/maven-releases/")
+
   pass {
     name = 'play26Plus'
     group = 'com.typesafe.play'

--- a/dd-java-agent/instrumentation/restlet-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/restlet-2.2/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("restlet", "https://maven.restlet.talend.com/")
+
   pass {
     group = "org.restlet.jse"
     module = "org.restlet"


### PR DESCRIPTION
# What Does This Do
Follow up to #8554 and #8592 . Has muzzle use the internal proxy. Additionally, special case repositories were moved from the muzzle plugin to the `extraRepository` directive of individual projects.

Testing was done by remove `central` as a repository to ensure muzzle still passed with only the proxy working.

# Motivation
Muzzle checks were not using the internal proxy and susceptible to maven central rate limits

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
