### PR TITLE
Clean up DSM context injection

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -26,21 +26,12 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.BitSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedClientDecorator {
-  public static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS;
-
-  static {
-    CLIENT_PATHWAY_EDGE_TAGS = new LinkedHashMap<>(2);
-    // TODO: Refactor TagsProcessor to move it into a package that we can link the constants for.
-    CLIENT_PATHWAY_EDGE_TAGS.put("direction", "out");
-    CLIENT_PATHWAY_EDGE_TAGS.put("type", "http");
-  }
 
   private static final Logger log = LoggerFactory.getLogger(HttpClientDecorator.class);
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -45,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,7 +182,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       final AgentSpan span,
       final CONNECTION connection,
       final REQUEST request,
-      final AgentSpanContext.Extracted context) {
+      @Nullable final AgentSpanContext.Extracted context) {
     Config config = Config.get();
     boolean clientIpResolverEnabled =
         config.isClientIpEnabled()

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.context.Context.root;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
-import static datadog.trace.api.datastreams.DataStreamsContext.fromTags;
+import static datadog.trace.api.datastreams.DataStreamsContext.forHttpServer;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extractContextAndGetSpanContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
@@ -38,7 +38,6 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.http.ClientIpAddressResolver;
 import java.net.InetAddress;
 import java.util.BitSet;
-import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -61,15 +60,6 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       "datadog.span.finish_dispatch_listener";
   public static final String DD_RESPONSE_ATTRIBUTE = "datadog.response";
   public static final String DD_IGNORE_COMMIT_ATTRIBUTE = "datadog.commit.ignore";
-
-  public static final LinkedHashMap<String, String> SERVER_PATHWAY_EDGE_TAGS;
-
-  static {
-    SERVER_PATHWAY_EDGE_TAGS = new LinkedHashMap<>(2);
-    // TODO: Refactor TagsProcessor to move it into a package that we can link the constants for.
-    SERVER_PATHWAY_EDGE_TAGS.put("direction", "in");
-    SERVER_PATHWAY_EDGE_TAGS.put("type", "http");
-  }
 
   private static final UTF8BytesString DEFAULT_RESOURCE_NAME = UTF8BytesString.create("/");
   protected static final UTF8BytesString NOT_FOUND_RESOURCE_NAME = UTF8BytesString.create("404");
@@ -165,7 +155,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (null != carrier && null != getter) {
-      tracer().getDataStreamsMonitoring().setCheckpoint(span, fromTags(SERVER_PATHWAY_EDGE_TAGS));
+      tracer().getDataStreamsMonitoring().setCheckpoint(span, forHttpServer());
     }
     return span;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
@@ -1,13 +1,18 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
+
+import datadog.context.Context;
+import datadog.context.propagation.CarrierSetter;
 import datadog.trace.api.Config;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.net.URI;
 import javax.annotation.Nonnull;
 
 public abstract class UriBasedClientDecorator extends ClientDecorator {
-
   public void onURI(@Nonnull final AgentSpan span, @Nonnull final URI uri) {
     String host = uri.getHost();
     int port = uri.getPort();
@@ -20,5 +25,22 @@ public abstract class UriBasedClientDecorator extends ClientDecorator {
         setPeerPort(span, port);
       }
     }
+  }
+
+  public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
+    // Add additional default DSM context for HTTP clients if missing but DSM is enabled
+    if (isDataStreamsEnabled(context) && DataStreamsContext.fromContext(context) == null) {
+      context = context.with(DataStreamsContext.forHttpClient());
+    }
+    // Inject context into carrier
+    defaultPropagator().inject(context, request, setter);
+  }
+
+  private static boolean isDataStreamsEnabled(Context context) {
+    final AgentSpan agentSpan;
+    final TraceConfig tracerConfig;
+    return (agentSpan = AgentSpan.fromContext(context)) != null
+        && (tracerConfig = agentSpan.traceConfig()) != null
+        && tracerConfig.isDataStreamsEnabled();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
@@ -1,11 +1,11 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 
 import datadog.context.Context;
 import datadog.context.propagation.CarrierSetter;
 import datadog.trace.api.Config;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -29,18 +29,10 @@ public abstract class UriBasedClientDecorator extends ClientDecorator {
 
   public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
     // Add additional default DSM context for HTTP clients if missing but DSM is enabled
-    if (isDataStreamsEnabled(context) && DataStreamsContext.fromContext(context) == null) {
+    if (DataStreamsContext.fromContext(context) == null && traceConfig().isDataStreamsEnabled()) {
       context = context.with(DataStreamsContext.forHttpClient());
     }
     // Inject context into carrier
     defaultPropagator().inject(context, request, setter);
-  }
-
-  private static boolean isDataStreamsEnabled(Context context) {
-    final AgentSpan agentSpan;
-    final TraceConfig tracerConfig;
-    return (agentSpan = AgentSpan.fromContext(context)) != null
-        && (tracerConfig = agentSpan.traceConfig()) != null
-        && tracerConfig.isDataStreamsEnabled();
   }
 }

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientHelpers.AkkaHttpHeaders;
@@ -18,7 +17,6 @@ import akka.http.scaladsl.model.HttpResponse;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
@@ -80,9 +78,7 @@ public final class AkkaHttpSingleRequestInstrumentation extends InstrumenterModu
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator()
-            .inject(getCurrentContext().with(span).with(dsmContext), request, headers);
+        defaultPropagator().inject(getCurrentContext().with(span), request, headers);
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.akkahttp;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -73,12 +72,12 @@ public final class AkkaHttpSingleRequestInstrumentation extends InstrumenterModu
         return null;
       }
 
-      final AgentSpan span = startSpan(AKKA_CLIENT_REQUEST);
+      final AgentSpan span = startSpan("akka-http", AKKA_CLIENT_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        defaultPropagator().inject(getCurrentContext().with(span), request, headers);
+        DECORATE.injectContext(getCurrentContext().with(span), request, headers);
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogAsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogAsyncHandlerWrapper.java
@@ -1,10 +1,11 @@
 package datadog.trace.instrumentation.akkahttp;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
+
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import akka.http.scaladsl.util.FastFuture$;
 import akka.stream.Materializer;
-import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -28,8 +29,7 @@ public class DatadogAsyncHandlerWrapper
   @Override
   public Future<HttpResponse> apply(final HttpRequest request) {
     final ContextScope scope = DatadogWrapperHelper.createSpan(request);
-    Context context = scope.context();
-    final AgentSpan span = AgentSpan.fromContext(context);
+    final AgentSpan span = fromContext(scope.context());
     Future<HttpResponse> futureResponse;
 
     // handle blocking in the beginning of the request

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.akkahttp;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
 import akka.http.scaladsl.model.HttpRequest;
@@ -67,7 +68,7 @@ public class DatadogServerRequestResponseFlowWrapper
               public void onPush() throws Exception {
                 final HttpRequest request = grab(requestInlet);
                 final ContextScope scope = DatadogWrapperHelper.createSpan(request);
-                final AgentSpan span = AgentSpan.fromContext(scope.context());
+                final AgentSpan span = fromContext(scope.context());
                 RequestContext requestContext = span.getRequestContext();
                 if (requestContext != null) {
                   HttpResponse response =
@@ -133,7 +134,7 @@ public class DatadogServerRequestResponseFlowWrapper
                 HttpResponse response = grab(responseInlet);
                 final ContextScope scope = scopes.poll();
                 if (scope != null) {
-                  AgentSpan span = AgentSpan.fromContext(scope.context());
+                  AgentSpan span = fromContext(scope.context());
                   HttpResponse newResponse =
                       BlockingResponseHelper.handleFinishForWaf(span, response);
                   if (newResponse != response) {
@@ -159,7 +160,7 @@ public class DatadogServerRequestResponseFlowWrapper
                 // remaining spans
                 ContextScope scope = scopes.poll();
                 while (scope != null) {
-                  AgentSpan.fromContext(scope.context()).finish();
+                  fromContext(scope.context()).finish();
                   scope = scopes.poll();
                 }
                 completeStage();
@@ -170,14 +171,14 @@ public class DatadogServerRequestResponseFlowWrapper
                 ContextScope scope = scopes.poll();
                 if (scope != null) {
                   // Mark the span as failed
-                  AgentSpan span = AgentSpan.fromContext(scope.context());
+                  AgentSpan span = fromContext(scope.context());
                   DatadogWrapperHelper.finishSpan(span, ex);
                 }
                 // We will not receive any more responses from the user code, so clean up any
                 // remaining spans
                 scope = scopes.poll();
                 while (scope != null) {
-                  AgentSpan.fromContext(scope.context()).finish();
+                  fromContext(scope.context()).finish();
                   scope = scopes.poll();
                 }
                 fail(responseOutlet, ex);

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -10,12 +10,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 public class DatadogWrapperHelper {
   public static ContextScope createSpan(final HttpRequest request) {
-    final Context extractedContext = DECORATE.extractContext(request);
-    final AgentSpan span = DECORATE.startSpan(request, extractedContext);
+    final Context context = DECORATE.extractContext(request);
+    final AgentSpan span = DECORATE.startSpan(request, context);
     DECORATE.afterStart(span);
-    DECORATE.onRequest(span, request, request, extractedContext);
+    DECORATE.onRequest(span, request, request, context);
 
-    return extractedContext.with(span).attach();
+    return context.with(span).attach();
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
@@ -1,9 +1,10 @@
 package datadog.trace.instrumentation.akkahttp106;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
+import static datadog.trace.instrumentation.akkahttp106.AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST;
+import static datadog.trace.instrumentation.akkahttp106.AkkaHttpClientDecorator.DECORATE;
 
 import akka.http.scaladsl.HttpExt;
 import akka.http.scaladsl.model.HttpRequest;
@@ -23,12 +24,11 @@ public class SingleRequestAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan(AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST);
-    AkkaHttpClientDecorator.DECORATE.afterStart(span);
-    AkkaHttpClientDecorator.DECORATE.onRequest(span, request);
-
+    final AgentSpan span = startSpan("akka-http", AKKA_CLIENT_REQUEST);
+    DECORATE.afterStart(span);
+    DECORATE.onRequest(span, request);
     if (request != null) {
-      defaultPropagator().inject(getCurrentContext().with(span), request, headers);
+      DECORATE.injectContext(getCurrentContext().with(span), request, headers);
       // Request is immutable, so we have to assign new value once we update headers
       request = headers.getRequest();
     }
@@ -51,8 +51,8 @@ public class SingleRequestAdvice {
       responseFuture.onComplete(
           new AkkaHttpClientHelpers.OnCompleteHandler(span), thiz.system().dispatcher());
     } else {
-      AkkaHttpClientDecorator.DECORATE.onError(span, throwable);
-      AkkaHttpClientDecorator.DECORATE.beforeFinish(span);
+      DECORATE.onError(span, throwable);
+      DECORATE.beforeFinish(span);
       span.finish();
     }
     scope.close();

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
@@ -4,12 +4,10 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 
 import akka.http.scaladsl.HttpExt;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
@@ -30,8 +28,7 @@ public class SingleRequestAdvice {
     AkkaHttpClientDecorator.DECORATE.onRequest(span, request);
 
     if (request != null) {
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, headers);
+      defaultPropagator().inject(getCurrentContext().with(span), request, headers);
       // Request is immutable, so we have to assign new value once we update headers
       request = headers.getRequest();
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
@@ -1,10 +1,9 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
 import org.apache.http.HttpException;
@@ -33,7 +32,7 @@ public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
   public HttpRequest generateRequest() throws IOException, HttpException {
     final HttpRequest request = delegate.generateRequest();
     DECORATE.onRequest(span, new HostAndRequestAsHttpUriRequest(delegate.getTarget(), request));
-    defaultPropagator().inject(Context.current().with(span), request, SETTER);
+    DECORATE.injectContext(current().with(span), request, SETTER);
     return request;
   }
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
@@ -1,12 +1,10 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
 import org.apache.http.HttpException;
@@ -35,10 +33,7 @@ public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
   public HttpRequest generateRequest() throws IOException, HttpException {
     final HttpRequest request = delegate.generateRequest();
     DECORATE.onRequest(span, new HostAndRequestAsHttpUriRequest(delegate.getTarget(), request));
-
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(Context.current().with(span).with(dsmContext), request, SETTER);
-
+    defaultPropagator().inject(Context.current().with(span), request, SETTER);
     return request;
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -1,13 +1,12 @@
 package datadog.trace.instrumentation.apachehttpclient;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -45,7 +44,7 @@ public class HelperMethods {
 
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      defaultPropagator().inject(Context.current().with(span), request, SETTER);
+      DECORATE.injectContext(current().with(span), request, SETTER);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -3,13 +3,11 @@ package datadog.trace.instrumentation.apachehttpclient;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -47,8 +45,7 @@ public class HelperMethods {
 
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(Context.current().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(Context.current().with(span), request, SETTER);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
@@ -1,11 +1,9 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
-import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
 import org.apache.hc.core5.http.EntityDetails;
@@ -27,7 +25,7 @@ public class DelegatingRequestChannel implements RequestChannel {
   public void sendRequest(HttpRequest request, EntityDetails entityDetails, HttpContext context)
       throws HttpException, IOException {
     DECORATE.onRequest(span, request);
-    defaultPropagator().inject(Context.current().with(span), request, SETTER);
+    DECORATE.injectContext(current().with(span), request, SETTER);
     delegate.sendRequest(request, entityDetails, context);
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestChannel.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
@@ -28,9 +27,7 @@ public class DelegatingRequestChannel implements RequestChannel {
   public void sendRequest(HttpRequest request, EntityDetails entityDetails, HttpContext context)
       throws HttpException, IOException {
     DECORATE.onRequest(span, request);
-
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(Context.current().with(span).with(dsmContext), request, SETTER);
+    defaultPropagator().inject(Context.current().with(span), request, SETTER);
     delegate.sendRequest(request, entityDetails, context);
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -1,13 +1,12 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -45,7 +44,7 @@ public class HelperMethods {
     final boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      defaultPropagator().inject(Context.current().with(span), request, SETTER);
+      DECORATE.injectContext(current().with(span), request, SETTER);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -3,13 +3,11 @@ package datadog.trace.instrumentation.apachehttpclient5;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -47,8 +45,7 @@ public class HelperMethods {
     final boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
     // AWS calls are often signed, so we can't add headers without breaking the signature.
     if (!awsClientCall) {
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(Context.current().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(Context.current().with(span), request, SETTER);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.armeria.grpc.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
@@ -134,7 +134,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
       if (null != responseListener && null != headers) {
         span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
         if (null != span) {
-          defaultPropagator().inject(span, headers, SETTER);
+          DECORATE.injectContext(current().with(span), headers, SETTER);
           return activateSpan(span);
         }
       }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.OPERATION_NAME;
@@ -20,7 +19,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -136,8 +134,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
       if (null != responseListener && null != headers) {
         span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
         if (null != span) {
-          DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-          defaultPropagator().inject(span.with(dsmContext), headers, SETTER);
+          defaultPropagator().inject(span, headers, SETTER);
           return activateSpan(span);
         }
       }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -1,9 +1,6 @@
 package datadog.trace.instrumentation.armeria.grpc.client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
-import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
-import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
@@ -18,7 +15,6 @@ import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.BitSet;
-import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -28,16 +24,6 @@ public class GrpcClientDecorator extends ClientDecorator {
           SpanNaming.instance().namingSchema().client().operationForProtocol("grpc"));
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("armeria-grpc-client");
   public static final CharSequence GRPC_MESSAGE = UTF8BytesString.create("grpc.message");
-
-  private static LinkedHashMap<String, String> createClientPathwaySortedTags() {
-    LinkedHashMap<String, String> result = new LinkedHashMap<>();
-    result.put(DIRECTION_TAG, DIRECTION_OUT);
-    result.put(TYPE_TAG, "grpc");
-    return result;
-  }
-
-  public static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS =
-      createClientPathwaySortedTags();
 
   public static final GrpcClientDecorator DECORATE = new GrpcClientDecorator();
 

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.armeria.grpc.client;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
@@ -44,7 +45,6 @@ public class GrpcClientDecorator extends ClientDecorator {
 
   private static final Set<String> IGNORED_METHODS = Config.get().getGrpcIgnoredOutboundMethods();
   private static final BitSet CLIENT_ERROR_STATUSES = Config.get().getGrpcClientErrorStatuses();
-  private static final boolean DATA_STREAMS_ENABLED = Config.get().isDataStreamsEnabled();
 
   private static final ClassValue<UTF8BytesString> MESSAGE_TYPES =
       GenericClassValue.of(
@@ -111,7 +111,7 @@ public class GrpcClientDecorator extends ClientDecorator {
   }
 
   public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
-    if (DATA_STREAMS_ENABLED) {
+    if (traceConfig().isDataStreamsEnabled()) {
       context = context.with(createDsmContext());
     }
     defaultPropagator().inject(context, request, setter);

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -1,11 +1,18 @@
 package datadog.trace.instrumentation.armeria.grpc.client;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
+import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
+import datadog.context.Context;
+import datadog.context.propagation.CarrierSetter;
 import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -15,6 +22,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.BitSet;
+import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -25,10 +33,18 @@ public class GrpcClientDecorator extends ClientDecorator {
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("armeria-grpc-client");
   public static final CharSequence GRPC_MESSAGE = UTF8BytesString.create("grpc.message");
 
+  private static DataStreamsContext createDsmContext() {
+    LinkedHashMap<String, String> result = new LinkedHashMap<>();
+    result.put(DIRECTION_TAG, DIRECTION_OUT);
+    result.put(TYPE_TAG, "grpc");
+    return DataStreamsContext.fromTags(result);
+  }
+
   public static final GrpcClientDecorator DECORATE = new GrpcClientDecorator();
 
   private static final Set<String> IGNORED_METHODS = Config.get().getGrpcIgnoredOutboundMethods();
   private static final BitSet CLIENT_ERROR_STATUSES = Config.get().getGrpcClientErrorStatuses();
+  private static final boolean DATA_STREAMS_ENABLED = Config.get().isDataStreamsEnabled();
 
   private static final ClassValue<UTF8BytesString> MESSAGE_TYPES =
       GenericClassValue.of(
@@ -82,7 +98,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return null;
     }
     AgentSpan span =
-        startSpan(OPERATION_NAME)
+        startSpan("grpc", OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions
@@ -92,6 +108,13 @@ public class GrpcClientDecorator extends ClientDecorator {
                     method.getFullMethodName(), MethodDescriptor::extractFullServiceName));
     span.setResourceName(method.getFullMethodName());
     return afterStart(span);
+  }
+
+  public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
+    if (DATA_STREAMS_ENABLED) {
+      context = context.with(createDsmContext());
+    }
+    defaultPropagator().inject(context, request, setter);
   }
 
   public AgentSpan onClose(final AgentSpan span, final Status status) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.aws.v0;
 
 import static datadog.trace.api.datastreams.DataStreamsContext.create;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities.RPC_COMMAND_NAME;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 
@@ -94,8 +95,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     CharSequence awsRequestName = AwsNameCache.getQualifiedName(request);
     span.setResourceName(awsRequestName, RPC_COMMAND_NAME);
 
-    if ("s3".equalsIgnoreCase(awsSimplifiedServiceName)
-        && span.traceConfig().isDataStreamsEnabled()) {
+    if ("s3".equalsIgnoreCase(awsSimplifiedServiceName) && traceConfig().isDataStreamsEnabled()) {
       span.setTag(Tags.HTTP_REQUEST_CONTENT_LENGTH, getRequestContentLength(request));
     }
 
@@ -192,7 +192,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     }
 
     // DSM
-    if (span.traceConfig().isDataStreamsEnabled()) {
+    if (traceConfig().isDataStreamsEnabled()) {
       if (null != streamArn && "AmazonKinesis".equals(awsServiceName)) {
         switch (awsOperation.getSimpleName()) {
           case PUT_RECORD_OPERATION_NAME:
@@ -242,7 +242,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   public AgentSpan onServiceResponse(
       final AgentSpan span, final String awsService, final Response response) {
     if ("s3".equalsIgnoreCase(simplifyServiceName(awsService))
-        && span.traceConfig().isDataStreamsEnabled()) {
+        && traceConfig().isDataStreamsEnabled()) {
       long responseSize = getResponseContentLength(response);
       span.setTag(Tags.HTTP_RESPONSE_CONTENT_LENGTH, responseSize);
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpanWithoutScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
@@ -107,12 +108,12 @@ public class TracingRequestHandler extends RequestHandler2 {
       }
     }
     if (span != null
-        && span.traceConfig().isDataStreamsEnabled()
+        && traceConfig().isDataStreamsEnabled()
         && "AmazonKinesis".equals(request.getServiceName())
         && "GetRecords".equals(requestAccess.getOperationNameFromType())) {
       String streamArn = requestAccess.getStreamARN(originalRequest);
       if (null != streamArn) {
-        List records =
+        List<?> records =
             GetterAccess.of(response.getAwsResponse()).getRecords(response.getAwsResponse());
         if (null != records) {
           LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.api.datastreams.DataStreamsContext.create;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
@@ -131,7 +132,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
 
     // S3
     request.getValueForField("Bucket", String.class).ifPresent(name -> setBucketName(span, name));
-    if ("s3".equalsIgnoreCase(awsServiceName) && span.traceConfig().isDataStreamsEnabled()) {
+    if ("s3".equalsIgnoreCase(awsServiceName) && traceConfig().isDataStreamsEnabled()) {
       request
           .getValueForField("Key", String.class)
           .ifPresent(key -> span.setTag(InstrumentationTags.AWS_OBJECT_KEY, key));
@@ -169,7 +170,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     Optional<String> kinesisStreamArn = request.getValueForField("StreamARN", String.class);
     kinesisStreamArn.ifPresent(
         streamArn -> {
-          if (span.traceConfig().isDataStreamsEnabled()) {
+          if (traceConfig().isDataStreamsEnabled()) {
             attributes.putAttribute(KINESIS_STREAM_ARN_ATTRIBUTE, streamArn);
           }
           int streamNameStart = streamArn.indexOf(":stream/");
@@ -182,7 +183,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     request.getValueForField("TableName", String.class).ifPresent(name -> setTableName(span, name));
 
     // DSM
-    if (span.traceConfig().isDataStreamsEnabled()) {
+    if (traceConfig().isDataStreamsEnabled()) {
       if (kinesisStreamArn.isPresent()
           && "kinesis".equalsIgnoreCase(awsServiceName)
           && KINESIS_PUT_RECORD_OPERATION_NAMES.contains(awsOperationName)) {
@@ -324,7 +325,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
 
       final String awsServiceName = attributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
       final String awsOperationName = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
-      if (span.traceConfig().isDataStreamsEnabled()
+      if (traceConfig().isDataStreamsEnabled()
           && "kinesis".equalsIgnoreCase(awsServiceName)
           && "GetRecords".equals(awsOperationName)) {
         // https://github.com/DataDog/dd-trace-py/blob/864abb6c99e1cb0449904260bac93e8232261f2a/ddtrace/contrib/botocore/patch.py#L350
@@ -373,7 +374,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
         }
       }
 
-      if ("s3".equalsIgnoreCase(awsServiceName) && span.traceConfig().isDataStreamsEnabled()) {
+      if ("s3".equalsIgnoreCase(awsServiceName) && traceConfig().isDataStreamsEnabled()) {
         long responseSize = getResponseContentLength(httpResponse);
         span.setTag(Tags.HTTP_RESPONSE_CONTENT_LENGTH, responseSize);
 

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.commonshttpclient;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -68,7 +67,7 @@ public class CommonsHttpClientInstrumentation extends InstrumenterModule.Tracing
 
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, httpMethod);
-        defaultPropagator().inject(getCurrentContext().with(span), httpMethod, SETTER);
+        DECORATE.injectContext(getCurrentContext().with(span), httpMethod, SETTER);
 
         return scope;
       } catch (BlockingException e) {

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.commonshttpclient.CommonsHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.commonshttpclient.CommonsHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.commonshttpclient.HttpHeadersInjectAdapter.SETTER;
@@ -17,7 +16,6 @@ import com.google.auto.service.AutoService;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -70,9 +68,7 @@ public class CommonsHttpClientInstrumentation extends InstrumenterModule.Tracing
 
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, httpMethod);
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator()
-            .inject(getCurrentContext().with(span).with(dsmContext), httpMethod, SETTER);
+        defaultPropagator().inject(getCurrentContext().with(span), httpMethod, SETTER);
 
         return scope;
       } catch (BlockingException e) {

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -1,11 +1,10 @@
 package datadog.trace.instrumentation.googlehttpclient;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapter.SETTER;
 
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
-import datadog.context.Context;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -38,7 +37,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   public AgentSpan prepareSpan(AgentSpan span, HttpRequest request) {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    defaultPropagator().inject(Context.current().with(span), request, SETTER);
+    DECORATE.injectContext(current().with(span), request, SETTER);
     return span;
   }
 

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -6,7 +6,6 @@ import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapte
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -39,8 +38,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   public AgentSpan prepareSpan(AgentSpan span, HttpRequest request) {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(Context.current().with(span).with(dsmContext), request, SETTER);
+    defaultPropagator().inject(Context.current().with(span), request, SETTER);
     return span;
   }
 

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -1,11 +1,10 @@
 package datadog.trace.instrumentation.grizzly.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.grizzly.client.ClientDecorator.DECORATE;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
+import static datadog.trace.instrumentation.grizzly.client.ClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.grizzly.client.ClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.grizzly.client.InjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -68,7 +67,7 @@ public final class AsyncHttpClientInstrumentation extends InstrumenterModule.Tra
       AgentSpan span = startSpan(HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+      DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
       handler = new AsyncHandlerAdapter<>(span, parentSpan, handler);
     }
   }

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -4,9 +4,8 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.grizzly.client.ClientDecorator.DECORATE;
+import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.grizzly.client.ClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.grizzly.client.InjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -18,7 +17,6 @@ import com.ning.http.client.Request;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Collections;
 import net.bytebuddy.asm.Advice;
@@ -70,8 +68,7 @@ public final class AsyncHttpClientInstrumentation extends InstrumenterModule.Tra
       AgentSpan span = startSpan(HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
       handler = new AsyncHandlerAdapter<>(span, parentSpan, handler);
     }
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.grpc.client;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.grpc.client.GrpcInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -13,7 +12,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -93,8 +91,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
         @Advice.Local("$$ddSpan") AgentSpan span) {
       span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
       if (null != span) {
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator().inject(span.with(dsmContext), headers, SETTER);
+        defaultPropagator().inject(span, headers, SETTER);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.grpc.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.DECORATE;
@@ -91,7 +90,7 @@ public final class ClientCallImplInstrumentation extends InstrumenterModule.Trac
         @Advice.Local("$$ddSpan") AgentSpan span) {
       span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
       if (null != span) {
-        defaultPropagator().inject(span, headers, SETTER);
+        DECORATE.injectContext(span, headers, SETTER);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -1,9 +1,6 @@
 package datadog.trace.instrumentation.grpc.client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
-import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
-import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
@@ -18,7 +15,6 @@ import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.BitSet;
-import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -28,16 +24,6 @@ public class GrpcClientDecorator extends ClientDecorator {
           SpanNaming.instance().namingSchema().client().operationForProtocol("grpc"));
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("grpc-client");
   public static final CharSequence GRPC_MESSAGE = UTF8BytesString.create("grpc.message");
-
-  private static LinkedHashMap<String, String> createClientPathwaySortedTags() {
-    LinkedHashMap<String, String> result = new LinkedHashMap<>();
-    result.put(DIRECTION_TAG, DIRECTION_OUT);
-    result.put(TYPE_TAG, "grpc");
-    return result;
-  }
-
-  public static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS =
-      createClientPathwaySortedTags();
 
   public static final GrpcClientDecorator DECORATE = new GrpcClientDecorator();
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.grpc.client;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
@@ -44,7 +45,6 @@ public class GrpcClientDecorator extends ClientDecorator {
 
   private static final Set<String> IGNORED_METHODS = Config.get().getGrpcIgnoredOutboundMethods();
   private static final BitSet CLIENT_ERROR_STATUSES = Config.get().getGrpcClientErrorStatuses();
-  private static final boolean DATA_STREAMS_ENABLED = Config.get().isDataStreamsEnabled();
 
   private static final ClassValue<UTF8BytesString> MESSAGE_TYPES =
       GenericClassValue.of(
@@ -111,7 +111,7 @@ public class GrpcClientDecorator extends ClientDecorator {
   }
 
   public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
-    if (DATA_STREAMS_ENABLED) {
+    if (traceConfig().isDataStreamsEnabled()) {
       context = context.with(createDsmContext());
     }
     defaultPropagator().inject(context, request, setter);

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -4,7 +4,6 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HeadersInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -15,7 +14,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
@@ -87,9 +85,7 @@ public class HttpUrlConnectionInstrumentation extends InstrumenterModule.Tracing
         if (!state.hasSpan() && !state.isFinished()) {
           final AgentSpan span = state.start(thiz);
           if (!connected) {
-            DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-            defaultPropagator()
-                .inject(getCurrentContext().with(span).with(dsmContext), thiz, SETTER);
+            defaultPropagator().inject(getCurrentContext().with(span), thiz, SETTER);
           }
         }
         return state;

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -1,9 +1,9 @@
 package datadog.trace.instrumentation.http_url_connection;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
+import static datadog.trace.bootstrap.instrumentation.decorator.UrlConnectionDecorator.DECORATE;
 import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HeadersInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -85,7 +85,7 @@ public class HttpUrlConnectionInstrumentation extends InstrumenterModule.Tracing
         if (!state.hasSpan() && !state.isFinished()) {
           final AgentSpan span = state.start(thiz);
           if (!connected) {
-            defaultPropagator().inject(getCurrentContext().with(span), thiz, SETTER);
+            DECORATE.injectContext(getCurrentContext().with(span), thiz, SETTER);
           }
         }
         return state;

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpHeadersInstrumentation.java
@@ -47,7 +47,9 @@ public class HttpHeadersInstrumentation extends InstrumenterModule.Tracing
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".HttpHeadersInjectAdapter"};
+    return new String[] {
+      packageName + ".HttpHeadersInjectAdapter", packageName + ".JavaNetClientDecorator",
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
@@ -2,11 +2,9 @@ package datadog.trace.instrumentation.httpclient;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.KEEP;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.SETTER;
 
-import datadog.trace.api.datastreams.DataStreamsContext;
 import java.net.http.HttpHeaders;
 import java.util.HashMap;
 import java.util.List;
@@ -17,8 +15,7 @@ public class HeadersAdvice {
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void methodExit(@Advice.Return(readOnly = false) HttpHeaders headers) {
     final Map<String, List<String>> headerMap = new HashMap<>(headers.map());
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(getCurrentContext().with(dsmContext), headerMap, SETTER);
+    defaultPropagator().inject(getCurrentContext(), headerMap, SETTER);
     headers = HttpHeaders.of(headerMap, KEEP);
   }
 }

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
@@ -1,9 +1,9 @@
 package datadog.trace.instrumentation.httpclient;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.KEEP;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.SETTER;
+import static datadog.trace.instrumentation.httpclient.JavaNetClientDecorator.DECORATE;
 
 import java.net.http.HttpHeaders;
 import java.util.HashMap;
@@ -15,7 +15,7 @@ public class HeadersAdvice {
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void methodExit(@Advice.Return(readOnly = false) HttpHeaders headers) {
     final Map<String, List<String>> headerMap = new HashMap<>(headers.map());
-    defaultPropagator().inject(getCurrentContext(), headerMap, SETTER);
+    DECORATE.injectContext(getCurrentContext(), headerMap, SETTER);
     headers = HttpHeaders.of(headerMap, KEEP);
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -7,7 +7,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.jaxrs.v1.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator.DECORATE;
@@ -21,7 +20,6 @@ import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
@@ -76,10 +74,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
-
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator()
-            .inject(getCurrentContext().with(span).with(dsmContext), request.getHeaders(), SETTER);
+        defaultPropagator().inject(getCurrentContext().with(span), request.getHeaders(), SETTER);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jaxrs.v1;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
@@ -74,7 +73,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
-        defaultPropagator().inject(getCurrentContext().with(span), request.getHeaders(), SETTER);
+        DECORATE.injectContext(getCurrentContext().with(span), request.getHeaders(), SETTER);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.jaxrs;
 
 import static datadog.context.Context.current;
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs.InjectAdapter.SETTER;
@@ -27,7 +26,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
-      defaultPropagator().inject(current().with(span), requestContext.getHeaders(), SETTER);
+      DECORATE.injectContext(current().with(span), requestContext.getHeaders(), SETTER);
       requestContext.setProperty(SPAN_PROPERTY_NAME, span);
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -4,12 +4,10 @@ import static datadog.context.Context.current;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.jaxrs.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.JAX_RS_CLIENT_CALL;
 
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import javax.annotation.Priority;
@@ -29,11 +27,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
-
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator()
-          .inject(current().with(span).with(dsmContext), requestContext.getHeaders(), SETTER);
-
+      defaultPropagator().inject(current().with(span), requestContext.getHeaders(), SETTER);
       requestContext.setProperty(SPAN_PROPERTY_NAME, span);
     }
   }

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
@@ -26,12 +26,12 @@ public class JettyServerAdvice {
         return activateSpan((AgentSpan) existingSpan);
       }
 
-      final Context extractedContext = DECORATE.extractContext(req);
-      span = DECORATE.startSpan(req, extractedContext);
-      final ContextScope scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(req);
+      span = DECORATE.startSpan(req, context);
+      final ContextScope scope = context.with(span).attach();
       span.setMeasured(true);
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, req, req, extractedContext);
+      DECORATE.onRequest(span, req, req, context);
 
       req.setAttribute(DD_SPAN_ATTRIBUTE, span);
       req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
@@ -27,12 +27,12 @@ public class JettyServerAdvice {
         }
       }
 
-      final Context extractedContext = JettyDecorator.DECORATE.extractContext(req);
-      final AgentSpan span = JettyDecorator.DECORATE.startSpan(req, extractedContext);
-      try (final ContextScope scope = extractedContext.with(span).attach()) {
+      final Context context = JettyDecorator.DECORATE.extractContext(req);
+      final AgentSpan span = JettyDecorator.DECORATE.startSpan(req, context);
+      try (final ContextScope scope = context.with(span).attach()) {
         span.setMeasured(true);
         JettyDecorator.DECORATE.afterStart(span);
-        JettyDecorator.DECORATE.onRequest(span, req, req, extractedContext);
+        JettyDecorator.DECORATE.onRequest(span, req, req, context);
 
         req.setAttribute(DD_SPAN_ATTRIBUTE, span);
         req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -170,11 +170,11 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
         return ((AgentSpan) existingSpan).attach();
       }
 
-      final Context extractedContext = DECORATE.extractContext(req);
-      span = DECORATE.startSpan(req, extractedContext);
-      final ContextScope scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(req);
+      span = DECORATE.startSpan(req, context);
+      final ContextScope scope = context.with(span).attach();
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, req, req, extractedContext);
+      DECORATE.onRequest(span, req, req, context);
 
       req.setAttribute(DD_SPAN_ATTRIBUTE, span);
       req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -24,12 +24,12 @@ public class HandleAdvice {
       return ((AgentSpan) existingSpan).attach();
     }
 
-    final Context extractedContext = DECORATE.extractContext(req);
-    span = DECORATE.startSpan(req, extractedContext);
+    final Context context = DECORATE.extractContext(req);
+    span = DECORATE.startSpan(req, context);
     DECORATE.afterStart(span);
-    DECORATE.onRequest(span, req, req, extractedContext);
+    DECORATE.onRequest(span, req, req, context);
 
-    final ContextScope scope = extractedContext.with(span).attach();
+    final ContextScope scope = context.with(span).attach();
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
     req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
     req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jetty_client10;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.jetty_client.HeadersInjectAdapter.SETTER;
@@ -25,7 +24,7 @@ public class SendAdvice {
     responseListeners.add(0, new SpanFinishingCompleteListener(span));
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+    DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
     return span;
   }
 

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/SendAdvice.java
@@ -3,12 +3,10 @@ package datadog.trace.instrumentation.jetty_client10;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.jetty_client.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jetty_client10.JettyClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.jetty_client10.JettyClientDecorator.HTTP_REQUEST;
 
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.List;
@@ -27,8 +25,7 @@ public class SendAdvice {
     responseListeners.add(0, new SpanFinishingCompleteListener(span));
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+    defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
     return span;
   }
 

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/main/java17/datadog/trace/instrumentation/jetty_client12/SendAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/main/java17/datadog/trace/instrumentation/jetty_client12/SendAdvice.java
@@ -4,11 +4,9 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.jetty_client12.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jetty_client12.JettyClientDecorator.HTTP_REQUEST;
 
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -23,8 +21,7 @@ public class SendAdvice {
     InstrumentationContext.get(Request.class, AgentSpan.class).put(request, span);
     JettyClientDecorator.DECORATE.afterStart(span);
     JettyClientDecorator.DECORATE.onRequest(span, request);
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-    defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+    defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
     return activateSpan(span);
   }
 

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.instrumentation.jetty_client.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jetty_client91.JettyClientDecorator.DECORATE;
@@ -19,7 +18,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
@@ -93,8 +91,7 @@ public class JettyClientInstrumentation extends InstrumenterModule.Tracing
       responseListeners.add(0, new SpanFinishingCompleteListener(span));
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
       return span;
     }
 

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client91/JettyClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jetty_client91;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -91,7 +90,7 @@ public class JettyClientInstrumentation extends InstrumenterModule.Tracing
       responseListeners.add(0, new SpanFinishingCompleteListener(span));
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+      DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
       return span;
     }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.kafka_clients;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_RECORDS_COUNT;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_POLL;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -205,13 +205,7 @@ public final class KafkaConsumerInfoInstrumentation extends InstrumenterModule.T
   public static class RecordsAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter() {
-      boolean dataStreamsEnabled;
-      if (activeSpan() != null) {
-        dataStreamsEnabled = activeSpan().traceConfig().isDataStreamsEnabled();
-      } else {
-        dataStreamsEnabled = Config.get().isDataStreamsEnabled();
-      }
-      if (dataStreamsEnabled) {
+      if (traceConfig().isDataStreamsEnabled()) {
         final AgentSpan span = startSpan(KAFKA_POLL);
         return activateSpan(span);
       }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
@@ -110,7 +111,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(TYPE_TAG, "kafka");
 
           final long payloadSize =
-              span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(val) : 0;
+              traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(val) : 0;
           if (STREAMING_CONTEXT.isDisabledForTopic(val.topic())) {
             AgentTracer.get()
                 .getDataStreamsMonitoring()

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
@@ -1,12 +1,11 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_RECORDS_COUNT;
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.KAFKA_POLL;
 
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -22,13 +21,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerDelegate;
 public class RecordsAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter() {
-    boolean dataStreamsEnabled;
-    if (activeSpan() != null) {
-      dataStreamsEnabled = activeSpan().traceConfig().isDataStreamsEnabled();
-    } else {
-      dataStreamsEnabled = Config.get().isDataStreamsEnabled();
-    }
-    if (dataStreamsEnabled) {
+    if (traceConfig().isDataStreamsEnabled()) {
       final AgentSpan span = startSpan(KAFKA_POLL);
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
@@ -110,7 +111,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(TYPE_TAG, "kafka");
 
           final long payloadSize =
-              span.traceConfig().isDataStreamsEnabled() ? Utils.computePayloadSizeBytes(val) : 0;
+              traceConfig().isDataStreamsEnabled() ? Utils.computePayloadSizeBytes(val) : 0;
           if (StreamingContext.STREAMING_CONTEXT.isDisabledForTopic(val.topic())) {
             AgentTracer.get()
                 .getDataStreamsMonitoring()

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.DSM_C
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extractContextAndGetSpanContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
@@ -262,7 +263,7 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
         sortedTags.put(TYPE_TAG, "kafka");
 
         final long payloadSize =
-            span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(record.value) : 0;
+            traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(record.value) : 0;
         if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())) {
           AgentTracer.get()
               .getDataStreamsMonitoring()

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -105,10 +105,10 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       } catch (NullPointerException e) {
       }
 
-      final Context extractedContext = DECORATE.extractContext(request);
-      request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
-      final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(request);
+      request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, context);
+      final AgentSpan span = DECORATE.startSpan(request, context);
+      scope = context.with(span).attach();
       if (Config.get().isJeeSplitByDeployment()) {
         final IWebAppDispatcherContext dispatcherContext = request.getWebAppDispatcherContext();
         if (dispatcherContext != null) {
@@ -122,7 +122,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
         }
       }
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, request, request, extractedContext);
+      DECORATE.onRequest(span, request, request, context);
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
       request.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
       request.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
@@ -107,10 +107,10 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       } catch (NullPointerException e) {
       }
 
-      final Context extractedContext = DECORATE.extractContext(request);
-      request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
-      final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(request);
+      request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, context);
+      final AgentSpan span = DECORATE.startSpan(request, context);
+      scope = context.with(span).attach();
       if (Config.get().isJeeSplitByDeployment()) {
         final IWebAppDispatcherContext dispatcherContext = request.getWebAppDispatcherContext();
         if (dispatcherContext != null) {
@@ -124,7 +124,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
         }
       }
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, request, request, extractedContext);
+      DECORATE.onRequest(span, request, request, context);
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
       request.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
       request.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -4,14 +4,12 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.DECORATE_SECURE;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty38.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -67,8 +65,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
         decorate.onPeerConnection(span, (InetSocketAddress) socketAddress);
       }
 
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(Context.current().with(dsmContext), request.headers(), SETTER);
+      defaultPropagator().inject(Context.current(), request.headers(), SETTER);
 
       channelTraceContext.setClientSpan(span);
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.netty38.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -9,7 +9,6 @@ import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty38.client.NettyResponseInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -65,7 +64,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
         decorate.onPeerConnection(span, (InetSocketAddress) socketAddress);
       }
 
-      defaultPropagator().inject(Context.current(), request.headers(), SETTER);
+      DECORATE.injectContext(current(), request.headers(), SETTER);
 
       channelTraceContext.setClientSpan(span);
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -4,7 +4,6 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.SPAN_ATTRIBUTE_KEY;
@@ -15,7 +14,6 @@ import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAd
 
 import datadog.context.Context;
 import datadog.trace.api.Config;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.netty.channel.ChannelHandler;
@@ -90,8 +88,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator().inject(Context.current().with(dsmContext), request.headers(), SETTER);
+        defaultPropagator().inject(Context.current(), request.headers(), SETTER);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.netty40.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -12,7 +12,6 @@ import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -88,7 +87,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        defaultPropagator().inject(Context.current(), request.headers(), SETTER);
+        DECORATE.injectContext(current(), request.headers(), SETTER);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -39,12 +39,12 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
     final HttpHeaders headers = request.headers();
-    final Context extractedContext = DECORATE.extractContext(headers);
-    final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
+    final Context context = DECORATE.extractContext(headers);
+    final AgentSpan span = DECORATE.startSpan(headers, context);
 
-    try (final ContextScope scope = extractedContext.with(span).attach()) {
+    try (final ContextScope scope = context.with(span).attach()) {
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, channel, request, extractedContext);
+      DECORATE.onRequest(span, channel, request, context);
 
       channel.attr(ANALYZED_RESPONSE_KEY).set(null);
       channel.attr(BLOCKED_RESPONSE_KEY).set(null);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -4,7 +4,6 @@ import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.SPAN_ATTRIBUTE_KEY;
@@ -15,7 +14,6 @@ import static datadog.trace.instrumentation.netty41.client.NettyResponseInjectAd
 
 import datadog.context.Context;
 import datadog.trace.api.Config;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.netty.channel.ChannelHandler;
@@ -91,8 +89,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator().inject(Context.current().with(dsmContext), request.headers(), SETTER);
+        defaultPropagator().inject(Context.current(), request.headers(), SETTER);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.netty41.client;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -12,7 +12,6 @@ import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty41.client.NettyResponseInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -89,7 +88,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!awsClientCall) {
-        defaultPropagator().inject(Context.current(), request.headers(), SETTER);
+        DECORATE.injectContext(current(), request.headers(), SETTER);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -38,12 +38,12 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
     final HttpHeaders headers = request.headers();
-    final Context extractedContext = DECORATE.extractContext(headers);
-    final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
+    final Context context = DECORATE.extractContext(headers);
+    final AgentSpan span = DECORATE.startSpan(headers, context);
 
-    try (final ContextScope scope = extractedContext.with(span).attach()) {
+    try (final ContextScope scope = context.with(span).attach()) {
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, channel, request, extractedContext);
+      DECORATE.onRequest(span, channel, request, context);
 
       channel.attr(ANALYZED_RESPONSE_KEY).set(null);
       channel.attr(BLOCKED_RESPONSE_KEY).set(null);

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.okhttp2;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.okhttp2.OkHttpClientDecorator.DECORATE;
@@ -10,7 +10,6 @@ import static datadog.trace.instrumentation.okhttp2.RequestBuilderInjectAdapter.
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
-import datadog.context.Context;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
@@ -22,11 +21,10 @@ public class TracingInterceptor implements Interceptor {
 
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
-
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      defaultPropagator().inject(Context.current(), requestBuilder, SETTER);
+      DECORATE.injectContext(current(), requestBuilder, SETTER);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.okhttp2;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.okhttp2.OkHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.okhttp2.OkHttpClientDecorator.OKHTTP_REQUEST;
 import static datadog.trace.instrumentation.okhttp2.RequestBuilderInjectAdapter.SETTER;
@@ -12,7 +11,6 @@ import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
@@ -28,8 +26,7 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(Context.current().with(dsmContext), requestBuilder, SETTER);
+      defaultPropagator().inject(Context.current(), requestBuilder, SETTER);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -1,13 +1,12 @@
 package datadog.trace.instrumentation.okhttp3;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.OKHTTP_REQUEST;
 import static datadog.trace.instrumentation.okhttp3.RequestBuilderInjectAdapter.SETTER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
@@ -29,7 +28,7 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      defaultPropagator().inject(Context.current(), requestBuilder, SETTER);
+      DECORATE.injectContext(current(), requestBuilder, SETTER);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -3,13 +3,11 @@ package datadog.trace.instrumentation.okhttp3;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.OKHTTP_REQUEST;
 import static datadog.trace.instrumentation.okhttp3.RequestBuilderInjectAdapter.SETTER;
 
 import datadog.context.Context;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
@@ -31,8 +29,7 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onRequest(span, chain.request());
 
       final Request.Builder requestBuilder = chain.request().newBuilder();
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(Context.current().with(dsmContext), requestBuilder, SETTER);
+      defaultPropagator().inject(Context.current(), requestBuilder, SETTER);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogAsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogAsyncHandlerWrapper.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.pekkohttp;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
+
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
@@ -24,8 +26,8 @@ public class DatadogAsyncHandlerWrapper
   @Override
   public Future<HttpResponse> apply(final HttpRequest request) {
     final ContextScope scope = DatadogWrapperHelper.createSpan(request);
-    AgentSpan span = AgentSpan.fromContext(scope.context());
-    Future<HttpResponse> futureResponse = null;
+    AgentSpan span = fromContext(scope.context());
+    Future<HttpResponse> futureResponse;
     try {
       futureResponse = userHandler.apply(request);
     } catch (final Throwable t) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogServerRequestResponseFlowWrapper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogServerRequestResponseFlowWrapper.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.pekkohttp;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
 import datadog.context.ContextScope;
@@ -113,7 +114,7 @@ public class DatadogServerRequestResponseFlowWrapper
                 final HttpResponse response = grab(responseInlet);
                 final ContextScope scope = scopes.poll();
                 if (scope != null) {
-                  AgentSpan span = AgentSpan.fromContext(scope.context());
+                  AgentSpan span = fromContext(scope.context());
                   DatadogWrapperHelper.finishSpan(span, response);
                   // Check if the active span matches the scope from when the request came in,
                   // and close it. If it's not, then it will be cleaned up actor message
@@ -132,7 +133,7 @@ public class DatadogServerRequestResponseFlowWrapper
                 // remaining spans
                 ContextScope scope = scopes.poll();
                 while (scope != null) {
-                  AgentSpan.fromContext(scope.context()).finish();
+                  fromContext(scope.context()).finish();
                   scope = scopes.poll();
                 }
                 completeStage();
@@ -143,14 +144,14 @@ public class DatadogServerRequestResponseFlowWrapper
                 ContextScope scope = scopes.poll();
                 if (scope != null) {
                   // Mark the span as failed
-                  AgentSpan span = AgentSpan.fromContext(scope.context());
+                  AgentSpan span = fromContext(scope.context());
                   DatadogWrapperHelper.finishSpan(span, ex);
                 }
                 // We will not receive any more responses from the user code, so clean up any
                 // remaining spans
                 scope = scopes.poll();
                 while (scope != null) {
-                  AgentSpan.fromContext(scope.context()).finish();
+                  fromContext(scope.context()).finish();
                   scope = scopes.poll();
                 }
                 fail(responseOutlet, ex);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
@@ -10,12 +10,12 @@ import org.apache.pekko.http.scaladsl.model.HttpResponse;
 
 public class DatadogWrapperHelper {
   public static ContextScope createSpan(final HttpRequest request) {
-    final Context extractedContext = DECORATE.extractContext(request);
-    final AgentSpan span = DECORATE.startSpan(request, extractedContext);
+    final Context context = DECORATE.extractContext(request);
+    final AgentSpan span = DECORATE.startSpan(request, context);
     DECORATE.afterStart(span);
-    DECORATE.onRequest(span, request, request, extractedContext);
+    DECORATE.onRequest(span, request, request, context);
 
-    return extractedContext.with(span).attach();
+    return context.with(span).attach();
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.PEKKO_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientHelpers.OnCompleteHandler;
@@ -15,7 +14,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
@@ -81,9 +79,7 @@ public final class PekkoHttpSingleRequestInstrumentation extends InstrumenterMod
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-        defaultPropagator()
-            .inject(getCurrentContext().with(span).with(dsmContext), request, headers);
+        defaultPropagator().inject(getCurrentContext().with(span), request, headers);
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.pekkohttp;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -79,7 +78,7 @@ public final class PekkoHttpSingleRequestInstrumentation extends InstrumenterMod
       DECORATE.onRequest(span, request);
 
       if (request != null) {
-        defaultPropagator().inject(getCurrentContext().with(span), request, headers);
+        DECORATE.injectContext(getCurrentContext().with(span), request, headers);
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -25,9 +25,9 @@ public class PlayAdvice {
     final ContextScope scope;
     if (activeSpan() == null) {
       Headers headers = req.headers();
-      final Context extractedContext = DECORATE.extractContext(headers);
-      span = DECORATE.startSpan(headers, extractedContext);
-      scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(headers);
+      span = DECORATE.startSpan(headers, context);
+      scope = context.with(span).attach();
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -31,9 +31,9 @@ public class PlayAdvice {
 
     if (activeSpan() == null) {
       final Headers headers = req.headers();
-      final Context extractedContext = DECORATE.extractContext(headers);
-      span = DECORATE.startSpan(headers, extractedContext);
-      scope = extractedContext.with(span).attach();
+      final Context context = DECORATE.extractContext(headers);
+      span = DECORATE.startSpan(headers, context);
+      scope = context.with(span).attach();
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -3,14 +3,12 @@ package datadog.trace.instrumentation.playws1;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.PLAY_WS_REQUEST;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.playws.BasePlayWSClientInstrumentation;
 import net.bytebuddy.asm.Advice;
@@ -31,8 +29,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.playws1;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +28,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+      DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -3,14 +3,12 @@ package datadog.trace.instrumentation.playws21;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.PLAY_WS_REQUEST;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.playws.BasePlayWSClientInstrumentation;
 import net.bytebuddy.asm.Advice;
@@ -31,8 +29,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.playws21;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +28,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+      DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -3,14 +3,12 @@ package datadog.trace.instrumentation.playws2;
 import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.PLAY_WS_REQUEST;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.playws.BasePlayWSClientInstrumentation;
 import net.bytebuddy.asm.Advice;
@@ -31,8 +29,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(getCurrentContext().with(span).with(dsmContext), request, SETTER);
+      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.playws2;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -29,7 +28,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
-      defaultPropagator().inject(getCurrentContext().with(span), request, SETTER);
+      DECORATE.injectContext(getCurrentContext().with(span), request, SETTER);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -52,11 +52,11 @@ public class Servlet2Advice {
       InstrumentationContext.get(ServletResponse.class, Integer.class).put(response, 200);
     }
 
-    final Context extractedContext = DECORATE.extractContext(httpServletRequest);
-    final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = extractedContext.with(span).attach();
+    final Context context = DECORATE.extractContext(httpServletRequest);
+    final AgentSpan span = DECORATE.startSpan(httpServletRequest, context);
+    scope = context.with(span).attach();
     DECORATE.afterStart(span);
-    DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);
+    DECORATE.onRequest(span, httpServletRequest, httpServletRequest, context);
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);
     httpServletRequest.setAttribute(

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -69,12 +69,12 @@ public class Servlet3Advice {
       return false;
     }
 
-    final Context extractedContext = DECORATE.extractContext(httpServletRequest);
-    final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = extractedContext.with(span).attach();
+    final Context context = DECORATE.extractContext(httpServletRequest);
+    final AgentSpan span = DECORATE.startSpan(httpServletRequest, context);
+    scope = context.with(span).attach();
 
     DECORATE.afterStart(span);
-    DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);
+    DECORATE.onRequest(span, httpServletRequest, httpServletRequest, context);
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);
     httpServletRequest.setAttribute(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.servlet.dispatcher;
 
 import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 
 import datadog.context.Context;
 import datadog.context.propagation.CarrierSetter;
-import datadog.trace.api.Config;
 import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -17,7 +17,6 @@ public class RequestDispatcherDecorator extends BaseDecorator {
       UTF8BytesString.create("java-web-servlet-dispatcher");
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
-  private static final boolean DATA_STREAMS_ENABLED = Config.get().isDataStreamsEnabled();
 
   @Override
   protected String[] instrumentationNames() {
@@ -46,7 +45,7 @@ public class RequestDispatcherDecorator extends BaseDecorator {
 
   public <C> void injectContext(Context context, final C request, CarrierSetter<C> setter) {
     // Add additional default DSM context for HTTP clients if missing but DSM is enabled
-    if (DATA_STREAMS_ENABLED) {
+    if (traceConfig().isDataStreamsEnabled()) {
       context = context.with(DataStreamsContext.forHttpClient());
     }
     // Inject context into carrier

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -9,7 +9,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet.ServletRequestSetter.SETTER;
 import static datadog.trace.instrumentation.servlet.SpanNameCache.SERVLET_PREFIX;
@@ -25,7 +24,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -122,8 +120,7 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       span.setSpanType(InternalSpanTypes.HTTP_SERVER);
 
       // In case we lose context, inject trace into to the request.
-      DataStreamsContext dsmContext = DataStreamsContext.fromTags(CLIENT_PATHWAY_EDGE_TAGS);
-      defaultPropagator().inject(span.with(dsmContext), request, SETTER);
+      defaultPropagator().inject(span, request, SETTER);
 
       // temporarily replace from request to avoid spring resource name bubbling up:
       requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.servlet.dispatcher;
 
-import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
@@ -120,7 +119,7 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       span.setSpanType(InternalSpanTypes.HTTP_SERVER);
 
       // In case we lose context, inject trace into to the request.
-      defaultPropagator().inject(span, request, SETTER);
+      DECORATE.injectContext(span, request, SETTER);
 
       // temporarily replace from request to avoid spring resource name bubbling up:
       requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.spark;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.core.datastreams.TagsProcessor.CONSUMER_GROUP_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
@@ -1297,7 +1298,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
 
   private static void reportKafkaOffsets(
       final String appName, final AgentSpan span, final SourceProgress progress) {
-    if (!span.traceConfig().isDataStreamsEnabled()
+    if (!traceConfig().isDataStreamsEnabled()
         || progress == null
         || progress.description() == null) {
       return;

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -7,6 +7,7 @@ import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.DECOR
 import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import net.bytebuddy.asm.Advice;
 import spray.http.HttpRequest;
 import spray.routing.RequestContext;
@@ -16,26 +17,26 @@ public class SprayHttpServerRunSealedRouteAdvice {
   public static ContextScope enter(
       @Advice.Argument(value = 1, readOnly = false) RequestContext ctx) {
     final AgentSpan span;
-    final Context extractedContext;
-    final ContextScope scope;
+    final AgentSpanContext.Extracted extractedSpanContext;
+    final Context context;
     if (activeSpan() == null) {
       // Propagate context in case income request was going through several routes
       // TODO: Add test for it
       final HttpRequest request = ctx.request();
-      extractedContext = DECORATE.extractContext(request);
+      Context extractedContext = DECORATE.extractContext(request);
+      extractedSpanContext = DECORATE.getExtractedSpanContext(extractedContext);
       span = DECORATE.startSpan(request, extractedContext);
-      scope = extractedContext.with(span).attach();
+      context = extractedContext.with(span);
     } else {
-      extractedContext = null;
+      extractedSpanContext = null;
       span = startSpan(DECORATE.spanName());
-      scope = span.attach();
+      context = span;
     }
 
+    ContextScope scope = context.attach();
     DECORATE.afterStart(span);
 
-    ctx =
-        SprayHelper.wrapRequestContext(
-            ctx, span, DECORATE.getExtractedSpanContext(extractedContext));
+    ctx = SprayHelper.wrapRequestContext(ctx, span, extractedSpanContext);
     return scope;
   }
 

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
@@ -68,20 +68,20 @@ public final class SynapseServerInstrumentation extends InstrumenterModule.Traci
 
       // check incoming request for distributed trace ids
       HttpRequest request = connection.getHttpRequest();
-      Context extractedContext = DECORATE.extractContext(request);
-      ContextScope scope;
+      Context context = DECORATE.extractContext(request);
 
       AgentSpan span;
-      if (null != extractedContext) {
-        span = DECORATE.startSpan(request, extractedContext);
-        scope = extractedContext.with(span).attach();
+      if (null != context) {
+        span = DECORATE.startSpan(request, context);
+        context = context.with(span);
       } else {
         span = startSpan(DECORATE.spanName());
         span.setMeasured(true);
-        scope = span.attach();
+        context = span;
       }
+      ContextScope scope = context.attach();
       DECORATE.afterStart(span);
-      DECORATE.onRequest(span, connection, request, extractedContext);
+      DECORATE.onRequest(span, connection, request, context);
 
       // capture span to be finished by one of the various server response advices
       connection.getContext().setAttribute(SYNAPSE_SPAN_KEY, span);

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpRequestParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpRequestParserInstrumentation.java
@@ -74,11 +74,11 @@ public class HttpRequestParserInstrumentation extends InstrumenterModule.Tracing
       ContextScope scope = null;
       try {
         if (span == null) {
-          final Context extractedContext = DECORATE.extractContext(exchange);
-          span = DECORATE.startSpan(exchange, extractedContext).setMeasured(true);
-          scope = extractedContext.with(span).attach();
+          final Context context = DECORATE.extractContext(exchange);
+          span = DECORATE.startSpan(exchange, context).setMeasured(true);
+          scope = context.with(span).attach();
           DECORATE.afterStart(span);
-          DECORATE.onRequest(span, exchange, exchange, extractedContext);
+          DECORATE.onRequest(span, exchange, exchange, context);
         }
         DECORATE.onError(span, throwable);
         // because we know that a http 400 will be thrown

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -36,7 +36,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   protected static final int READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5) as int
   protected static final BASIC_AUTH_KEY = "custom_authorization_header"
   protected static final BASIC_AUTH_VAL = "plain text auth token"
-  protected static final DSM_EDGE_TAGS = DataStreamsContext.client().sortedTags().collect { key, value ->
+  protected static final DSM_EDGE_TAGS = DataStreamsContext.forHttpClient().sortedTags().collect { key, value ->
     return key + ":" + value
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.agent.test.server.http.HttpProxy
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.datastreams.DataStreamsContext
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.api.URIUtils
 import datadog.trace.core.DDSpan
@@ -27,7 +28,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TA
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS
 import static org.junit.Assume.assumeTrue
 
 abstract class HttpClientTest extends VersionedNamingTestBase {
@@ -36,7 +36,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   protected static final int READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5) as int
   protected static final BASIC_AUTH_KEY = "custom_authorization_header"
   protected static final BASIC_AUTH_VAL = "plain text auth token"
-  protected static final DSM_EDGE_TAGS = CLIENT_PATHWAY_EDGE_TAGS.collect { key, value ->
+  protected static final DSM_EDGE_TAGS = DataStreamsContext.client().sortedTags().collect { key, value ->
     return key + ":" + value
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -14,6 +14,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.ProductActivation
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.datastreams.DataStreamsContext
 import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.function.TriFunction
@@ -96,14 +97,13 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.SERVER_PATHWAY_EDGE_TAGS
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.junit.Assume.assumeTrue
 
 abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   public static final Logger SERVER_LOGGER = LoggerFactory.getLogger("http-server")
-  protected static final DSM_EDGE_TAGS = SERVER_PATHWAY_EDGE_TAGS.collect {
+  protected static final DSM_EDGE_TAGS = DataStreamsContext.forHttpServer().sortedTags().collect {
     key, value ->
     return key + ":" + value
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsPropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsPropagator.java
@@ -104,7 +104,7 @@ public class DataStreamsPropagator implements Propagator {
         && span.getTag(COMPONENT) instanceof CharSequence
         && "java-web-servlet-dispatcher"
             .equals(((CharSequence) span.getTag(COMPONENT)).toString())) {
-      return DataStreamsContext.client();
+      return DataStreamsContext.forHttpClient();
     }
     return null;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -91,7 +91,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
             V01_DATASTREAMS_ENDPOINT,
             false,
             true,
-            Collections.<String, String>emptyMap()),
+            Collections.emptyMap()),
         sharedCommunicationObjects.featuresDiscovery(config),
         timeSource,
         traceConfigSupplier,
@@ -135,12 +135,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     schemaSamplers = new ConcurrentHashMap<>();
 
     this.propagator =
-        new DataStreamsPropagator(
-            this,
-            this.traceConfigSupplier,
-            this.timeSource,
-            this.hashOfKnownTags,
-            serviceNameOverride);
+        new DataStreamsPropagator(this, this.timeSource, this.hashOfKnownTags, serviceNameOverride);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
@@ -22,21 +22,16 @@ public class StatsBucket {
     // we want to perform aggregation per dataset, to allow
     // lower-level granularity and unblock dataset name manipulations on the backend
     // without affecting the precision.
-    StatsGroup statsGroup = hashToGroup.get(statsPoint.getAggregationHash());
-
-    // FIXME Java 7
-    if (statsGroup == null) {
-      // stats group remains the same
-      statsGroup =
-          new StatsGroup(
-              statsPoint.getEdgeTags(), statsPoint.getHash(), statsPoint.getParentHash());
-      hashToGroup.put(statsPoint.getAggregationHash(), statsGroup);
-    }
-
-    statsGroup.add(
-        statsPoint.getPathwayLatencyNano(),
-        statsPoint.getEdgeLatencyNano(),
-        statsPoint.getPayloadSizeBytes());
+    hashToGroup
+        .computeIfAbsent(
+            statsPoint.getAggregationHash(),
+            hash ->
+                new StatsGroup(
+                    statsPoint.getEdgeTags(), statsPoint.getHash(), statsPoint.getParentHash()))
+        .add(
+            statsPoint.getPathwayLatencyNano(),
+            statsPoint.getEdgeLatencyNano(),
+            statsPoint.getPayloadSizeBytes());
   }
 
   public void addBacklog(Backlog backlog) {

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/DataStreamsContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/DataStreamsContext.java
@@ -9,6 +9,7 @@ public class DataStreamsContext implements ImplicitContextKeyed {
   private static final ContextKey<DataStreamsContext> CONTEXT_KEY =
       ContextKey.named("dsm-context-key");
   private static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS;
+  private static final LinkedHashMap<String, String> SERVER_PATHWAY_EDGE_TAGS;
 
   final LinkedHashMap<String, String> sortedTags;
   final long defaultTimestamp;
@@ -20,6 +21,10 @@ public class DataStreamsContext implements ImplicitContextKeyed {
     // TODO: Refactor TagsProcessor to move it into a package that we can link the constants for.
     CLIENT_PATHWAY_EDGE_TAGS.put("direction", "out");
     CLIENT_PATHWAY_EDGE_TAGS.put("type", "http");
+    SERVER_PATHWAY_EDGE_TAGS = new LinkedHashMap<>(2);
+    // TODO: Refactor TagsProcessor to move it into a package that we can link the constants for.
+    SERVER_PATHWAY_EDGE_TAGS.put("direction", "in");
+    SERVER_PATHWAY_EDGE_TAGS.put("type", "http");
   }
 
   public static DataStreamsContext fromContext(Context context) {
@@ -27,12 +32,21 @@ public class DataStreamsContext implements ImplicitContextKeyed {
   }
 
   /**
-   * Return default DSM context for HTTP clients.
+   * Gets default DSM context for HTTP clients.
    *
    * @return The default DSM context for HTTP clients.
    */
-  public static DataStreamsContext client() {
+  public static DataStreamsContext forHttpClient() {
     return fromTags(CLIENT_PATHWAY_EDGE_TAGS);
+  }
+
+  /**
+   * Gets default DSM context for HTTP servers.
+   *
+   * @return The default DSM context for HTTP servers.
+   */
+  public static DataStreamsContext forHttpServer() {
+    return fromTags(SERVER_PATHWAY_EDGE_TAGS);
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/DataStreamsContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/DataStreamsContext.java
@@ -8,14 +8,31 @@ import java.util.LinkedHashMap;
 public class DataStreamsContext implements ImplicitContextKeyed {
   private static final ContextKey<DataStreamsContext> CONTEXT_KEY =
       ContextKey.named("dsm-context-key");
+  private static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS;
 
   final LinkedHashMap<String, String> sortedTags;
   final long defaultTimestamp;
   final long payloadSizeBytes;
   final boolean sendCheckpoint;
 
+  static {
+    CLIENT_PATHWAY_EDGE_TAGS = new LinkedHashMap<>(2);
+    // TODO: Refactor TagsProcessor to move it into a package that we can link the constants for.
+    CLIENT_PATHWAY_EDGE_TAGS.put("direction", "out");
+    CLIENT_PATHWAY_EDGE_TAGS.put("type", "http");
+  }
+
   public static DataStreamsContext fromContext(Context context) {
     return context.get(CONTEXT_KEY);
+  }
+
+  /**
+   * Return default DSM context for HTTP clients.
+   *
+   * @return The default DSM context for HTTP clients.
+   */
+  public static DataStreamsContext client() {
+    return fromTags(CLIENT_PATHWAY_EDGE_TAGS);
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -1,7 +1,9 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import static datadog.context.Context.root;
 import static datadog.context.propagation.Concern.named;
 import static datadog.context.propagation.Concern.withPriority;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
 
 import datadog.context.Context;
 import datadog.context.propagation.CarrierVisitor;
@@ -25,8 +27,8 @@ public final class AgentPropagation {
   @Deprecated
   public static <C> AgentSpanContext.Extracted extractContextAndGetSpanContext(
       final C carrier, final ContextVisitor<C> getter) {
-    Context extracted = Propagators.defaultPropagator().extract(Context.root(), carrier, getter);
-    AgentSpan extractedSpan = AgentSpan.fromContext(extracted);
+    Context extracted = Propagators.defaultPropagator().extract(root(), carrier, getter);
+    AgentSpan extractedSpan = fromContext(extracted);
     return extractedSpan == null ? null : (AgentSpanContext.Extracted) extractedSpan.context();
   }
 


### PR DESCRIPTION
# What Does This Do

This PR introduce context injection helper methods for HTTP client and server decorators.
Those new methods now handle the Data Streams context injection too, simplifying the instrumentation themselves.
DSM was also refactor to own its data / logic into its own classes rather than relying on the generic tracing ones.
Context API usage was simplified too.

# Motivation

This will simplify instrumentation logic by removing most of the DSM code, unless DSM actually has interesting data to send.
This will also reduce context allocation by not updating context if DSM is not enabled.
DSM refactoring should help with code ownership.
Context refactoring should help to set examples about how to use it.

# Additional Notes

Injection was moved to the `UriBasedClientDecorator` rather than the `HttpClientDecorator` as it is needed for the `UrlConnectionDecorator` too.
I though about reusing `HttpClientDecorator` `REQUEST` type for the `injectContext()` method and add an abstract `setter()` method (similar to the `HttpServerDecorator.getter()` method) but 1. not all setters are stateless (immutable collection make setters need to update their internal references once a field is set) 2. `REQUEST` and carrier are not always the same type.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-474]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-474]: https://datadoghq.atlassian.net/browse/LANGPLAT-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ