### PR TITLE
Add process tags to dynamic instrumentation intake payload

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
@@ -6,6 +6,7 @@ import com.datadog.debugger.util.MoshiSnapshotHelper;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.api.Config;
+import datadog.trace.api.ProcessTags;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 
@@ -56,6 +57,9 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
 
     private final String ddtags;
 
+    @Json(name = "process_tags")
+    private final String processTags;
+
     @Json(name = "dd.trace_id")
     private String traceId;
 
@@ -87,6 +91,8 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
       this.message = debugger.snapshot.getMessage();
       this.ddtags = debugger.snapshot.getProbe().getStrTags();
       this.timestamp = debugger.snapshot.getTimestamp();
+      final CharSequence pt = ProcessTags.getTagsForSerialization();
+      this.processTags = pt != null ? pt.toString() : null;
     }
 
     public String getService() {
@@ -135,6 +141,10 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
 
     public String getLoggerThreadName() {
       return loggerThreadName;
+    }
+
+    public String getProcessTags() {
+      return processTags;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
@@ -1,6 +1,8 @@
 package com.datadog.debugger.sink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.verify;
@@ -14,6 +16,7 @@ import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Types;
 import datadog.trace.api.Config;
+import datadog.trace.api.ProcessTags;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -26,6 +29,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -63,8 +68,11 @@ public class SnapshotSinkTest {
     probeStatusSink = new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false);
   }
 
-  @Test
-  public void addHighRateSnapshot() throws IOException {
+  @ParameterizedTest(name = "Process tags enabled ''{0}''")
+  @ValueSource(booleans = {true, false})
+  public void addHighRateSnapshot(boolean processTagsEnabled) throws IOException {
+    when(config.isExperimentalPropagateProcessTagsEnabled()).thenReturn(processTagsEnabled);
+    ProcessTags.reset(config);
     SnapshotSink snapshotSink = createSnapshotSink();
     snapshotSink.start();
     Snapshot snapshot = createSnapshot();
@@ -86,6 +94,13 @@ public class SnapshotSinkTest {
             .getDebugger()
             .getRuntimeId()
             .matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"));
+    if (processTagsEnabled) {
+      assertNotNull(ProcessTags.getTagsForSerialization());
+      assertEquals(
+          ProcessTags.getTagsForSerialization().toString(), intakeRequest.getProcessTags());
+    } else {
+      assertNull(intakeRequest.getProcessTags());
+    }
   }
 
   @Test

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -27,6 +27,8 @@ import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
@@ -44,9 +46,10 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
     return TagsHelper.sanitize("SpringBootTestApplication");
   }
 
-  @Test
+  @ParameterizedTest(name = "Process tags enabled ''{0}''")
+  @ValueSource(booleans = {true, false})
   @DisplayName("testTracer")
-  void testTracer() throws Exception {
+  void testTracer(boolean processTagsEnabled) throws Exception {
     LogProbe logProbe =
         LogProbe.builder()
             .probeId(PROBE_ID)
@@ -56,13 +59,22 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
                 "(HttpServletRequest, HttpServletResponse)")
             .captureSnapshot(true)
             .build();
-    JsonSnapshotSerializer.IntakeRequest request = doTestTracer(logProbe);
+    JsonSnapshotSerializer.IntakeRequest request = doTestTracer(logProbe, processTagsEnabled);
     Snapshot snapshot = request.getDebugger().getSnapshot();
     assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
     assertTrue(Pattern.matches("[0-9a-f]+", request.getTraceId()));
     assertTrue(Pattern.matches("\\d+", request.getSpanId()));
     assertFalse(
         logHasErrors(logFilePath, it -> it.contains("TypePool$Resolution$NoSuchTypeException")));
+    if (processTagsEnabled) {
+      assertNotNull(request.getProcessTags());
+      assertTrue(
+          request
+              .getProcessTags()
+              .contains("entrypoint.name:" + TagsHelper.sanitize(DEBUGGER_TEST_APP_CLASS)));
+    } else {
+      assertNull(request.getProcessTags());
+    }
   }
 
   @Test
@@ -146,9 +158,18 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   private JsonSnapshotSerializer.IntakeRequest doTestTracer(LogProbe logProbe) throws Exception {
+    return doTestTracer(logProbe, false);
+  }
+
+  private JsonSnapshotSerializer.IntakeRequest doTestTracer(
+      LogProbe logProbe, boolean enableProcessTags) throws Exception {
     setCurrentConfiguration(createConfig(logProbe));
     String httpPort = String.valueOf(PortUtils.randomOpenPort());
-    targetProcess = createProcessBuilder(logFilePath, "--server.port=" + httpPort).start();
+    ProcessBuilder processBuilder = createProcessBuilder(logFilePath, "--server.port=" + httpPort);
+    if (enableProcessTags) {
+      processBuilder.environment().put("DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED", "true");
+    }
+    targetProcess = processBuilder.start();
     // assert in logs app started
     waitForSpecificLogLine(
         logFilePath,


### PR DESCRIPTION
# What Does This Do

Adds process tag collection to dynamic instrumentation payload. It will be put in the intake request in the `process_tags` field in the same location than  the service name field.

The `process_tag` field will contain the process tags encoded as a comma separated list. Each entry is encoded using the `key:value` format. The values are tag normalized according our standards.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-628]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-628]: https://datadoghq.atlassian.net/browse/AIDM-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ