### PR TITLE
Collect process tags for profiling upload requests

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -27,6 +27,7 @@ import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Platform;
+import datadog.trace.api.ProcessTags;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.api.profiling.RecordingData;
@@ -469,6 +470,7 @@ public final class ProfileUploader {
       if (recordingData == null) {
         return;
       }
+      final CharSequence processTags = ProcessTags.getTagsForSerialization();
       writer.beginObject();
       writer.name("attachments");
       writer.beginArray();
@@ -476,6 +478,10 @@ public final class ProfileUploader {
       writer.endArray();
       writer.name(V4_PROFILE_TAGS_PARAM);
       writer.value(tags + ",snapshot:" + recordingData.getKind().name().toLowerCase(Locale.ROOT));
+      if (processTags != null) {
+        writer.name("process_tags");
+        writer.value(processTags.toString());
+      }
       writer.name(V4_PROFILE_START_PARAM);
       writer.value(recordingData.getStart().toString());
       writer.name(V4_PROFILE_END_PARAM);

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -147,9 +147,14 @@ public class ProcessTags {
 
   /** Visible for testing. */
   static void reset() {
+    reset(Config.get());
+  }
+
+  /** Visible for testing. */
+  public static void reset(Config config) {
     synchronized (Lazy.TAGS) {
       empty();
-      enabled = Config.get().isExperimentalPropagateProcessTagsEnabled();
+      enabled = config.isExperimentalPropagateProcessTagsEnabled();
       Lazy.TAGS.putAll(Lazy.loadTags());
     }
   }


### PR DESCRIPTION
# What Does This Do

For service renaming we're surfacing all the process tags to all the payloads.
This PR adds the process tags to the profile upload request on the field `process_tags` (as other products are already doing).
The value is a comma separated list of tags encoded as `key:value` . The value is already normalized according to our tag standards.
The collection of this tag is today behind a feature flag and not enabled by default

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-628]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-628]: https://datadoghq.atlassian.net/browse/AIDM-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ