### PR TITLE
Update gradle plugin to support Java 24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'
   id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 
-  id "com.github.johnrengelman.shadow" version "8.1.1" apply false
+  id "com.gradleup.shadow" version "8.3.6" apply false
   id "me.champeau.jmh" version "0.7.0" apply false
   id 'org.gradle.playframework' version '0.13' apply false
   id 'info.solidsoft.pitest' version '1.9.11'  apply false

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   java
   groovy
   id("com.diffplug.spotless") version "6.13.0"
-  id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.gradleup.shadow") version "8.3.6"
 }
 
 java {

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -1,6 +1,6 @@
 // The shadowJar of this project will be injected into the JVM's bootstrap classloader
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'me.champeau.jmh'
 }
 

--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -1,7 +1,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
   id 'me.champeau.jmh'
   id 'java-test-fixtures'
   id 'com.google.protobuf' version '0.8.18'

--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -6,7 +6,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import static java.nio.file.StandardOpenOption.CREATE
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-java-agent/agent-logs-intake/build.gradle
+++ b/dd-java-agent/agent-logs-intake/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
+++ b/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 def otelApiVersion = '1.38.0'

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 ext {

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -2,7 +2,7 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id "me.champeau.jmh"
   id 'java-test-fixtures'
 }

--- a/dd-java-agent/benchmark-integration/build.gradle
+++ b/dd-java-agent/benchmark-integration/build.gradle
@@ -29,6 +29,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 subprojects { sub ->
-  sub.apply plugin: 'com.github.johnrengelman.shadow'
+  sub.apply plugin: 'com.gradleup.shadow'
   sub.apply from: "$rootDir/gradle/java.gradle"
 }

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import java.util.concurrent.atomic.AtomicBoolean
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 description = 'dd-java-agent'

--- a/dd-java-agent/cws-tls/build.gradle
+++ b/dd-java-agent/cws-tls/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -24,7 +24,7 @@ buildscript {
   }
 }
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-java-agent/instrumentation/liberty-23/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-23/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java-test-fixtures'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-smoke-tests/appsec/spring-tomcat7/build.gradle
+++ b/dd-smoke-tests/appsec/spring-tomcat7/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 ext {

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot/build.gradle
+++ b/dd-smoke-tests/appsec/springboot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'application'
   id 'java'
   id "com.diffplug.spotless" version "6.13.0"
-  id "com.github.johnrengelman.shadow" version "7.1.2"
+  id "com.gradleup.shadow" version "8.3.6"
   id 'com.google.protobuf' version '0.9.3'
 }
 

--- a/dd-smoke-tests/cli/build.gradle
+++ b/dd-smoke-tests/cli/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/concurrent/java-21/build.gradle
+++ b/dd-smoke-tests/concurrent/java-21/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'application'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-smoke-tests/concurrent/java-8/build.gradle
+++ b/dd-smoke-tests/concurrent/java-8/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'application'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/crashtracking/build.gradle
+++ b/dd-smoke-tests/crashtracking/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 ext {

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 description = 'Check classes loaded by custom system class-loader are transformed'

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java'
   id 'org.springframework.boot' version '2.6.3'
 }

--- a/dd-smoke-tests/debugger-integration-tests/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     id 'application'
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 shadowJar {

--- a/dd-smoke-tests/dynamic-config/build.gradle
+++ b/dd-smoke-tests/dynamic-config/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/field-injection/build.gradle
+++ b/dd-smoke-tests/field-injection/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 description = 'Check fields get injected where expected'

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -2,7 +2,7 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/grpc-1.5/build.gradle
+++ b/dd-smoke-tests/grpc-1.5/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'java'
   id 'java-test-fixtures'
   id 'com.google.protobuf' version '0.9.4'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
   id 'java'
   id 'org.jetbrains.kotlin.jvm' version '1.9.24'
   id 'scala'

--- a/dd-smoke-tests/jersey-2/build.gradle
+++ b/dd-smoke-tests/jersey-2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/jersey-3/build.gradle
+++ b/dd-smoke-tests/jersey-3/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/lib-injection/build.gradle
+++ b/dd-smoke-tests/lib-injection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'application'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/log-injection/build.gradle
+++ b/dd-smoke-tests/log-injection/build.gradle
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/opentelemetry/build.gradle
+++ b/dd-smoke-tests/opentelemetry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'application'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/opentracing/build.gradle
+++ b/dd-smoke-tests/opentracing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 ext {

--- a/dd-smoke-tests/resteasy/build.gradle
+++ b/dd-smoke-tests/resteasy/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/spring-boot-rabbit/build.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'com.google.protobuf' version '0.8.18'
 }
 

--- a/dd-smoke-tests/springboot-mongo/build.gradle
+++ b/dd-smoke-tests/springboot-mongo/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot/build.gradle
+++ b/dd-smoke-tests/springboot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/vertx-3.4/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.4/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.gradleup.shadow") version "8.3.6"
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-3.4/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.4/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.github.johnrengelman.shadow") version "7.0.0"
+  id("com.gradleup.shadow") version "8.3.6"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-3.9-resteasy/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.9-resteasy/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.gradleup.shadow") version "8.3.6"
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-3.9-resteasy/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.9-resteasy/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.github.johnrengelman.shadow") version "7.0.0"
+  id("com.gradleup.shadow") version "8.3.6"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-3.9/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.9/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.gradleup.shadow") version "8.3.6"
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-3.9/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-3.9/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.github.johnrengelman.shadow") version "7.0.0"
+  id("com.gradleup.shadow") version "8.3.6"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-4.2/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-4.2/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.gradleup.shadow") version "8.3.6"
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-smoke-tests/vertx-4.2/application/build.gradle.kts
+++ b/dd-smoke-tests/vertx-4.2/application/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 plugins {
   java
   application
-  id("com.github.johnrengelman.shadow") version "7.0.0"
+  id("com.gradleup.shadow") version "8.3.6"
 }
 
 if (hasProperty("appBuildDir")) {

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow"
+  id "com.gradleup.shadow"
   id "me.champeau.jmh"
 }
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -242,7 +242,7 @@ project.afterEvaluate {
   }
 }
 
-if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
+if (project.plugins.hasPlugin('com.gradleup.shadow')) {
   // Remove the no-deps jar from the archives to prevent publication
   configurations.archives.with {
     artifacts.remove artifacts.find {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -21,7 +21,7 @@ assert !forceLocal || forceLocal != isGitlabCI
 publishing {
   publications {
     maven(MavenPublication) { MavenPublication publication ->
-      if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
+      if (project.plugins.hasPlugin('com.gradleup.shadow')) {
         publication.artifact(project.tasks.shadowJar)
 
         // Required by Maven Central:
@@ -56,7 +56,7 @@ publishing {
   }
 }
 
-if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
+if (project.plugins.hasPlugin('com.gradleup.shadow')) {
   // Disable gradle module metadata to avoid publishing contradictory info.
   tasks.withType(GenerateModuleMetadata).configureEach {
     enabled = false


### PR DESCRIPTION
# What Does This Do

Update gradle plugin id from `com.github.johnrengelman.shadow` to `com.gradleup.shadow` and version to `8.3.6` in order to support Java 24.

# Motivation

We want our build to support the latest version of Java.

# Additional Notes

Version `8.3.6` supports Java 24 ([ref](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md#836---2025-02-02)).
Versions `8.3.0` and up update the plugin ID from `com.github.johnrengelman.shadow` to `com.gradleup.shadow` ([ref](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md#830---2024-08-08)).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
