### PR TITLE
Fix git information caching to avoid unnecessary builds

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -55,11 +55,10 @@ public class GitInfoProvider {
   public GitInfo getGitInfo(@Nullable String repositoryPath) {
     if (repositoryPath == null) {
       repositoryPath = NULL_PATH_STRING;
-    } else if (!repositoryPath.endsWith(File.separator)) {
-      // normalize to correctly hit the cache
-      repositoryPath = repositoryPath + File.separator;
     }
-    return gitInfoCache.computeIfAbsent(repositoryPath, this::buildGitInfo);
+
+    // normalize path to avoid creating two entries in the cache
+    return gitInfoCache.computeIfAbsent(Paths.get(repositoryPath).toString(), this::buildGitInfo);
   }
 
   private GitInfo buildGitInfo(String repositoryPath) {

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -9,6 +9,7 @@ import datadog.trace.api.civisibility.telemetry.tag.GitProviderExpected;
 import datadog.trace.api.civisibility.telemetry.tag.GitShaDiscrepancyType;
 import datadog.trace.api.civisibility.telemetry.tag.GitShaMatch;
 import datadog.trace.util.Strings;
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +55,9 @@ public class GitInfoProvider {
   public GitInfo getGitInfo(@Nullable String repositoryPath) {
     if (repositoryPath == null) {
       repositoryPath = NULL_PATH_STRING;
+    } else if (!repositoryPath.endsWith(File.separator)) {
+      // normalize to correctly hit the cache
+      repositoryPath = repositoryPath + File.separator;
     }
     return gitInfoCache.computeIfAbsent(repositoryPath, this::buildGitInfo);
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
@@ -17,7 +17,7 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilder = givenABuilderReturning(
       new GitInfo("repoUrl", "branch", "tag", new CommitInfo("sha"))
-      )
+    )
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilder)
@@ -36,11 +36,11 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null, new CommitInfo(null))
-      )
+    )
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo(null, "branch", "tag", new CommitInfo("sha")), 2
-      )
+    )
 
     def gitInfoProvider = new GitInfoProvider()
     // registering provider with higher order first, to check that the registration logic will do proper reordering after the second registration
@@ -61,11 +61,11 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", "", "", new CommitInfo(""))
-      )
+    )
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo(null, "branch", "tag", new CommitInfo("sha"))
-      )
+    )
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -85,11 +85,11 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", " ", " ", new CommitInfo(" "))
-      )
+    )
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo(null, "branch", "tag", new CommitInfo("sha"))
-      )
+    )
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -109,17 +109,17 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      PersonInfo.NOOP,
-      PersonInfo.NOOP,
-      null)))
+        new CommitInfo("sha",
+          PersonInfo.NOOP,
+          PersonInfo.NOOP,
+          null)))
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message")))
+        new CommitInfo("sha",
+          new PersonInfo("author name", "author email", "author date"),
+          new PersonInfo("committer name", "committer email", "committer date"),
+          "message")))
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -144,17 +144,17 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      new PersonInfo("", "", ""),
-      new PersonInfo("", "", ""),
-      "")))
+        new CommitInfo("sha",
+          new PersonInfo("", "", ""),
+          new PersonInfo("", "", ""),
+          "")))
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message")))
+        new CommitInfo("sha",
+          new PersonInfo("author name", "author email", "author date"),
+          new PersonInfo("committer name", "committer email", "committer date"),
+          "message")))
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -179,17 +179,17 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      new PersonInfo(" ", " ", " "),
-      new PersonInfo(" ", " ", " "),
-      " ")))
+        new CommitInfo("sha",
+          new PersonInfo(" ", " ", " "),
+          new PersonInfo(" ", " ", " "),
+          " ")))
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message")))
+        new CommitInfo("sha",
+          new PersonInfo("author name", "author email", "author date"),
+          new PersonInfo("committer name", "committer email", "committer date"),
+          "message")))
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -214,17 +214,17 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("sha",
-      PersonInfo.NOOP,
-      PersonInfo.NOOP,
-      "message")))
+        new CommitInfo("sha",
+          PersonInfo.NOOP,
+          PersonInfo.NOOP,
+          "message")))
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
-      new CommitInfo("different sha",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message")))
+        new CommitInfo("different sha",
+          new PersonInfo("author name", "author email", "author date"),
+          new PersonInfo("committer name", "committer email", "committer date"),
+          "message")))
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -252,21 +252,21 @@ class GitInfoProviderTest extends Specification {
 
     def gitInfoA = new GitInfo("repoUrlA", null, null,
       new CommitInfo("shaA",
-      PersonInfo.NOOP,
-      PersonInfo.NOOP,
-      "message"
+        PersonInfo.NOOP,
+        PersonInfo.NOOP,
+        "message"
       ))
     def gitInfoB = new GitInfo("repoUrlA", null, null,
       new CommitInfo("shaB",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message"
+        new PersonInfo("author name", "author email", "author date"),
+        new PersonInfo("committer name", "committer email", "committer date"),
+        "message"
       ))
     def gitInfoC = new GitInfo("repoUrlB", null, null,
       new CommitInfo("shaC",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message"
+        new PersonInfo("author name", "author email", "author date"),
+        new PersonInfo("committer name", "committer email", "committer date"),
+        "message"
       ))
 
     def gitInfoBuilderA = givenABuilderReturning(gitInfoA, 1, GitProviderExpected.CI_PROVIDER, GitProviderDiscrepant.CI_PROVIDER)
@@ -294,15 +294,15 @@ class GitInfoProviderTest extends Specification {
 
     def gitInfoA = new GitInfo("repoUrlA", null, null,
       new CommitInfo("shaA",
-      PersonInfo.NOOP,
-      PersonInfo.NOOP,
-      "message"
+        PersonInfo.NOOP,
+        PersonInfo.NOOP,
+        "message"
       ))
     def gitInfoB = new GitInfo("repoUrlA", null, null,
       new CommitInfo("shaA",
-      new PersonInfo("author name", "author email", "author date"),
-      new PersonInfo("committer name", "committer email", "committer date"),
-      "message"
+        new PersonInfo("author name", "author email", "author date"),
+        new PersonInfo("committer name", "committer email", "committer date"),
+        "message"
       ))
 
     def gitInfoBuilderA = givenABuilderReturning(gitInfoA, 1, GitProviderExpected.CI_PROVIDER, GitProviderDiscrepant.CI_PROVIDER)
@@ -324,11 +324,11 @@ class GitInfoProviderTest extends Specification {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("file://uselessUrl", null, null, new CommitInfo(null)), 1
-      )
+    )
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("http://usefulUrl", null, null, new CommitInfo(null)), 2
-      )
+    )
 
     def gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
@@ -339,6 +339,25 @@ class GitInfoProviderTest extends Specification {
 
     then:
     actualGitInfo.repositoryURL == "http://usefulUrl"
+  }
+
+  def "test caches git info regardless of path normalization"() {
+    setup:
+    def gitInfo = new GitInfo("repoUrl", "branch", "tag", new CommitInfo("sha"))
+    def gitInfoBuilder = Mock(GitInfoBuilder)
+    gitInfoBuilder.order() >> 1
+    gitInfoBuilder.providerAsExpected() >> GitProviderExpected.USER_SUPPLIED
+    gitInfoBuilder.providerAsDiscrepant() >> GitProviderDiscrepant.USER_SUPPLIED
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilder)
+
+    when:
+    gitInfoProvider.getGitInfo(REPO_PATH)
+    gitInfoProvider.getGitInfo(REPO_PATH + File.separator)
+
+    then:
+    1 * gitInfoBuilder.build(REPO_PATH) >> gitInfo
   }
 
   private GitInfoBuilder givenABuilderReturning(GitInfo gitInfo) {


### PR DESCRIPTION
# What Does This Do

- Fixes the caching of git information in `datadog.trace.api.git.GitInfoProvider` to ignore trailing separators in the repository path.

# Motivation

The method `datadog.trace.api.git.GitInfoProvider#getGitInfo(java.lang.String)` is sometimes called with a normalized path (`datadog.trace.civisibility.ci.CITagsProvider#getCiTags`) and others with a regular path without trailing separator (`datadog.trace.common.GitMetadataTraceInterceptor#onTraceComplete`). This means that the same git information will be built twice, as it is cached using the repository path. For example: `/repo/path` and `/repo/path/` were not considered the same.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
