### PR TITLE
Add appsec.waf.input_truncated metric

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
@@ -465,6 +465,8 @@ public class WAFModule implements AppSecModule {
 
             if (stringTooLong > 0 || listMapTooLarge > 0 || objectTooDeep > 0) {
               reqCtx.setWafTruncated();
+              WafMetricCollector.get()
+                  .wafInputTruncated(stringTooLong > 0, listMapTooLarge > 0, objectTooDeep > 0);
             }
           }
         }


### PR DESCRIPTION
# What Does This Do

This PR adds support for a new telemetry metric: `appsec.waf.input_truncated`. This is a count metric that tracks the number of times a WAF input was truncated, which may happen multiple times per request. The metric includes a truncation_reason tag, represented as a bitfield, with the following values:

-  1: string too long
-  2: list or map too large
-  4: object too deep

# Motivation

[RFC](https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?tab=t.0)

# Additional Notes

For every call to WAF, if truncation occurred during serialization, we should emit the metric. This will increment the count for each run where truncation was detected, and each metric will include the bitfield indicating the types of truncation that occurred.

This metric should also be triggered when ObjectInstrospector truncates the object send to the WAF. This corner case affects parsed request body and grpc. This should be fixed after https://github.com/DataDog/dd-trace-java/pull/8748

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56479](https://datadoghq.atlassian.net/browse/APPSEC-56479)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56479]: https://datadoghq.atlassian.net/browse/APPSEC-56479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ