### PR TITLE
Read hsperfdata for Java PIDs if jvmstat is unavailable

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/PidHelper.java
+++ b/internal-api/src/main/java/datadog/trace/util/PidHelper.java
@@ -99,8 +99,8 @@ public final class PidHelper {
     // Some JDKs don't have jvmstat available as a module, attempt to read from the hsperfdata
     // directory instead
     try (Stream<Path> stream =
-       // Emulating the hotspot way to enumerate the JVM processes using the perfdata file
-       // https://github.com/openjdk/jdk/blob/d7cb933b89839b692f5562aeeb92076cd25a99f6/src/hotspot/share/runtime/perfMemory.cpp#L244
+        // Emulating the hotspot way to enumerate the JVM processes using the perfdata file
+        // https://github.com/openjdk/jdk/blob/d7cb933b89839b692f5562aeeb92076cd25a99f6/src/hotspot/share/runtime/perfMemory.cpp#L244
         Files.list(Paths.get(getOSTempDir(), "hsperfdata_" + System.getProperty("user.name")))) {
       return stream
           .filter(file -> !Files.isDirectory(file))


### PR DESCRIPTION
# What Does This Do
This reads from the `hsperfdata` directory created by JDKs with the `perfdata` feature enabled (on by default) to identify the process IDs of other JVMs on the system.

# Motivation
This follows up on #8641 - initially, we had assumed that though `jps` may not be present or invocable across all distributions, the internal `jvmstat` module would be. We've discovered that this isn't the case via system tests and telemetry, so this PR adds in a new mechanism to reproduces `jvmstat`'s behaviour. 

# Additional Notes
This PR is intended to be part of a phased rollout - we will likely deprecate the other means of getting the Java PIDs after introducing this one.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11673]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11673]: https://datadoghq.atlassian.net/browse/PROF-11673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ