### PR TITLE
Rename test methods to remove duplicate method names

### DIFF
--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy
@@ -63,7 +63,7 @@ class WeakCipherTest extends AgentTestRunner {
   }
 
   // Key Generator
-  def "test weak cipher instrumentation"() {
+  def "test weak keygen instrumentation"() {
     setup:
     WeakCipherModule module = Mock(WeakCipherModule)
     InstrumentationBridge.registerIastModule(module)
@@ -75,7 +75,7 @@ class WeakCipherTest extends AgentTestRunner {
     1 * module.onCipherAlgorithm(_)
   }
 
-  def "test weak cipher instrumentation with provider"() {
+  def "test weak keygen instrumentation with provider"() {
     setup:
     WeakCipherModule module = Mock(WeakCipherModule)
     InstrumentationBridge.registerIastModule(module)
@@ -88,7 +88,7 @@ class WeakCipherTest extends AgentTestRunner {
     1 * module.onCipherAlgorithm(_)
   }
 
-  def "test weak cipher instrumentation with provider string"() {
+  def "test weak keygen instrumentation with provider string"() {
     setup:
     WeakCipherModule module = Mock(WeakCipherModule)
     InstrumentationBridge.registerIastModule(module)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
@@ -56,7 +56,7 @@ class SamplerTest extends DDSpecification{
     !(sampler instanceof AsmStandaloneSampler)
   }
 
-  void "test that AsmStandaloneSampler is not selected when apm tracing and asm not enabled"() {
+  void "test that AsmStandaloneSampler is not selected when apm tracing enabled and asm not enabled"() {
     setup:
     Config config = new Config()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
@@ -230,7 +230,7 @@ class PrioritizationTest extends DDSpecification {
     []    | USER_KEEP    | 1             | 0                | ENQUEUED_FOR_SERIALIZATION
   }
 
-  def "drop strategy respects force keep" () {
+  def "span sampling drop strategy respects force keep" () {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> spanSampling = Mock(Queue)

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRouterSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRouterSpecification.groovy
@@ -329,7 +329,7 @@ class TelemetryRouterSpecification extends Specification {
     500        | null           | agentTelemetryUrl
   }
 
-  def 'switch to Intake when Agent fails to receive telemetry requests'() {
+  def 'switch to Intake then back to Agent when both fail to receive telemetry requests'() {
     Request request
 
     when:


### PR DESCRIPTION
# Motivation

Observed when doing some testing locally - gradle only seems to notice when you add/remove a test class in the same module which I assume causes it to do a full compile (see https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/932703279)

Quick scan using `grep` revealed the following duplicates per test file:
```
      2 dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy:  def "test weak cipher instrumentation with provider string"() {
      2 dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy:  def "test weak cipher instrumentation with provider"() {
      2 dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy:  def "test weak cipher instrumentation"() {
      2 dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy:  def "drop strategy respects force keep" () {
      2 telemetry/src/test/groovy/datadog/telemetry/TelemetryRouterSpecification.groovy:  def "switch to Intake when Agent fails to receive telemetry requests"() {
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
