### PR TITLE
Notify listeners when the scope top changes after switching scope stacks

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -384,7 +384,13 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
 
     @Override
     public void activate() {
+      ContinuableScope oldScope = tlsScopeStack.get().top;
       tlsScopeStack.set(localScopeStack);
+      ContinuableScope newScope = localScopeStack.top;
+      if (oldScope != newScope && newScope != null) {
+        newScope.beforeActivated();
+        newScope.afterActivated();
+      }
     }
 
     @Override


### PR DESCRIPTION
# Motivation

We should notify registered listeners when the scope changes after switching the scope stack for coroutines or fibers - previously we switched scope stacks without notifying listeners. (This includes notifying the profiling integration that the context has switched for this thread.)

Note that switching the scope stack doesn't imply the previous scope was closed - the [ScopeListener javadoc](https://github.com/DataDog/dd-trace-java/blob/f494c33b01b4edb75bc2d47c82b9e2d3b8eb6814/internal-api/src/main/java/datadog/trace/api/scopemanager/ScopeListener.java#L11) clearly states that there may be many calls to `afterScopeActivated` as the context flows between parent and child scopes and back again. Switching between coroutines should therefore also trigger `afterScopeActivated`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
