### PR TITLE
Implement Context.swap() on top of scope stacks

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -60,7 +60,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.BlackHoleSpan;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
-import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
@@ -292,16 +291,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       return profilingContextIntegration.onRootSpanStarted(root);
     }
     return null;
-  }
-
-  @Override
-  public ScopeState oldScopeState() {
-    return scopeManager.oldScopeState();
-  }
-
-  @Override
-  public ScopeState newScopeState() {
-    return scopeManager.newScopeState();
   }
 
   public static class CoreTracerBuilder {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -24,8 +24,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTraceCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
-import datadog.trace.bootstrap.instrumentation.api.ScopeState;
-import datadog.trace.bootstrap.instrumentation.api.ScopeStateAware;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
@@ -45,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * from being reported even if all related spans are finished. It also delegates to other
  * ScopeInterceptors to provide additional functionality.
  */
-public final class ContinuableScopeManager implements ScopeStateAware, ContextManager {
+public final class ContinuableScopeManager implements ContextManager {
 
   static final Logger log = LoggerFactory.getLogger(ContinuableScopeManager.class);
   static final RatelimitedLogger ratelimitedLog = new RatelimitedLogger(log, 1, MINUTES);
@@ -350,16 +348,6 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
   }
 
   @Override
-  public ScopeState oldScopeState() {
-    return new ContinuableScopeState(tlsScopeStack.get());
-  }
-
-  @Override
-  public ScopeState newScopeState() {
-    return new ContinuableScopeState(tlsScopeStack.initialValue());
-  }
-
-  @Override
   public Context current() {
     final ContinuableScope active = scopeStack().active();
     return active == null ? Context.root() : active.context;
@@ -372,31 +360,33 @@ public final class ContinuableScopeManager implements ScopeStateAware, ContextMa
 
   @Override
   public Context swap(Context context) {
-    throw new UnsupportedOperationException("Not yet implemented");
-  }
+    ScopeStack oldStack = tlsScopeStack.get();
+    ContinuableScope oldScope = oldStack.top;
 
-  private class ContinuableScopeState implements ScopeState {
-    private final ScopeStack localScopeStack;
-
-    ContinuableScopeState(ScopeStack scopeStack) {
-      this.localScopeStack = scopeStack;
+    ScopeStack newStack;
+    ContinuableScope newScope;
+    if (context instanceof ScopeContext) {
+      // restore previously swapped context stack
+      newStack = ((ScopeContext) context).scopeStack;
+      newScope = newStack.top;
+    } else if (context != Context.root()) {
+      // start a new stack and record the new context as active
+      newStack = new ScopeStack(profilingContextIntegration);
+      newScope = new ContinuableScope(this, context, CONTEXT, true, createScopeState(context));
+      newStack.top = newScope;
+    } else {
+      // start a new stack with no active context
+      newStack = new ScopeStack(profilingContextIntegration);
+      newScope = null;
     }
 
-    @Override
-    public void activate() {
-      ContinuableScope oldScope = tlsScopeStack.get().top;
-      tlsScopeStack.set(localScopeStack);
-      ContinuableScope newScope = localScopeStack.top;
-      if (oldScope != newScope && newScope != null) {
-        newScope.beforeActivated();
-        newScope.afterActivated();
-      }
+    tlsScopeStack.set(newStack);
+    if (oldScope != newScope && newScope != null) {
+      newScope.beforeActivated();
+      newScope.afterActivated();
     }
 
-    @Override
-    public ScopeState copy() {
-      return new ContinuableScopeState(localScopeStack.copy());
-    }
+    return new ScopeContext(oldStack);
   }
 
   static final class ScopeStackThreadLocal extends ThreadLocal<ScopeStack> {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
@@ -1,0 +1,31 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.context.Context;
+import datadog.context.ContextKey;
+import javax.annotation.Nullable;
+
+/** Wraps a {@link ScopeStack} as a {@link Context} so it can be swapped back later. */
+final class ScopeContext implements Context {
+  final ScopeStack scopeStack;
+  private final Context context;
+
+  ScopeContext(ScopeStack scopeStack) {
+    this(scopeStack, scopeStack.top != null ? scopeStack.top.context : Context.root());
+  }
+
+  private ScopeContext(ScopeStack scopeStack, Context context) {
+    this.scopeStack = scopeStack;
+    this.context = context;
+  }
+
+  @Nullable
+  @Override
+  public <T> T get(ContextKey<T> key) {
+    return context.get(key);
+  }
+
+  @Override
+  public <T> Context with(ContextKey<T> key, @Nullable T value) {
+    return context.with(key, value);
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -70,89 +70,6 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.close()
   }
 
-  def "scope state should be able to fetch and activate state when there is no active span"() {
-    when:
-    def initialScopeState = scopeManager.oldScopeState()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    def newScopeState = scopeManager.newScopeState()
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    def span = tracer.buildSpan("test", "test").start()
-    def scope = tracer.activateSpan(span)
-
-    then:
-    scope.span() == span
-    scopeManager.active() == scope
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == scope
-
-    when:
-    span.finish()
-    scope.close()
-    writer.waitForTraces(1)
-
-    then:
-    writer == [[scope.span()]]
-    scopeManager.active() == null
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-  }
-
-  def "scope state should be able to fetch and activate state when there is an active span"() {
-    when:
-    def span = tracer.buildSpan("test", "test").start()
-    def scope = tracer.activateSpan(span)
-    def initialScopeState = scopeManager.oldScopeState()
-
-    then:
-    scope.span() == span
-    scopeManager.active() == scope
-
-    when:
-    def newScopeState = scopeManager.newScopeState()
-    newScopeState.activate()
-
-    then:
-    scopeManager.active() == null
-
-    when:
-    initialScopeState.activate()
-
-    then:
-    scopeManager.active() == scope
-
-    when:
-    span.finish()
-    scope.close()
-    writer.waitForTraces(1)
-
-    then:
-    scopeManager.active() == null
-    writer == [[scope.span()]]
-  }
-
   def "non-ddspan activation results in a continuable scope"() {
     when:
     def scope = scopeManager.activateSpan(noopSpan())
@@ -1210,6 +1127,73 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.rollbackActiveToCheckpoint()
     then:
     scopeManager.activeSpan() == null
+  }
+
+  def "contexts can be swapped out and back"() {
+    setup:
+    def testKey = ContextKey.named("test")
+    def context1 = Context.root().with(testKey, "first-value")
+    def context2 = context1.with(testKey, "second-value")
+
+    when:
+    def swappedOut = scopeManager.swap(Context.root())
+
+    then:
+    scopeManager.active() == null
+    scopeManager.current() == Context.root()
+
+    when:
+    scopeManager.swap(context1)
+
+    then:
+    scopeManager.active() != null
+    scopeManager.current() == context1
+
+    when:
+    scopeManager.swap(swappedOut)
+
+    then:
+    scopeManager.active() == null
+    scopeManager.current() == Context.root()
+
+    when:
+    def contextScope = scopeManager.attach(context1)
+
+    then:
+    scopeManager.active() == contextScope
+    scopeManager.current() == context1
+
+    when:
+    swappedOut = scopeManager.swap(context2)
+
+    then:
+    scopeManager.active() != null
+    scopeManager.active() != contextScope
+    scopeManager.current() == context2
+    swappedOut.get(testKey) == "first-value"
+
+    when:
+    def context3 = swappedOut.with(testKey, "third-value")
+    scopeManager.swap(context3)
+
+    then:
+    scopeManager.active() != null
+    scopeManager.active() != contextScope
+    scopeManager.current() == context3
+
+    when:
+    scopeManager.swap(swappedOut)
+
+    then:
+    scopeManager.active() == contextScope
+    scopeManager.current() == context1
+
+    when:
+    contextScope.close()
+
+    then:
+    scopeManager.active() == null
+    scopeManager.current() == Context.root()
   }
 
   boolean spanFinished(AgentSpan span) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -290,7 +290,7 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer, InternalTracer, EndpointCheckpointer, ScopeStateAware {
+      extends datadog.trace.api.Tracer, InternalTracer, EndpointCheckpointer {
 
     /**
      * Create and start a new span.
@@ -637,16 +637,6 @@ public class AgentTracer {
 
     @Override
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
-
-    @Override
-    public ScopeState oldScopeState() {
-      return null;
-    }
-
-    @Override
-    public ScopeState newScopeState() {
-      return null;
-    }
 
     @Override
     public AgentDataStreamsMonitoring getDataStreamsMonitoring() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeState.java
@@ -1,7 +1,0 @@
-package datadog.trace.bootstrap.instrumentation.api;
-
-public interface ScopeState {
-  void activate();
-
-  ScopeState copy();
-}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeStateAware.java
@@ -1,9 +1,0 @@
-package datadog.trace.bootstrap.instrumentation.api;
-
-public interface ScopeStateAware {
-  /** @return The old connected scope stack */
-  ScopeState oldScopeState();
-
-  /** @return A new disconnected scope stack */
-  ScopeState newScopeState();
-}


### PR DESCRIPTION
and use it for Kotlin coroutines and Zio fibers

# Motivation

Lets us remove the earlier `ScopeState` abstraction in favour of the new Context API.

We're now close to the point we can have switchable scope manager implementations 🎉 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1396]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-1396]: https://datadoghq.atlassian.net/browse/APMAPI-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ