### PR TITLE
Migrate publishing namespace to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
   id "de.thetaphi.forbiddenapis" version "3.8"
 
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'
-  id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
+  id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 
   id "com.gradleup.shadow" version "8.3.6" apply false
   id "me.champeau.jmh" version "0.7.0" apply false

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,10 @@ nexusPublishing {
         allowInsecureProtocol = true
       }
     } else {
+      // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
       sonatype {
+        nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+        snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         username = System.getenv("SONATYPE_USERNAME")
         password = System.getenv("SONATYPE_PASSWORD")
       }

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -15,7 +15,7 @@ repositories {
     mavenContent {
       snapshotsOnly()
     }
-    url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    url 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
   }
   ivy {
     artifactPattern 'https://sqreen-ci-java.s3.amazonaws.com/jars/[organisation]/[artifact]-[revision](-[classifier]).[ext]'


### PR DESCRIPTION
# What Does This Do

Update `gradle-nexus/publish-plugin` to v2.0.0, and change URL namespaces to Central Portal

# Motivation

Sonatype's OSSRH is reaching end of life on June 30, 2025. We need to migrate to Maven Central ASAP.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-493

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
