### PR TITLE
Add process tags to crashtracking

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -14,6 +14,7 @@ import datadog.common.version.VersionInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.ProcessTags;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.PidHelper;
 import datadog.trace.util.RandomUtils;
@@ -139,6 +140,7 @@ public final class CrashUploader {
         writer.beginObject();
         writer.name("ddsource").value("crashtracker");
         writer.name("ddtags").value(tags);
+        writeProcessTags(writer);
         writer.name("hostname").value(config.getHostName());
         writer.name("service").value(config.getServiceName());
         writer.name("message").value(message);
@@ -153,6 +155,13 @@ public final class CrashUploader {
       }
 
       out.println(buf.readByteString().utf8());
+    }
+  }
+
+  private void writeProcessTags(JsonWriter writer) throws IOException {
+    final CharSequence processTags = ProcessTags.getTagsForSerialization();
+    if (processTags != null) {
+      writer.name("process_tags").value(processTags.toString());
     }
   }
 
@@ -306,6 +315,7 @@ public final class CrashUploader {
         writer.name("service_name").value(config.getServiceName());
         writer.name("service_version").value(config.getVersion());
         writer.name("tracer_version").value(VersionInfo.VERSION);
+        writeProcessTags(writer);
         writer.endObject();
         writer.name("host");
         writer.beginObject();


### PR DESCRIPTION
# What Does This Do

Adds Process tags (when enabled) to crashtracking payload. Depending on the payload the tags are:
* logs payload -> `/process_tags` 
* telemetry payload -> `/application/process_tags`

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
