### PR TITLE
Extend JPS re-implementation to J9 family

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/PidHelper.java
+++ b/internal-api/src/main/java/datadog/trace/util/PidHelper.java
@@ -142,12 +142,15 @@ public final class PidHelper {
                 // Hotspot,
                 // but they are directories for J9.
                 // This also makes sense as defensive programming.
-                try {
-                  Integer.parseInt(name);
-                  return true;
-                } catch (Exception e) {
+                if (name.isEmpty()) {
                   return false;
                 }
+                for (int i = 0; i < name.length(); i++) {
+                  if (!Character.isDigit(name.charAt(i))) {
+                    return false;
+                  }
+                }
+                return true;
               })
           .collect(Collectors.toSet());
     } catch (IOException e) {


### PR DESCRIPTION
# What Does This Do
This adds support for obtaining running Java process IDs for the J9 family of JDKs, which use a directory other than Hotspot's `hsperfdata_USER`.

# Motivation
#8792 was designed with Hotspot in mind. A follow-up dive into J9's source confirmed our suspicions that their implementation diverges & requires additional logic.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11787]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11787]: https://datadoghq.atlassian.net/browse/PROF-11787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ