### PR TITLE
Send initial telemetry in separate thread to reduce start-up latency.

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -1,11 +1,9 @@
 package datadog.trace.bootstrap;
 
 import datadog.json.JsonWriter;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /** Thread safe telemetry class used to relay information about tracer activation. */
 public abstract class BootstrapInitializationTelemetry {
@@ -179,7 +177,7 @@ public abstract class BootstrapInitializationTelemetry {
   }
 
   public interface JsonSender {
-    void send(byte[] payload) throws IOException;
+    void send(byte[] payload);
   }
 
   public static final class ForwarderJsonSender implements JsonSender {
@@ -190,19 +188,34 @@ public abstract class BootstrapInitializationTelemetry {
     }
 
     @Override
-    public void send(byte[] payload) throws IOException {
+    public void send(byte[] payload) {
+      ForwarderJsonSenderThread t = new ForwarderJsonSenderThread(forwarderPath, payload);
+      t.start();
+    }
+  }
+
+  public static final class ForwarderJsonSenderThread extends Thread {
+    private final String forwarderPath;
+    private final byte[] payload;
+
+    public ForwarderJsonSenderThread(String forwarderPath, byte[] payload) {
+      super("dd-forwarder-json-sender");
+      this.forwarderPath = forwarderPath;
+      this.payload = payload;
+    }
+
+    @Override
+    public void run() {
       ProcessBuilder builder = new ProcessBuilder(forwarderPath, "library_entrypoint");
 
-      Process process = builder.start();
-      try (OutputStream out = process.getOutputStream()) {
-        out.write(payload);
-      }
-
       try {
-        process.waitFor(1, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        // just for hygiene, reset the interrupt status
-        Thread.currentThread().interrupt();
+        Process process = builder.start();
+        try (OutputStream out = process.getOutputStream()) {
+          out.write(payload);
+        }
+      } catch (Throwable e) {
+        // We don't have a log manager here, so just print.
+        System.err.println("Failed to send telemetry: " + e.getMessage());
       }
     }
   }


### PR DESCRIPTION
# What Does This Do
  Send bootstrap telemetry from separate thread. 

# Motivation
 Reduce start-up latency

# Additional Notes
Change already covered by existing tests.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
