### PR TITLE
fix: kotlin compiler daemon memory settings

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -1,7 +1,10 @@
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.kotlin.coroutines.AbstractKotlinCoroutineInstrumentationTest
+import kotlin.OptIn
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@OptIn(markerClass = ExperimentalCoroutinesApi)
 class KotlinCoroutineInstrumentationTest extends AbstractKotlinCoroutineInstrumentationTest<KotlinCoroutineTests> {
 
   @Override

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/kotlin/KotlinCoroutineTests.kt
@@ -3,11 +3,13 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
 import datadog.trace.instrumentation.kotlin.coroutines.CoreKotlinCoroutineTests
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.channels.toChannel
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
 class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutineTests(dispatcher) {
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -228,9 +228,7 @@ project.afterEvaluate {
   if (project.plugins.hasPlugin('kotlin')) {
     ['compileKotlin', 'compileTestKotlin'].each { type ->
       tasks.named(type).configure {
-        kotlinOptions {
-          freeCompilerArgs += '-Xmx256m'
-        }
+        kotlinDaemonJvmArguments = ["-Xmx256m", "-XX:+UseParallelGC"]
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

JVM memory settings for the kotlin compiler daemon are now passed to the correct property.

Also, use parallel gc and explicitly opt in for coroutine api to avoid unnecessary opt-in warnings.

Follow-up to #8833 

# Motivation

Help fix CircleCI

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
