### PR TITLE
Trace websocket for spring webflux reactive handlers

### DIFF
--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerInboundTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerInboundTracingHandler.java
@@ -17,13 +17,12 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 
 @ChannelHandler.Sharable
-public class WebSocketServerRequestTracingHandler extends ChannelInboundHandlerAdapter {
-  public static WebSocketServerRequestTracingHandler INSTANCE =
-      new WebSocketServerRequestTracingHandler();
+public class WebSocketServerInboundTracingHandler extends ChannelInboundHandlerAdapter {
+  public static WebSocketServerInboundTracingHandler INSTANCE =
+      new WebSocketServerInboundTracingHandler();
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object frame) {
-
     if (frame instanceof WebSocketFrame) {
       Channel channel = ctx.channel();
       HandlerContext.Receiver receiverContext =

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerOutboundTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerOutboundTracingHandler.java
@@ -17,9 +17,9 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 
 @ChannelHandler.Sharable
-public class WebSocketServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
-  public static WebSocketServerResponseTracingHandler INSTANCE =
-      new WebSocketServerResponseTracingHandler();
+public class WebSocketServerOutboundTracingHandler extends ChannelOutboundHandlerAdapter {
+  public static WebSocketServerOutboundTracingHandler INSTANCE =
+      new WebSocketServerOutboundTracingHandler();
 
   @Override
   public void write(ChannelHandlerContext ctx, Object frame, ChannelPromise promise)

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/websocket/WebSocketServerTracingHandler.java
@@ -4,11 +4,11 @@ import io.netty.channel.CombinedChannelDuplexHandler;
 
 public class WebSocketServerTracingHandler
     extends CombinedChannelDuplexHandler<
-        WebSocketServerRequestTracingHandler, WebSocketServerResponseTracingHandler> {
+        WebSocketServerInboundTracingHandler, WebSocketServerOutboundTracingHandler> {
 
   public WebSocketServerTracingHandler() {
     super(
-        WebSocketServerRequestTracingHandler.INSTANCE,
-        WebSocketServerResponseTracingHandler.INSTANCE);
+        WebSocketServerInboundTracingHandler.INSTANCE,
+        WebSocketServerOutboundTracingHandler.INSTANCE);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -1,8 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.base.OkHttpWebsocketClient
-import datadog.trace.agent.test.base.WebsocketServer
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -24,21 +22,12 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.BodyExtractors
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.socket.WebSocketHandler
-import org.springframework.web.reactive.socket.WebSocketSession
-import org.springframework.web.reactive.socket.client.WebSocketClient
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.WEBSOCKET
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.WEBSOCKET
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.WEBSOCKET
 import static datadog.trace.agent.test.base.HttpServerTest.websocketCloseSpan
 import static datadog.trace.agent.test.base.HttpServerTest.websocketReceiveSpan
 import static datadog.trace.agent.test.base.HttpServerTest.websocketSendSpan
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static org.junit.Assume.assumeTrue
-import static org.junit.Assume.assumeTrue
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration],

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/SpringWebFluxTestApplication.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/SpringWebFluxTestApplication.groovy
@@ -5,11 +5,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.HandlerMapping
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping
+import org.springframework.web.reactive.socket.WebSocketHandler
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter
 import reactor.core.publisher.Mono
 
 import java.time.Duration
@@ -24,6 +28,22 @@ class SpringWebFluxTestApplication {
   @Bean
   RouterFunction<ServerResponse> echoRouterFunction(EchoHandler echoHandler) {
     return route(POST("/echo"), new EchoHandlerFunction(echoHandler))
+  }
+
+  @Bean
+  WebSocketHandlerAdapter webSocketHandlerAdapter() {
+    return new WebSocketHandlerAdapter()
+  }
+
+  @Bean
+  HandlerMapping wsHandlerMapping(WsHandler wsHandler) {
+    Map<String, WebSocketHandler> map = new HashMap<>()
+    map.put("/websocket", wsHandler)
+
+    SimpleUrlHandlerMapping handlerMapping = new SimpleUrlHandlerMapping()
+    handlerMapping.setOrder(1)
+    handlerMapping.setUrlMap(map)
+    return handlerMapping
   }
 
   @Bean

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
@@ -1,0 +1,73 @@
+package dd.trace.instrumentation.springwebflux.server;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
+
+@Component
+public class WsHandler implements WebSocketHandler {
+
+  volatile WebSocketSession activeSession;
+
+  @Override
+  public Mono<Void> handle(WebSocketSession webSocketSession) {
+    // An echo server the closes after the first echoed message
+    activeSession = webSocketSession;
+    synchronized (this) {
+      notifyAll();
+    }
+    return webSocketSession
+        .receive()
+        .map(
+            msg -> {
+              if (msg.getType() == WebSocketMessage.Type.TEXT) {
+                return webSocketSession.textMessage(msg.getPayloadAsText());
+              }
+              byte[] bytes = new byte[msg.getPayload().readableByteCount()];
+              msg.getPayload().read(bytes);
+              return webSocketSession.binaryMessage(
+                  dataBufferFactory -> dataBufferFactory.wrap(bytes));
+            })
+        .flatMap(
+            msg ->
+                webSocketSession
+                    .send(Mono.just(msg))
+                    .doFinally(
+                        ignored -> {
+                          synchronized (this) {
+                            activeSession = null;
+                            notifyAll();
+                          }
+                        }))
+        .then();
+  }
+
+  public void awaitExchangeComplete() {
+    synchronized (this) {
+      if (activeSession == null) {
+        return;
+      }
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  public void awaitConnected() {
+    synchronized (this) {
+      if (activeSession != null) {
+        return;
+      }
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    assert activeSession != null;
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -49,7 +49,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
   @Autowired
   WsHandler wsHandler
 
-  WebClient client = WebClient.builder().clientConnector (new ReactorClientHttpConnector(buildClient())).build()
+  WebClient client = WebClient.builder().clientConnector(new ReactorClientHttpConnector(buildClient())).build()
 
   @Override
   protected void configurePreAgent() {
@@ -72,7 +72,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       sortSpansByStart()
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url))
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
       }
       trace(2) {
         span {
@@ -153,7 +153,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       def traceParent
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url))
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
       }
       trace(3) {
         span {
@@ -247,7 +247,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       def traceParent
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url))
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
       }
       trace(3) {
         span {
@@ -295,7 +295,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       def traceParent
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url), 404, true)
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 404, true)
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 404, true)
       }
       trace(2) {
         span {
@@ -341,7 +341,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
     String url = "http://localhost:$port/echo"
 
     when:
-    def response = client.post().uri(url).body(BodyInserters.fromPublisher(Mono.just(echoString),String)).exchange().block()
+    def response = client.post().uri(url).body(BodyInserters.fromPublisher(Mono.just(echoString), String)).exchange().block()
 
     then:
     response.statusCode().value() == 202
@@ -351,7 +351,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       def traceParent
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "POST", URI.create(url), 202)
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "POST", URI.create(url), 202)
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "POST", URI.create(url), 202)
       }
       trace(3) {
         span {
@@ -416,7 +416,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       def traceParent
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url), 500)
-        traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 500)
+        traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 500)
       }
       trace(2) {
         span {
@@ -505,7 +505,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       trace(2) {
         sortSpansByStart()
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url), 307)
-        traceParent1 =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 307)
+        traceParent1 = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), 307)
       }
 
       trace(2) {
@@ -550,7 +550,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       trace(2) {
         sortSpansByStart()
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(finalUrl))
-        traceParent2 =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(finalUrl))
+        traceParent2 = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(finalUrl))
       }
       trace(2) {
         sortSpansByStart()
@@ -609,7 +609,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
         def traceParent
         trace(2) {
           clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url))
-          traceParent =  clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
+          traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url))
         }
         trace(2) {
           span {
@@ -684,7 +684,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
       sortSpansByStart()
       trace(2) {
         clientSpan(it, null, "http.request", "spring-webflux-client", "GET", URI.create(url), null, false, null, false,
-          [ "message":"The subscription was cancelled", "event":"cancelled"])
+          ["message": "The subscription was cancelled", "event": "cancelled"])
         traceParent = clientSpan(it, span(0), "netty.client.request", "netty-client", "GET", URI.create(url), null)
       }
       trace(2) {
@@ -786,7 +786,7 @@ class SpringWebfluxHttp11Test extends AgentTestRunner {
     })
     where:
     message                                 | msgType  | chunks | size
-    RandomString.make(10) | "text" | 1 | 10
+    RandomString.make(10)                   | "text"   | 1      | 10
     RandomString.make(20).getBytes("UTF-8") | "binary" | 1      | 20
   }
 

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/SpringWebFluxTestApplication.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/SpringWebFluxTestApplication.groovy
@@ -5,11 +5,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.HandlerMapping
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping
+import org.springframework.web.reactive.socket.WebSocketHandler
 import reactor.core.publisher.Mono
 
 import java.time.Duration
@@ -20,6 +23,17 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 
 @SpringBootApplication
 class SpringWebFluxTestApplication {
+
+  @Bean
+  HandlerMapping wsHandlerMapping(WsHandler wsHandler) {
+    Map<String, WebSocketHandler> map = new HashMap<>()
+    map.put("/websocket", wsHandler)
+
+    SimpleUrlHandlerMapping handlerMapping = new SimpleUrlHandlerMapping()
+    handlerMapping.setOrder(1)
+    handlerMapping.setUrlMap(map)
+    return handlerMapping
+  }
 
   @Bean
   RouterFunction<ServerResponse> echoRouterFunction(EchoHandler echoHandler) {

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
@@ -1,0 +1,73 @@
+package dd.trace.instrumentation.springwebflux.server;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
+
+@Component
+public class WsHandler implements WebSocketHandler {
+
+  volatile WebSocketSession activeSession;
+
+  @Override
+  public Mono<Void> handle(WebSocketSession webSocketSession) {
+    // An echo server the closes after the first echoed message
+    activeSession = webSocketSession;
+    synchronized (this) {
+      notifyAll();
+    }
+    return webSocketSession
+        .receive()
+        .map(
+            msg -> {
+              if (msg.getType() == WebSocketMessage.Type.TEXT) {
+                return webSocketSession.textMessage(msg.getPayloadAsText());
+              }
+              byte[] bytes = new byte[msg.getPayload().readableByteCount()];
+              msg.getPayload().read(bytes);
+              return webSocketSession.binaryMessage(
+                  dataBufferFactory -> dataBufferFactory.wrap(bytes));
+            })
+        .flatMap(
+            msg ->
+                webSocketSession
+                    .send(Mono.just(msg))
+                    .doFinally(
+                        ignored -> {
+                          synchronized (this) {
+                            activeSession = null;
+                            notifyAll();
+                          }
+                        }))
+        .then();
+  }
+
+  public void awaitExchangeComplete() {
+    synchronized (this) {
+      if (activeSession == null) {
+        return;
+      }
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  public void awaitConnected() {
+    synchronized (this) {
+      if (activeSession != null) {
+        return;
+      }
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    assert activeSession != null;
+  }
+}


### PR DESCRIPTION
# What Does This Do

Extend the in-place netty pipeline to trace websocket messages when reactor-netty is used. Spring webflux is composing the pipeline by adding separately frame decoder/encoder hence our instrumentation was not applied correctly.
This applies only to netty 4.1+ (since reactor-netty at worst uses a 4.1+ version). I also did a small refactoring of what was in place 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
