### PR TITLE
Remove static inherited fields collection

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -1,6 +1,5 @@
 package com.datadog.debugger.instrumentation;
 
-import static com.datadog.debugger.instrumentation.ASMHelper.extractSuperClass;
 import static com.datadog.debugger.instrumentation.ASMHelper.getStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeConstructor;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
@@ -1136,49 +1135,11 @@ public class CapturedContextInstrumentor extends Instrumentor {
         }
       }
     }
-    if (!Config.get().isDynamicInstrumentationInstrumentTheWorld()) {
-      // Collects inherited static fields only if the ITW mode is not enabled
-      // because it can lead to LinkageError: attempted duplicate class definition
-      // for example, when a probe is located in method overridden in enum element
-      addInheritedStaticFields(classNode, classLoader, limits, results, fieldCount);
-    }
+    // Collecting inherited static fields is problematic because it some cases can lead to
+    // LinkageError: attempted duplicate class definition
+    // as we force to load a class to get the static fields in a different order than the JVM
+    // for example, when a probe is located in method overridden in enum element
     return results;
-  }
-
-  private static void addInheritedStaticFields(
-      ClassNode classNode,
-      ClassLoader classLoader,
-      Limits limits,
-      List<FieldNode> results,
-      int fieldCount) {
-    String superClassName = extractSuperClass(classNode);
-    while (!superClassName.equals(Object.class.getTypeName())) {
-      Class<?> clazz;
-      try {
-        clazz = Class.forName(superClassName, false, classLoader);
-      } catch (ClassNotFoundException ex) {
-        break;
-      }
-      try {
-        for (Field field : clazz.getDeclaredFields()) {
-          if (isStaticField(field) && !isFinalField(field)) {
-            String desc = Type.getDescriptor(field.getType());
-            FieldNode fieldNode =
-                new FieldNode(field.getModifiers(), field.getName(), desc, null, field);
-            results.add(fieldNode);
-            LOGGER.debug("Adding static inherited field {}", fieldNode.name);
-            fieldCount++;
-            if (fieldCount > limits.maxFieldCount) {
-              return;
-            }
-          }
-        }
-      } catch (ClassCircularityError ex) {
-        break;
-      }
-      clazz = clazz.getSuperclass();
-      superClassName = clazz.getTypeName();
-    }
   }
 
   private int declareContextVar(InsnList insnList) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -940,27 +940,6 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
-  @EnabledForJreRange(min = JRE.JAVA_17)
-  public void staticFieldExtractorNotAccessible() throws IOException, URISyntaxException {
-    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot30";
-    LogProbe logProbe =
-        createMethodProbe(PROBE_ID, CLASS_NAME + "$MyHttpURLConnection", "process", "()");
-    TestSnapshotListener listener = installProbes(logProbe);
-    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    int result = Reflect.onClass(testClass).call("main", "static").get();
-    assertEquals(42, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
-    assertCaptureStaticFieldsNotCaptured(
-        snapshot.getCaptures().getReturn(),
-        "followRedirects",
-        "Field is not accessible: module java.base does not opens/exports to the current module");
-    assertCaptureStaticFieldsNotCaptured(
-        snapshot.getCaptures().getReturn(),
-        "factory",
-        "Field is not accessible: module java.base does not opens/exports to the current module");
-  }
-
-  @Test
   public void uncaughtException() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot05";
     TestSnapshotListener listener =
@@ -1611,12 +1590,9 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, CapturedContext.CapturedValue> staticFields =
         snapshot.getCaptures().getReturn().getStaticFields();
-    assertEquals(7, staticFields.size());
+    // inherited static fields are not collected
+    assertEquals(2, staticFields.size());
     assertEquals("barfoo", MoshiSnapshotTestHelper.getValue(staticFields.get("strValue")));
-    assertEquals("48", MoshiSnapshotTestHelper.getValue(staticFields.get("intValue")));
-    assertEquals("6.28", MoshiSnapshotTestHelper.getValue(staticFields.get("doubleValue")));
-    assertEquals("[1, 2, 3, 4]", MoshiSnapshotTestHelper.getValue(staticFields.get("longValues")));
-    assertEquals("[foo, bar]", MoshiSnapshotTestHelper.getValue(staticFields.get("strValues")));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
To avoid premature class loading and potential LinkageError we are not collecting the static inherited fields of a class

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3855]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3855]: https://datadoghq.atlassian.net/browse/DEBUG-3855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ