### PR TITLE
Bump build-inst resource class on circle ci

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -183,9 +183,9 @@ commands:
           # The file does not seem to exist when DLC is disabled
           command: |
             # Show cgroupv2 memory usage
-            printf "cgroup memory.peak: $(cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo 'not found')"
-            printf "cgroup memory.max : $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo 'not found')"
-            printf "cgroup memory.high: $(cat /sys/fs/cgroup/memory.high 2>/dev/null || echo 'not found')"
+            printf "cgroup memory.peak: $(cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo 'not found')%s\n"
+            printf "cgroup memory.max : $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo 'not found')%s\n"
+            printf "cgroup memory.high: $(cat /sys/fs/cgroup/memory.high 2>/dev/null || echo 'not found')%s\n"
             printf "ram memory        : $(grep MemTotal /proc/meminfo | tr -s ' ' | cut -d ' ' -f 2)%s\n"
           when: always
 
@@ -983,10 +983,12 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
   - build:
       name: build_latestdep
+      resourceClass: 2xlarge
       gradleTarget: :instrumentationLatestDepTest
       cacheType: latestdep
   - build:
       name: build_smoke
+      resourceClass: 2xlarge
       gradleTarget: :smokeTest
       cacheType: smoke
   - build:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -392,6 +392,9 @@ jobs:
     <<: *defaults
 
     parameters:
+      resourceClass:
+        type: string
+        default: medium+
       parallelism:
         type: integer
         default: 1
@@ -403,7 +406,7 @@ jobs:
         type: string
         default: ".*"
 
-    resource_class: medium+
+    resource_class: << parameters.resourceClass >>
 
     parallelism: << parameters.parallelism >>
 
@@ -453,6 +456,8 @@ jobs:
           when: on_fail
           command: .circleci/cancel_workflow.sh
 
+      - display_memory_usage
+
   build_clean_cache:
     <<: *defaults
 
@@ -501,13 +506,13 @@ jobs:
 
   tests: &tests
     <<: *defaults
-    # since tests use test containers, they will use a Linux VM / Remote Docker executor, so there is no medium+ size
-    resource_class: large
-
     docker:
       - image: << pipeline.parameters.docker_image >>:{{ docker_image_prefix }}<< parameters.testJvm >>
 
     parameters:
+      resourceClass:
+        type: string
+        default: large
       environment:
         type: string
         default: ""
@@ -542,6 +547,9 @@ jobs:
         default: false
       cacheType:
         type: string
+
+    # since tests use test containers, they will use a Linux VM / Remote Docker executor, so there is no medium+ size
+    resource_class: << parameters.resourceClass >>
 
     parallelism: << parameters.parallelism >>
 
@@ -660,13 +668,18 @@ jobs:
               exit 1
             fi
 
+  # TODO: merge xlarge_tests and tests? or rename this?
   xlarge_tests:
     <<: *tests
 
     docker:
+      # The first image listed in your configuration for a job is referred to as the primary container image
+      # and this is where all steps in the job will run. Secondary containers can also be specified to run
+      # alongside for running services, such as, databases.
       - image: << pipeline.parameters.docker_image >>:{{ docker_image_prefix }}<< parameters.testJvm >>
         environment:
           - CI_USE_TEST_AGENT=true
+
       - image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.11.0
         environment:
           - LOG_LEVEL=DEBUG
@@ -675,8 +688,6 @@ jobs:
           - DD_POOL_TRACE_CHECK_FAILURES=true
           - DD_DISABLE_ERROR_RESPONSES=true
           - ENABLED_CHECKS=trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
-    # TODO: merge xlarge_tests and tests? or rename this?
-    resource_class: large
 
 
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
@@ -1012,6 +1023,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: check_base
+      resourceClass: large
       gradleTarget: ":baseCheck"
       cacheType: base
 
@@ -1019,6 +1031,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: check_inst
+      resourceClass: large
       parallelism: 5
       gradleTarget: ":instrumentationCheck"
       cacheType: inst
@@ -1028,6 +1041,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: check_smoke
+      resourceClass: large
       gradleTarget: ":smokeCheck"
       cacheType: smoke
 
@@ -1086,6 +1100,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: z_test_<< matrix.testJvm >>_inst
+      resourceClass: xlarge
       gradleTarget: ":instrumentationTest"
       gradleParameters: "-PskipFlakyTests"
       triggeredBy: *instrumentation_modules
@@ -1114,6 +1129,7 @@ build_test_jobs: &build_test_jobs
         - ok_to_test
         - build_latestdep
       name: test_8_inst_latest
+      resourceClass: xlarge
       gradleTarget: ":instrumentationLatestDepTest"
       gradleParameters: "-PskipFlakyTests"
       triggeredBy: *instrumentation_modules
@@ -1128,6 +1144,7 @@ build_test_jobs: &build_test_jobs
         - ok_to_test
         - build_latestdep
       name: test_17_inst_latest
+      resourceClass: xlarge
       gradleTarget: ":instrumentationLatestDepTest"
       gradleParameters: "-PskipFlakyTests"
       triggeredBy: *instrumentation_modules
@@ -1315,6 +1332,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: z_test_8_smoke
+      resourceClass: xlarge
       gradleTarget: "stageMainDist :smokeTest"
       gradleParameters: "-PskipFlakyTests"
       stage: smoke

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1031,7 +1031,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: check_inst
-      resourceClass: large
+      resourceClass: xlarge
       parallelism: 5
       gradleTarget: ":instrumentationCheck"
       cacheType: inst

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -179,9 +179,14 @@ commands:
   display_memory_usage:
     steps:
       - run:
-          name: Max Memory Used
+          name: Runner Memory Usage
           # The file does not seem to exist when DLC is disabled
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes || true
+          command: |
+            # Show cgroupv2 memory usage
+            printf "cgroup memory.peak: $(cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo 'not found')"
+            printf "cgroup memory.max : $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo 'not found')"
+            printf "cgroup memory.high: $(cat /sys/fs/cgroup/memory.high 2>/dev/null || echo 'not found')"
+            printf "ram memory        : $(grep MemTotal /proc/meminfo | tr -s ' ' | cut -d ' ' -f 2)%s\n"
           when: always
 
 
@@ -282,7 +287,7 @@ commands:
 jobs:
   build:
     <<: *defaults
-    resource_class: xlarge
+    resource_class: 2xlarge
 
     parameters:
       gradleTarget:
@@ -304,15 +309,15 @@ jobs:
 
       - restore_dependency_cache:
           cacheType: << parameters.cacheType >>
-
+          
       - run:
           name: Build Project
           command: >-
 {% if is_nightly %}
-            ./gradlew resolveAndLockAll --write-locks &&
+            ./gradlew resolveAndLockAll --write-locks --no-daemon &&
 {% endif %}
             MAVEN_OPTS="-Xms64M -Xmx256M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2560M -Xms2560M -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2560M -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
             ./gradlew clean
             << parameters.gradleTarget >>
             -PskipTests

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -287,9 +287,11 @@ commands:
 jobs:
   build:
     <<: *defaults
-    resource_class: 2xlarge
 
     parameters:
+      resourceClass:
+        type: string
+        default: xlarge
       gradleTarget:
         type: string
       cacheType:
@@ -301,6 +303,7 @@ jobs:
         type: string
         default: ".*"
 
+    resource_class: << parameters.resourceClass >>
     steps:
       - setup_code
 
@@ -974,6 +977,7 @@ build_test_jobs: &build_test_jobs
       cacheType: base
   - build:
       name: build_inst
+      resourceClass: 2xlarge
       gradleTarget: :instrumentationTest
       cacheType: inst
       triggeredBy: *instrumentation_modules

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1031,7 +1031,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
       name: check_inst
-      resourceClass: xlarge
+      resourceClass: 2xlarge
       parallelism: 5
       gradleTarget: ":instrumentationCheck"
       cacheType: inst


### PR DESCRIPTION
# What Does This Do
The build_inst job (`./gradlew clean :instrumentationTest ...`) memory usage is close to 16GiB, this is very likely cause to builds failing a daemon disappearing (`org.gradle.launcher.daemon.client.DaemonDisappearedException: Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)`) 

https://circleci.com/docs/configuration-reference/#resourceclass

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
