### PR TITLE
Various Gitlab tweaks and test fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -377,8 +377,8 @@ muzzle-dep-report:
   needs: [ build_tests ]
   stage: tests
   variables:
-    KUBERNETES_MEMORY_REQUEST: 16Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_MEMORY_REQUEST: 17Gi
+    KUBERNETES_MEMORY_LIMIT: 17Gi
     KUBERNETES_CPU_REQUEST: 10
     GRADLE_WORKERS: 4
     GRADLE_MEM: 3G

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -402,7 +402,7 @@ muzzle-dep-report:
       export PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/${CI_JOB_NAME_SLUG}.jfr,dumponexit=true";
       fi
     - *prepare_test_env
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEM -Xmx$GRADLE_MEM $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEM -Xmx$GRADLE_MEM $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=1024M -Ddatadog.forkedMinHeapSize=128M"
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PtestJvm=$testJvm -PtaskPartitionCount=$NORMALIZED_NODE_TOTAL -PtaskPartition=$NORMALIZED_NODE_INDEX $GRADLE_ARGS --continue || $CONTINUE_ON_FAILURE
   after_script:
     - *restore_pretest_env

--- a/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionHistogramTest.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionHistogramTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.common.item.Aggregators;
@@ -60,9 +61,13 @@ public class ExceptionHistogramTest {
   private Recording snapshot;
   private ExceptionHistogram instance;
 
+  @BeforeAll
+  public static void precheck() {
+    assumeFalse(Platform.isJ9());
+  }
+
   @BeforeEach
   public void setup() {
-    assumeFalse(Platform.isJ9());
     recording = new Recording();
     recording.enable("datadog.ExceptionCount");
     recording.start();

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProcessBuilderHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProcessBuilderHelper.java
@@ -32,7 +32,7 @@ class ProcessBuilderHelper {
         Arrays.asList(
             javaPath(),
             // "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5006",
-            "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M"),
+            "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1024M"),
             "-Xms" + System.getProperty("datadog.forkedMinHeapSize", "64M"),
             "-javaagent:" + agentShadowJar(),
             "-XX:ErrorFile=/tmp/hs_err_pid%p.log",

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -748,7 +748,7 @@ class JFRBasedProfilingIntegrationTest {
     final List<String> command =
         Arrays.asList(
             javaPath(),
-            "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M"),
+            "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1024M"),
             "-Xms" + System.getProperty("datadog.forkedMinHeapSize", "64M"),
             "-javaagent:" + agentShadowJar(),
             "-XX:ErrorFile=/tmp/hs_err_pid%p.log",

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
@@ -28,7 +28,7 @@ final class SmokeTestUtils {
         new ArrayList<>(
             Arrays.asList(
                 javaPath(),
-                "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M"),
+                "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1024M"),
                 "-Xms" + System.getProperty("datadog.forkedMinHeapSize", "64M"),
                 "-javaagent:" + agentShadowJar(),
                 "-XX:ErrorFile=/tmp/hs_err_pid%p.log",

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
@@ -2,7 +2,7 @@ package datadog.trace.test.util;
 
 public class ForkedTestUtils {
   public static String getMaxMemoryArgumentForFork() {
-    return "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M");
+    return "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1024M");
   }
 
   public static String getMinMemoryArgumentForFork() {


### PR DESCRIPTION
# What Does This Do
* Bump memory for tests
* Increase memory for forked tests
* Fix `ExceptionHistogramTest` on J9

# Motivation
I was regularly seeing OOMs on forked tests when running on all JDKs (the nightly). The `512mb` limit is lower than the limit for regular tests. Some of these OOMs were nonobvious because the job would fail much later

This PR aligns forks to use `1024mb` across all the ways tests could be forked.

Additionally, I fixed the `ExceptionHistogramTest`, which only failed during the nightly.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
