### PR TITLE
Fix Exception Replay in Lambda

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -148,6 +148,13 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       int[] mapping = createThrowableMapping(currentEx, t);
       StackTraceElement[] innerTrace = currentEx.getStackTrace();
       int currentIdx = innerTrace.length - snapshot.getStack().size();
+
+      if (currentIdx < 0) {
+        // This means the innerTrace was truncated by the underlying environment.
+        // This is known to happen in AWS Lambda, but may also happen elsewhere.
+        currentIdx = i;
+      }
+
       if (!sanityCheckSnapshotAssignment(snapshot, innerTrace, currentIdx)) {
         continue;
       }


### PR DESCRIPTION
# What Does This Do

In Lambda, the inner stack trace is truncated -- stack frames from `fileName='AWSLambda.java'` are removed. Therefore, in the original code, we would end up with a negative `currentIdx`, resulting in an error occurring in `sanityCheckSnapshotAssignment`.

This change adds a simple fallback:
```
      int currentIdx = innerTrace.length - snapshot.getStack().size();

      if (currentIdx < 0) {
        // This means the innerTrace was truncated by the underlying environment.
        // This is known to happen in AWS Lambda, but may also happen elsewhere.
        currentIdx = i;
      }
```

From manual testing in Lambda, this correctly gets the index in Lambda for all snapshots.
<img width="900" alt="Screenshot 2025-05-19 at 1 21 16 PM" src="https://github.com/user-attachments/assets/8474f200-649f-4978-9eca-b67b2c4c1772" />

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-6855

# Additional Notes

- Exception Replay requires the exception to occur twice in Java: the first occurrence transforms the class, and the second occurrence captures the local variables
- In Java, currently method parameters are captured by Exception Replay but other local variables are not captured yet

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
