### PR TITLE
chore: remove jmh from projects that don't have any benchmarks

### DIFF
--- a/components/cli/build.gradle.kts
+++ b/components/cli/build.gradle.kts
@@ -1,9 +1,1 @@
-plugins {
-  id("me.champeau.jmh")
-}
-
 apply(from = "$rootDir/gradle/java.gradle")
-
-jmh {
-  version = "1.28"
-}

--- a/components/context/build.gradle.kts
+++ b/components/context/build.gradle.kts
@@ -1,12 +1,4 @@
-plugins {
-  id("me.champeau.jmh")
-}
-
 apply(from = "$rootDir/gradle/java.gradle")
-
-jmh {
-  version = "1.28"
-}
 
 val excludedClassesInstructionCoverage by extra {
   listOf("datadog.context.ContextProviders") // covered by forked test

--- a/components/yaml/build.gradle.kts
+++ b/components/yaml/build.gradle.kts
@@ -1,12 +1,4 @@
-plugins {
-  id("me.champeau.jmh")
-}
-
 apply(from = "$rootDir/gradle/java.gradle")
-
-jmh {
-  version = "1.28"
-}
 
 // https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.pom
 dependencies {

--- a/components/yaml/build.gradle.kts
+++ b/components/yaml/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+  `java-library`
+}
+
 apply(from = "$rootDir/gradle/java.gradle")
 
 // https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.pom


### PR DESCRIPTION
# What Does This Do
Remove jmh gradle plugin when the project actually has no benchmarks

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
