### PR TITLE
Fix Max captured frames for Exception Replay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -212,7 +212,8 @@ public class DebuggerAgent {
             configurationUpdater,
             classNameFilter,
             Duration.ofSeconds(config.getDebuggerExceptionCaptureInterval()),
-            config.getDebuggerMaxExceptionPerSecond());
+            config.getDebuggerMaxExceptionPerSecond(),
+            config.getDebuggerExceptionMaxCapturedFrames());
     DebuggerContext.initExceptionDebugger(exceptionDebugger);
     LOGGER.info("Started Exception Replay");
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -67,7 +67,7 @@ public class DefaultExceptionDebuggerTest {
             new HashSet<>(singletonList("com.datadog.debugger.exception.ThirdPartyCode")));
     exceptionDebugger =
         new DefaultExceptionDebugger(
-            configurationUpdater, classNameFiltering, Duration.ofHours(1), 100);
+            configurationUpdater, classNameFiltering, Duration.ofHours(1), 100, 3);
     listener = new TestSnapshotListener(createConfig(), mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
   }
@@ -275,7 +275,7 @@ public class DefaultExceptionDebuggerTest {
   public void filteringOutErrors() {
     ExceptionProbeManager manager = mock(ExceptionProbeManager.class);
     exceptionDebugger =
-        new DefaultExceptionDebugger(manager, configurationUpdater, classNameFiltering, 100);
+        new DefaultExceptionDebugger(manager, configurationUpdater, classNameFiltering, 100, 3);
     exceptionDebugger.handleException(new AssertionError("test"), mock(AgentSpan.class));
     verify(manager, times(0)).isAlreadyInstrumented(any());
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -17,7 +17,6 @@ import static utils.TestHelper.setFieldInConfig;
 import com.datadog.debugger.agent.ClassesToRetransformFinder;
 import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.agent.ConfigurationUpdater;
-import com.datadog.debugger.agent.DebuggerAgent;
 import com.datadog.debugger.agent.DebuggerAgentHelper;
 import com.datadog.debugger.agent.DebuggerTransformer;
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
@@ -99,7 +98,10 @@ public class ExceptionProbeInstrumentationTest {
     ProbeRateLimiter.setSamplerSupplier(rate -> rate < 101 ? probeSampler : globalSampler);
     ProbeRateLimiter.setGlobalSnapshotRate(1000);
     // to activate the call to DebuggerContext.handleException
-    DebuggerAgent.startExceptionReplay();
+    DebuggerContext.ProductConfigUpdater mockProductConfigUpdater =
+        mock(DebuggerContext.ProductConfigUpdater.class);
+    when(mockProductConfigUpdater.isExceptionReplayEnabled()).thenReturn(true);
+    DebuggerContext.initProductConfigUpdater(mockProductConfigUpdater);
     setFieldInConfig(Config.get(), "debuggerExceptionEnabled", true);
     setFieldInConfig(Config.get(), "dynamicInstrumentationClassFileDumpEnabled", true);
   }
@@ -224,7 +226,8 @@ public class ExceptionProbeInstrumentationTest {
     callMethodFiboException(testClass); // generate snapshots
     Map<String, Set<String>> probeIdsByMethodName =
         extractProbeIdsByMethodName(exceptionProbeManager);
-    assertEquals(10, listener.snapshots.size());
+    // limited by Config::getDebuggerExceptionMaxCapturedFrames
+    assertEquals(3, listener.snapshots.size());
     Snapshot snapshot0 = listener.snapshots.get(0);
     assertProbeId(probeIdsByMethodName, "fiboException", snapshot0.getProbe().getId());
     assertEquals(
@@ -234,8 +237,6 @@ public class ExceptionProbeInstrumentationTest {
     assertEquals("2", getValue(snapshot1.getCaptures().getReturn().getArguments().get("n")));
     Snapshot snapshot2 = listener.snapshots.get(2);
     assertEquals("3", getValue(snapshot2.getCaptures().getReturn().getArguments().get("n")));
-    Snapshot snapshot9 = listener.snapshots.get(9);
-    assertEquals("10", getValue(snapshot9.getCaptures().getReturn().getArguments().get("n")));
     // sampling happens only once ont he first snapshot then forced for coordinated sampling
     assertEquals(1, probeSampler.getCallCount());
     assertEquals(1, globalSampler.getCallCount());
@@ -382,7 +383,7 @@ public class ExceptionProbeInstrumentationTest {
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     DefaultExceptionDebugger exceptionDebugger =
         new DefaultExceptionDebugger(
-            exceptionProbeManager, configurationUpdater, classNameFiltering, 100);
+            exceptionProbeManager, configurationUpdater, classNameFiltering, 100, 3);
     DebuggerContext.initExceptionDebugger(exceptionDebugger);
     configurationUpdater.accept(REMOTE_CONFIG, definitions);
     return listener;

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -153,6 +153,8 @@ public class ServerDebuggerTestApplication {
       tracedMethodWithDeepException1(42, "foobar", 3.42, map, "var1", "var2", "var3");
     } else if ("lambdaOops".equals(arg)) {
       tracedMethodWithLambdaException(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    } else if ("recursiveOops".equals(arg)) {
+      tracedMethodWithRecursiveException(42, "foobar", 3.42, map, "var1", "var2", "var3");
     } else {
       tracedMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
     }
@@ -237,6 +239,15 @@ public class ServerDebuggerTestApplication {
   private static void tracedMethodWithLambdaException(
       int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
     throw toRuntimeException("lambdaOops");
+  }
+
+  private static void tracedMethodWithRecursiveException(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    if (argInt > 0) {
+      tracedMethodWithRecursiveException(argInt - 8, argStr, argDouble, argMap, argVar);
+    } else {
+      throw new RuntimeException("recursiveOops");
+    }
   }
 
   private static RuntimeException toRuntimeException(String msg) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -45,7 +45,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
     LogProbe probe =
         LogProbe.builder()
             .probeId(LINE_PROBE_ID1)
-            .where("ServerDebuggerTestApplication.java", 301)
+            .where("ServerDebuggerTestApplication.java", 312)
             .build();
     setCurrentConfiguration(createConfig(probe));
     waitForFeatureStarted(appUrl, "Dynamic Instrumentation");


### PR DESCRIPTION
# What Does This Do
For recursive frames we were sending snapshot as long as the frame are the same. frame capture was relying on the fact they were different. Now we are limiting the snapshot sent to config parameter

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
