### PR TITLE
Add support for isDefined in log template

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -50,7 +50,8 @@ public class JsonToExpressionConverter {
               "endsWith",
               "contains",
               "matches",
-              "instanceof"));
+              "instanceof",
+              "isDefined"));
 
   @FunctionalInterface
   interface BinaryPredicateExpressionFunction<T extends Expression> {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_01.txt
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_01.txt
@@ -19,3 +19,4 @@
 {"dsl": "", "json": {"contains": [{"ref": "str"}, "ll"]}}
 {"dsl": "", "json": {"matches": [{"ref": "str"}, "[helo]+"]}}
 {"dsl": "", "json": {"instanceof": [{"ref": "str"}, "java.lang.String"]}}
+{"dsl": "", "json": {"isDefined": {"ref": "str"}}}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_value_expr_01.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_value_expr_01.json
@@ -24,7 +24,8 @@
           {"endsWith": [{"ref": "str"}, "llo"]},
           {"contains": [{"ref": "str"}, "ll"]},
           {"matches": [{"ref": "str"}, "[helo]+"]},
-          {"instanceof": [{"ref": "str"}, "java.lang.String"]}
+          {"instanceof": [{"ref": "str"}, "java.lang.String"]},
+          {"isDefined": {"ref": "str"}}
         ]
       }
     ]


### PR DESCRIPTION
# What Does This Do
Add isDefined as top level predicate for log template values

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3338]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3338]: https://datadoghq.atlassian.net/browse/DEBUG-3338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ