### PR TITLE
Show link to datadog CI app in test results

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -414,6 +414,8 @@ muzzle-dep-report:
     - .circleci/collect_results.sh
     - .circleci/upload_ciapp.sh tests $testJvm
     - gitlab_section_end "collect-reports"
+    - URL_ENCODED_JOB_NAME=$(jq -rn --arg x "$CI_JOB_NAME" '$x|@uri')
+    - echo -e "${TEXT_BOLD}${TEXT_YELLOW}See test results in Datadog:${TEXT_CLEAR} https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A${CI_PIPELINE_ID}%20%40ci.job.name%3A%22${URL_ENCODED_JOB_NAME}%22"
   artifacts:
     when: always
     paths:

--- a/.gitlab/gitlab-utils.sh
+++ b/.gitlab/gitlab-utils.sh
@@ -15,3 +15,13 @@ function gitlab_section_end () {
 
   echo -e "section_end:`date +%s`:${section_title}\r\e[0K"
 }
+
+# A subset of ansi color/formatting codes https://misc.flogisoft.com/bash/tip_colors_and_formatting
+export TEXT_RED="\e[31m"
+export TEXT_GREEN="\e[32m"
+export TEXT_YELLOW="\e[33m"
+export TEXT_BLUE="\e[34m"
+export TEXT_MAGENTA="\e[35m"
+export TEXT_CYAN="\e[36m"
+export TEXT_CLEAR="\e[0m"
+export TEXT_BOLD="\e[1m"


### PR DESCRIPTION
# What Does This Do
Adds a link to Datadog test results

# Motivation
This makes it easier to pivot to test failures/results as Gitlab has a subpar test experience

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
