### PR TITLE
Add support for JUnit 5.13-RC1

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -117,10 +117,7 @@ public class JUnit5Instrumentation extends InstrumenterModule.CiVisibility
       EngineExecutionListener compositeListener =
           new CompositeEngineListener(tracingListener, originalListener);
       executionRequest =
-          new ExecutionRequest(
-              executionRequest.getRootTestDescriptor(),
-              compositeListener,
-              executionRequest.getConfigurationParameters());
+          JUnitPlatformUtils.createExecutionRequest(executionRequest, compositeListener);
     }
 
     // JUnit 5.3.0 and above


### PR DESCRIPTION
# What Does This Do

- Updates JUnit 5 instrumentation to reflect changes introduced in version 5.13-RC1 to `org.junit.platform.engine.ExecutionRequest`, adding two new fields to the class, at least one of them required for the execution of tests. The instrumentation now chooses the available method to create objects of the class through reflection.

# Motivation

Unblocks https://github.com/DataDog/dd-trace-java/pull/8842

# Additional Notes

Tested locally by upgrading the gradle dependencies on `junit-5.3` and `junit-5.8` instrumentations and running both `test` and `latestDepTest`. 

Passing results for `junit-5.3`:

<img width="607" alt="image" src="https://github.com/user-attachments/assets/2396a51b-f6de-4ae2-b282-4d9a17ce056f" />

<img width="599" alt="image" src="https://github.com/user-attachments/assets/cc42f24c-8095-49a7-9fde-4c35a19f1713" />

Passing results for `junit-5.8`:

<img width="604" alt="image" src="https://github.com/user-attachments/assets/5389d24d-ae45-49fa-bdf1-7daac457eebe" />

<img width="598" alt="image" src="https://github.com/user-attachments/assets/b408e287-dc6c-459f-9af1-2dc17156fb17" />


# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
