### PR TITLE
Use constructor as fallback in ExecutionRequest creation in JUnit5 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -116,12 +117,6 @@ public abstract class JUnitPlatformUtils {
       METHOD_HANDLES.method(ExecutionRequest.class, "getOutputDirectoryProvider");
   private static final MethodHandle GET_STORE =
       METHOD_HANDLES.method(ExecutionRequest.class, "getStore");
-  private static final String[] CREATE_FALLBACK_PARAMETER_TYPES =
-      new String[] {
-        "org.junit.platform.engine.TestDescriptor",
-        "org.junit.platform.engine.EngineExecutionListener",
-        "org.junit.platform.engine.ConfigurationParameters"
-      };
   private static final String[] CREATE_PARAMETER_TYPES =
       new String[] {
         "org.junit.platform.engine.TestDescriptor",
@@ -143,14 +138,11 @@ public abstract class JUnitPlatformUtils {
                       Arrays.stream(m.getParameterTypes()).map(Class::getName).toArray(),
                       CREATE_PARAMETER_TYPES));
     } else {
-      return METHOD_HANDLES.method(
+      return METHOD_HANDLES.constructor(
           ExecutionRequest.class,
-          m ->
-              "create".equals(m.getName())
-                  && m.getParameterCount() == 3
-                  && Arrays.equals(
-                      Arrays.stream(m.getParameterTypes()).map(Class::getName).toArray(),
-                      CREATE_FALLBACK_PARAMETER_TYPES));
+          TestDescriptor.class,
+          EngineExecutionListener.class,
+          ConfigurationParameters.class);
     }
   }
 


### PR DESCRIPTION
# What Does This Do

- Changes the fallback method to create `org.junit.platform.engine.ExecutionRequest` from `create` to the constructor, as it was originally implemented in the instrumentation.

# Motivation

Fixes a bug introduced in https://github.com/DataDog/dd-trace-java/pull/8865. It would only fail on the earliest version of the module, in which the `create` method is not available.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
