### PR TITLE
Update muzzle directive for spark-2.13

### DIFF
--- a/.github/workflows/check-ci-pipelines.yml
+++ b/.github/workflows/check-ci-pipelines.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Run Ensure CI Success
         uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754
         with:
-          initial-delay-seconds: "1000"
+          initial-delay-seconds: "500"
           max-retries: "60"
           ignored-name-patterns: |
             dd-gitlab/default-pipeline
-            dd-gitlab/test_smoke: [11, 2/2]
-            dd-gitlab/test_smoke: [8, 2/2]
+            dd-gitlab/test_smoke: \\[11, 2/2\\]
+            dd-gitlab/test_smoke: \\[8, 2/2\\]

--- a/.github/workflows/check-ci-pipelines.yml
+++ b/.github/workflows/check-ci-pipelines.yml
@@ -29,9 +29,5 @@ jobs:
           max-retries: "60"
           ignored-name-patterns: |
             dd-gitlab/default-pipeline
-            dd-gitlab/check_inst 4/4
-
-# ignored jobs : 
-#
-# * dd-gitlab/default-pipeline => success rate of 70% (needs an owner)
-# * dd-gitlab/check_inst 4/4   => success rate of 78% (needs an owner)
+            dd-gitlab/test_smoke: [11, 2/2]
+            dd-gitlab/test_smoke: [8, 2/2]

--- a/.github/workflows/check-ci-pipelines.yml
+++ b/.github/workflows/check-ci-pipelines.yml
@@ -29,5 +29,5 @@ jobs:
           max-retries: "60"
           ignored-name-patterns: |
             dd-gitlab/default-pipeline
-            dd-gitlab/test_smoke: \\[11, 2/2\\]
-            dd-gitlab/test_smoke: \\[8, 2/2\\]
+            dd-gitlab/test_smoke: \[11, 2/2\]
+            dd-gitlab/test_smoke: \[8, 2/2\]

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -10,8 +10,13 @@ muzzle {
   pass {
     group = "org.apache.spark"
     module = "spark-sql_$scalaVersion"
-    versions = "[$sparkVersion,)"
-    assertInverse = true
+    versions = "[$sparkVersion,4.0.0)"
+  }
+  pass {
+    group = "org.apache.spark"
+    module = "spark-sql_$scalaVersion"
+    versions = "[4.0.0,)"
+    javaVersion = 17
   }
 }
 


### PR DESCRIPTION
# What Does This Do

- Updates the muzzle directive por `spark_2.13` to use Java 17 from `4.0.0` onwards

# Motivation

Version `4.0.0` was released a couple of days ago: https://repo1.maven.org/maven2/org/apache/spark/spark-sql_2.13/4.0.0/

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
