### PR TITLE
Use tag as fallback in api requests if no branch is available

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
@@ -106,6 +106,7 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
         .env(config.getEnv())
         .repositoryUrl(gitInfo.getRepositoryURL())
         .branch(gitInfo.getBranch())
+        .tag(gitInfo.getTag())
         .sha(gitInfo.getCommit().getSha())
         .commitMessage(gitInfo.getCommit().getFullMessage())
         .osPlatform(wellKnownTags.getOsPlatform().toString())

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TracerEnvironment.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TracerEnvironment.java
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.config;
 
 import com.squareup.moshi.Json;
 import datadog.trace.api.civisibility.config.Configurations;
+import datadog.trace.util.Strings;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -111,6 +112,7 @@ public class TracerEnvironment {
     private String env;
     private String repositoryUrl;
     private String branch;
+    private String tag; // will act as fallback if no branch is provided
     private String sha;
     private String commitMessage;
     private String osPlatform;
@@ -140,6 +142,11 @@ public class TracerEnvironment {
 
     public Builder branch(String branch) {
       this.branch = branch;
+      return this;
+    }
+
+    public Builder tag(String tag) {
+      this.tag = tag;
       return this;
     }
 
@@ -203,7 +210,7 @@ public class TracerEnvironment {
           service,
           env,
           repositoryUrl,
-          branch,
+          Strings.isNotBlank(branch) ? branch : tag,
           sha,
           commitMessage,
           new Configurations(

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TracerEnvironmentTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/TracerEnvironmentTest.groovy
@@ -1,0 +1,21 @@
+package datadog.trace.civisibility.config
+
+import spock.lang.Specification
+
+class TracerEnvironmentTest extends Specification {
+  def "test fallback to tag on no branch"() {
+    setup:
+    def builder = TracerEnvironment.builder()
+    def environment = builder.branch(branch).tag(tag).build()
+
+    expect:
+    environment.branch == environmentBranch
+
+    where:
+    branch | tag       | environmentBranch
+    "main" | "v.1.0.0" | "main"
+    "main" | null      | "main"
+    null   | "v.1.0.0" | "v.1.0.0"
+    null   | null      | null
+  }
+}


### PR DESCRIPTION
# What Does This Do

When building the tracer environment used in the API requests to the backend, `git.tag` will be used as `branch` when this value is not available. 

# Motivation

When a GitHub action is triggered on a tag push (not a branch), we end up sending requests with `branch: null`, causing a 400 to be returned from the backend.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-2035]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
