### PR TITLE
Improve setJavaVersion to set standard javaLauncher for Groovy and Scala

### DIFF
--- a/dd-smoke-tests/iast-util/iast-util-11/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-11/build.gradle
@@ -21,13 +21,10 @@ dependencies {
   testFixturesImplementation testFixtures(project(":dd-smoke-tests:iast-util"))
 }
 
-project.tasks.withType(AbstractCompile).configureEach {
+tasks.named("compileJava", JavaCompile).configure {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
-  if (it instanceof JavaCompile) {
-    it.options.release.set(11)
-  }
 }
 
 forbiddenApisMain {

--- a/dd-smoke-tests/iast-util/iast-util-17/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-17/build.gradle
@@ -21,13 +21,10 @@ dependencies {
   testFixturesImplementation testFixtures(project(":dd-smoke-tests:iast-util"))
 }
 
-project.tasks.withType(AbstractCompile).configureEach {
+tasks.named("compileJava", JavaCompile).configure {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
-  if (it instanceof JavaCompile) {
-    it.options.release.set(17)
-  }
 }
 
 forbiddenApisMain {

--- a/dd-smoke-tests/java9-modules/build.gradle
+++ b/dd-smoke-tests/java9-modules/build.gradle
@@ -13,17 +13,15 @@ jar {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-[JavaCompile, GroovyCompile].each {
-  tasks.withType(it).configureEach { AbstractCompile ac ->
-    setJavaVersion(ac, 11)
-    // read up classpath lazily to avoid early locking of gradle settings
-    ac.options.compilerArgumentProviders.add(new CommandLineArgumentProvider() {
-        @Override
-        Iterable<String> asArguments() {
-          { return ['--module-path', ac.classpath.asPath]}
-        }
-      })
-  }
+tasks.withType(JavaCompile).configureEach { JavaCompile jc ->
+  setJavaVersion(jc, 11)
+  // read up classpath lazily to avoid early locking of gradle settings
+  jc.options.compilerArgumentProviders.add(new CommandLineArgumentProvider() {
+      @Override
+      Iterable<String> asArguments() {
+        { return ['--module-path', jc.classpath.asPath]}
+      }
+    })
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -22,13 +22,10 @@ dependencies {
   implementation project(':dd-smoke-tests:iast-util:iast-util-11')
 }
 
-project.tasks.withType(AbstractCompile).configureEach {
+tasks.named("compileJava", JavaCompile).configure {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
-  if (it instanceof JavaCompile) {
-    it.options.release.set(11)
-  }
 }
 
 forbiddenApisMain {

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -22,13 +22,10 @@ dependencies {
   implementation project(':dd-smoke-tests:iast-util:iast-util-17')
 }
 
-project.tasks.withType(AbstractCompile).configureEach {
+tasks.named("compileJava", JavaCompile).configure {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
-  if (it instanceof JavaCompile) {
-    it.options.release.set(17)
-  }
 }
 
 forbiddenApisMain {

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -264,18 +264,27 @@ if (project.hasProperty("removeJarVersionNumbers") && removeJarVersionNumbers) {
 }
 
 ext.setJavaVersion = (it, javaVersionInteger) -> {
-  AbstractCompile ac = (AbstractCompile) it
   Provider<JavaCompiler> compiler = javaToolchains.compilerFor {
     languageVersion = JavaLanguageVersion.of(javaVersionInteger)
   }
+  Provider<JavaLauncher> launcher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(javaVersionInteger)
+  }
   try {
-    ac.configure {
-      options.fork = true
-      if (ac.hasProperty('javaCompiler')) {
-        javaCompiler = compiler
-      } else {
-        options.forkOptions.javaHome = compiler.get().metadata.installationPath.asFile
+    if (it instanceof JavaCompile) {
+      JavaCompile jc = (JavaCompile) it
+      jc.javaCompiler = compiler
+      if (javaVersionInteger == 8) {
+        jc.options.release = null
       }
+    } else if (it instanceof GroovyCompile) {
+      GroovyCompile gc = (GroovyCompile) it
+      gc.javaLauncher = launcher
+    } else if (it instanceof ScalaCompile) {
+      ScalaCompile sc = (ScalaCompile) it
+      sc.javaLauncher = launcher
+    } else {
+      throw new GradleException("Unsupported compile type: ${it.getClass()}")
     }
   } catch (NoSuchElementException ignored) {
     throw new GradleException("Unable to find compiler for Java $javaVersionInteger. Have you set JAVA_${javaVersionInteger}_HOME?")


### PR DESCRIPTION
# What Does This Do
Modify `setJavaVersion` to support JavaCompile, GroovyCompile and ScalaCompile. The later two were already supported, but in a non-stanard way. They did set `options.forkOptions.javaHome` to the desired version, while they kept `javaLauncher` untouched. While this worked in practice, it makes the result confusing when debugging, as `javaLauncher` will correspond to a JDK other than the effective one.

# Motivation
Part of a series of changes to use JDK 17 to run gradle.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMJAVA-1342](https://datadoghq.atlassian.net/browse/APMJAVA-1342)
<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1342]: https://datadoghq.atlassian.net/browse/APMJAVA-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ