### PR TITLE
don't override route with / in vertx instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
@@ -7,6 +7,7 @@ import static datadog.trace.instrumentation.vertx_3_4.server.RouteHandlerWrapper
 import static datadog.trace.instrumentation.vertx_3_4.server.VertxDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -29,7 +30,10 @@ public class EndHandlerWrapper implements Handler<Void> {
         actual.handle(event);
       }
     } finally {
-      if (path != null && parentSpan != null) {
+      if (path != null
+          && parentSpan != null
+          // do not override route with a "/" if it's already set (it's probably more meaningful)
+          && !(path.equals("/") && parentSpan.getTag(Tags.HTTP_ROUTE) != null)) {
         HTTP_RESOURCE_DECORATOR.withRoute(
             parentSpan, routingContext.request().rawMethod(), path, true);
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
@@ -7,6 +7,7 @@ import static datadog.trace.instrumentation.vertx_4_0.server.RouteHandlerWrapper
 import static datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -29,7 +30,10 @@ public class EndHandlerWrapper implements Handler<Void> {
         actual.handle(event);
       }
     } finally {
-      if (path != null && parentSpan != null) {
+      if (path != null
+          && parentSpan != null
+          // do not override route with a "/" if it's already set (it's probably more meaningful)
+          && !(path.equals("/") && parentSpan.getTag(Tags.HTTP_ROUTE) != null)) {
         HTTP_RESOURCE_DECORATOR.withRoute(
             parentSpan, routingContext.request().method().name(), path, true);
       }


### PR DESCRIPTION
# What Does This Do

prevent vertx instrumentation from overriding http route if it has already been set by an other instrumentation AND it was going to set the route to `/`, in which case we know we're not going to do better than whatever is already there.

TODO: add a test

# Motivation

customer report

# Additional Notes

adding a unit test looks... not easy

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-15882]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-15882]: https://datadoghq.atlassian.net/browse/APMS-15882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ