### PR TITLE
Optimized allocations for collection filter functions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -182,12 +182,14 @@ public class CapturedContext implements ValueReferenceResolver {
     return new CapturedContext(this, extensions);
   }
 
-  public void removeExtension(String name) {
-    extensions.remove(name);
+  @Override
+  public void addExtension(String name, Object value) {
+    extensions.put(name, value);
   }
 
-  private void addExtension(String name, Object value) {
-    extensions.put(name, value);
+  @Override
+  public void removeExtension(String name) {
+    extensions.remove(name);
   }
 
   public void addArguments(CapturedValue[] values) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
@@ -8,6 +8,10 @@ public interface ValueReferenceResolver {
 
   Object getMember(Object target, String name);
 
+  default void addExtension(String name, Object value) {}
+
+  default void removeExtension(String name) {}
+
   default ValueReferenceResolver withExtensions(Map<String, Object> extensions) {
     return this;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
@@ -14,9 +14,6 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.SetValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -43,15 +40,17 @@ public final class HasAnyExpression extends MatchingExpression {
         return Boolean.FALSE;
       }
       int len = collection.count();
-      for (int i = 0; i < len; i++) {
-        Value<?> val = collection.get(i);
-        if (filterPredicateExpression.evaluate(
-            valueRefResolver.withExtensions(
-                Collections.singletonMap(ValueReferences.ITERATOR_EXTENSION_NAME, val)))) {
-          return Boolean.TRUE;
+      try {
+        for (int i = 0; i < len; i++) {
+          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, collection.get(i));
+          if (filterPredicateExpression.evaluate(valueRefResolver)) {
+            return Boolean.TRUE;
+          }
         }
+        return Boolean.FALSE;
+      } finally {
+        valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
       }
-      return Boolean.FALSE;
     }
     if (value instanceof MapValue) {
       MapValue map = (MapValue) value;
@@ -59,19 +58,23 @@ public final class HasAnyExpression extends MatchingExpression {
       if (map.isEmpty()) {
         return Boolean.FALSE;
       }
-      for (Value<?> key : map.getKeys()) {
-        Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
-        Map<String, Object> valueRefExtensions = new HashMap<>();
-        valueRefExtensions.put(ValueReferences.KEY_EXTENSION_NAME, key);
-        valueRefExtensions.put(ValueReferences.VALUE_EXTENSION_NAME, val);
-        valueRefExtensions.put(
-            ValueReferences.ITERATOR_EXTENSION_NAME, new MapValue.Entry(key, val));
-        if (filterPredicateExpression.evaluate(
-            valueRefResolver.withExtensions(valueRefExtensions))) {
-          return Boolean.TRUE;
+      try {
+        for (Value<?> key : map.getKeys()) {
+          Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
+          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, key);
+          valueRefResolver.addExtension(ValueReferences.VALUE_EXTENSION_NAME, val);
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, new MapValue.Entry(key, val));
+          if (filterPredicateExpression.evaluate(valueRefResolver)) {
+            return Boolean.TRUE;
+          }
         }
+        return Boolean.FALSE;
+      } finally {
+        valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
+        valueRefResolver.removeExtension(ValueReferences.KEY_EXTENSION_NAME);
+        valueRefResolver.removeExtension(ValueReferences.VALUE_EXTENSION_NAME);
       }
-      return Boolean.FALSE;
     }
     if (value instanceof SetValue) {
       SetValue set = (SetValue) value;
@@ -79,15 +82,17 @@ public final class HasAnyExpression extends MatchingExpression {
       if (set.isEmpty()) {
         return Boolean.FALSE;
       }
-      for (Object val : setHolder) {
-        if (filterPredicateExpression.evaluate(
-            valueRefResolver.withExtensions(
-                Collections.singletonMap(
-                    ValueReferences.ITERATOR_EXTENSION_NAME, Value.of(val))))) {
-          return Boolean.TRUE;
+      try {
+        for (Object val : setHolder) {
+          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, Value.of(val));
+          if (filterPredicateExpression.evaluate(valueRefResolver)) {
+            return Boolean.TRUE;
+          }
         }
+        return Boolean.FALSE;
+      } finally {
+        valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
       }
-      return Boolean.FALSE;
     }
     throw new EvaluationException(
         "Unsupported collection class: " + value.getValue().getClass().getTypeName(), print(this));


### PR DESCRIPTION
# What Does This Do
We were allocating some unnecessary objects for each item in the collection we attempt to filter with any, all and filter expression. introduced withExtension/removeExtension method to reduce those allocations

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3958]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3958]: https://datadoghq.atlassian.net/browse/DEBUG-3958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ