### PR TITLE
Stable Config: make Selector.matches field optional

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/stableconfig/Selector.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/stableconfig/Selector.java
@@ -21,7 +21,9 @@ public final class Selector {
     Map map = (Map) yaml;
     origin = (String) map.get("origin");
     key = (String) map.get("key");
-    matches = Collections.unmodifiableList((List<String>) map.get("matches"));
+    List<String> rawMatches = (List<String>) map.get("matches");
+    matches =
+        rawMatches != null ? Collections.unmodifiableList(rawMatches) : Collections.emptyList();
     operator = (String) map.get("operator");
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigParserTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigParserTest.groovy
@@ -42,6 +42,12 @@ apm_configuration_rules:
       matches: ["mysvc"]
     configuration:
       KEY_FOUR: "ignored"
+  - selectors:
+    - origin: process_arguments
+      key: "-Darg1"
+      operator: exists
+    configuration:
+      KEY_FIVE: "ignored"
 """
     Files.write(filePath, yaml.getBytes())
     StableConfigSource.StableConfig cfg = StableConfigParser.parse(filePath.toString())


### PR DESCRIPTION
# What Does This Do
Modifies stableconfig yaml parsing to account for Selectors without a `matches` entry. 

# Motivation
Stableconfig yaml parsing was modified since the v1.49.0 release in this [PR](https://github.com/DataDog/dd-trace-java/pull/8790). With the latest dev version, I encountered null ptr exception while testing the following **valid** file:
```
apm_configuration_rules:
  - selectors:
    - origin: process_arguments
       key: "-Darg1"
       operator: exists
  configuration:
    SOME_KEY: "value"
```
See: https://github.com/DataDog/system-tests/actions/runs/15278035597/job/42969611110?pr=4333
```
[dd.trace 2025-05-27 14:34:32:780 +0000] [main] WARN datadog.trace.bootstrap.config.provider.StableConfigSource - Encountered the following exception when attempting to read stable configuration file at path: /etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml, dropping configs.
java.lang.NullPointerException: Cannot invoke "java.util.List.getClass()" because "list" is null
	at java.base/java.util.Collections.unmodifiableList(Collections.java:1473)
	at datadog.trace.bootstrap.config.provider.stableconfig.Selector.<init>(Selector.java:24)
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
