### PR TITLE
Fixed build logic for dd-java-agent to correctly handle classes compiled with Java 6.

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -29,7 +29,6 @@ compileMain_java6Java.configure {
   setJavaVersion(it, 8)
   sourceCompatibility = JavaVersion.VERSION_1_6
   targetCompatibility = JavaVersion.VERSION_1_6
-  destinationDirectory = layout.buildDirectory.dir("classes/java/main")
 }
 
 tasks.compileJava.dependsOn compileMain_java6Java
@@ -51,6 +50,9 @@ ext.generalShadowJarConfig = {
   mergeServiceFiles()
 
   duplicatesStrategy = DuplicatesStrategy.FAIL
+
+  // Include AgentPreCheck compiled with Java 6.
+  from sourceSets.main_java6.output
 
   // Remove some cruft from the final jar.
   // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is


### PR DESCRIPTION
# What Does This Do
Fixed build logic for dd-java-agent to correctly handle classes compiled with Java 6.

# Motivation
Gradle's caching logic did not correctly handle the previous implementation.

# Additional Notes
To test, just execute 2 times without changing any in sources:
```
./gradlew clean assemble
java -javaagent:dd-java-agent/build/libs/dd-java-agent-1.50.0-SNAPSHOT.jar -version
```
Previous implementation worked for the first run and failed with `Exception in thread "main" java.lang.ClassNotFoundException: datadog.trace.bootstrap.AgentPreCheck` on second run.
Gradle's caching logic did not copy `AgentPreCheck` class from cache.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
