### PR TITLE
Use CACHE_TYPE to mark tests

### DIFF
--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 SERVICE_NAME="dd-trace-java"
-PIPELINE_STAGE=$1
+CACHE_TYPE=$1
 TEST_JVM=$2
 
 # JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
@@ -23,7 +23,7 @@ junit_upload() {
     DD_API_KEY=$1 \
         datadog-ci junit upload --service $SERVICE_NAME \
         --logs \
-        --tags "test.traits:{\"marker\":[\"$PIPELINE_STAGE\"]}" \
+        --tags "test.traits:{\"category\":[\"$CACHE_TYPE\"]}" \
         --tags "runtime.name:$(java_prop java.runtime.name)" \
         --tags "runtime.vendor:$(java_prop java.vendor)" \
         --tags "runtime.version:$(java_prop java.version)" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -406,7 +406,7 @@ muzzle-dep-report:
     - .circleci/collect_reports.sh
     - if [ "$PROFILE_TESTS" == "true" ]; then .circleci/collect_profiles.sh; fi
     - .circleci/collect_results.sh
-    - .circleci/upload_ciapp.sh tests $testJvm
+    - .circleci/upload_ciapp.sh $CACHE_TYPE $testJvm
     - gitlab_section_end "collect-reports"
     - URL_ENCODED_JOB_NAME=$(jq -rn --arg x "$CI_JOB_NAME" '$x|@uri')
     - echo -e "${TEXT_BOLD}${TEXT_YELLOW}See test results in Datadog:${TEXT_CLEAR} https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A${CI_PIPELINE_ID}%20%40ci.job.name%3A%22${URL_ENCODED_JOB_NAME}%22"


### PR DESCRIPTION
# What Does This Do
Use `CACHE_TYPE` to mark tests. The previous mechanism marked all tests with `marker:tests` and was useless since the migration to gitlab. With `CACHE_TYPE`, tests are broadly grouped in:

* `lib`
* `base`
* `profiling`
* `inst`
* `latestdep`
* `smoke`

Using `category` instead of `marker` to follow the convention of other tests.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
