### PR TITLE
Update BsonScrubber34.java

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber34.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber34.java
@@ -65,6 +65,8 @@ public class BsonScrubber34 implements BsonWriter, BsonScrubber {
         case "find":
         case "count":
         case "create":
+        case "findAndModify":
+        case "commit":
           obfuscate = false;
           break;
         default:


### PR DESCRIPTION
[inst][mongodb] Disable obfuscation for findAndModify and commit commands

# What Does This Do
`findAndModify` and `commit` commands in MongoDB are currently having their collection names obfuscated, unlike other commands like `find`, `count`, and `create`. This change disables obfuscation for these commands to maintain consistency in collection name visibility across all MongoDB operations.

# Motivation
This improvement will help users better monitor and debug their MongoDB operations by ensuring collection names are visible in traces for all command types, making the behavior consistent across different MongoDB operations.

# Additional Notes
The change modifies the `BsonScrubber34.java` file to add `findAndModify` and `commit` to the list of commands that should not be obfuscated.

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [x] Labels to add: `type:enhancement` and `inst:mongodb`
- [x] No linking keywords used that would auto-close issues
- [ ] No CODEOWNERS file update needed (no file additions/moves/deletions)
- [ ] No documentation update needed (no new configuration changes)