### PR TITLE
Fix OT packaging for exception replay

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     // why all communication pulls in remote config is beyond me...
     exclude(group: 'com.datadoghq', module: 'remote-config-core')
   }
+  // exception replay
+  implementation(project(':dd-java-agent:agent-debugger:debugger-bootstrap'))
 
   // OpenTracing
   api group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'


### PR DESCRIPTION

# What Does This Do
add dependency on debugger-bootstrap to include DebuggerContext class in the OT jar as it is used in DDSpan::addThrowable when checking for exception replay is enabled

# Motivation

#8910 

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
