### PR TITLE
Use resolved address for peer.hostname when available without hitting the cache

### DIFF
--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -65,3 +65,11 @@ jmh {
   jmhVersion = '1.32'
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+project.afterEvaluate {
+  tasks.withType(Test).configureEach {
+    if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
+      jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED'] // for HostNameResolverForkedTest
+    }
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -2,13 +2,12 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.trace.api.cache.RadixTreeCache.PORTS;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
+import static datadog.trace.bootstrap.instrumentation.java.net.HostNameResolver.hostName;
 
 import datadog.context.ContextScope;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
-import datadog.trace.api.cache.DDCache;
-import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -39,8 +38,6 @@ public abstract class BaseDecorator {
             }
           },
           Functions.PrefixJoin.of("."));
-
-  private static final DDCache<String, String> HOSTNAME_CACHE = DDCaches.newFixedSizeCache(64);
 
   protected final boolean traceAnalyticsEnabled;
   protected final Double traceAnalyticsSampleRate;
@@ -199,12 +196,5 @@ public abstract class BaseDecorator {
   public CharSequence className(final Class<?> clazz) {
     String simpleName = clazz.getSimpleName();
     return simpleName.isEmpty() ? CLASS_NAMES.getClassName(clazz) : simpleName;
-  }
-
-  private static String hostName(InetAddress remoteAddress, String ip) {
-    if (null != ip) {
-      return HOSTNAME_CACHE.computeIfAbsent(ip, _ip -> remoteAddress.getHostName());
-    }
-    return remoteAddress.getHostName();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolver.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolver.java
@@ -1,0 +1,72 @@
+package datadog.trace.bootstrap.instrumentation.java.net;
+
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.util.MethodHandles;
+import java.lang.invoke.MethodHandle;
+import java.net.InetAddress;
+
+public final class HostNameResolver {
+  private static final MethodHandle HOLDER_GET;
+  private static final MethodHandle HOSTNAME_GET;
+
+  private static final DDCache<String, String> HOSTNAME_CACHE = DDCaches.newFixedSizeCache(64);
+
+  static {
+    MethodHandle holderTmp = null, hostnameTmp = null;
+    try {
+      final ClassLoader cl = HostNameResolver.class.getClassLoader();
+      final MethodHandles methodHandles = new MethodHandles(cl);
+
+      final Class<?> holderClass =
+          Class.forName("java.net.InetAddress$InetAddressHolder", false, cl);
+      holderTmp = methodHandles.method(InetAddress.class, "holder");
+      if (holderTmp != null) {
+        hostnameTmp = methodHandles.method(holderClass, "getHostName");
+      }
+    } catch (Throwable ignored) {
+      holderTmp = null;
+    } finally {
+      if (holderTmp != null && hostnameTmp != null) {
+        HOLDER_GET = holderTmp;
+        HOSTNAME_GET = hostnameTmp;
+      } else {
+        HOLDER_GET = null;
+        HOSTNAME_GET = null;
+      }
+    }
+  }
+
+  private HostNameResolver() {}
+
+  static String getAlreadyResolvedHostName(InetAddress address) {
+    if (HOLDER_GET == null) {
+      return null;
+    }
+    try {
+      final Object holder = HOLDER_GET.invoke(address);
+      return (String) HOSTNAME_GET.invoke(holder);
+    } catch (final Throwable ignored) {
+    }
+    return null;
+  }
+
+  private static String fromCache(InetAddress remoteAddress, String ip) {
+    final String alreadyResolved = HostNameResolver.getAlreadyResolvedHostName(remoteAddress);
+    if (alreadyResolved != null) {
+      return alreadyResolved;
+    }
+    if (null != ip) {
+      return HOSTNAME_CACHE.computeIfAbsent(ip, _ip -> remoteAddress.getHostName());
+    }
+    return remoteAddress.getHostName();
+  }
+
+  public static String hostName(InetAddress address, String ip) {
+    final String alreadyResolved = getAlreadyResolvedHostName(address);
+    if (alreadyResolved != null) {
+      return alreadyResolved;
+    }
+    return fromCache(address, ip);
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolver.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolver.java
@@ -52,10 +52,6 @@ public final class HostNameResolver {
   }
 
   private static String fromCache(InetAddress remoteAddress, String ip) {
-    final String alreadyResolved = HostNameResolver.getAlreadyResolvedHostName(remoteAddress);
-    if (alreadyResolved != null) {
-      return alreadyResolved;
-    }
     if (null != ip) {
       return HOSTNAME_CACHE.computeIfAbsent(ip, _ip -> remoteAddress.getHostName());
     }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverForkedTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverForkedTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.instrumentation.java.net
 
 import datadog.trace.test.util.DDSpecification
 
-class HostNameResolverTest extends DDSpecification {
+class HostNameResolverForkedTest extends DDSpecification {
   def "should directly get the hostname for already resolved address #address"() {
     given:
     def host = HostNameResolver.getAlreadyResolvedHostName(address)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverForkedTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverForkedTest.groovy
@@ -26,20 +26,18 @@ class HostNameResolverForkedTest extends DDSpecification {
   }
 
   def "should use the cache for unresolved addresses"() {
-    setup:
-    def inet1 = Mock(InetAddress)
-    def inet2 = Mock(InetAddress)
+    given:
+    def inet1 = new Inet4Address(null, InetAddress.getLocalHost().getAddress())
+    def inet2 = new Inet4Address(null, 0) // this will fail if a resolution will happen
     when:
     def address = new InetSocketAddress(inet1, 666)
     def host = HostNameResolver.hostName(address.getAddress(), "127.0.0.1")
     then:
-    host == "somehost"
-    1 * inet1.getHostName() >> "somehost"
+    host != null
     when:
     address = new InetSocketAddress(inet2, 666)
-    host = HostNameResolver.hostName(address.getAddress(), "127.0.0.1")
+    def host2 = HostNameResolver.hostName(address.getAddress(), "127.0.0.1")
     then:
-    0 * inet2.getHostName()
-    host == "somehost"
+    host == host2
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/java/net/HostNameResolverTest.groovy
@@ -1,0 +1,45 @@
+package datadog.trace.bootstrap.instrumentation.java.net
+
+import datadog.trace.test.util.DDSpecification
+
+class HostNameResolverTest extends DDSpecification {
+  def "should directly get the hostname for already resolved address #address"() {
+    given:
+    def host = HostNameResolver.getAlreadyResolvedHostName(address)
+    expect:
+    host == expected
+    where:
+    address                                                           | expected
+    new Inet4Address("test", InetAddress.getLocalHost().getAddress()) | "test"
+    new Inet6Address("test", InetAddress.getLocalHost().getAddress()) | "test"
+  }
+
+  def "should return null when directly get the address for unresolved #address"() {
+    given:
+    def host = HostNameResolver.getAlreadyResolvedHostName(address)
+    expect:
+    host == null
+    where:
+    address                                                           | _
+    InetAddress.getByAddress(InetAddress.getLocalHost().getAddress()) | _
+    new Inet6Address(null, InetAddress.getLocalHost().getAddress())   | _
+  }
+
+  def "should use the cache for unresolved addresses"() {
+    setup:
+    def inet1 = Mock(InetAddress)
+    def inet2 = Mock(InetAddress)
+    when:
+    def address = new InetSocketAddress(inet1, 666)
+    def host = HostNameResolver.hostName(address.getAddress(), "127.0.0.1")
+    then:
+    host == "somehost"
+    1 * inet1.getHostName() >> "somehost"
+    when:
+    address = new InetSocketAddress(inet2, 666)
+    host = HostNameResolver.hostName(address.getAddress(), "127.0.0.1")
+    then:
+    0 * inet2.getHostName()
+    host == "somehost"
+  }
+}


### PR DESCRIPTION
# What Does This Do

It may happen to have different hostnames pointing to the same IP. In this case, our hostname cache will hit the first resolved hostname giving a bad result.
In the case we have an already resolved hostname, this PR will avoid using the cache by using introspection to gather the already known hostname on the internal holder.

Note: as an additional mechanisms,  if this is not enough, we can also compare the host provided by `http.url` with the one extracted from the inet address and force a resolution if not matching. This is not implemented here
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
