### PR TITLE
Support attaching tags to telemetry logs

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -36,6 +36,7 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
           new LogMessage()
               .message(rawLogMsg.message)
               .tracerTime(rawLogMsg.timestamp)
+              .tags(rawLogMsg.tags)
               .count(rawLogMsg.count);
 
       if (rawLogMsg.logLevel != null) {

--- a/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
@@ -21,6 +21,21 @@ class LogPeriodicActionTest extends DDSpecification {
     LogCollector.get().drain()
   }
 
+  void 'log with tags'() {
+    LogMessage logMessage
+
+    when:
+    LogCollector.get().addLogMessage('ERROR', "test", null, 'tag1:value1,tag2:value2')
+    periodicAction.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addLogMessage(_) >> { args -> logMessage = args[0] }
+    0 * _
+    logMessage.getLevel() == LogMessageLevel.ERROR
+    logMessage.getMessage() == 'test'
+    logMessage.getTags() == 'tag1:value1,tag2:value2'
+  }
+
   void 'log with datadog throwable'() {
     LogMessage logMessage
 


### PR DESCRIPTION
# What Does This Do
Add support for `LogCollector` to create telemetry logs with tags. Tags are defined as a string, a comma-separated list, e.g. `tag1:value1,tag2:value2`.

# Motivation
We have new use cases in AppSec to send telemetry logs with more structured data in tags. This functionality was already in our telemetry system, but not exposed in `internal-api`.

This is still not exposed via regular SLF4J logging integration. For the time being, if one needs this, they'll have to use the telemetry-specific interface in this PR.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
