### PR TITLE
Revert "SSI smoke tests should only run as part of nightly"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -557,9 +557,7 @@ test_smoke:
 
 test_ssi_smoke:
   extends: .test_job
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: on_success
+  rules: *master_only
   variables:
     GRADLE_TARGET: "stageMainDist :smokeTest"
     CACHE_TYPE: "smoke"


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#8914

We cannot proceed to a release without validating the smoke tests.

Related to #8925