### PR TITLE
Revert "Run tests on all jdks as part of nightly instead of every master pipeline"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -387,7 +387,7 @@ muzzle-dep-report:
       when: on_success
     - if: $NON_DEFAULT_JVMS == "true"
       when: on_success
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_BRANCH == "master"
       when: on_success
   script:
     - >


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#8900

We cannot proceed to a release without validating the smoke tests.