### PR TITLE
🍒 8872 - use java 17 on version 4.0.0 onwards

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -10,8 +10,13 @@ muzzle {
   pass {
     group = "org.apache.spark"
     module = "spark-sql_$scalaVersion"
-    versions = "[$sparkVersion,)"
-    assertInverse = true
+    versions = "[$sparkVersion,4.0.0)"
+  }
+  pass {
+    group = "org.apache.spark"
+    module = "spark-sql_$scalaVersion"
+    versions = "[4.0.0,)"
+    javaVersion = 17
   }
 }
 


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-java/pull/8872 to release/v1.49.x