### PR TITLE
Update test source file reporting to match codeowners file

### DIFF
--- a/.circleci/collect_results.sh
+++ b/.circleci/collect_results.sh
@@ -35,7 +35,7 @@ function get_source_file () {
         fi
       done
     done < <(grep -rl "class $class" "$file_path")
-    file_path="$common_root"
+    file_path="/$common_root"
   fi
 }
 


### PR DESCRIPTION
# What Does This Do

Add initial `\` to test source file paths in order to match changes made to the CODEOWNERS file in #8830 

# Motivation

After updating the CODEOWNERS file in #8830, our reported test case source file paths no longer matched. This resulted in a loss of codeowner data (see [the past week's reports](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1748552349906&end=1749157149906&paused=false) vs [a month ago's reports](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&index=citest&start=1745812800000&end=1746503999999&paused=true)).

# Additional Notes

We can check this change by looking at the test source files [here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40git.branch%3Asarahchen6%2Ffix-codeowner-retrieval&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1748553596499&end=1749158396499&paused=false).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
