### PR TITLE
Fix flaky Gradle Daemon instrumentation smoke test

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -50,7 +50,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
 
     where:
     gradleVersion | projectName                                        | successExpected | expectedTraces | expectedCoverages
-    "3.0"         | "test-succeed-old-gradle"                          | true            | 5              | 1
+    "3.5"         | "test-succeed-old-gradle"                          | true            | 5              | 1
     "7.6.4"       | "test-succeed-legacy-instrumentation"              | true            | 5              | 1
     "7.6.4"       | "test-succeed-multi-module-legacy-instrumentation" | true            | 7              | 2
     "7.6.4"       | "test-succeed-multi-forks-legacy-instrumentation"  | true            | 6              | 2

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -244,7 +244,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
       .withProjectDir(projectFolder.toFile())
       .withGradleVersion(gradleVersion)
       .withArguments(arguments)
-      .withEnvironment(Collections.singletonMap("GRADLE_VERSION", gradleVersion))
+      .withEnvironment(["GRADLE_VERSION": gradleVersion])
       .forwardOutput()
 
     println "${new Date()}: $specificationContext.currentIteration.displayName - Starting Gradle run"

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -244,6 +244,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
       .withProjectDir(projectFolder.toFile())
       .withGradleVersion(gradleVersion)
       .withArguments(arguments)
+      .withEnvironment(Collections.singletonMap("GRADLE_VERSION", gradleVersion))
       .forwardOutput()
 
     println "${new Date()}: $specificationContext.currentIteration.displayName - Starting Gradle run"

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/coverages.ftl
@@ -1,6 +1,6 @@
 [ {
   "files" : [ {
-    "bitmap" : "AAAAx98=",
+    "bitmap" : "AAAAx+EN",
     "filename" : "src/test/java/datadog/smoke/HelloPluginFunctionalTest.java"
   } ],
   "span_id" : ${content_span_id_4},

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/events.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/events.ftl
@@ -215,7 +215,7 @@
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
-      "test.source.end" : 40,
+      "test.source.end" : 44,
       "test.source.start" : 16
     },
     "name" : "junit5.test_suite",
@@ -273,7 +273,7 @@
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
-      "test.source.end" : 39,
+      "test.source.end" : 43,
       "test.source.start" : 30
     },
     "name" : "junit5.test",

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
@@ -30,7 +30,11 @@ class HelloPluginFunctionalTest {
     BuildResult result = GradleRunner.create()
         .withProjectDir(testProjectDir.toFile())
         .withPluginClasspath()
-        .withGradleVersion("8.5")
+        // Use the same Gradle version as of the actual smoke test that builds this project.
+        // This is to ensure Gradle is already downloaded and available in the environment.
+        // Gradle Test Kit can download a Gradle distribution by itself,
+        // but sometimes these downloads fail, making the test flaky.
+        .withGradleVersion(System.getenv("GRADLE_VERSION"))
         .withArguments("hello", "--stacktrace")
         .forwardOutput()
         .build();


### PR DESCRIPTION
# What Does This Do

Fixes flaky Gradle Daemon instrumentation test: `test-succeed-gradle-plugin-test`.

# Motivation

This test case is different from the others because the _instrumented project_ builds a Gradle plugin and uses Gradle Test Kit to test it.
There was an [issue](https://github.com/DataDog/dd-trace-java/pull/8465) where our Gradle Launcher instrumentation interfered with Gradle Test Kit, and this test case was added to ensure the issue does not reappear.

The test inside the instrumented project runs a Gradle build. So we have three nested Gradle builds:
- the "outermost" build of the tracer (run with whatever Gradle version is used to build the tracer at the moment)
- the build that is run by smoke test (run with Gradle Test Kit and uses Gradle version that is specified in the smoke test case)
- the "innermost" build that is triggered as part of running the tests in the sample project (run with Gradle Test Kit and uses Gradle version that is specified in the sample project's testcase)

If the Gradle version used by Gradle Test Kit is not available locally, the test kit downloads it.
These Gradle downloads sometimes fail.
In the case of this flaky test the download that fails is of the Gradle distribution needed to run the "innermost" build.

In the smoke test itself ("middle" nested build) we solve it by having a custom download logic with extended timeout and retries. 

The fix is to update the test inside the sample project to use the same Gradle version that is used to run the project itself (Gradle version is propagated from the smoke test with an env var).
As that Gradle distribution is already available locally, the test will not try to redownload it.

N.B. All downloads are stored under `~/.gradle/wrapper/`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
