### PR TITLE
Disable Debugger tracer smoke tests for j9

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -27,6 +27,7 @@ import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -49,6 +50,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
   @ParameterizedTest(name = "Process tags enabled ''{0}''")
   @ValueSource(booleans = {true, false})
   @DisplayName("testTracer")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testTracer(boolean processTagsEnabled) throws Exception {
     LogProbe logProbe =
         LogProbe.builder()
@@ -79,6 +81,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @DisplayName("testTracerDynamicLog")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testTracerDynamicLog() throws Exception {
     LogProbe logProbe =
         LogProbe.builder()
@@ -101,6 +104,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @DisplayName("testTracerSameMethod")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testTracerSameMethod() throws Exception {
     LogProbe logProbe =
         LogProbe.builder()
@@ -120,6 +124,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @DisplayName("testTracerLineSnapshotProbe")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testTracerLineSnapshotProbe() throws Exception {
     LogProbe logProbe =
         LogProbe.builder()
@@ -139,6 +144,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @DisplayName("testTracerLineDynamicLogProbe")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testTracerLineDynamicLogProbe() throws Exception {
     final String LOG_TEMPLATE = "processWithArg {argInt}";
     LogProbe logProbe =


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
