### PR TITLE
Remove appsec_no_iast benchmark scenarios

### DIFF
--- a/benchmark/load/petclinic/benchmark.json
+++ b/benchmark/load/petclinic/benchmark.json
@@ -30,12 +30,6 @@
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true"
       }
     },
-    "appsec_no_iast": {
-      "env": {
-        "VARIANT": "appsec_no_iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true -Ddd.iast.enabled=false"
-      }
-    },
     "iast": {
       "env": {
         "VARIANT": "iast",

--- a/benchmark/startup/petclinic/benchmark.json
+++ b/benchmark/startup/petclinic/benchmark.json
@@ -24,12 +24,6 @@
         "JAVA_OPTS": "-Ddd.appsec.enabled=true"
       }
     },
-    "appsec_no_iast": {
-      "env": {
-        "VARIANT": "appsec",
-        "JAVA_OPTS": "-Ddd.appsec.enabled=true -Ddd.iast.enabled=false"
-      }
-    },
     "iast": {
       "env": {
         "VARIANT": "iast",


### PR DESCRIPTION
# What Does This Do
This scenario corresponds to a combination of AppSec enabled explicitly and IAST disabled explicitly. It is an uncommon scenario used back in the day to validate some features, but of little use today. And slightly confusing, because having appsec and appsec_no_iast misleads into thinking that "appsec" has IAST enabled. Let's make some room for useful scenarios.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
