### PR TITLE
Add new config for debugger upload interval

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -73,6 +73,7 @@ public class DebuggerSink {
     } else {
       currentLowRateFlushInterval = uploadFlushInterval;
     }
+    LOGGER.debug("Scheduling low rate debugger sink flush to {}ms", currentLowRateFlushInterval);
     lowRateScheduled =
         lowRateScheduler.scheduleAtFixedRate(
             this::lowRateFlush, this, 0, currentLowRateFlushInterval, TimeUnit.MILLISECONDS);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -10,6 +10,8 @@ public final class DebuggerConfig {
       "dynamic.instrumentation.upload.timeout";
   public static final String DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL =
       "dynamic.instrumentation.upload.flush.interval";
+  public static final String DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS =
+      "dynamic.instrumentation.upload.interval.seconds";
   public static final String DYNAMIC_INSTRUMENTATION_UPLOAD_BATCH_SIZE =
       "dynamic.instrumentation.upload.batch.size";
   public static final String DYNAMIC_INSTRUMENTATION_MAX_PAYLOAD_SIZE =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1673,10 +1673,19 @@ public class Config {
     dynamicInstrumentationUploadTimeout =
         configProvider.getInteger(
             DYNAMIC_INSTRUMENTATION_UPLOAD_TIMEOUT, DEFAULT_DYNAMIC_INSTRUMENTATION_UPLOAD_TIMEOUT);
-    dynamicInstrumentationUploadFlushInterval =
-        configProvider.getInteger(
-            DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL,
-            DEFAULT_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL);
+    if (configProvider.isSet(DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS)) {
+      dynamicInstrumentationUploadFlushInterval =
+          (int)
+              (configProvider.getFloat(
+                      DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS,
+                      DEFAULT_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL)
+                  * 1000);
+    } else {
+      dynamicInstrumentationUploadFlushInterval =
+          configProvider.getInteger(
+              DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL,
+              DEFAULT_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL);
+    }
     dynamicInstrumentationClassFileDumpEnabled =
         configProvider.getBoolean(
             DYNAMIC_INSTRUMENTATION_CLASSFILE_DUMP_ENABLED,

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -40,6 +40,7 @@ import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_PR
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_SNAPSHOT_URL
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_UPLOAD_BATCH_SIZE
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL
+import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_UPLOAD_TIMEOUT
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE
 import static datadog.trace.api.config.DebuggerConfig.EXCEPTION_REPLAY_ENABLED
@@ -253,7 +254,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(DYNAMIC_INSTRUMENTATION_ENABLED, "true")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_PROBE_FILE, "file location")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_UPLOAD_TIMEOUT, "10")
-    prop.setProperty(DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL, "1000")
+    prop.setProperty(DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS, "0.234")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_UPLOAD_BATCH_SIZE, "200")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_METRICS_ENABLED, "false")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_CLASSFILE_DUMP_ENABLED, "true")
@@ -349,7 +350,7 @@ class ConfigTest extends DDSpecification {
     config.getFinalDebuggerSnapshotUrl() == "http://somehost:123/debugger/v1/input"
     config.dynamicInstrumentationProbeFile == "file location"
     config.dynamicInstrumentationUploadTimeout == 10
-    config.dynamicInstrumentationUploadFlushInterval == 1000
+    config.dynamicInstrumentationUploadFlushInterval == 234
     config.dynamicInstrumentationUploadBatchSize == 200
     config.dynamicInstrumentationMetricsEnabled == false
     config.dynamicInstrumentationClassFileDumpEnabled == true


### PR DESCRIPTION
# What Does This Do
Add `dynamic.instrumentation.upoad.interval.seconds` config parameter that takes float in seconds

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4003]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
