### PR TITLE
Improve stability of InstrumenterUnloadTest

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/InstrumenterUnloadTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/InstrumenterUnloadTest.groovy
@@ -26,16 +26,26 @@ class InstrumenterUnloadTest extends Specification {
       , ["DD_API_KEY": API_KEY]
       , new PrintStream(testOutput))
 
-    int unloadCount = 0
+    boolean canaryUnloaded = false
+    int unloadedInstrumentationCount = 0
     new ByteArrayInputStream((testOutput.toByteArray())).eachLine {
       System.out.println(it)
-      if (it =~ /(?i)unload.* datadog.trace.instrumentation./) {
-        unloadCount++
+      if (it =~ /(?i)unload.*Canary/) {
+        canaryUnloaded = true
       }
+      if (it =~ /(?i)unload.* datadog.trace.instrumentation./) {
+        unloadedInstrumentationCount++
+      }
+    }
+
+    if (!canaryUnloaded) {
+      System.out.println("WARNING: Canary class was not unloaded!")
     }
 
     then:
     returnCode == 0
-    unloadCount > 0
+    // skip check if we couldn't even unload our Canary class, as that
+    // indicates full GC didn't happen enough to trigger any unloading
+    !canaryUnloaded || unloadedInstrumentationCount > 0
   }
 }

--- a/dd-java-agent/src/test/java/jvmbootstraptest/UnloadingChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/UnloadingChecker.java
@@ -1,13 +1,32 @@
 package jvmbootstraptest;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import datadog.trace.test.util.GCUtils;
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
 
 public class UnloadingChecker {
-  public static void main(final String[] args) {
-    try {
-      GCUtils.awaitGC();
-    } catch (InterruptedException e) {
-      e.printStackTrace();
+  static class Canary {}
+
+  public static void main(final String[] args) throws Exception {
+    ClassLoadingMXBean classLoadingMXBean = ManagementFactory.getClassLoadingMXBean();
+    long initialUnloadCount = classLoadingMXBean.getUnloadedClassCount();
+
+    // load an isolated class which we know can be unloaded after a full GC
+    new IsolatingClassLoader().loadClass("jvmbootstraptest.UnloadingChecker$Canary");
+
+    long waitNanos = MINUTES.toNanos(2);
+    long startNanos = System.nanoTime();
+
+    while (System.nanoTime() - startNanos < waitNanos) {
+      try {
+        GCUtils.awaitGC();
+      } catch (Throwable ignore) {
+      }
+      if (initialUnloadCount < classLoadingMXBean.getUnloadedClassCount()) {
+        break; // some class unloading has taken place, stop and check results
+      }
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Introduces a canary class which we use to detect when we've done enough to trigger class unloading. If we weren't able to trigger any class unloading then we effectively skip this test, because the results are inconclusive.

# Motivation

Hopefully less flakiness

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
