### PR TITLE
Always call System.gc() and System.runFinalization() at least once in `awaitGC`

### DIFF
--- a/utils/test-utils/src/main/java/datadog/trace/test/util/GCUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/GCUtils.java
@@ -22,6 +22,8 @@ public abstract class GCUtils {
 
   public static void awaitGC(final WeakReference<?> ref, final long duration, final TimeUnit unit)
       throws InterruptedException {
+    System.gc();
+    System.runFinalization();
     final long waitNanos = unit.toNanos(duration);
     final long start = System.nanoTime();
     while (System.nanoTime() - start < waitNanos) {


### PR DESCRIPTION
# Motivation

Just in case the reference passed in has already been cleared via a partial GC, this way we at least try to force a full GC at least once.

There are other improvements we could make, but I don't think we need to invest too much into this test method as it's only used in a very few places.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
