### PR TITLE
Update Gradle Daemon smoke tests to use Maven repository proxy when available

### DIFF
--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -18,6 +18,11 @@ test {
     events "passed", "skipped", "failed", "standardOut", "standardError"
   }
 
+  if (project.hasProperty("mavenRepositoryProxy")) {
+    // propagate proxy URL to tests, to then propagate it to nested Gradle builds
+    environment "MAVEN_REPOSITORY_PROXY", project.property("mavenRepositoryProxy")
+  }
+
   // overriding the default timeout of 9 minutes set in configure_tests.gradle,
   // as Gradle smoke tests might run for a longer duration
   timeout = Duration.of(15, ChronoUnit.MINUTES)

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -239,12 +239,19 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
   }
 
   private runGradle(String gradleVersion, List<String> arguments, boolean successExpected) {
+    def buildEnv = ["GRADLE_VERSION": gradleVersion]
+
+    def mavenRepositoryProxy = System.getenv("MAVEN_REPOSITORY_PROXY")
+    if (mavenRepositoryProxy != null) {
+      buildEnv += ["MAVEN_REPOSITORY_PROXY": System.getenv("MAVEN_REPOSITORY_PROXY")]
+    }
+
     GradleRunner gradleRunner = GradleRunner.create()
       .withTestKitDir(testKitFolder.toFile())
       .withProjectDir(projectFolder.toFile())
       .withGradleVersion(gradleVersion)
       .withArguments(arguments)
-      .withEnvironment(["GRADLE_VERSION": gradleVersion])
+      .withEnvironment(buildEnv)
       .forwardOutput()
 
     println "${new Date()}: $specificationContext.currentIteration.displayName - Starting Gradle run"

--- a/dd-smoke-tests/gradle/src/test/resources/test-corrupted-config-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-corrupted-config-legacy-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-corrupted-config-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-corrupted-config-new-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-failed-flaky-retries/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-failed-flaky-retries/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-failed-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-failed-legacy-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-failed-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-failed-new-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-skip-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-skip-legacy-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-skip-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-skip-new-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/build.gradleTest
@@ -14,6 +14,16 @@ gradlePlugin {
 
 repositories {
     mavenLocal()
+
+    def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+    if (proxyUrl) {
+      println "Using proxy repository: $proxyUrl"
+      maven {
+        url = proxyUrl
+        allowInsecureProtocol = true
+      }
+    }
+
     mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
@@ -8,7 +8,6 @@ repositories {
     println "Using proxy repository: $proxyUrl"
     maven {
       url = proxyUrl
-      allowInsecureProtocol = true
     }
   }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/build.gradleTest
@@ -3,6 +3,16 @@ apply plugin: 'jvm-test-suite'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-legacy-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-legacy-instrumentation/build.gradleTest
@@ -3,6 +3,16 @@ subprojects {
 
     repositories {
         mavenLocal()
+
+        def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+        if (proxyUrl) {
+          println "Using proxy repository: $proxyUrl"
+          maven {
+            url = proxyUrl
+            allowInsecureProtocol = true
+          }
+        }
+
         mavenCentral()
     }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-new-instrumentation/build.gradleTest
@@ -3,6 +3,16 @@ subprojects {
 
     repositories {
         mavenLocal()
+
+        def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+        if (proxyUrl) {
+          println "Using proxy repository: $proxyUrl"
+          maven {
+            url = proxyUrl
+            allowInsecureProtocol = true
+          }
+        }
+
         mavenCentral()
     }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-new-instrumentation/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/build.gradleTest
@@ -2,6 +2,16 @@ apply plugin: 'java'
 
 repositories {
   mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    println "Using proxy repository: $proxyUrl"
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
   mavenCentral()
 }
 

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/build.gradleTest
@@ -8,7 +8,6 @@ repositories {
     println "Using proxy repository: $proxyUrl"
     maven {
       url = proxyUrl
-      allowInsecureProtocol = true
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Updates Gradle Daemon smoke tests to use Maven repository proxy when available.

The proxy URL is retrieved from a Gradle project property, then propagated to the tests as an environment variable, and then propagated to the "nested" Gradle builds started by the tests, again as an environment variable.

The reason it is not propagated as a project property is that project property is a part of Gradle command, and Gradle command is reported as a span tag by the Test Optimization, which makes it a part of the test fixtures.
The proxy not always being present would make the test command (and the test fixtures) unstable.

# Motivation

Gradle Daemon smoke tests need to use caching Maven proxy, otherwise the nested Gradle builds downloading their artifacts (e.g. JUnit) can be rate-limited by Maven Central (which makes the tests flaky).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
