### PR TITLE
Update Maven smoke tests to use repository proxy

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -98,7 +98,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
 
     where:
     gradleVersion         | projectName                           | flakyTests | expectedOrder | eventsNumber
-    "5.1"                 | "test-succeed-junit-4-class-ordering" | [
+    "7.6.4"               | "test-succeed-junit-4-class-ordering" | [
       test("datadog.smoke.TestSucceedB", "test_succeed"),
       test("datadog.smoke.TestSucceedB", "test_succeed_another"),
       test("datadog.smoke.TestSucceedA", "test_succeed")

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-4-class-ordering/build.gradleTest
@@ -8,6 +8,7 @@ repositories {
     println "Using proxy repository: $proxyUrl"
     maven {
       url = proxyUrl
+      allowInsecureProtocol = true
     }
   }
 

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -20,4 +20,9 @@ jar {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
   jvmArgs "-Ddatadog.smoketest.maven.jar.path=${tasks.shadowJar.archiveFile.get()}"
+
+  if (project.hasProperty("mavenRepositoryProxy")) {
+    // propagate proxy URL to tests, to then propagate it to nested Gradle builds
+    environment "MAVEN_REPOSITORY_PROXY", project.property("mavenRepositoryProxy")
+  }
 }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -348,6 +348,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     command.addAll(jvmArguments(runWithAgent, setServiceName, additionalAgentArgs))
     command.addAll((String[]) ["-jar", mavenRunnerShadowJar])
     command.addAll(programArguments())
+    command.addAll(["-s", "${projectHome.toAbsolutePath()}/settings.xml".toString()])
     command.addAll(mvnCommand)
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
@@ -356,6 +357,11 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
     for (envVar in additionalEnvVars) {
       processBuilder.environment().put(envVar.key, envVar.value)
+    }
+
+    def mavenRepositoryProxy = System.getenv("MAVEN_REPOSITORY_PROXY")
+    if (mavenRepositoryProxy != null) {
+      processBuilder.environment().put("MAVEN_REPOSITORY_PROXY", mavenRepositoryProxy)
     }
 
     return processBuilder
@@ -370,6 +376,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     def arguments = [
       "-D${MavenWrapperMain.MVNW_VERBOSE}=true".toString(),
       "-Duser.dir=${projectHome.toAbsolutePath()}".toString(),
+      "-Dmaven.mainClass=org.apache.maven.cli.MavenCli".toString(),
       "-Dmaven.multiModuleProjectDirectory=${projectHome.toAbsolutePath()}".toString(),
     ]
     if (runWithAgent) {

--- a/dd-smoke-tests/maven/src/test/resources/test_failed_maven_run_flaky_retries/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_failed_maven_run_flaky_retries/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_builtin_coverage/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_builtin_coverage/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_child_service_propagation/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_child_service_propagation/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_impacted_tests/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_impacted_tests/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit4_class_ordering/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit4_class_ordering/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit4_class_ordering_parallel/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit4_class_ordering_parallel/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit_platform_runner/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_junit_platform_runner/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_multiple_forks/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_multiple_forks/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_0_0/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_0_0/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_5_0/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_5_0/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_test_management/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_test_management/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_arg_line_property/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_arg_line_property/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_cucumber/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_cucumber/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/settings.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/settings.xml
@@ -1,0 +1,39 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>with-proxy</id>
+      <activation>
+        <property>
+          <name>env.MAVEN_REPOSITORY_PROXY</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>env-proxy</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>env-proxy-plugins</id>
+          <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>


### PR DESCRIPTION
# What Does This Do

Updates Maven smoke tests to use caching Maven repository proxy in CI.

# Motivation

The tests need to download Maven artifacts for the tested projects.
When downloading directly from Maven Central, the tests fail because of download query rate limits.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
