### PR TITLE
Add DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED alias for runtime id generation

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -54,6 +54,8 @@ public final class GeneralConfig {
 
   public static final String RUNTIME_METRICS_ENABLED = "runtime.metrics.enabled";
   public static final String RUNTIME_ID_ENABLED = "runtime-id.enabled";
+  public static final String RUNTIME_METRICS_RUNTIME_ID_ENABLED =
+      "runtime.metrics.runtime-id.enabled";
 
   public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
   public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -601,7 +601,8 @@ public class Config {
     this.configProvider = configProvider;
     this.instrumenterConfig = instrumenterConfig;
     configFileStatus = configProvider.getConfigFileStatus();
-    runtimeIdEnabled = configProvider.getBoolean(RUNTIME_ID_ENABLED, true);
+    runtimeIdEnabled =
+        configProvider.getBoolean(RUNTIME_ID_ENABLED, true, RUNTIME_METRICS_RUNTIME_ID_ENABLED);
     runtimeVersion = System.getProperty("java.version", "unknown");
 
     // Note: We do not want APiKey to be loaded from property for security reasons

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
@@ -3,18 +3,30 @@ package datadog.trace.api
 import spock.lang.Specification
 
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_RUNTIME_ID_ENABLED
 
 class ConfigForkedTest extends Specification {
 
   static final String PREFIX = "dd."
 
+  def getSetting() {
+    RUNTIME_ID_ENABLED
+  }
+
   def "test random runtime id generation can be turned off"(){
     setup:
-    System.setProperty(PREFIX + RUNTIME_ID_ENABLED, "false")
+    System.setProperty(PREFIX + getSetting(), "false")
 
     when:
     def config = new Config()
     then:
     config.runtimeId == ""
+  }
+}
+
+class RuntimeMetricsRuntimeIdAliasForkedTest extends ConfigForkedTest {
+  @Override
+  def getSetting() {
+    RUNTIME_METRICS_RUNTIME_ID_ENABLED
   }
 }


### PR DESCRIPTION
# What Does This Do

Add one configuration alias (`DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED`) to drive runtime_id generation.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
