### PR TITLE
Fix gRPC handler null superclass

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
@@ -46,7 +46,8 @@ public class GrpcRequestMessageHandler implements BiFunction<RequestContext, Obj
   }
 
   static boolean visitProtobufArtifact(@Nonnull final Class<?> kls) {
-    if (kls.getSuperclass().getName().startsWith(GENERATED_MESSAGE)) {
+    final Class<?> superClass = kls.getSuperclass();
+    if (superClass != null && superClass.getName().startsWith(GENERATED_MESSAGE)) {
       return true; // GRPC custom messages
     }
     if (MAP_FIELD.equals(kls.getName())) {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
@@ -113,6 +113,14 @@ class GrpcRequestMessageHandlerTest extends IastModuleImplTestBase {
     buildProto3Message() | _
   }
 
+  void 'visitProtobufArtifact handles classes without superclass'() {
+    when:
+    boolean result = GrpcRequestMessageHandler.visitProtobufArtifact(Object)
+
+    then:
+    !result
+  }
+
   private static def buildProto2Message() {
     final child = Test2.Proto2Child.newBuilder()
     .setOptional("optional")


### PR DESCRIPTION
## Summary
- avoid NPE when class has no superclass in gRPC handler
- test handling of classes without super class

## Testing
- `./gradlew :dd-java-agent:agent-iast:test --no-daemon --offline` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_684c29513b90832ea66f4215df35a943