### PR TITLE
Fix ByteCountingInputStream when reading past EOF

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ByteCountingInputStream.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ByteCountingInputStream.java
@@ -15,7 +15,9 @@ final class ByteCountingInputStream extends InputStream {
   @Override
   public int read() throws IOException {
     int data = source.read();
-    readBytes++;
+    if (data >= 0) {
+      readBytes++;
+    }
     return data;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ByteCountingInputStreamTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ByteCountingInputStreamTest.java
@@ -1,0 +1,26 @@
+package com.datadog.profiling.uploader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ByteCountingInputStreamTest {
+
+  @Test
+  public void testDoesNotCountAfterEof() throws IOException {
+    byte[] data = {1, 2, 3};
+
+    ByteCountingInputStream in = new ByteCountingInputStream(new ByteArrayInputStream(data));
+    for (byte datum : data) {
+      int b = in.read();
+      assertEquals(datum, b);
+    }
+    assertEquals(data.length, (int) in.getReadBytes());
+
+    // read past EOF
+    assertEquals(-1, in.read());
+    assertEquals(data.length, (int) in.getReadBytes());
+  }
+}


### PR DESCRIPTION
# What Does This Do

Fixes `ByteCountingInputStream` when reading single bytes past EOF.

# Motivation

# Additional Notes

This PR was generated with CODEX with the following prompt:

> Go through the codebase, find issues and propose one task to fix a typo, one task to fix a bug, one task to fix a code comment or documentation discrepancy, and one task to improve a test.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
