### PR TITLE
Replace `System.currentTimeMillis` by `nanoTime`

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -254,14 +254,14 @@ public class TraceProcessingWorker implements AutoCloseable {
       final SpanPostProcessor postProcessor = SpanPostProcessor.Holder.INSTANCE;
       try {
         final long timeout = Config.get().getTracePostProcessingTimeout();
-        final long deadline = System.currentTimeMillis() + timeout;
+        final long deadline = System.nanoTime() + timeout * 1000 * 1000;
         final boolean[] timedOut = {false};
         final BooleanSupplier timeoutCheck =
             () -> {
               if (timedOut[0]) {
                 return true;
               }
-              if (System.currentTimeMillis() > deadline) {
+              if (System.nanoTime() > deadline) {
                 timedOut[0] = true;
               }
               return timedOut[0];


### PR DESCRIPTION
# What Does This Do

`System.nanoTime` is a better fit for time measurement.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
