### PR TITLE
Store the http.route tag value inside the appsec request context in Play

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -158,6 +158,7 @@ public class GatewayBridge {
     subscriptionService.registerCallback(EVENTS.shellCmd(), this::onShellCmd);
     subscriptionService.registerCallback(EVENTS.user(), this::onUser);
     subscriptionService.registerCallback(EVENTS.loginEvent(), this::onLoginEvent);
+    subscriptionService.registerCallback(EVENTS.httpRoute(), this::onHttpRoute);
 
     if (additionalIGEvents.contains(EVENTS.requestPathParams())) {
       subscriptionService.registerCallback(EVENTS.requestPathParams(), this::onRequestPathParams);
@@ -222,6 +223,14 @@ public class GatewayBridge {
         userIdSubInfo = null;
       }
     }
+  }
+
+  private void onHttpRoute(final RequestContext ctx_, final String route) {
+    final AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
+    if (ctx == null) {
+      return;
+    }
+    ctx.setRoute(route);
   }
 
   private Flow<Void> onLoginEvent(

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -114,6 +114,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   BiFunction<RequestContext, String, Flow<Void>> shellCmdCB
   BiFunction<RequestContext, String, Flow<Void>> userCB
   TriFunction<RequestContext, LoginEvent, String, Flow<Void>> loginEventCB
+  BiConsumer<RequestContext, String> httpRouteCB
 
   WafMetricCollector wafMetricCollector = Mock(WafMetricCollector)
 
@@ -477,6 +478,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * ig.registerCallback(EVENTS.shellCmd(), _) >> { shellCmdCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.user(), _) >> { userCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.loginEvent(), _) >> { loginEventCB = it[1]; null }
+    1 * ig.registerCallback(EVENTS.httpRoute(), _) >> { httpRouteCB = it[1]; null }
     0 * ig.registerCallback(_, _)
 
     bridge.init()
@@ -1325,6 +1327,17 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * traceSegment.setTagTop('http.response.headers.x-other-header-2', 'value3')
     1 * traceSegment.setTagTop('_dd.appsec.response.header_collection.discarded', 1)
     0 * traceSegment.setTagTop(_, _)
+  }
+
+  void 'test on httpRoute'() {
+    given:
+    final route = 'dummy-route'
+
+    when:
+    httpRouteCB.accept(ctx, route)
+
+    then:
+    arCtx.getRoute() == route
   }
 
 }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -1,8 +1,12 @@
 package datadog.trace.instrumentation.play23;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
@@ -12,6 +16,9 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.CompletionException;
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.api.Routes;
 import play.api.mvc.Headers;
 import play.api.mvc.Request;
@@ -19,6 +26,7 @@ import scala.Option;
 
 public class PlayHttpServerDecorator
     extends HttpServerDecorator<Request, Request, play.api.mvc.Result, Headers> {
+  private static final Logger LOG = LoggerFactory.getLogger(PlayHttpServerDecorator.class);
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -88,9 +96,33 @@ public class PlayHttpServerDecorator
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
         HTTP_RESOURCE_DECORATOR.withRoute(span, request.method(), path);
+        dispatchRoute(span, path);
       }
     }
     return span;
+  }
+
+  /**
+   * Play does not set the http.route in the local root span so we need to store it in the context
+   * for API security
+   */
+  private void dispatchRoute(final AgentSpan span, final String route) {
+    try {
+      final RequestContext ctx = span.getRequestContext();
+      if (ctx == null) {
+        return;
+      }
+      final CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiConsumer<RequestContext, String> cb = cbp.getCallback(EVENTS.httpRoute());
+      if (cb != null) {
+        cb.accept(ctx, route);
+      }
+    } catch (final Throwable t) {
+      LOG.debug("Failed to dispatch route", t);
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -1,8 +1,12 @@
 package datadog.trace.instrumentation.play24;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
@@ -12,6 +16,9 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.CompletionException;
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
@@ -19,6 +26,7 @@ import scala.Option;
 
 public class PlayHttpServerDecorator
     extends HttpServerDecorator<Request, Request, Result, Headers> {
+  private static final Logger LOG = LoggerFactory.getLogger(PlayHttpServerDecorator.class);
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -88,9 +96,33 @@ public class PlayHttpServerDecorator
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
         HTTP_RESOURCE_DECORATOR.withRoute(span, request.method(), path);
+        dispatchRoute(span, path);
       }
     }
     return span;
+  }
+
+  /**
+   * Play does not set the http.route in the local root span so we need to store it in the context
+   * for API security
+   */
+  private void dispatchRoute(final AgentSpan span, final String route) {
+    try {
+      final RequestContext ctx = span.getRequestContext();
+      if (ctx == null) {
+        return;
+      }
+      final CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiConsumer<RequestContext, String> cb = cbp.getCallback(EVENTS.httpRoute());
+      if (cb != null) {
+        cb.accept(ctx, route);
+      }
+    } catch (final Throwable t) {
+      LOG.debug("Failed to dispatch route", t);
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -1,15 +1,20 @@
 package datadog.trace.instrumentation.play26;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.invoke.MethodHandle;
@@ -18,6 +23,9 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.CompletionException;
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
@@ -29,6 +37,7 @@ import scala.Option;
 
 public class PlayHttpServerDecorator
     extends HttpServerDecorator<Request, Request, Result, Headers> {
+  private static final Logger LOG = LoggerFactory.getLogger(PlayHttpServerDecorator.class);
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -143,9 +152,33 @@ public class PlayHttpServerDecorator
             PATH_CACHE.computeIfAbsent(
                 defOption.get().path(), p -> addMissingSlash(p, request.path()));
         HTTP_RESOURCE_DECORATOR.withRoute(span, request.method(), path, true);
+        dispatchRoute(span, path);
       }
     }
     return span;
+  }
+
+  /**
+   * Play does not set the http.route in the local root span so we need to store it in the context
+   * for API security
+   */
+  private void dispatchRoute(final AgentSpan span, final CharSequence route) {
+    try {
+      final RequestContext ctx = span.getRequestContext();
+      if (ctx == null) {
+        return;
+      }
+      final CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiConsumer<RequestContext, String> cb = cbp.getCallback(EVENTS.httpRoute());
+      if (cb != null) {
+        cb.accept(ctx, URIUtils.decode(route.toString()));
+      }
+    } catch (final Throwable t) {
+      LOG.debug("Failed to dispatch route", t);
+    }
   }
 
   /*

--- a/dd-smoke-tests/play-2.4/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.4/app/controllers/AppSecController.scala
@@ -1,0 +1,11 @@
+package controllers
+
+import play.api.mvc.{Action, AnyContent, Controller}
+
+class AppSecController extends Controller {
+
+  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+    Status(statusCode)("EXECUTED")
+  }
+
+}

--- a/dd-smoke-tests/play-2.4/build.gradle
+++ b/dd-smoke-tests/play-2.4/build.gradle
@@ -63,6 +63,7 @@ dependencies {
   implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
+  testImplementation project(':dd-smoke-tests:appsec')
 }
 
 configurations.testImplementation {

--- a/dd-smoke-tests/play-2.4/conf/routes
+++ b/dd-smoke-tests/play-2.4/conf/routes
@@ -6,3 +6,6 @@
 # An example controller showing a sample home page
 GET     /welcomej                           controllers.JController.doGet(id: Int ?= 0)
 GET     /welcomes                           controllers.SController.doGet(id: Option[Int])
+
+# AppSec endpoints for testing
+GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)

--- a/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
@@ -1,0 +1,92 @@
+package datadog.smoketest
+
+import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Shared
+
+import java.nio.file.Files
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class AppSecPlayNettySmokeTest  extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  File playDirectory = new File("${buildDirectory}/stage/main")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // If the server is not shut down correctly, this file can be left there and will block
+    // the start of a new test
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
+    if (runningPid.exists()) {
+      runningPid.delete()
+    }
+    def command = isWindows() ? 'main.bat' : 'main'
+    ProcessBuilder processBuilder = new ProcessBuilder("${playDirectory}/bin/${command}")
+    processBuilder.directory(playDirectory)
+    processBuilder.environment().put("JAVA_OPTS",
+      (defaultAppSecProperties + defaultJavaProperties).collect({ it.replace(' ', '\\ ')}).join(" ")
+      + " -Dconfig.file=${playDirectory}/conf/application.conf"
+      + " -Dhttp.port=${httpPort}"
+      + " -Dhttp.address=127.0.0.1"
+      + " -Dplay.server.provider=play.core.server.NettyServerProvider"
+      + " -Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter")
+    return processBuilder
+  }
+
+  @Override
+  File createTemporaryFile() {
+    return new File("${buildDirectory}/tmp/trace-structure-play-2.4-appsec-netty.out")
+  }
+
+  void 'API Security samples only one request per endpoint'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/sampling/200?test=value"
+    def client = OkHttpUtils.clientBuilder().build()
+    def request = new Request.Builder()
+      .url(url)
+      .addHeader('X-My-Header', "value")
+      .get()
+      .build()
+
+    when:
+    List<Response> responses = (1..3).collect {
+      client.newCall(request).execute()
+    }
+
+    then:
+    responses.each {
+      assert it.code() == 200
+    }
+    waitForTraceCount(3)
+    def spans = rootSpans.toList().toSorted { it.span.duration }
+    spans.size() == 3
+    def sampledSpans = spans.findAll { it.meta.keySet().any { it.startsWith('_dd.appsec.s.req.') } }
+    sampledSpans.size() == 1
+    def span = sampledSpans[0]
+    span.meta.containsKey('_dd.appsec.s.req.query')
+    span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  // Ensure to clean up server and not only the shell script that starts it
+  def cleanupSpec() {
+    def pid = runningServerPid()
+    if (pid) {
+      def commands = isWindows() ? ['taskkill', '/PID', pid, '/T', '/F'] : ['kill', '-9', pid]
+      new ProcessBuilder(commands).start().waitFor(10, SECONDS)
+    }
+  }
+
+  def runningServerPid() {
+    def runningPid = new File(playDirectory.getPath(), 'RUNNING_PID')
+    if (runningPid.exists()) {
+      return Files.lines(runningPid.toPath()).findAny().orElse(null)
+    }
+  }
+
+  static isWindows() {
+    return System.getProperty('os.name').toLowerCase().contains('win')
+  }
+}

--- a/dd-smoke-tests/play-2.5/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.5/app/controllers/AppSecController.scala
@@ -1,0 +1,11 @@
+package controllers
+
+import play.api.mvc.{Action, AnyContent, Controller}
+
+class AppSecController extends Controller {
+
+  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+    Status(statusCode)("EXECUTED")
+  }
+
+}

--- a/dd-smoke-tests/play-2.5/build.gradle
+++ b/dd-smoke-tests/play-2.5/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
+  testImplementation project(':dd-smoke-tests:appsec')
 }
 
 configurations.testImplementation {

--- a/dd-smoke-tests/play-2.5/conf/routes
+++ b/dd-smoke-tests/play-2.5/conf/routes
@@ -6,3 +6,6 @@
 # An example controller showing a sample home page
 GET     /welcomej                           controllers.JController.doGet(id: Int ?= 0)
 GET     /welcomes                           controllers.SController.doGet(id: Option[Int])
+
+# AppSec endpoints for testing
+GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)

--- a/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
@@ -1,0 +1,92 @@
+package datadog.smoketest
+
+import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Shared
+
+import java.nio.file.Files
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class AppSecPlayNettySmokeTest extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  File playDirectory = new File("${buildDirectory}/stage/main")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // If the server is not shut down correctly, this file can be left there and will block
+    // the start of a new test
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
+    if (runningPid.exists()) {
+      runningPid.delete()
+    }
+    def command = isWindows() ? 'main.bat' : 'main'
+    ProcessBuilder processBuilder = new ProcessBuilder("${playDirectory}/bin/${command}")
+    processBuilder.directory(playDirectory)
+    processBuilder.environment().put("JAVA_OPTS",
+      (defaultAppSecProperties + defaultJavaProperties).collect({ it.replace(' ', '\\ ')}).join(" ")
+      + " -Dconfig.file=${playDirectory}/conf/application.conf"
+      + " -Dhttp.port=${httpPort}"
+      + " -Dhttp.address=127.0.0.1"
+      + " -Dplay.server.provider=play.core.server.NettyServerProvider"
+      + " -Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter")
+    return processBuilder
+  }
+
+  @Override
+  File createTemporaryFile() {
+    return new File("${buildDirectory}/tmp/trace-structure-play-2.5-appsec-netty.out")
+  }
+
+  void 'API Security samples only one request per endpoint'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/sampling/200?test=value"
+    def client = OkHttpUtils.clientBuilder().build()
+    def request = new Request.Builder()
+      .url(url)
+      .addHeader('X-My-Header', "value")
+      .get()
+      .build()
+
+    when:
+    List<Response> responses = (1..3).collect {
+      client.newCall(request).execute()
+    }
+
+    then:
+    responses.each {
+      assert it.code() == 200
+    }
+    waitForTraceCount(3)
+    def spans = rootSpans.toList().toSorted { it.span.duration }
+    spans.size() == 3
+    def sampledSpans = spans.findAll { it.meta.keySet().any { it.startsWith('_dd.appsec.s.req.') } }
+    sampledSpans.size() == 1
+    def span = sampledSpans[0]
+    span.meta.containsKey('_dd.appsec.s.req.query')
+    span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  // Ensure to clean up server and not only the shell script that starts it
+  def cleanupSpec() {
+    def pid = runningServerPid()
+    if (pid) {
+      def commands = isWindows() ? ['taskkill', '/PID', pid, '/T', '/F'] : ['kill', '-9', pid]
+      new ProcessBuilder(commands).start().waitFor(10, SECONDS)
+    }
+  }
+
+  def runningServerPid() {
+    def runningPid = new File(playDirectory.getPath(), 'RUNNING_PID')
+    if (runningPid.exists()) {
+      return Files.lines(runningPid.toPath()).findAny().orElse(null)
+    }
+  }
+
+  static isWindows() {
+    return System.getProperty('os.name').toLowerCase().contains('win')
+  }
+}

--- a/dd-smoke-tests/play-2.6/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.6/app/controllers/AppSecController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import javax.inject._
+import play.api.mvc._
+
+@Singleton
+class AppSecController @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+
+  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+    Status(statusCode)("EXECUTED")
+  }
+
+}

--- a/dd-smoke-tests/play-2.6/build.gradle
+++ b/dd-smoke-tests/play-2.6/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
+  testImplementation project(':dd-smoke-tests:appsec')
 }
 
 configurations.testImplementation {

--- a/dd-smoke-tests/play-2.6/conf/routes
+++ b/dd-smoke-tests/play-2.6/conf/routes
@@ -6,3 +6,6 @@
 # An example controller showing a sample home page
 GET     /welcomej                           controllers.JController.doGet(id: Int ?= 0)
 GET     /welcomes                           controllers.SController.doGet(id: Option[Int])
+
+# AppSec endpoints for testing
+GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)

--- a/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
@@ -1,0 +1,123 @@
+package datadog.smoketest
+
+import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Shared
+
+import java.nio.file.Files
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+abstract class AppSecPlaySmokeTest extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  File playDirectory = new File("${buildDirectory}/stage/main")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // If the server is not shut down correctly, this file can be left there and will block
+    // the start of a new test
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
+    if (runningPid.exists()) {
+      runningPid.delete()
+    }
+    def command = isWindows() ? 'main.bat' : 'main'
+    ProcessBuilder processBuilder =
+      new ProcessBuilder("${playDirectory}/bin/${command}")
+    processBuilder.directory(playDirectory)
+    processBuilder.environment().put("JAVA_OPTS",
+      (defaultAppSecProperties + defaultJavaProperties).collect({ it.replace(' ', '\\ ')}).join(" ")
+      + " -Dconfig.file=${playDirectory}/conf/application.conf"
+      + " -Dhttp.port=${httpPort}"
+      + " -Dhttp.address=127.0.0.1"
+      + " -Dplay.server.provider=${serverProvider()}"
+      + " -Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter")
+    return processBuilder
+  }
+
+  @Override
+  File createTemporaryFile() {
+    new File("${buildDirectory}/tmp/trace-structure-play-2.6-appsec-${serverProviderName()}.out")
+  }
+
+  abstract String serverProviderName()
+
+  abstract String serverProvider()
+
+  void 'API Security samples only one request per endpoint'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/sampling/200?test=value"
+    def client = OkHttpUtils.clientBuilder().build()
+    def request = new Request.Builder()
+      .url(url)
+      .addHeader('X-My-Header', "value")
+      .get()
+      .build()
+
+    when:
+    List<Response> responses = (1..3).collect {
+      client.newCall(request).execute()
+    }
+
+    then:
+    responses.each {
+      assert it.code() == 200
+    }
+    waitForTraceCount(3)
+    def spans = rootSpans.toList().toSorted { it.span.duration }
+    spans.size() == 3
+    def sampledSpans = spans.findAll { it.meta.keySet().any { it.startsWith('_dd.appsec.s.req.') } }
+    sampledSpans.size() == 1
+    def span = sampledSpans[0]
+    span.meta.containsKey('_dd.appsec.s.req.query')
+    span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+
+  // Ensure to clean up server and not only the shell script that starts it
+  def cleanupSpec() {
+    def pid = runningServerPid()
+    if (pid) {
+      def commands = isWindows() ? ['taskkill', '/PID', pid, '/T', '/F'] : ['kill', '-9', pid]
+      new ProcessBuilder(commands).start().waitFor(10, SECONDS)
+    }
+  }
+
+  def runningServerPid() {
+    def runningPid = new File(playDirectory.getPath(), 'RUNNING_PID')
+    if (runningPid.exists()) {
+      return Files.lines(runningPid.toPath()).findAny().orElse(null)
+    }
+  }
+
+  static isWindows() {
+    return System.getProperty('os.name').toLowerCase().contains("win")
+  }
+
+  static class Akka extends AppSecPlaySmokeTest {
+
+    @Override
+    String serverProviderName() {
+      return "akka-http"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.AkkaHttpServerProvider"
+    }
+  }
+
+  static class Netty extends AppSecPlaySmokeTest {
+    @Override
+    String serverProviderName() {
+      return "netty"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.NettyServerProvider"
+    }
+  }
+}

--- a/dd-smoke-tests/play-2.7/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.7/app/controllers/AppSecController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import javax.inject._
+import play.api.mvc._
+
+@Singleton
+class AppSecController @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+
+  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+    Status(statusCode)("EXECUTED")
+  }
+
+}

--- a/dd-smoke-tests/play-2.7/build.gradle
+++ b/dd-smoke-tests/play-2.7/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
+  testImplementation project(':dd-smoke-tests:appsec')
 }
 
 configurations.testImplementation {

--- a/dd-smoke-tests/play-2.7/conf/routes
+++ b/dd-smoke-tests/play-2.7/conf/routes
@@ -6,3 +6,6 @@
 # An example controller showing a sample home page
 GET     /welcomej                           controllers.JController.doGet(id: Int ?= 0)
 GET     /welcomes                           controllers.SController.doGet(id: Option[Int])
+
+# AppSec endpoints for testing
+GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)

--- a/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
@@ -1,0 +1,122 @@
+package datadog.smoketest
+
+import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Shared
+
+import java.nio.file.Files
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+abstract class AppSecPlaySmokeTest extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  File playDirectory = new File("${buildDirectory}/stage/main")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // If the server is not shut down correctly, this file can be left there and will block
+    // the start of a new test
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
+    if (runningPid.exists()) {
+      runningPid.delete()
+    }
+    def command = isWindows() ? 'main.bat' : 'main'
+    ProcessBuilder processBuilder =
+      new ProcessBuilder("${playDirectory}/bin/${command}")
+    processBuilder.environment().put("JAVA_OPTS",
+      (defaultAppSecProperties + defaultJavaProperties).collect({ it.replace(' ', '\\ ')}).join(" ")
+      + " -Dconfig.file=${playDirectory}/conf/application.conf"
+      + " -Dhttp.port=${httpPort}"
+      + " -Dhttp.address=127.0.0.1"
+      + " -Dplay.server.provider=${serverProvider()}"
+      + " -Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter")
+    return processBuilder
+  }
+
+  @Override
+  File createTemporaryFile() {
+    new File("${buildDirectory}/tmp/trace-structure-play-2.7-appsec-${serverProviderName()}.out")
+  }
+
+  abstract String serverProviderName()
+
+  abstract String serverProvider()
+
+  void 'API Security samples only one request per endpoint'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/sampling/200?test=value"
+    def client = OkHttpUtils.clientBuilder().build()
+    def request = new Request.Builder()
+      .url(url)
+      .addHeader('X-My-Header', "value")
+      .get()
+      .build()
+
+    when:
+    List<Response> responses = (1..3).collect {
+      client.newCall(request).execute()
+    }
+
+    then:
+    responses.each {
+      assert it.code() == 200
+    }
+    waitForTraceCount(3)
+    def spans = rootSpans.toList().toSorted { it.span.duration }
+    spans.size() == 3
+    def sampledSpans = spans.findAll { it.meta.keySet().any { it.startsWith('_dd.appsec.s.req.') } }
+    sampledSpans.size() == 1
+    def span = sampledSpans[0]
+    span.meta.containsKey('_dd.appsec.s.req.query')
+    span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  // Ensure to clean up server and not only the shell script that starts it
+  def cleanupSpec() {
+    def pid = runningServerPid()
+    if (pid) {
+      def commands = isWindows() ? ['taskkill', '/PID', pid, '/T', '/F'] : ['kill', '-9', pid]
+      new ProcessBuilder(commands).start().waitFor(10, SECONDS)
+    }
+  }
+
+  def runningServerPid() {
+    def runningPid = new File(playDirectory.getPath(), 'RUNNING_PID')
+    if (runningPid.exists()) {
+      return Files.lines(runningPid.toPath()).findAny().orElse(null)
+    }
+  }
+
+  static isWindows() {
+    return System.getProperty('os.name').toLowerCase().contains('win')
+  }
+
+  static class Akka extends AppSecPlaySmokeTest {
+
+    @Override
+    String serverProviderName() {
+      return "akka-http"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.AkkaHttpServerProvider"
+    }
+  }
+
+  static class Netty extends AppSecPlaySmokeTest {
+    @Override
+    String serverProviderName() {
+      return "netty"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.NettyServerProvider"
+    }
+  }
+
+}

--- a/dd-smoke-tests/play-2.8/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.8/app/controllers/AppSecController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import javax.inject._
+import play.api.mvc._
+
+@Singleton
+class AppSecController @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+
+  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+    Status(statusCode)("EXECUTED")
+  }
+
+}

--- a/dd-smoke-tests/play-2.8/build.gradle
+++ b/dd-smoke-tests/play-2.8/build.gradle
@@ -64,6 +64,7 @@ dependencies {
   implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
+  testImplementation project(':dd-smoke-tests:appsec')
 }
 
 configurations.testImplementation {

--- a/dd-smoke-tests/play-2.8/conf/routes
+++ b/dd-smoke-tests/play-2.8/conf/routes
@@ -6,3 +6,6 @@
 # An example controller showing a sample home page
 GET     /welcomej                           controllers.JController.doGet(id: Int ?= 0)
 GET     /welcomes                           controllers.SController.doGet(id: Option[Int])
+
+# AppSec endpoints for testing
+GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)

--- a/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
@@ -1,0 +1,123 @@
+package datadog.smoketest
+
+import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Shared
+
+import java.nio.file.Files
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+abstract class AppSecPlaySmokeTest extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  File playDirectory = new File("${buildDirectory}/stage/main")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // If the server is not shut down correctly, this file can be left there and will block
+    // the start of a new test
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
+    if (runningPid.exists()) {
+      runningPid.delete()
+    }
+    def command = isWindows() ? 'main.bat' : 'main'
+    ProcessBuilder processBuilder =
+      new ProcessBuilder("${playDirectory}/bin/${command}")
+    processBuilder.directory(playDirectory)
+    processBuilder.environment().put("JAVA_OPTS",
+      (defaultAppSecProperties + defaultJavaProperties).collect({ it.replace(' ', '\\ ')}).join(" ")
+      + " -Dconfig.file=${playDirectory}/conf/application.conf"
+      + " -Dhttp.port=${httpPort}"
+      + " -Dhttp.address=127.0.0.1"
+      + " -Dplay.server.provider=${serverProvider()}"
+      + " -Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter")
+    return processBuilder
+  }
+
+  @Override
+  File createTemporaryFile() {
+    new File("${buildDirectory}/tmp/trace-structure-play-2.8-appsec-${serverProviderName()}.out")
+  }
+
+  abstract String serverProviderName()
+
+  abstract String serverProvider()
+
+  void 'API Security samples only one request per endpoint'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/sampling/200?test=value"
+    def client = OkHttpUtils.clientBuilder().build()
+    def request = new Request.Builder()
+      .url(url)
+      .addHeader('X-My-Header', "value")
+      .get()
+      .build()
+
+    when:
+    List<Response> responses = (1..3).collect {
+      client.newCall(request).execute()
+    }
+
+    then:
+    responses.each {
+      assert it.code() == 200
+    }
+    waitForTraceCount(3)
+    def spans = rootSpans.toList().toSorted { it.span.duration }
+    spans.size() == 3
+    def sampledSpans = spans.findAll { it.meta.keySet().any { it.startsWith('_dd.appsec.s.req.') } }
+    sampledSpans.size() == 1
+    def span = sampledSpans[0]
+    span.meta.containsKey('_dd.appsec.s.req.query')
+    span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  // Ensure to clean up server and not only the shell script that starts it
+  def cleanupSpec() {
+    def pid = runningServerPid()
+    if (pid) {
+      def commands = isWindows() ? ['taskkill', '/PID', pid, '/T', '/F'] : ['kill', '-9', pid]
+      new ProcessBuilder(commands).start().waitFor(10, SECONDS)
+    }
+  }
+
+  def runningServerPid() {
+    def runningPid = new File(playDirectory.getPath(), 'RUNNING_PID')
+    if (runningPid.exists()) {
+      return Files.lines(runningPid.toPath()).findAny().orElse(null)
+    }
+  }
+
+  static isWindows() {
+    return System.getProperty('os.name').toLowerCase().contains('win')
+  }
+
+  static class Akka extends AppSecPlaySmokeTest {
+
+    @Override
+    String serverProviderName() {
+      return "akka-http"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.AkkaHttpServerProvider"
+    }
+  }
+
+  static class Netty extends AppSecPlaySmokeTest {
+    @Override
+    String serverProviderName() {
+      return "netty"
+    }
+
+    @Override
+    String serverProvider() {
+      return "play.core.server.NettyServerProvider"
+    }
+  }
+
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -312,6 +312,16 @@ public final class Events<D> {
     return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) SHELL_CMD;
   }
 
+  static final int HTTP_ROUTE_ID = 26;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType HTTP_ROUTE = new ET<>("http.route", HTTP_ROUTE_ID);
+
+  @SuppressWarnings("unchecked")
+  public EventType<BiConsumer<RequestContext, String>> httpRoute() {
+    return (EventType<BiConsumer<RequestContext, String>>) HTTP_ROUTE;
+  }
+
   static final int MAX_EVENTS = nextId.get();
 
   private static final class ET<T> extends EventType<T> {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -7,6 +7,7 @@ import static datadog.trace.api.gateway.Events.FILE_LOADED_ID;
 import static datadog.trace.api.gateway.Events.GRAPHQL_SERVER_REQUEST_MESSAGE_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_METHOD_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_REQUEST_MESSAGE_ID;
+import static datadog.trace.api.gateway.Events.HTTP_ROUTE_ID;
 import static datadog.trace.api.gateway.Events.LOGIN_EVENT_ID;
 import static datadog.trace.api.gateway.Events.MAX_EVENTS;
 import static datadog.trace.api.gateway.Events.NETWORK_CONNECTION_ID;
@@ -374,6 +375,7 @@ public class InstrumentationGateway {
               }
             };
       case DATABASE_CONNECTION_ID:
+      case HTTP_ROUTE_ID:
         return (C)
             new BiConsumer<RequestContext, String>() {
               @Override

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -223,6 +223,8 @@ public class InstrumentationGatewayTest {
     cbp.getCallback(events.execCmd()).apply(null, null);
     ss.registerCallback(events.shellCmd(), callback);
     cbp.getCallback(events.shellCmd()).apply(null, null);
+    ss.registerCallback(events.httpRoute(), callback);
+    cbp.getCallback(events.httpRoute()).accept(null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
@@ -293,6 +295,8 @@ public class InstrumentationGatewayTest {
     cbp.getCallback(events.execCmd()).apply(null, null);
     ss.registerCallback(events.shellCmd(), throwback);
     cbp.getCallback(events.shellCmd()).apply(null, null);
+    ss.registerCallback(events.httpRoute(), throwback);
+    cbp.getCallback(events.httpRoute()).accept(null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);
   }
 


### PR DESCRIPTION
# What Does This Do

Store the `http.route` tag value inside the appsec request context in Play framework instrumentation

# Motivation

AppSec API protection requires the `http.route` span tag to be set on the local root span so it can be used for its sampling decision. Since Play does not use the local root span for the `http.route` we have to store it in the appsec request context before the sampling decision is made.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56869]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56869]: https://datadoghq.atlassian.net/browse/APPSEC-56869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ