### PR TITLE
Simplified ListWriter await logic.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -1,36 +1,27 @@
 package datadog.trace.common.writer;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.MetadataConsumer;
-import datadog.trace.core.tagprocessor.PeerServiceCalculator;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** List writer used by tests mostly */
 public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Writer {
-
   private static final Logger log = LoggerFactory.getLogger(ListWriter.class);
+  private static final Filter ACCEPT_ALL = trace -> true;
 
-  public static final Filter ACCEPT_ALL =
-      new Filter() {
-        @Override
-        public boolean accept(List<DDSpan> trace) {
-          return true;
-        }
-      };
-
-  private final List<CountDownLatch> latches = new ArrayList<>();
   private final AtomicInteger traceCount = new AtomicInteger();
   private final TraceStructureWriter structureWriter = new TraceStructureWriter(true);
+  private final Object monitor = new Object();
 
-  private final PeerServiceCalculator peerServiceCalculator = new PeerServiceCalculator();
   private Filter filter = ACCEPT_ALL;
 
   public List<DDSpan> firstTrace() {
@@ -47,30 +38,41 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
       // remotely realistic so the test actually test something
       span.processTagsAndBaggage(MetadataConsumer.NO_OP);
     }
-    traceCount.incrementAndGet();
-    synchronized (latches) {
-      add(trace);
-      for (final CountDownLatch latch : latches) {
-        if (size() >= latch.getCount()) {
-          while (latch.getCount() > 0) {
-            latch.countDown();
-          }
-        }
-      }
-    }
+
+    add(trace);
     structureWriter.write(trace);
+
+    traceCount.incrementAndGet();
+    synchronized (monitor) {
+      monitor.notifyAll();
+    }
   }
 
-  public boolean waitForTracesMax(final int number, int seconds)
-      throws InterruptedException, TimeoutException {
-    final CountDownLatch latch = new CountDownLatch(number);
-    synchronized (latches) {
-      if (size() >= number) {
+  private boolean awaitUntilDeadline(long timeout, TimeUnit unit, BooleanSupplier predicate)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
+
+    while (true) {
+      if (predicate.getAsBoolean()) {
         return true;
       }
-      latches.add(latch);
+
+      long now = System.currentTimeMillis();
+      long waitTime = deadline - now;
+      if (waitTime <= 0) {
+        break;
+      }
+
+      synchronized (monitor) {
+        monitor.wait(waitTime);
+      }
     }
-    return latch.await(seconds, TimeUnit.SECONDS);
+
+    return false;
+  }
+
+  public boolean waitForTracesMax(final int number, int seconds) throws InterruptedException {
+    return awaitUntilDeadline(seconds, SECONDS, () -> traceCount.get() >= number);
   }
 
   public void waitForTraces(final int number) throws InterruptedException, TimeoutException {
@@ -88,24 +90,17 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   public void waitUntilReported(final DDSpan span) throws InterruptedException, TimeoutException {
-    waitUntilReported(span, 20, TimeUnit.SECONDS);
+    waitUntilReported(span, 20, SECONDS);
   }
 
   public void waitUntilReported(final DDSpan span, int timeout, TimeUnit unit)
       throws InterruptedException, TimeoutException {
-    while (true) {
-      final CountDownLatch latch = new CountDownLatch(size() + 1);
-      synchronized (latches) {
-        latches.add(latch);
-      }
-      if (isReported(span)) {
-        return;
-      }
-      if (!latch.await(timeout, unit)) {
-        String msg = "Timeout waiting for span to be reported: " + span;
-        log.warn(msg);
-        throw new TimeoutException(msg);
-      }
+    boolean reported = awaitUntilDeadline(timeout, unit, () -> isReported(span));
+
+    if (!reported) {
+      String msg = "Timeout waiting for span to be reported: " + span;
+      log.warn(msg);
+      throw new TimeoutException(msg);
     }
   }
 
@@ -143,16 +138,15 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   @Override
+  public void clear() {
+    super.clear();
+
+    traceCount.set(0);
+  }
+
+  @Override
   public void close() {
     clear();
-    synchronized (latches) {
-      for (final CountDownLatch latch : latches) {
-        while (latch.getCount() > 0) {
-          latch.countDown();
-        }
-      }
-      latches.clear();
-    }
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Refactored await logic from quite complex manipulations with list of latches with simple `wait/notifyAll` approach.

# Motivation
Green CI.

PekkoHttpServerInstrumentationAsyncTest failed from time to time with `TimeoutException`:

```
PekkoHttpServerInstrumentationAsyncTest > propagate trace id when we ping pekko-http concurrently FAILED
 org.spockframework.runtime.ConditionFailedWithExceptionError at PekkoHttpServerInstrumentationTest.groovy:74
         Caused by: java.util.concurrent.TimeoutException at ListWriter.java:86
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
