### PR TITLE
Fix Maven smoke test timeout in CI

### DIFF
--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -41,7 +41,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
   private static final String JAVAC_PLUGIN_VERSION = Config.get().ciVisibilityCompilerPluginVersion
   private static final String JACOCO_PLUGIN_VERSION = Config.get().ciVisibilityJacocoPluginVersion
 
-  private static final int PROCESS_TIMEOUT_SECS = 60
+  private static final int PROCESS_TIMEOUT_SECS = 80
 
   private static final int DEPENDENCIES_DOWNLOAD_RETRIES = 5
 


### PR DESCRIPTION
# What Does This Do

Increases the maven smoke test timeout for CI. Numerous maven smoke tests are failing in CI, du to process timeout. Locally the tests are passing, let's increase a tad the timeouts.

```
java.util.concurrent.TimeoutException: Instrumented process failed to exit
	at datadog.smoketest.MavenSmokeTest.runProcess(MavenSmokeTest.groovy:336)
	at datadog.smoketest.MavenSmokeTest.retryUntilSuccessfulOrNoAttemptsLeft(MavenSmokeTest.groovy:312)
	at datadog.smoketest.MavenSmokeTest.givenMavenDependenciesAreLoaded(MavenSmokeTest.groovy:294)
	at datadog.smoketest.MavenSmokeTest.test #projectName, v#mavenVersion(MavenSmokeTest.groovy:65)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
