### PR TITLE
Extract Play json body response schemas

### DIFF
--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/ResultsStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/ResultsStatusInstrumentation.java
@@ -1,0 +1,44 @@
+package datadog.trace.instrumentation.play25.appsec;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(InstrumenterModule.class)
+public class ResultsStatusInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public ResultsStatusInstrumentation() {
+    super("play");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "play25only";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return MuzzleReferences.PLAY_25_ONLY;
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "play.api.mvc.Results$Status";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".BodyParserHelpers",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(named("apply"), packageName + ".ResultsStatusApplyAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/StatusHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/StatusHeaderInstrumentation.java
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.play25.appsec;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(InstrumenterModule.class)
+public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public StatusHeaderInstrumentation() {
+    super("play");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "play25only";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return MuzzleReferences.PLAY_25_ONLY;
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "play.mvc.StatusHeader";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("sendJson").and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode"))),
+        packageName + ".StatusHeaderSendJsonAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/BodyParserHelpers.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/BodyParserHelpers.java
@@ -39,6 +39,7 @@ import scala.collection.Iterable;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 import scala.compat.java8.JFunction1;
+import scala.math.BigDecimal;
 
 public class BodyParserHelpers {
 
@@ -231,7 +232,11 @@ public class BodyParserHelpers {
     log.warn(logMessage, e);
   }
 
-  private static Object jsValueToJavaObject(JsValue value, int maxRecursion) {
+  public static Object jsValueToJavaObject(JsValue value) {
+    return jsValueToJavaObject(value, MAX_RECURSION);
+  }
+
+  public static Object jsValueToJavaObject(JsValue value, int maxRecursion) {
     if (value == null || maxRecursion <= 0) {
       return null;
     }
@@ -239,7 +244,8 @@ public class BodyParserHelpers {
     if (value instanceof JsString) {
       return ((JsString) value).value();
     } else if (value instanceof JsNumber) {
-      return ((JsNumber) value).value();
+      final BigDecimal number = ((JsNumber) value).value();
+      return number == null ? null : number.bigDecimal();
     } else if (value instanceof JsBoolean) {
       return ((JsBoolean) value).value();
     } else if (value instanceof JsObject) {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/ResultsStatusApplyAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/ResultsStatusApplyAdvice.java
@@ -1,0 +1,57 @@
+package datadog.trace.instrumentation.play25.appsec;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.instrumentation.play25.appsec.BodyParserHelpers.jsValueToJavaObject;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+import play.api.libs.json.JsValue;
+
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+public class ResultsStatusApplyAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void after(
+      @Advice.Argument(0) final Object content, @ActiveRequestContext RequestContext reqCtx) {
+
+    if (!(content instanceof JsValue)) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    if (cbp == null) {
+      return;
+    }
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.responseBody());
+    if (callback == null) {
+      return;
+    }
+
+    Flow<Void> flow = callback.apply(reqCtx, jsValueToJavaObject((JsValue) content));
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+      if (blockResponseFunction == null) {
+        return;
+      }
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      blockResponseFunction.tryCommitBlockingResponse(
+          reqCtx.getTraceSegment(),
+          rba.getStatusCode(),
+          rba.getBlockingContentType(),
+          rba.getExtraHeaders());
+
+      throw new BlockingException("Blocked request (for Results$Status/apply)");
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/StatusHeaderSendJsonAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/StatusHeaderSendJsonAdvice.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.play25.appsec;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+import play.mvc.StatusHeader;
+
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+public class StatusHeaderSendJsonAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void before() {
+    CallDepthThreadLocalMap.incrementCallDepth(StatusHeader.class);
+  }
+
+  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  static void after(
+      @Advice.Argument(0) final JsonNode json, @ActiveRequestContext RequestContext reqCtx) {
+    final int depth = CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
+    if (depth > 0) {
+      return;
+    }
+
+    if (json == null) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    if (cbp == null) {
+      return;
+    }
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.responseBody());
+    if (callback == null) {
+      return;
+    }
+
+    Flow<Void> flow = callback.apply(reqCtx, json);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+      if (blockResponseFunction == null) {
+        return;
+      }
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      blockResponseFunction.tryCommitBlockingResponse(
+          reqCtx.getTraceSegment(),
+          rba.getStatusCode(),
+          rba.getBlockingContentType(),
+          rba.getExtraHeaders());
+
+      throw new BlockingException("Blocked request (for StatusHeader/sendJson)");
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayRouters.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayRouters.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.play25.server
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.transform.CompileStatic
@@ -130,7 +129,7 @@ class PlayRouters {
         ->
         JsonNode json = body().asJson()
         controller(BODY_JSON) {
-          Results.status(BODY_JSON.status, new ObjectMapper().writeValueAsString(json))
+          Results.status(BODY_JSON.status, json)
         }
       } as Supplier)
       .build()
@@ -253,7 +252,7 @@ class PlayRouters {
         CompletableFuture.supplyAsync({
           ->
           controller(BODY_JSON) {
-            Results.status(BODY_JSON.status, new ObjectMapper().writeValueAsString(json))
+            Results.status(BODY_JSON.status, json)
           }
         }, execContext)
       } as Supplier)

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
@@ -94,6 +94,11 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testResponseBodyJson() {
+    true
+  }
+
+  @Override
   String testPathParam() {
     '/path/?/param'
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/test/scala/datadog/trace/instrumentation/play25/PlayController.scala
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/scala/datadog/trace/instrumentation/play25/PlayController.scala
@@ -77,7 +77,7 @@ class PlayController(implicit ec: ExecutionContext) extends Controller {
 
   def bodyJson = controller(ServerEndpoint.BODY_JSON) { request =>
     val body: JsValue = request.body.asJson.getOrElse(JsNull)
-    Results.Ok(Json.stringify(body))
+    Results.Ok(body)
   }
 
   private def controller(endpoint: ServerEndpoint)(block: Request[AnyContent] => Result) : Action[AnyContent] = {

--- a/dd-java-agent/instrumentation/play-2.4/src/test/scala/datadog/trace/instrumentation/play25/PlayRoutersScala.scala
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/scala/datadog/trace/instrumentation/play25/PlayRoutersScala.scala
@@ -143,7 +143,7 @@ object PlayRoutersScala {
       case POST(p"/body-json") => Action.async(parser) { request =>
         controller(BODY_JSON) {
           val body: JsValue = request.body.asJson.getOrElse(JsNull)
-          Results.Ok(Json.stringify(body))
+          Results.Ok(body)
         }
       }
     }

--- a/dd-java-agent/instrumentation/play-2.6/src/baseTest/groovy/datadog/trace/instrumentation/play26/server/PlayRouters.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/baseTest/groovy/datadog/trace/instrumentation/play26/server/PlayRouters.groovy
@@ -1,11 +1,11 @@
 package datadog.trace.instrumentation.play26.server
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.transform.CompileStatic
 import play.BuiltInComponents
 import play.api.libs.json.JsValue
-import play.api.libs.json.Json$
 import play.api.mvc.AnyContent
 import play.libs.concurrent.HttpExecution
 import play.mvc.Http
@@ -150,7 +150,7 @@ class PlayRouters {
         ->
         controller(BODY_JSON) {
           JsValue json = body().asJson().get()
-          Results.status(BODY_JSON.status, Json$.MODULE$.stringify(json))
+          Results.status(BODY_JSON.status, new ObjectMapper().readTree(json.toString()))
         }
       } as Supplier)
       .POST(BODY_XML.path).routeTo({
@@ -286,7 +286,7 @@ class PlayRouters {
         CompletableFuture.supplyAsync({
           ->
           controller(BODY_JSON) {
-            Results.status(BODY_JSON.status, Json$.MODULE$.stringify(json))
+            Results.status(BODY_JSON.status, new ObjectMapper().readTree(json.toString()))
           }
         }, execContext)
       } as Supplier)

--- a/dd-java-agent/instrumentation/play-2.6/src/baseTest/groovy/datadog/trace/instrumentation/play26/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/baseTest/groovy/datadog/trace/instrumentation/play26/server/PlayServerTest.groovy
@@ -97,6 +97,11 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testResponseBodyJson() {
+    true
+  }
+
+  @Override
   String testPathParam() {
     '/path/?/param'
   }

--- a/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/groovy/datadog/trace/instrumentation/play26/server/latestdep/PlayRouters.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/groovy/datadog/trace/instrumentation/play26/server/latestdep/PlayRouters.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.play26.server.latestdep
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.play26.server.TestHttpErrorHandler
@@ -121,7 +120,7 @@ class PlayRouters {
       .POST(BODY_JSON.path).routingTo({ Http.Request req ->
         controller(BODY_JSON) {
           JsonNode json = req.body().asJson()
-          Results.status(BODY_JSON.status, new ObjectMapper().writeValueAsString(json))
+          Results.status(BODY_JSON.status, json)
         }
       } as RequestFunctions.Params0<Result>)
       .POST(BODY_XML.path).routingTo({ Http.Request req ->
@@ -254,7 +253,7 @@ class PlayRouters {
         CompletableFuture.supplyAsync({
           ->
           controller(BODY_JSON) {
-            Results.status(BODY_JSON.status, new ObjectMapper().writeValueAsString(json))
+            Results.status(BODY_JSON.status, json)
           }
         }, execContext)
       } as RequestFunctions.Params0<? extends CompletionStage<Result>>)

--- a/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/scala/datadog/trace/instrumentation/play26/server/latestdep/PlayController.scala
+++ b/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/scala/datadog/trace/instrumentation/play26/server/latestdep/PlayController.scala
@@ -79,7 +79,7 @@ class PlayController(cc: ControllerComponents)(implicit ec: ExecutionContext) ex
 
   def bodyJson = controller(ServerEndpoint.BODY_JSON) { request =>
     val body: JsValue = request.body.asJson.getOrElse(JsNull)
-    Results.Ok(Json.stringify(body))
+    Results.Ok(body)
   }
 
   def bodyXml = controller(ServerEndpoint.BODY_XML) { request =>

--- a/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/scala/datadog/trace/instrumentation/play26/server/latestdep/PlayRoutersScala.scala
+++ b/dd-java-agent/instrumentation/play-2.6/src/latestDepTest/scala/datadog/trace/instrumentation/play26/server/latestdep/PlayRoutersScala.scala
@@ -147,7 +147,7 @@ object PlayRoutersScala {
       case POST(p"/body-json") => defaultActionBuilder.async(parser) { request =>
         controller(BODY_JSON) {
           val body: JsValue = request.body.asJson.getOrElse(JsNull)
-          Results.Ok(Json.stringify(body))
+          Results.Ok(body)
         }
       }
 

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/BodyParserHelpers.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/BodyParserHelpers.java
@@ -45,6 +45,7 @@ import scala.collection.Iterable;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 import scala.compat.java8.JFunction1;
+import scala.math.BigDecimal;
 import scala.xml.Elem;
 import scala.xml.Node;
 import scala.xml.NodeSeq;
@@ -277,7 +278,11 @@ public class BodyParserHelpers {
     log.warn(logMessage, e);
   }
 
-  private static Object jsValueToJavaObject(JsValue value, int maxRecursion) {
+  public static Object jsValueToJavaObject(JsValue value) {
+    return jsValueToJavaObject(value, MAX_RECURSION);
+  }
+
+  public static Object jsValueToJavaObject(JsValue value, int maxRecursion) {
     if (value == null || maxRecursion <= 0) {
       return null;
     }
@@ -285,7 +290,9 @@ public class BodyParserHelpers {
     if (value instanceof JsString) {
       return ((JsString) value).value();
     } else if (value instanceof JsNumber) {
-      return ((JsNumber) value).value();
+      // migrate away from scala types
+      final BigDecimal number = ((JsNumber) value).value();
+      return number == null ? null : number.bigDecimal();
     } else if (value instanceof JsBoolean) {
       return ((JsBoolean) value).value();
     } else if (value instanceof JsObject) {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/ResultsStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/ResultsStatusInstrumentation.java
@@ -1,0 +1,100 @@
+package datadog.trace.instrumentation.play26.appsec;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.instrumentation.play26.appsec.BodyParserHelpers.jsValueToJavaObject;
+
+import com.google.auto.service.AutoService;
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.play26.MuzzleReferences;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+import play.api.libs.json.JsValue;
+
+@AutoService(InstrumenterModule.class)
+public class ResultsStatusInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public ResultsStatusInstrumentation() {
+    super("play");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "play26Plus";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return MuzzleReferences.PLAY_26_PLUS;
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "play.api.mvc.Results$Status";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".BodyParserHelpers",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("apply"), ResultsStatusInstrumentation.class.getName() + "$ResultsStatusApplyAdvice");
+  }
+
+  @RequiresRequestContext(RequestContextSlot.APPSEC)
+  public static class ResultsStatusApplyAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    static void after(
+        @Advice.Argument(0) final Object content, @ActiveRequestContext RequestContext reqCtx) {
+
+      if (!(content instanceof JsValue)) {
+        return;
+      }
+
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
+          cbp.getCallback(EVENTS.responseBody());
+      if (callback == null) {
+        return;
+      }
+
+      Flow<Void> flow = callback.apply(reqCtx, jsValueToJavaObject((JsValue) content));
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+        if (blockResponseFunction == null) {
+          return;
+        }
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        blockResponseFunction.tryCommitBlockingResponse(
+            reqCtx.getTraceSegment(),
+            rba.getStatusCode(),
+            rba.getBlockingContentType(),
+            rba.getExtraHeaders());
+
+        throw new BlockingException("Blocked request (for Results$Status/apply)");
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
@@ -1,0 +1,105 @@
+package datadog.trace.instrumentation.play26.appsec;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.auto.service.AutoService;
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.play26.MuzzleReferences;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+import play.mvc.StatusHeader;
+
+@AutoService(InstrumenterModule.class)
+public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public StatusHeaderInstrumentation() {
+    super("play");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "play26Plus";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return MuzzleReferences.PLAY_26_PLUS; // force failure in <2.6
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "play.mvc.StatusHeader";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("sendJson").and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode"))),
+        StatusHeaderInstrumentation.class.getName() + "$StatusHeaderSendJsonAdvice");
+  }
+
+  @RequiresRequestContext(RequestContextSlot.APPSEC)
+  public static class StatusHeaderSendJsonAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    static void before() {
+      CallDepthThreadLocalMap.incrementCallDepth(StatusHeader.class);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    static void after(
+        @Advice.Argument(0) final JsonNode json, @ActiveRequestContext RequestContext reqCtx) {
+      final int depth = CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
+      if (depth > 0) {
+        return;
+      }
+
+      if (json == null) {
+        return;
+      }
+
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
+          cbp.getCallback(EVENTS.responseBody());
+      if (callback == null) {
+        return;
+      }
+
+      Flow<Void> flow = callback.apply(reqCtx, json);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+        if (blockResponseFunction == null) {
+          return;
+        }
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        blockResponseFunction.tryCommitBlockingResponse(
+            reqCtx.getTraceSegment(),
+            rba.getStatusCode(),
+            rba.getBlockingContentType(),
+            rba.getExtraHeaders());
+
+        throw new BlockingException("Blocked request (for StatusHeader/sendJson)");
+      }
+    }
+  }
+}

--- a/dd-smoke-tests/play-2.5/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.5/app/controllers/AppSecController.scala
@@ -1,11 +1,18 @@
 package controllers
 
-import play.api.mvc.{Action, AnyContent, Controller}
+import play.api.mvc.{Action, AnyContent, AnyContentAsJson, Controller}
 
 class AppSecController extends Controller {
 
-  def apiSecuritySampling(statusCode: Int, test: String): Action[AnyContent] = Action {
+  def apiSecuritySampling(statusCode: Int, test: String) = Action {
     Status(statusCode)("EXECUTED")
+  }
+
+  def apiResponse(): Action[AnyContent] = Action { request =>
+    request.body match {
+      case AnyContentAsJson(data) => Ok(data).as("application/json")
+      case _                      => BadRequest("No JSON")
+    }
   }
 
 }

--- a/dd-smoke-tests/play-2.5/conf/routes
+++ b/dd-smoke-tests/play-2.5/conf/routes
@@ -9,3 +9,4 @@ GET     /welcomes                           controllers.SController.doGet(id: Op
 
 # AppSec endpoints for testing
 GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)
+POST    /api_security/response              controllers.AppSecController.apiResponse()

--- a/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/AppSecPlayNettySmokeTest.groovy
@@ -2,11 +2,16 @@ package datadog.smoketest
 
 import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
 import datadog.trace.agent.test.utils.OkHttpUtils
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import okhttp3.MediaType
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import spock.lang.Shared
 
 import java.nio.file.Files
+import java.util.zip.GZIPInputStream
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -68,6 +73,37 @@ class AppSecPlayNettySmokeTest extends AbstractAppSecServerSmokeTest {
     def span = sampledSpans[0]
     span.meta.containsKey('_dd.appsec.s.req.query')
     span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  void 'test response schema extraction'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/response"
+    def client = OkHttpUtils.clientBuilder().build()
+    def body = [
+      "main"    : [["key": "id001", "value": 1345.67], ["value": 1567.89, "key": "id002"]],
+      "nullable": null,
+    ]
+    def request = new Request.Builder()
+      .url(url)
+      .post(RequestBody.create(MediaType.get('application/json'), JsonOutput.toJson(body)))
+      .build()
+
+    when:
+    final response = client.newCall(request).execute()
+    waitForTraceCount(1)
+
+    then:
+    response.code() == 200
+    def span = rootSpans.first()
+    span.meta.containsKey('_dd.appsec.s.res.headers')
+    span.meta.containsKey('_dd.appsec.s.res.body')
+    final schema = new JsonSlurper().parse(unzip(span.meta.get('_dd.appsec.s.res.body')))
+    assert schema == [["main": [[[["key": [8], "value": [16]]]], ["len": 2]], "nullable": [1]]]
+  }
+
+  private static byte[] unzip(final String text) {
+    final inflaterStream = new GZIPInputStream(new ByteArrayInputStream(text.decodeBase64()))
+    return inflaterStream.getBytes()
   }
 
   // Ensure to clean up server and not only the shell script that starts it

--- a/dd-smoke-tests/play-2.6/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.6/app/controllers/AppSecController.scala
@@ -10,4 +10,11 @@ class AppSecController @Inject() (cc: ControllerComponents) extends AbstractCont
     Status(statusCode)("EXECUTED")
   }
 
+  def apiResponse(): Action[AnyContent] = Action { request =>
+    request.body match {
+      case AnyContentAsJson(data) => Ok(data).as("application/json")
+      case _                      => BadRequest("No JSON")
+    }
+  }
+
 }

--- a/dd-smoke-tests/play-2.6/conf/routes
+++ b/dd-smoke-tests/play-2.6/conf/routes
@@ -9,3 +9,4 @@ GET     /welcomes                           controllers.SController.doGet(id: Op
 
 # AppSec endpoints for testing
 GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)
+POST    /api_security/response              controllers.AppSecController.apiResponse()

--- a/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
@@ -2,11 +2,16 @@ package datadog.smoketest
 
 import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
 import datadog.trace.agent.test.utils.OkHttpUtils
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import okhttp3.MediaType
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import spock.lang.Shared
 
 import java.nio.file.Files
+import java.util.zip.GZIPInputStream
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -73,6 +78,37 @@ abstract class AppSecPlaySmokeTest extends AbstractAppSecServerSmokeTest {
     def span = sampledSpans[0]
     span.meta.containsKey('_dd.appsec.s.req.query')
     span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  void 'test response schema extraction'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/response"
+    def client = OkHttpUtils.clientBuilder().build()
+    def body = [
+      "main"    : [["key": "id001", "value": 1345.67], ["value": 1567.89, "key": "id002"]],
+      "nullable": null,
+    ]
+    def request = new Request.Builder()
+      .url(url)
+      .post(RequestBody.create(MediaType.get('application/json'), JsonOutput.toJson(body)))
+      .build()
+
+    when:
+    final response = client.newCall(request).execute()
+    waitForTraceCount(1)
+
+    then:
+    response.code() == 200
+    def span = rootSpans.first()
+    span.meta.containsKey('_dd.appsec.s.res.headers')
+    span.meta.containsKey('_dd.appsec.s.res.body')
+    final schema = new JsonSlurper().parse(unzip(span.meta.get('_dd.appsec.s.res.body')))
+    assert schema == [["main": [[[["key": [8], "value": [16]]]], ["len": 2]], "nullable": [1]]]
+  }
+
+  private static byte[] unzip(final String text) {
+    final inflaterStream = new GZIPInputStream(new ByteArrayInputStream(text.decodeBase64()))
+    return inflaterStream.getBytes()
   }
 
 

--- a/dd-smoke-tests/play-2.7/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.7/app/controllers/AppSecController.scala
@@ -10,4 +10,11 @@ class AppSecController @Inject() (cc: ControllerComponents) extends AbstractCont
     Status(statusCode)("EXECUTED")
   }
 
+  def apiResponse(): Action[AnyContent] = Action { request =>
+    request.body match {
+      case AnyContentAsJson(data) => Ok(data).as("application/json")
+      case _                      => BadRequest("No JSON")
+    }
+  }
+
 }

--- a/dd-smoke-tests/play-2.7/conf/routes
+++ b/dd-smoke-tests/play-2.7/conf/routes
@@ -9,3 +9,4 @@ GET     /welcomes                           controllers.SController.doGet(id: Op
 
 # AppSec endpoints for testing
 GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)
+POST    /api_security/response              controllers.AppSecController.apiResponse()

--- a/dd-smoke-tests/play-2.8/app/controllers/AppSecController.scala
+++ b/dd-smoke-tests/play-2.8/app/controllers/AppSecController.scala
@@ -10,4 +10,11 @@ class AppSecController @Inject() (cc: ControllerComponents) extends AbstractCont
     Status(statusCode)("EXECUTED")
   }
 
+  def apiResponse(): Action[AnyContent] = Action { request =>
+    request.body match {
+      case AnyContentAsJson(data) => Ok(data).as("application/json")
+      case _                      => BadRequest("No JSON")
+    }
+  }
+
 }

--- a/dd-smoke-tests/play-2.8/conf/routes
+++ b/dd-smoke-tests/play-2.8/conf/routes
@@ -9,3 +9,4 @@ GET     /welcomes                           controllers.SController.doGet(id: Op
 
 # AppSec endpoints for testing
 GET     /api_security/sampling/:statusCode  controllers.AppSecController.apiSecuritySampling(statusCode: Int, test: String)
+POST    /api_security/response              controllers.AppSecController.apiResponse()

--- a/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/AppSecPlaySmokeTest.groovy
@@ -2,11 +2,16 @@ package datadog.smoketest
 
 import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
 import datadog.trace.agent.test.utils.OkHttpUtils
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import okhttp3.MediaType
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import spock.lang.Shared
 
 import java.nio.file.Files
+import java.util.zip.GZIPInputStream
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -73,6 +78,37 @@ abstract class AppSecPlaySmokeTest extends AbstractAppSecServerSmokeTest {
     def span = sampledSpans[0]
     span.meta.containsKey('_dd.appsec.s.req.query')
     span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  void 'test response schema extraction'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/response"
+    def client = OkHttpUtils.clientBuilder().build()
+    def body = [
+      "main"    : [["key": "id001", "value": 1345.67], ["value": 1567.89, "key": "id002"]],
+      "nullable": null,
+    ]
+    def request = new Request.Builder()
+      .url(url)
+      .post(RequestBody.create(MediaType.get('application/json'), JsonOutput.toJson(body)))
+      .build()
+
+    when:
+    final response = client.newCall(request).execute()
+    waitForTraceCount(1)
+
+    then:
+    response.code() == 200
+    def span = rootSpans.first()
+    span.meta.containsKey('_dd.appsec.s.res.headers')
+    span.meta.containsKey('_dd.appsec.s.res.body')
+    final schema = new JsonSlurper().parse(unzip(span.meta.get('_dd.appsec.s.res.body')))
+    assert schema == [["main": [[[["key": [8], "value": [16]]]], ["len": 2]], "nullable": [1]]]
+  }
+
+  private static byte[] unzip(final String text) {
+    final inflaterStream = new GZIPInputStream(new ByteArrayInputStream(text.decodeBase64()))
+    return inflaterStream.getBytes()
   }
 
   // Ensure to clean up server and not only the shell script that starts it


### PR DESCRIPTION
# What Does This Do

Adds response body extraction for Play JSON endpoints to enable automatic API schema discovery and protection by the Web Application Firewall (WAF). Support is for Play >= 2.4+ (leverages new [JSON](https://github.com/playframework/playframework/blob/2.4.0/framework/src/play/src/main/java/play/mvc/Results.java#L79) response API)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-57914]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-57914]: https://datadoghq.atlassian.net/browse/APPSEC-57914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ