### PR TITLE
Enable test retry in CI

### DIFF
--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -333,7 +333,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
 
     if (!p.waitFor(PROCESS_TIMEOUT_SECS, TimeUnit.SECONDS)) {
       p.destroyForcibly()
-      throw new TimeoutException("Instrumented process failed to exit")
+      throw new TimeoutException("Instrumented process failed to exit within $PROCESS_TIMEOUT_SECS")
     }
 
     return p.exitValue()

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -124,3 +124,13 @@ if (!project.property("activePartition")) {
     }
   }
 }
+
+tasks.withType(Test) {
+  // https://docs.gradle.com/develocity/flaky-test-detection/
+  // https://docs.gradle.com/develocity/gradle-plugin/current/#test_retry
+  develocity.testRetry {
+    if (System.getenv().containsKey("CI")) {
+      maxRetries = 3
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Retry tests in CI, I wonder however if these should be tracked ? Maybe Test Optim has that?


Note:
When a test fails it is captured by [_Test Optimization_](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.branch%3Atest-retry-in-ci%20%40test.status%3A%28fail%20OR%20pass%29%20%40test.suite%3APekkoHttpServerInstrumentationAsyncHttp2Test%20%40ci.job.name%3A%22test_inst%3A%20%5B17%2C%205%2F6%5D%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A327%2C%40test.name%3A386%2C%40duration%3A146%2C%40test.service%3A129%2C%40git.branch%2C%40ci.job.name&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1749643041273&end=1750247841273&paused=true).


```
@git.branch:test-retry-in-ci @test.status:(fail OR pass) @test.suite:PekkoHttpServerInstrumentationAsyncHttp2Test @ci.job.name:"test_inst: [17, 5/6]"
```

![image](https://github.com/user-attachments/assets/bf6370c2-03f4-463e-b7e2-cc7e6da56986)


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
