### PR TITLE
Extract Vert.x json body response schemas

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -105,6 +105,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean reqDataPublished;
   private boolean rawReqBodyPublished;
   private boolean convertedReqBodyPublished;
+  private boolean responseBodyPublished;
   private boolean respDataPublished;
   private boolean pathParamsPublished;
   private volatile Map<String, String> derivatives;
@@ -500,6 +501,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public void setConvertedReqBodyPublished(boolean convertedReqBodyPublished) {
     this.convertedReqBodyPublished = convertedReqBodyPublished;
+  }
+
+  public boolean isResponseBodyPublished() {
+    return responseBodyPublished;
+  }
+
+  public void setResponseBodyPublished(final boolean responseBodyPublished) {
+    this.responseBodyPublished = responseBodyPublished;
   }
 
   public boolean isRespDataPublished() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -98,6 +98,7 @@ public class GatewayBridge {
   private volatile DataSubscriberInfo initialReqDataSubInfo;
   private volatile DataSubscriberInfo rawRequestBodySubInfo;
   private volatile DataSubscriberInfo requestBodySubInfo;
+  private volatile DataSubscriberInfo responseBodySubInfo;
   private volatile DataSubscriberInfo pathParamsSubInfo;
   private volatile DataSubscriberInfo respDataSubInfo;
   private volatile DataSubscriberInfo grpcServerMethodSubInfo;
@@ -137,6 +138,7 @@ public class GatewayBridge {
     subscriptionService.registerCallback(EVENTS.requestMethodUriRaw(), this::onRequestMethodUriRaw);
     subscriptionService.registerCallback(EVENTS.requestBodyStart(), this::onRequestBodyStart);
     subscriptionService.registerCallback(EVENTS.requestBodyDone(), this::onRequestBodyDone);
+    subscriptionService.registerCallback(EVENTS.responseBody(), this::onResponseBody);
     subscriptionService.registerCallback(
         EVENTS.requestClientSocketAddress(), this::onRequestClientSocketAddress);
     subscriptionService.registerCallback(
@@ -177,6 +179,7 @@ public class GatewayBridge {
     initialReqDataSubInfo = null;
     rawRequestBodySubInfo = null;
     requestBodySubInfo = null;
+    responseBodySubInfo = null;
     pathParamsSubInfo = null;
     respDataSubInfo = null;
     grpcServerMethodSubInfo = null;
@@ -634,6 +637,39 @@ public class GatewayBridge {
         return producerService.publishDataEvent(subInfo, ctx, bundle, gwCtx);
       } catch (ExpiredSubscriberInfoException e) {
         rawRequestBodySubInfo = null;
+      }
+    }
+  }
+
+  private Flow<Void> onResponseBody(RequestContext ctx_, Object obj) {
+    AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
+    if (ctx == null) {
+      return NoopFlow.INSTANCE;
+    }
+
+    if (ctx.isResponseBodyPublished()) {
+      log.debug(
+          "Response body already published; will ignore new value of type {}", obj.getClass());
+      return NoopFlow.INSTANCE;
+    }
+    ctx.setResponseBodyPublished(true);
+
+    while (true) {
+      DataSubscriberInfo subInfo = responseBodySubInfo;
+      if (subInfo == null) {
+        subInfo = producerService.getDataSubscribers(KnownAddresses.RESPONSE_BODY_OBJECT);
+        responseBodySubInfo = subInfo;
+      }
+      if (subInfo == null || subInfo.isEmpty()) {
+        return NoopFlow.INSTANCE;
+      }
+      Object converted = ObjectIntrospection.convert(obj, ctx);
+      DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.RESPONSE_BODY_OBJECT, converted);
+      try {
+        GatewayContext gwCtx = new GatewayContext(false);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, gwCtx);
+      } catch (ExpiredSubscriberInfoException e) {
+        responseBodySubInfo = null;
       }
     }
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
@@ -2,13 +2,10 @@ package com.datadog.appsec.event.data
 
 import com.datadog.appsec.gateway.AppSecRequestContext
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import datadog.trace.api.telemetry.WafMetricCollector
 import datadog.trace.test.util.DDSpecification
 import groovy.json.JsonBuilder
 import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
 import spock.lang.Shared
 
 import java.nio.CharBuffer
@@ -465,6 +462,17 @@ class ObjectIntrospectionSpecification extends DDSpecification {
     MAPPER.readTree('"unicode: \\u0041"')          || 'unicode: A'
   }
 
+  void 'iterable json objects'() {
+    setup:
+    final map = [name: 'This is just a test', list: [1, 2, 3, 4, 5]]
+
+    when:
+    final result = convert(new IterableJsonObject(map), ctx)
+
+    then:
+    result == map
+  }
+
   private static int countNesting(final Map<String, Object>object, final int levels) {
     if (object.isEmpty()) {
       return levels
@@ -474,5 +482,19 @@ class ObjectIntrospectionSpecification extends DDSpecification {
       return levels
     }
     return countNesting(object.values().first() as Map, levels + 1)
+  }
+
+  private static class IterableJsonObject implements Iterable<Map.Entry<String, Object>> {
+
+    private final Map<String, Object> map
+
+    IterableJsonObject(Map<String, Object> map) {
+      this.map = map
+    }
+
+    @Override
+    Iterator<Map.Entry<String, Object>> iterator() {
+      return map.entrySet().iterator()
+    }
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -99,6 +99,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   BiFunction<RequestContext, StoredBodySupplier, Void> requestBodyStartCB
   BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestBodyDoneCB
   BiFunction<RequestContext, Object, Flow<Void>> requestBodyProcessedCB
+  BiFunction<RequestContext, Object, Flow<Void>> responseBodyCB
   BiFunction<RequestContext, Integer, Flow<Void>> responseStartedCB
   TriConsumer<RequestContext, String, String> respHeaderCB
   Function<RequestContext, Flow<Void>> respHeadersDoneCB
@@ -463,6 +464,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * ig.registerCallback(EVENTS.requestBodyStart(), _) >> { requestBodyStartCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.requestBodyDone(), _) >> { requestBodyDoneCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.requestBodyProcessed(), _) >> { requestBodyProcessedCB = it[1]; null }
+    1 * ig.registerCallback(EVENTS.responseBody(), _) >> { responseBodyCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.responseStarted(), _) >> { responseStartedCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.responseHeader(), _) >> { respHeaderCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.responseHeaderDone(), _) >> { respHeadersDoneCB = it[1]; null }
@@ -1338,6 +1340,19 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     then:
     arCtx.getRoute() == route
+  }
+
+  void 'test on response body callback'() {
+    when:
+    responseBodyCB.apply(ctx, [test: 'this is a test'])
+
+    then:
+    1 * eventDispatcher.getDataSubscribers(KnownAddresses.RESPONSE_BODY_OBJECT) >> nonEmptyDsInfo
+    1 * eventDispatcher.publishDataEvent(_, _, _, _) >> {
+      final bundle = it[2] as DataBundle
+      final body = bundle.get(KnownAddresses.RESPONSE_BODY_OBJECT)
+      assert body['test'] == 'this is a test'
+    }
   }
 
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextInstrumentation.java
@@ -1,0 +1,41 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import io.vertx.ext.web.impl.RoutingContextImpl;
+
+/**
+ * @see RoutingContextImpl#getBodyAsJson(int)
+ * @see RoutingContextImpl#getBodyAsJsonArray(int)
+ */
+@AutoService(InstrumenterModule.class)
+public class RoutingContextInstrumentation extends InstrumenterModule.AppSec
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public RoutingContextInstrumentation() {
+    super("vertx", "vertx-4.0");
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE};
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.vertx.ext.web.RoutingContext";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("json").and(takesArguments(1)).and(takesArgument(0, Object.class)),
+        packageName + ".RoutingContextJsonResponseAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonResponseAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonResponseAdvice.java
@@ -1,0 +1,55 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+class RoutingContextJsonResponseAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void before(
+      @Advice.Argument(0) final Object object, @ActiveRequestContext final RequestContext reqCtx) {
+
+    if (object == null) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    if (cbp == null) {
+      return;
+    }
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.responseBody());
+    if (callback == null) {
+      return;
+    }
+
+    Flow<Void> flow = callback.apply(reqCtx, object);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+      if (blockResponseFunction == null) {
+        return;
+      }
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      blockResponseFunction.tryCommitBlockingResponse(
+          reqCtx.getTraceSegment(),
+          rba.getStatusCode(),
+          rba.getBlockingContentType(),
+          rba.getExtraHeaders());
+
+      throw new BlockingException("Blocked request (for RoutingContext/json)");
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -84,6 +84,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testResponseBodyJson() {
+    true
+  }
+
+  @Override
   boolean testBlocking() {
     true
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -127,7 +127,8 @@ public class VertxTestServer extends AbstractVerticle {
                     BODY_JSON,
                     () -> {
                       JsonObject json = ctx.getBodyAsJson();
-                      ctx.response().setStatusCode(BODY_JSON.getStatus()).end(json.toString());
+                      ctx.response().setStatusCode(BODY_JSON.getStatus());
+                      ctx.json(json);
                     }));
     router
         .route(QUERY_ENCODED_BOTH.getRawPath())

--- a/dd-java-agent/instrumentation/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -68,6 +68,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testResponseBodyJson() {
+    true
+  }
+
+  @Override
   boolean testBodyUrlencoded() {
     true
   }

--- a/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-5.0/src/test/java/server/VertxTestServer.java
@@ -118,7 +118,8 @@ public class VertxTestServer extends AbstractVerticle {
                     BODY_JSON,
                     () -> {
                       JsonObject json = ctx.body().asJsonObject();
-                      ctx.response().setStatusCode(BODY_JSON.getStatus()).end(json.toString());
+                      ctx.response().setStatusCode(BODY_JSON.getStatus());
+                      ctx.json(json);
                     }));
     router
         .route(QUERY_ENCODED_BOTH.getRawPath())

--- a/dd-smoke-tests/vertx-4.2/application/src/main/java/datadog/vertx_4_2/MainVerticle.java
+++ b/dd-smoke-tests/vertx-4.2/application/src/main/java/datadog/vertx_4_2/MainVerticle.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
 import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -50,6 +51,15 @@ public class MainVerticle extends AbstractVerticle {
                 ctx.response()
                     .setStatusCode(Integer.parseInt(ctx.request().getParam("status_code")))
                     .end("EXECUTED"));
+
+    router.route("/api_security/response").handler(BodyHandler.create());
+    router
+        .route("/api_security/response")
+        .handler(
+            ctx -> {
+              ctx.response().setStatusCode(200);
+              ctx.json(ctx.getBodyAsJson());
+            });
 
     vertx
         .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))

--- a/dd-smoke-tests/vertx-4.2/src/test/groovy/AppSecVertxSmokeTest.groovy
+++ b/dd-smoke-tests/vertx-4.2/src/test/groovy/AppSecVertxSmokeTest.groovy
@@ -1,8 +1,14 @@
 import datadog.smoketest.appsec.AbstractAppSecServerSmokeTest
 import datadog.trace.agent.test.utils.OkHttpUtils
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import okhttp3.MediaType
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import spock.lang.IgnoreIf
+
+import java.util.zip.GZIPInputStream
 
 @IgnoreIf({
   // TODO https://github.com/eclipse-vertx/vert.x/issues/2172
@@ -69,5 +75,37 @@ class AppSecVertxSmokeTest extends AbstractAppSecServerSmokeTest {
     span.meta.containsKey('_dd.appsec.s.req.query')
     span.meta.containsKey('_dd.appsec.s.req.params')
     span.meta.containsKey('_dd.appsec.s.req.headers')
+  }
+
+  void 'test response schema extraction'() {
+    given:
+    def url = "http://localhost:${httpPort}/api_security/response"
+    def client = OkHttpUtils.clientBuilder().build()
+    def body = [
+      "main"    : [["key": "id001", "value": 1345.67], ["value": 1567.89, "key": "id002"]],
+      "nullable": null,
+    ]
+    def request = new Request.Builder()
+      .url(url)
+      .post(RequestBody.create(MediaType.get('application/json'), JsonOutput.toJson(body)))
+      .build()
+
+    when:
+    final response = client.newCall(request).execute()
+    waitForTraceCount(1)
+
+    then:
+    response.code() == 200
+    def span = rootSpans.first()
+    span.meta.containsKey('_dd.appsec.s.res.headers')
+    span.meta.containsKey('_dd.appsec.s.res.body')
+    final schema = new JsonSlurper().parse(unzip(span.meta.get('_dd.appsec.s.res.body')))
+    assert schema == [["main": [[[["key": [8], "value": [16]]]], ["len": 2]], "nullable": [1]]]
+  }
+
+
+  private static byte[] unzip(final String text) {
+    final inflaterStream = new GZIPInputStream(new ByteArrayInputStream(text.decodeBase64()))
+    return inflaterStream.getBytes()
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -322,6 +322,18 @@ public final class Events<D> {
     return (EventType<BiConsumer<RequestContext, String>>) HTTP_ROUTE;
   }
 
+  static final int RESPONSE_BODY_ID = 27;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType RESPONSE_BODY = new ET<>("response.body", RESPONSE_BODY_ID);
+  /**
+   * The original response body object used by the framework before being serialized to the response
+   */
+  @SuppressWarnings("unchecked")
+  public EventType<BiFunction<RequestContext, Object, Flow<Void>>> responseBody() {
+    return (EventType<BiFunction<RequestContext, Object, Flow<Void>>>) RESPONSE_BODY;
+  }
+
   static final int MAX_EVENTS = nextId.get();
 
   private static final class ET<T> extends EventType<T> {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -23,6 +23,7 @@ import static datadog.trace.api.gateway.Events.REQUEST_METHOD_URI_RAW_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_PATH_PARAMS_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_SESSION_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_STARTED_ID;
+import static datadog.trace.api.gateway.Events.RESPONSE_BODY_ID;
 import static datadog.trace.api.gateway.Events.RESPONSE_HEADER_DONE_ID;
 import static datadog.trace.api.gateway.Events.RESPONSE_HEADER_ID;
 import static datadog.trace.api.gateway.Events.RESPONSE_STARTED_ID;
@@ -347,6 +348,7 @@ public class InstrumentationGateway {
       case GRPC_SERVER_REQUEST_MESSAGE_ID:
       case GRAPHQL_SERVER_REQUEST_MESSAGE_ID:
       case REQUEST_BODY_CONVERTED_ID:
+      case RESPONSE_BODY_ID:
         return (C)
             new BiFunction<RequestContext, Object, Flow<Void>>() {
               @Override

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -190,6 +190,9 @@ public class InstrumentationGatewayTest {
     ss.registerCallback(events.requestBodyProcessed(), callback);
     assertThat(cbp.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.responseBody(), callback);
+    assertThat(cbp.getCallback(events.responseBody()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.grpcServerMethod(), callback);
     assertThat(cbp.getCallback(events.grpcServerMethod()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
@@ -261,6 +264,9 @@ public class InstrumentationGatewayTest {
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.requestBodyProcessed(), throwback);
     assertThat(cbp.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.responseBody(), throwback);
+    assertThat(cbp.getCallback(events.responseBody()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.grpcServerMethod(), throwback);
     assertThat(cbp.getCallback(events.grpcServerMethod()).apply(null, null).getAction())


### PR DESCRIPTION
# What Does This Do

Adds response body extraction for Vert.x JSON endpoints to enable automatic API schema discovery and protection by the Web Application Firewall (WAF).  Support is for Vert.x >= 4.x (leverages new [JSON](https://github.com/vert-x3/vertx-web/blob/4.0.0/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java#L678) response API introduced in v4.x)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-57920]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-57920]: https://datadoghq.atlassian.net/browse/APPSEC-57920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ