### PR TITLE
Revert "Enable API Security by default"

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -113,7 +113,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
-  static final boolean DEFAULT_API_SECURITY_ENABLED = true;
+  static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_SAMPLE_DELAY = 30.0f;
   // TODO: change to true once the RFC is approved
   static final boolean DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED = false;


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#8511

The PR introduces a slight startup performance regression, so we will revert for the 1.50.0 release. 

See [BP UI ref](https://benchmarking.us1.prod.dog/benchmarks?ciJobDateStart=1749678549537&ciJobDateEnd=1750283349537&projectId=4&gitBranch=sarahchen6%2F1.49.0-branch&page=1) runs 68139155 and 68120382 (candidate branch does not include this PR) vs. 68164219 and 68155119 (candidate PR does include this PR). Note that in this case, `master`/1.50.0 is the baseline and the 1.49.0 branch is the candidate, so the performance improvements/regressions are reversed.