### PR TITLE
Enable jax-ws integration by default

### DIFF
--- a/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
@@ -37,11 +37,6 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String hierarchyMarkerType() {
     return null; // bootstrap type
   }

--- a/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
@@ -35,11 +35,6 @@ public final class WebServiceProviderInstrumentation extends InstrumenterModule.
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String hierarchyMarkerType() {
     return null; // bootstrap type
   }


### PR DESCRIPTION
# What Does This Do
Enables the `jax-ws` integration by default

# Motivation
Enabling integrations by default, unless objectionable to do so, gives users the best possible experience

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
