### PR TITLE
KTLO: unify Gradle files with single quotes and replace deprecated 'mainClassName' with 'mainClass'.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,18 +13,18 @@ buildscript {
 }
 
 plugins {
-  id "datadog.gradle-debug"
-  id "datadog.dependency-locking"
+  id 'datadog.gradle-debug'
+  id 'datadog.dependency-locking'
 
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
   id 'com.github.spotbugs' version '5.0.14'
-  id "de.thetaphi.forbiddenapis" version "3.8"
+  id 'de.thetaphi.forbiddenapis' version "3.8"
 
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'
   id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 
-  id "com.gradleup.shadow" version "8.3.6" apply false
-  id "me.champeau.jmh" version "0.7.0" apply false
+  id 'com.gradleup.shadow' version '8.3.6' apply false
+  id 'me.champeau.jmh' version '0.7.0' apply false
   id 'org.gradle.playframework' version '0.13' apply false
   id 'info.solidsoft.pitest' version '1.9.11'  apply false
 }

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -10,7 +10,7 @@ class CallSiteInstrumentationPluginTest extends Specification {
     plugins {
       id 'java'
       id 'call-site-instrumentation'
-      id("com.diffplug.spotless") version "6.13.0"
+      id 'com.diffplug.spotless' version '6.13.0'
     }
     
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -1,6 +1,6 @@
 // The shadowJar of this project will be injected into the JVM's bootstrap classloader
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'me.champeau.jmh'
 }
 

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "scala"
+  id 'scala'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -6,7 +6,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import static java.nio.file.StandardOpenOption.CREATE
 
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
+++ b/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 def otelApiVersion = '1.38.0'

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -2,8 +2,8 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
 plugins {
-  id "com.gradleup.shadow"
-  id "me.champeau.jmh"
+  id 'com.gradleup.shadow'
+  id 'me.champeau.jmh'
   id 'java-test-fixtures'
 }
 

--- a/dd-java-agent/benchmark/build.gradle
+++ b/dd-java-agent/benchmark/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "me.champeau.jmh"
+  id 'me.champeau.jmh'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import java.util.concurrent.atomic.AtomicBoolean
 
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 description = 'dd-java-agent'

--- a/dd-java-agent/cws-tls/build.gradle
+++ b/dd-java-agent/cws-tls/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -24,7 +24,7 @@ buildscript {
   }
 }
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-java-agent/instrumentation/protobuf/build.gradle
+++ b/dd-java-agent/instrumentation/protobuf/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.google.protobuf" version "0.9.4"
+  id 'com.google.protobuf' version '0.9.4'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/spring-tomcat7/build.gradle
+++ b/dd-smoke-tests/appsec/spring-tomcat7/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot/build.gradle
+++ b/dd-smoke-tests/appsec/springboot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 plugins {
   id 'application'
   id 'java'
-  id "com.diffplug.spotless" version "6.13.0"
-  id "com.gradleup.shadow" version "8.3.6"
+  id 'com.diffplug.spotless' version '6.13.0'
+  id 'com.gradleup.shadow' version '8.3.6'
   id 'com.google.protobuf' version '0.9.3'
 }
 

--- a/dd-smoke-tests/cli/build.gradle
+++ b/dd-smoke-tests/cli/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/concurrent/java-21/build.gradle
+++ b/dd-smoke-tests/concurrent/java-21/build.gradle
@@ -34,7 +34,7 @@ forbiddenApisMain {
 }
 
 application {
-  mainClassName = 'datadog.smoketest.concurrent.ConcurrentApp'
+  mainClass = 'datadog.smoketest.concurrent.ConcurrentApp'
 }
 
 dependencies {

--- a/dd-smoke-tests/concurrent/java-8/build.gradle
+++ b/dd-smoke-tests/concurrent/java-8/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/java.gradle"
 description = 'JDK 8 Concurrent Integration Tests'
 
 application {
-  mainClassName = 'datadog.smoketest.concurrent.ConcurrentApp'
+  mainClass = 'datadog.smoketest.concurrent.ConcurrentApp'
 }
 
 dependencies {

--- a/dd-smoke-tests/crashtracking/build.gradle
+++ b/dd-smoke-tests/crashtracking/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 description = 'Check classes loaded by custom system class-loader are transformed'

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java'
   id 'org.springframework.boot' version '2.6.3'
 }

--- a/dd-smoke-tests/debugger-integration-tests/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 shadowJar {
     // Define the main class for the application.
-    mainClassName = 'App'
+    mainClass = 'App'
 }
 
 def latestJdk = 17

--- a/dd-smoke-tests/dynamic-config/build.gradle
+++ b/dd-smoke-tests/dynamic-config/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/field-injection/build.gradle
+++ b/dd-smoke-tests/field-injection/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 description = 'Check fields get injected where expected'

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -2,7 +2,7 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/jersey-2/build.gradle
+++ b/dd-smoke-tests/jersey-2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/jersey-3/build.gradle
+++ b/dd-smoke-tests/jersey-3/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/log-injection/build.gradle
+++ b/dd-smoke-tests/log-injection/build.gradle
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/opentracing/build.gradle
+++ b/dd-smoke-tests/opentracing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 ext {

--- a/dd-smoke-tests/quarkus-native/application/build.gradle
+++ b/dd-smoke-tests/quarkus-native/application/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'io.quarkus'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/quarkus/application/build.gradle
+++ b/dd-smoke-tests/quarkus/application/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'io.quarkus'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/resteasy/build.gradle
+++ b/dd-smoke-tests/resteasy/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '2.7.4'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id 'org.graalvm.buildtools.native' version '0.9.28'
-  id 'com.diffplug.spotless' version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.3-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.3-webmvc/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.3.5'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-rabbit/build.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'com.google.protobuf' version '0.8.18'
 }
 

--- a/dd-smoke-tests/springboot-mongo/build.gradle
+++ b/dd-smoke-tests/springboot-mongo/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot/build.gradle
+++ b/dd-smoke-tests/springboot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradleup.shadow"
+  id 'com.gradleup.shadow'
   id 'java-test-fixtures'
 }
 

--- a/dd-smoke-tests/wildfly/spring-ear/build.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'ear'
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id "com.gradleup.shadow"
-  id "me.champeau.jmh"
+  id 'com.gradleup.shadow'
+  id 'me.champeau.jmh'
 }
 
 description = 'dd-trace-ot'

--- a/test-published-dependencies/agent-logs-on-java-7/build.gradle
+++ b/test-published-dependencies/agent-logs-on-java-7/build.gradle
@@ -36,7 +36,7 @@ jar {
 }
 
 application {
-  mainClassName = 'test.published.dependencies.App'
+  mainClass = 'test.published.dependencies.App'
 }
 
 compileTestJava {

--- a/test-published-dependencies/all-deps-exist/build.gradle
+++ b/test-published-dependencies/all-deps-exist/build.gradle
@@ -14,5 +14,5 @@ dependencies {
 }
 
 application {
-  mainClassName = 'test.published.dependencies.App'
+  mainClass = 'test.published.dependencies.App'
 }

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.diffplug.spotless" version "6.13.0"
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 def sharedConfigDirectory = "$rootDir/../gradle"

--- a/test-published-dependencies/ot-pulls-in-api/build.gradle
+++ b/test-published-dependencies/ot-pulls-in-api/build.gradle
@@ -21,5 +21,5 @@ test {
 }
 
 application {
-  mainClassName = 'test.published.dependencies.App'
+  mainClass = 'test.published.dependencies.App'
 }


### PR DESCRIPTION
# What Does This Do
Gradle files cleanup:
- unify Gradle files with single quotes
- replace deprecated 'mainClassName' with 'mainClass'.

# Motivation
 - Consistency in quoting.
 - Reduce warning from Gradle during build.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
