### PR TITLE
Fixing bug with dropping baggage when `TracePropagationBehaviorExtract=IGNORE`

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -4,7 +4,7 @@ import static datadog.communication.monitor.DDAgentStatsDClientManager.statsDCli
 import static datadog.trace.api.DDTags.DJM_ENABLED;
 import static datadog.trace.api.DDTags.DSM_ENABLED;
 import static datadog.trace.api.DDTags.PROFILING_CONTEXT_ENGINE;
-import static datadog.trace.api.TracePropagationBehaviorExtract.RESTART;
+import static datadog.trace.api.TracePropagationBehaviorExtract.IGNORE;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.BAGGAGE_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.DSM_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.TRACING_CONCERN;
@@ -716,7 +716,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (config.isDataStreamsEnabled()) {
       Propagators.register(DSM_CONCERN, this.dataStreamsMonitoring.propagator());
     }
-    if (config.isBaggagePropagationEnabled()) {
+    if (config.isBaggagePropagationEnabled()
+        && config.getTracePropagationBehaviorExtract() != IGNORE) {
       Propagators.register(BAGGAGE_CONCERN, new BaggagePropagator(config));
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
@@ -1,6 +1,5 @@
 package datadog.trace.core.baggage;
 
-import static datadog.trace.api.TracePropagationBehaviorExtract.IGNORE;
 import static java.util.Collections.emptyMap;
 
 import datadog.context.Context;
@@ -8,7 +7,6 @@ import datadog.context.propagation.CarrierSetter;
 import datadog.context.propagation.CarrierVisitor;
 import datadog.context.propagation.Propagator;
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationBehaviorExtract;
 import datadog.trace.bootstrap.instrumentation.api.Baggage;
 import datadog.trace.core.util.PercentEscaper;
 import datadog.trace.core.util.PercentEscaper.Escaped;
@@ -30,29 +28,21 @@ public class BaggagePropagator implements Propagator {
   private final boolean extractBaggage;
   private final int maxItems;
   private final int maxBytes;
-  private final TracePropagationBehaviorExtract behaviorExtract;
 
   public BaggagePropagator(Config config) {
     this(
         config.isBaggageInject(),
         config.isBaggageExtract(),
         config.getTraceBaggageMaxItems(),
-        config.getTraceBaggageMaxBytes(),
-        config.getTracePropagationBehaviorExtract());
+        config.getTraceBaggageMaxBytes());
   }
 
   // use primarily for testing purposes
-  BaggagePropagator(
-      boolean injectBaggage,
-      boolean extractBaggage,
-      int maxItems,
-      int maxBytes,
-      TracePropagationBehaviorExtract behaviorExtract) {
+  BaggagePropagator(boolean injectBaggage, boolean extractBaggage, int maxItems, int maxBytes) {
     this.injectBaggage = injectBaggage;
     this.extractBaggage = extractBaggage;
     this.maxItems = maxItems;
     this.maxBytes = maxBytes;
-    this.behaviorExtract = behaviorExtract;
   }
 
   @Override
@@ -114,11 +104,7 @@ public class BaggagePropagator implements Propagator {
 
   @Override
   public <C> Context extract(Context context, C carrier, CarrierVisitor<C> visitor) {
-    if (!this.extractBaggage
-        || this.behaviorExtract == IGNORE
-        || context == null
-        || carrier == null
-        || visitor == null) {
+    if (!this.extractBaggage || context == null || carrier == null || visitor == null) {
       return context;
     }
     BaggageExtractor baggageExtractor = new BaggageExtractor();

--- a/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
@@ -35,7 +35,7 @@ public class BaggagePropagator implements Propagator {
   public BaggagePropagator(Config config) {
     this(
         config.isBaggageInject(),
-        config.isBaggageInject(),
+        config.isBaggageExtract(),
         config.getTraceBaggageMaxItems(),
         config.getTraceBaggageMaxBytes(),
         config.getTracePropagationBehaviorExtract());

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/baggage/BaggagePropagatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/baggage/BaggagePropagatorTest.groovy
@@ -11,6 +11,7 @@ import java.util.function.BiConsumer
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_BYTES
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_ITEMS
+import static datadog.trace.api.TracePropagationBehaviorExtract.CONTINUE
 import static datadog.trace.core.baggage.BaggagePropagator.BAGGAGE_KEY
 
 class BaggagePropagatorTest extends DDSpecification {
@@ -35,7 +36,7 @@ class BaggagePropagatorTest extends DDSpecification {
   }
 
   def setup() {
-    this.propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, DEFAULT_TRACE_BAGGAGE_MAX_BYTES)
+    this.propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE)
     this.setter = new MapCarrierAccessor()
     this.carrier = [:]
     this.context = Context.root()
@@ -65,7 +66,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage inject item limit"() {
     setup:
-    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE) //creating a new instance after injecting config
     context = Baggage.create(baggage).storeInto(context)
 
     when:
@@ -82,7 +83,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage inject bytes limit"() {
     setup:
-    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20, CONTINUE) //creating a new instance after injecting config
     context = Baggage.create(baggage).storeInto(context)
 
     when:
@@ -184,7 +185,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage cache items limit"(){
     setup:
-    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE) //creating a new instance after injecting config
     def headers = [
       (BAGGAGE_KEY) : baggageHeader,
     ]
@@ -205,7 +206,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage cache bytes limit"(){
     setup:
-    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20, CONTINUE) //creating a new instance after injecting config
     def headers = [
       (BAGGAGE_KEY) : baggageHeader,
     ]

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/baggage/BaggagePropagatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/baggage/BaggagePropagatorTest.groovy
@@ -11,7 +11,6 @@ import java.util.function.BiConsumer
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_BYTES
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_ITEMS
-import static datadog.trace.api.TracePropagationBehaviorExtract.CONTINUE
 import static datadog.trace.core.baggage.BaggagePropagator.BAGGAGE_KEY
 
 class BaggagePropagatorTest extends DDSpecification {
@@ -36,7 +35,7 @@ class BaggagePropagatorTest extends DDSpecification {
   }
 
   def setup() {
-    this.propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE)
+    this.propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, DEFAULT_TRACE_BAGGAGE_MAX_BYTES)
     this.setter = new MapCarrierAccessor()
     this.carrier = [:]
     this.context = Context.root()
@@ -66,7 +65,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage inject item limit"() {
     setup:
-    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES) //creating a new instance after injecting config
     context = Baggage.create(baggage).storeInto(context)
 
     when:
@@ -83,7 +82,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage inject bytes limit"() {
     setup:
-    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20, CONTINUE) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20) //creating a new instance after injecting config
     context = Baggage.create(baggage).storeInto(context)
 
     when:
@@ -185,7 +184,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage cache items limit"(){
     setup:
-    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES, CONTINUE) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES) //creating a new instance after injecting config
     def headers = [
       (BAGGAGE_KEY) : baggageHeader,
     ]
@@ -206,7 +205,7 @@ class BaggagePropagatorTest extends DDSpecification {
 
   def "test baggage cache bytes limit"(){
     setup:
-    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20, CONTINUE) //creating a new instance after injecting config
+    propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20) //creating a new instance after injecting config
     def headers = [
       (BAGGAGE_KEY) : baggageHeader,
     ]


### PR DESCRIPTION
# What Does This Do
Previously, baggage was not being dropped when `TracePropagationBehaviorExtract=IGNORE`. This PR fixes that bug and addresses failures in [APMAPI-1443](https://datadoghq.atlassian.net/browse/APMAPI-1443).

Also fixes bug in call to base `BaggagePropagator` constructor.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1443](https://datadoghq.atlassian.net/browse/APMAPI-1443)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-1443]: https://datadoghq.atlassian.net/browse/APMAPI-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1443]: https://datadoghq.atlassian.net/browse/APMAPI-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ