### PR TITLE
Increase MavenSmokeTest timeout

### DIFF
--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 plugins {
   id "com.gradleup.shadow"
 }
@@ -20,6 +22,10 @@ jar {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
   jvmArgs "-Ddatadog.smoketest.maven.jar.path=${tasks.shadowJar.archiveFile.get()}"
+
+  // overriding the default timeout set in configure_tests.gradle, as Maven smoke
+  // tests might run for a longer duration
+  timeout = Duration.ofMinutes(20)
 
   if (project.hasProperty("mavenRepositoryProxy")) {
     // propagate proxy URL to tests, to then propagate it to nested Gradle builds

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -1,4 +1,5 @@
 import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 plugins {
   id "com.gradleup.shadow"
@@ -25,7 +26,7 @@ tasks.withType(Test).configureEach {
 
   // overriding the default timeout set in configure_tests.gradle, as Maven smoke
   // tests might run for a longer duration
-  timeout = Duration.ofMinutes(20)
+  timeout = Duration.of(20, ChronoUnit.MINUTES)
 
   if (project.hasProperty("mavenRepositoryProxy")) {
     // propagate proxy URL to tests, to then propagate it to nested Gradle builds


### PR DESCRIPTION
# What Does This Do

- Increases the Maven smoke test timeout to 20 minutes, due to the tests taking longer after increasing their timeout limit.

# Motivation

After the Maven smoke tests were updated to use the Maven proxy for dependencies, they started to time out in CI. Their timeout value was doubled to keep them from failing because of this (#8997). With this change, although the smoke tests don't timeout individually anymore, the `:smokeTest` target does sometimes go over the timeout limit for Gradle tests configured in `configure_tests.gradle` ([example failure](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/999738668) and [failed jobs on master](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40git.repository.id%3A%22gitlab.ddbuild.io%2FDataDog%2Fapm-reliability%2Fdd-trace-java%22%20%40ci.job.name%3A%28test_smoke%2A%20%2A2%2F4%2A%29%20%40git.branch%3Amaster&agg_m=count&agg_m_source=base&agg_q=%40ci.status&agg_q_source=base&agg_t=count&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=jobs&fromUser=false&graphType=flamegraph&index=cipipeline&sort=time&spanViewType=logs&top_n=10&top_o=top&viz=stream&x_missing=true&start=1750342655732&end=1750947455732&paused=false))

After some [preliminary investigation](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40git.repository.id%3A%22gitlab.ddbuild.io%2FDataDog%2Fapm-reliability%2Fdd-trace-java%22%20%40git.branch%3A%22daniel.mohedano%2Fincrease-maven-smoke-test-timeout%22%20%40ci.job.name%3A%28test_smoke%2A%20%2A2%2F4%2A%29&agg_m=count&agg_m_source=base&agg_q=%40ci.job.name&agg_q_source=base&agg_t=count&fromUser=false&index=cipipeline&top_n=50&top_o=top&viz=stream&x_missing=true&start=1750342680736&end=1750947480736&paused=false), it seems like the execution time for the whole job ranges from 10 to 19 minutes.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
