### PR TITLE
Configure Spotless to automatically remove unused imports.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,17 @@ def isCI = System.getenv("CI") != null
 
 apply from: "$rootDir/gradle/repositories.gradle"
 apply from: "$rootDir/gradle/scm.gradle"
+
 spotless {
   // only resolve the spotless dependencies once in the build
   predeclareDeps()
 }
+
 spotlessPredeclare {
   // these need to align with the types and versions in gradle/spotless.gradle
   java {
+    removeUnusedImports()
+
     // This is the last Google Java Format version that supports Java 8
     googleJavaFormat('1.7')
   }


### PR DESCRIPTION
# What Does This Do
Configure Spotless to automatically remove unused imports.

# Motivation
Clean code.

# Additional Notes
After investigating, I found that Spotless does not support expanding wildcard imports when using google-java-format, which is what we're currently using. This behavior is only supported by eclipse-java-format.

Switching to the Eclipse formatter would introduce a large number of formatting changes, which we want to avoid for now.

As a compromise, this PR enables removeUnusedImports() via Spotless to help clean up unnecessary imports automatically.
For wildcard imports, we’ll handle them manually as needed and enforce their avoidance during code review to prevent them from being merged.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
