### PR TITLE
Update the config origin metric to match what it's mapping

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+// https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/
+// GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/conf_key_value.md
 public enum ConfigOrigin {
   /** configurations that are set through environment variables */
   ENV("env_var"),
@@ -11,6 +13,12 @@ public enum ConfigOrigin {
   LOCAL_STABLE_CONFIG("local_stable_config"),
   /** configuration read in the stable config file, managed by fleet */
   FLEET_STABLE_CONFIG("fleet_stable_config"),
+  /** configurations that are set through the customer application */
+  CODE("code"),
+  /** set by the dd.yaml file or json */
+  DD_CONFIG("dd_config"),
+  /** set for cases where it is difficult/not possible to determine the source of a config. */
+  UNKNOWN("unknown"),
   /** set when the user has not set any configuration for the key (defaults to a value) */
   DEFAULT("default");
 


### PR DESCRIPTION
# What Does This Do
Matches the config origin to https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/conf_key_value.md

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
