### PR TITLE
Ensure all response body advices are OnMethodEnter

### DIFF
--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/StatusHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play25/appsec/StatusHeaderInstrumentation.java
@@ -34,7 +34,9 @@ public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
   @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        named("sendJson").and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode"))),
+        named("sendJson")
+            .and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode")))
+            .and(takesArgument(1, named("com.fasterxml.jackson.core.JsonEncoding"))),
         packageName + ".StatusHeaderSendJsonAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/ResultsStatusApplyAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/ResultsStatusApplyAdvice.java
@@ -20,8 +20,8 @@ import play.api.libs.json.JsValue;
 public class ResultsStatusApplyAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  static void after(
-      @Advice.Argument(0) final Object content, @ActiveRequestContext RequestContext reqCtx) {
+  static void before(
+      @Advice.Argument(0) final Object content, @ActiveRequestContext final RequestContext reqCtx) {
 
     if (!(content instanceof JsValue)) {
       return;

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/StatusHeaderSendJsonAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java_play25/datadog/trace/instrumentation/play25/appsec/StatusHeaderSendJsonAdvice.java
@@ -11,27 +11,16 @@ import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
-import play.mvc.StatusHeader;
 
 @RequiresRequestContext(RequestContextSlot.APPSEC)
 public class StatusHeaderSendJsonAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  static void before() {
-    CallDepthThreadLocalMap.incrementCallDepth(StatusHeader.class);
-  }
-
-  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  static void after(
-      @Advice.Argument(0) final JsonNode json, @ActiveRequestContext RequestContext reqCtx) {
-    final int depth = CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
-    if (depth > 0) {
-      return;
-    }
+  static void before(
+      @Advice.Argument(0) final JsonNode json, @ActiveRequestContext final RequestContext reqCtx) {
 
     if (json == null) {
       return;

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
@@ -17,12 +17,10 @@ import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.instrumentation.play26.MuzzleReferences;
 import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
-import play.mvc.StatusHeader;
 
 @AutoService(InstrumenterModule.class)
 public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
@@ -50,7 +48,9 @@ public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
   @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        named("sendJson").and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode"))),
+        named("sendJson")
+            .and(takesArgument(0, named("com.fasterxml.jackson.databind.JsonNode")))
+            .and(takesArgument(1, named("com.fasterxml.jackson.core.JsonEncoding"))),
         StatusHeaderInstrumentation.class.getName() + "$StatusHeaderSendJsonAdvice");
   }
 
@@ -58,17 +58,9 @@ public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
   public static class StatusHeaderSendJsonAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    static void before() {
-      CallDepthThreadLocalMap.incrementCallDepth(StatusHeader.class);
-    }
-
-    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    static void after(
-        @Advice.Argument(0) final JsonNode json, @ActiveRequestContext RequestContext reqCtx) {
-      final int depth = CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
-      if (depth > 0) {
-        return;
-      }
+    static void before(
+        @Advice.Argument(0) final JsonNode json,
+        @ActiveRequestContext final RequestContext reqCtx) {
 
       if (json == null) {
         return;


### PR DESCRIPTION
# What Does This Do
Ensures that all advices dealing with the response body object are declared as `OnMethodEnter`.

# Motivation
In case there is a block of the resopnse, it is important to block it before the actual response is committed.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
