### PR TITLE
Update Backport Script to not Accept Release Branch Name as Patch Release Name

### DIFF
--- a/tooling/backport-pr-to-patch-release.sh
+++ b/tooling/backport-pr-to-patch-release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# PATCH_RELEASE_NAME should be the name of the release that is being done without the patch number.
 PATCH_RELEASE_NAME=$1
 PATCH_RELEASE_BRANCH=release/$PATCH_RELEASE_NAME
 PR_NUMBER=$2
@@ -11,7 +12,7 @@ PR_NUMBER=$2
 # Check if no arguments are provided
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <patch-release-name> <pr-number>"
-    echo "<patch-release-name>: v1.2.x or release/v1.2.x"
+    echo "<patch-release-name>: v1.2.x"
     echo "<pr-number>: PR number to backport"
     exit 1
 fi
@@ -20,9 +21,10 @@ if [ -z "$PATCH_RELEASE_NAME" ]; then
     echo "Patch release name is not provided: $0 <patch-release-name> <pr-number>"
     exit 1
 fi
-# Check patch release name starts with "release/"
-if [[ ! "$PATCH_RELEASE_NAME" =~ ^release/.* ]]; then
-    PATCH_RELEASE_NAME="release/$PATCH_RELEASE_NAME"
+# Check patch release name does not start with "release/"
+if [[ "$PATCH_RELEASE_NAME" =~ ^release/.* ]]; then
+    echo "Patch release name should not be the same as the release branch name. Only include the release name without patch number. (e.g. 1.2.x)"
+    exit 1
 fi
 # Check PR number is provided
 if [ -z "$PR_NUMBER" ]; then


### PR DESCRIPTION
# What Does This Do
Currently the backport script expects that the `PATCH_RELEASE_NAME` is prefixed with `release/`. This does not make sense because the `PATCH_RELEASE_BRANCH` is defined as `release/$PATCH_RELEASE_NAME`, which could potentially lead to branch names such as `release/release/v1.50.x`. This PR removes the check to ensure that `PATCH_RELEASE_NAME` is prefixed with `release/` (since the variable is no longer used afterwards), and actually enforces that it does not start with that prefix to avoid the `release/release/v.1.50.x` scenario.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
