### PR TITLE
Graceful error handling in .gitlab/find-gh-base-ref.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,11 @@ default:
   - |
     if [[ ! $CI_COMMIT_BRANCH =~ ^(master|release/.*)$ ]]; then
       export GIT_BASE_REF=$(.gitlab/find-gh-base-ref.sh)
-      export GRADLE_PARAMS="$GRADLE_PARAMS -PgitBaseRef=origin/$GIT_BASE_REF"
+      if [[ -n "$GIT_BASE_REF" ]]; then
+        export GRADLE_PARAMS="$GRADLE_PARAMS -PgitBaseRef=origin/$GIT_BASE_REF"
+      else
+        echo "Failed to find base ref for PR" >&2
+      fi
     fi
 
 .gradle_build: &gradle_build

--- a/.gitlab/find-gh-base-ref.sh
+++ b/.gitlab/find-gh-base-ref.sh
@@ -8,6 +8,7 @@ if [[ -z "${CURRENT_HEAD_SHA:-}" ]]; then
   exit 1
 fi
 
+# 'workspace' is declared in the ci pipeline cache
 CACHE_PATH=workspace/find-gh-base-ref.cache
 save_cache() {
   local base_ref="$1"

--- a/.gitlab/find-gh-base-ref.sh
+++ b/.gitlab/find-gh-base-ref.sh
@@ -23,11 +23,11 @@ if [[ -f $CACHE_PATH ]]; then
   source "$CACHE_PATH"
   set +a
   if [[ "$CURRENT_HEAD_SHA" == "${CACHED_HEAD_SHA:-}" && -n "${CACHED_BASE_REF:-}" ]]; then
-    echo "Cache hit" >&2
+    echo "Cache hit on $CACHE_PATH" >&2
     echo "$CACHED_BASE_REF"
     exit 0
   else
-    echo "Cache miss" >&2
+    echo "Cache miss on $CACHE_PATH" >&2
   fi
 fi
 


### PR DESCRIPTION
# What Does This Do
- If `aws ssm` fails, print an error.
- If `.gitlab/find-gh-base-ref.sh` does not determine any base branch, do not set `-PgitBaseRef=` at all.
- Cache the result.

# Motivation
- Some pipelines fail with an empty git base ref, most likely because of an incorrectly handled rate limit.

# Additional Notes
Doing this for quick CI recovery, but ideally:
- Could use `gh` CLI with `gh pr view -R DataDog/dd-trace-java $CI_COMMIT_REF_NAME --json baseRefName --jq .baseRefName` as suggested by @PerfectSlayer.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
