### PR TITLE
Fix IAST VerifyError on custom StreamReader with super call

### DIFF
--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.PropagationModule
+import foo.bar.TestCustomInputStreamReader
 import foo.bar.TestInputStreamReaderSuite
 
 import java.nio.charset.Charset
@@ -26,5 +27,22 @@ class InputStreamReaderCallSiteTest extends  BaseIoCallSiteTest{
       // InputStream input
       [new ByteArrayInputStream("test".getBytes())]// Reader input
     ]
+  }
+
+  void 'test InputStreamReader.<init> with super call and parameter'(){
+    // XXX: Do not modify the constructor call here. Regression test for APPSEC-58131.
+    given:
+    PropagationModule iastModule = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestCustomInputStreamReader(*args)
+
+    then:
+    1 * iastModule.taintObjectIfTainted(_ as InputStreamReader, _ as InputStream)
+    0 * _
+
+    where:
+    args << [[new ByteArrayInputStream("test".getBytes()), Charset.defaultCharset()],]
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomInputStreamReader.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomInputStreamReader.java
@@ -1,0 +1,26 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+public class TestCustomInputStreamReader extends InputStreamReader {
+
+  public TestCustomInputStreamReader(final InputStream in) throws IOException {
+    super(in);
+  }
+
+  public TestCustomInputStreamReader(final InputStream in, final Charset charset)
+      throws IOException {
+    // XXX: DO NOT MODIFY THIS CODE. This is testing a very specific error (APPSEC-58131).
+    // This caused the following error:
+    //   VerifyError: Inconsistent stackmap frames at branch target \d
+    //   Reason: urrent frame's stack size doesn't match stackmap.
+    // To trigger this, it is necessary to consume an argument after the super call.
+    super(in, charset);
+    if (charset != null) {
+      System.out.println("Using charset: " + charset.name());
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
- TBD: Fix VerifyError
- Add regression test

# Motivation

# Additional Notes

[APPSEC-58131](https://datadoghq.atlassian.net/browse/APPSEC-58131)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-58131]: https://datadoghq.atlassian.net/browse/APPSEC-58131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ