### PR TITLE
Change Sonatype names to Maven Central

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -743,8 +743,8 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
     UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
 
-# If the deploy_to_sonatype job is re-run, re-trigger the deploy_artifacts_to_github job as well so that the artifacts match.
-deploy_to_sonatype:
+# If the deploy_to_maven_central job is re-run, re-trigger the deploy_artifacts_to_github job as well so that the artifacts match.
+deploy_to_maven_central:
   extends: .gradle_build
   stage: publish
   needs: [ build ]
@@ -761,8 +761,8 @@ deploy_to_sonatype:
     - when: manual
       allow_failure: true
   script:
-    - export SONATYPE_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.central_username --with-decryption --query "Parameter.Value" --out text)
-    - export SONATYPE_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.central_password --with-decryption --query "Parameter.Value" --out text)
+    - export MAVEN_CENTRAL_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.central_username --with-decryption --query "Parameter.Value" --out text)
+    - export MAVEN_CENTRAL_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.central_password --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
     - ./gradlew -PbuildInfo.build.number=$CI_JOB_ID publishToSonatype closeSonatypeStagingRepository -PskipTests $GRADLE_ARGS
@@ -780,11 +780,11 @@ deploy_artifacts_to_github:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
-  # Requires the deploy_to_sonatype job to have run first (the UP-TO-DATE gradle check across jobs is broken)
+  # Requires the deploy_to_maven_central job to have run first (the UP-TO-DATE gradle check across jobs is broken)
   # This will deploy the artifacts built from the publishToSonatype task to the GitHub release
   needs:
-    - job: deploy_to_sonatype
-      # The deploy_to_sonatype job is not run for release candidate versions
+    - job: deploy_to_maven_central
+      # The deploy_to_maven_central job is not run for release candidate versions
       optional: true
   script:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh_release_token --with-decryption --query "Parameter.Value" --out text > github-token.txt

--- a/build.gradle
+++ b/build.gradle
@@ -110,8 +110,8 @@ nexusPublishing {
       sonatype {
         nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
         snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        username = System.getenv("SONATYPE_USERNAME")
-        password = System.getenv("SONATYPE_PASSWORD")
+        username = System.getenv("MAVEN_CENTRAL_USERNAME")
+        password = System.getenv("MAVEN_CENTRAL_PASSWORD")
       }
     }
   }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -3,8 +3,8 @@ apply plugin: 'signing'
 
 /**
  * Proper publishing requires the following environment variables:
- * SONATYPE_USERNAME
- * SONATYPE_PASSWORD
+ * MAVEN_CENTRAL_USERNAME
+ * MAVEN_CENTRAL_PASSWORD
  * GPG_PRIVATE_KEY
  * GPG_PASSWORD
  */
@@ -81,8 +81,8 @@ gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
   if (taskGraph.hasTask(publish) || taskGraph.hasTask("publishToSonatype")) {
     assert project.findProperty("removeJarVersionNumbers") != true
     if (taskGraph.hasTask("publishToSonatype")) {
-      assert System.getenv("SONATYPE_USERNAME") != null
-      assert System.getenv("SONATYPE_PASSWORD") != null
+      assert System.getenv("MAVEN_CENTRAL_USERNAME") != null
+      assert System.getenv("MAVEN_CENTRAL_PASSWORD") != null
       if (isCI) {
         assert System.getenv("GPG_PRIVATE_KEY") != null
         assert System.getenv("GPG_PASSWORD") != null

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -10,7 +10,7 @@ repositories {
     }
   }
   mavenCentral()
-  // add sonatype repository for snapshot dependencies
+  // add maven central repository for snapshot dependencies
   maven {
     content {
       includeGroup "com.datadoghq"


### PR DESCRIPTION
# What Does This Do

Changes a few `sonatype` namings to `maven central`

# Motivation

Update our naming, now that we are publishing to the Maven Central repository (#8807).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
