### PR TITLE
Fix verify error when ctor params are used after a call site

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -370,7 +370,8 @@ public class Advices {
         @Nonnull TypeDescription type, @Nonnull ConstantPool pool, final byte[] classFile);
   }
 
-  private interface TypedAdvice {
+  // Kept public only for testing
+  public interface TypedAdvice {
     byte getType();
 
     static CallSiteAdvice withType(final CallSiteAdvice advice, final byte type) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -360,10 +360,12 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
     @Override
     public void advice(final String owner, final String name, final String descriptor) {
       if (isSuperCall) {
-        // append this to the stack after super call
-        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ALOAD, 0); // append this to the stack after super call
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, owner, name, descriptor, false);
+        mv.visitInsn(Opcodes.POP); // pop the result of the advice call
+      } else {
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, owner, name, descriptor, false);
       }
-      mv.visitMethodInsn(Opcodes.INVOKESTATIC, owner, name, descriptor, false);
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -54,7 +54,7 @@ class BaseCallSiteTest extends DDSpecification {
         advices
         .computeIfAbsent(owner, t -> [:])
         .computeIfAbsent(method, m -> [:])
-        .put(descriptor, advice)
+        .put(descriptor, Advices.TypedAdvice.withType(advice, type))
       }
       addHelpers(_ as String[]) >> {
         Collections.addAll(helpers, it[0] as String[])
@@ -82,6 +82,9 @@ class BaseCallSiteTest extends DDSpecification {
       }
       getHelpers() >> {
         helpers as String[]
+      }
+      typeOf(_ as CallSiteAdvice) >> {
+        ((Advices.TypedAdvice) it[0]).type
       }
     }
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -68,7 +68,7 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     0 * builder.visit(_ as AsmVisitorWrapper) >> builder
   }
 
-  void 'test call site transformer with super call in ctor'() {
+  void 'test call site transformer with super call in ctor (#test)'() {
     setup:
     SuperInCtorExampleAdvice.CALLS.set(0)
     final source = Type.getType(SuperInCtorExample)
@@ -91,11 +91,16 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     when:
     final transformedClass = transformType(source, target, callSiteTransformer)
     final transformed = loadClass(target, transformedClass)
-    final reader = transformed.newInstance("test")
+    final reader = transformed.newInstance(param)
 
     then:
     reader != null
     SuperInCtorExampleAdvice.CALLS.get() > 0
+
+    where:
+    param                     | test
+    "test"                    | "Operand stack underflow"
+    new StringBuilder("test") | "Inconsistent stackmap frames"
   }
 
   static class StringCallSites implements CallSites, TestCallSites {

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
@@ -5,8 +5,14 @@ import java.io.StringReader;
 public class SuperInCtorExample extends StringReader {
 
   public SuperInCtorExample(String s) {
+    // triggers APPSEC-55918
     super(s + new StringReader(s + "Test" + new StringBuilder("another test")));
-    if (s.isEmpty()) { // triggers APPSEC-58131
+  }
+
+  public SuperInCtorExample(StringBuilder s) {
+    super(s.toString());
+    // triggers APPSEC-58131
+    if (s.length() == 0) {
       throw new IllegalArgumentException();
     }
   }

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
@@ -6,5 +6,8 @@ public class SuperInCtorExample extends StringReader {
 
   public SuperInCtorExample(String s) {
     super(s + new StringReader(s + "Test" + new StringBuilder("another test")));
+    if (s.isEmpty()) { // triggers APPSEC-58131
+      throw new IllegalArgumentException();
+    }
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.PropagationModule
+import foo.bar.TestCustomInputStreamReader
 import foo.bar.TestInputStreamReaderSuite
 
 import java.nio.charset.Charset
@@ -26,5 +27,22 @@ class InputStreamReaderCallSiteTest extends  BaseIoCallSiteTest{
       // InputStream input
       [new ByteArrayInputStream("test".getBytes())]// Reader input
     ]
+  }
+
+  void 'test InputStreamReader.<init> with super call and parameter'(){
+    // XXX: Do not modify the constructor call here. Regression test for APPSEC-58131.
+    given:
+    PropagationModule iastModule = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestCustomInputStreamReader(*args)
+
+    then:
+    1 * iastModule.taintObjectIfTainted(_ as InputStreamReader, _ as InputStream)
+    0 * _
+
+    where:
+    args << [[new ByteArrayInputStream("test".getBytes()), Charset.defaultCharset()],]
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomInputStreamReader.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomInputStreamReader.java
@@ -1,0 +1,26 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+public class TestCustomInputStreamReader extends InputStreamReader {
+
+  public TestCustomInputStreamReader(final InputStream in) throws IOException {
+    super(in);
+  }
+
+  public TestCustomInputStreamReader(final InputStream in, final Charset charset)
+      throws IOException {
+    // XXX: DO NOT MODIFY THIS CODE. This is testing a very specific error (APPSEC-58131).
+    // This caused the following error:
+    //   VerifyError: Inconsistent stackmap frames at branch target \d
+    //   Reason: urrent frame's stack size doesn't match stackmap.
+    // To trigger this, it is necessary to consume an argument after the super call.
+    super(in, charset);
+    if (charset != null) {
+      System.out.println("Using charset: " + charset.name());
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
This PR fixes an issue with call sites that incorrectly handle `super` calls inside constructors. Specifically, it ensures the return value of constructor-targeted call sites is properly managed when used in a `super` context.

# Motivation
Constructor-targeted call sites are designed to return the newly constructed instance to maintain correct stack behavior. However, when such call sites are used within `super` calls, the returned value must be discarded (i.e., popped off the stack). Failing to do so can lead to incorrect behavior or runtime issues—such as the one recently reported by a customer

```
Caused by: java.lang.VerifyError: Inconsistent stackmap frames at branch target 57
Exception Details:
  Location:
    x/y/z/ResourceStreamReader.<init>(Lx/y/z/Resource;Ljava/io/InputStream;Ljava/nio/charset/Charset;)V @44: ifnonnull
  Reason:
    Current frame's stack size doesn't match stackmap.
  Current Frame:
    bci: @44
    flags: { }
    locals: { 'x/y/z/ResourceStreamReader', 'x/y/z/Resource', 'java/io/InputStream', 'java/nio/charset/Charset' }
    stack: { 'java/io/InputStreamReader', 'x/y/z/Resource' }
  Stackmap Frame:
    bci: @57
    flags: { }
    locals: { 'x/y/z/ResourceStreamReader.', 'x/y/z/Resource', 'java/io/InputStream', 'java/nio/charset/Charset' }
    stack: { }
  Bytecode:
    0000000: 2a2c 2d05 bd00 455a 5f10 015f 535a 5f10
    0000010: 005f 535a 5903 32c0 0028 5f59 0432 c000
    0000020: 395f 57b7 0017 1900 b800 4b2b c700 0dbb
    0000030: 0007 5912 09b7 000b bf2a 2bb5 000e b1
  Stackmap Table:
    full_frame(@57,{Object[#15],Object[#38],Object[#40],Object[#57]},{})

```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-58131](https://datadoghq.atlassian.net/browse/APPSEC-58131)

[APPSEC-58131]: https://datadoghq.atlassian.net/browse/APPSEC-58131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ