### PR TITLE
Update ddapm-test-agent to latest 1.27.1 with fixed docker-in-docker support.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -521,7 +521,7 @@ muzzle-dep-report:
     CI_USE_TEST_AGENT: "true"
     CI_AGENT_HOST: local-agent
   services:
-    - name: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.1
+    - name: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.27.1
       alias: local-agent
       variables:
         LOG_LEVEL: "DEBUG"

--- a/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
@@ -116,7 +116,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
 
   def startTestAgentContainer() {
     //noinspection GrDeprecatedAPIUsage Use FixedHostPortGenericContainer against deprecation because we need to know the exposed to configure the tracer at start
-    def agentContainer = new FixedHostPortGenericContainer("ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.1")
+    def agentContainer = new FixedHostPortGenericContainer("ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.27.1")
       .withFixedExposedPort(agentContainerPort, DEFAULT_TRACE_AGENT_PORT)
       .withEnv("ENABLED_CHECKS", "trace_count_header,meta_tracer_version_header,trace_content_length")
       .waitingFor(Wait.forHttp("/test/traces"))


### PR DESCRIPTION
# What Does This Do
Making another attempt to update `ddapm-test-agent` to the latest available version, `1.27.1`.
The previous attempt (PR #9043) failed because, starting from `1.17.0`, the test agent switched to a slim base image, which broke **Docker-in-Docker** (DinD) functionality on GitLab.

# Motivation
Update to latest version to stay current with improvements and fixes.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
