### PR TITLE
Add validation checks for user provided arguments in git commands

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
@@ -278,7 +278,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public List<String> getTags(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return Collections.emptyList();
     }
     return executeCommand(
@@ -309,7 +309,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getSha(String reference)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(reference) && !GitUtils.isValidRef(reference)) {
+    if (GitUtils.isNotValidCommit(reference)) {
       return null;
     }
     return executeCommand(
@@ -334,7 +334,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getFullMessage(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -359,7 +359,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getAuthorName(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -384,7 +384,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getAuthorEmail(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -409,7 +409,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getAuthorDate(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -434,7 +434,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getCommitterName(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -459,7 +459,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getCommitterEmail(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(
@@ -484,7 +484,7 @@ public class ShellGitClient implements GitClient {
   @Override
   public String getCommitterDate(String commit)
       throws IOException, TimeoutException, InterruptedException {
-    if (!GitUtils.isValidCommitSha(commit) && !GitUtils.isValidRef(commit)) {
+    if (GitUtils.isNotValidCommit(commit)) {
       return null;
     }
     return executeCommand(

--- a/internal-api/src/main/java/datadog/trace/api/git/GitUtils.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitUtils.java
@@ -244,7 +244,7 @@ public class GitUtils {
    *   <li>every character is a hexadecimal digit
    * </ul>
    */
-  public static boolean isValidFullCommitSha(final String commitSha) {
+  public static boolean isValidCommitShaFull(final String commitSha) {
     return isValidCommitSha(commitSha, FULL_SHA_LENGTH);
   }
 
@@ -291,5 +291,10 @@ public class GitUtils {
   /** Checks if the provided string is a valid system path for Git operations */
   public static boolean isValidPath(@Nonnull String path) {
     return PATH_PATTERN.matcher(path).matches();
+  }
+
+  /** Checks if the provided string is neither a valid commit SHA nor a valid Git reference */
+  public static boolean isNotValidCommit(@Nullable String commit) {
+    return !isValidCommitSha(commit) && !isValidRef(commit);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
@@ -89,7 +89,7 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
       }
 
       String commitSha = gitInfo.getCommit().getSha();
-      if (!GitUtils.isValidFullCommitSha(commitSha)) {
+      if (!GitUtils.isValidCommitShaFull(commitSha)) {
         log.error(
             "Git commit SHA could not be resolved or is invalid: "
                 + commitSha

--- a/internal-api/src/test/groovy/datadog/trace/api/git/GitUtilsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/git/GitUtilsTest.groovy
@@ -24,7 +24,7 @@ class GitUtilsTest extends Specification {
 
   def "test commit SHA validity of full length (#sha): #expectedResult "() {
     when:
-    def result = GitUtils.isValidFullCommitSha(sha)
+    def result = GitUtils.isValidCommitShaFull(sha)
 
     then:
     result == expectedResult


### PR DESCRIPTION
# What Does This Do

- Adds validation checks for user provided arguments in git commands, i.e. commit shas, branches, repo root paths, etc.

# Motivation

The arguments are used in git commands which renders them vulnerable to code injection.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [VULN-11396]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[VULN-11396]: https://datadoghq.atlassian.net/browse/VULN-11396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ