### PR TITLE
Migrate libddwaf to maven central

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '15.0.1-SNAPSHOT'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '15.0.1'
   implementation libs.moshi
 
   testImplementation libs.bytebuddy

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '15.0.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '15.0.1-SNAPSHOT'
   implementation libs.moshi
 
   testImplementation libs.bytebuddy

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -14,19 +14,13 @@ repositories {
   maven {
     content {
       includeGroup "com.datadoghq"
+      includeGroup "io.sqreen"
     }
     mavenContent {
       snapshotsOnly()
     }
     // see https://central.sonatype.org/publish/publish-portal-snapshots/#consuming-via-gradle
     url 'https://central.sonatype.com/repository/maven-snapshots/'
-  }
-  ivy {
-    artifactPattern 'https://sqreen-ci-java.s3.amazonaws.com/jars/[organisation]/[artifact]-[revision](-[classifier]).[ext]'
-    ivyPattern 'https://sqreen-ci-java.s3.amazonaws.com/jars/[organisation]/[module]-[revision].xml'
-    content {
-      includeGroup 'io.sqreen'
-    }
   }
   maven {
     url 'https://packages.confluent.io/maven/'


### PR DESCRIPTION
# What Does This Do

Migrate the libddwaf artifact from an S3 bucket to Maven Central by:                                                                                                                                                                                                                                          
- Removing the custom Ivy repository configuration that pointed to `https://sqreen-ci-java.s3.amazonaws.com/jars/`                                                                                                                                                                                            
- Adding `io.sqreen` group to the existing Maven Central Sonatype snapshots repository                                                                                                                                                                                                                         
- Updating the `libsqreen` dependency version from `15.0.0` to `15.0.1`    

# Motivation

The account owning the S3 bucket with the Ivy repository needs to be removed.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-9858](https://datadoghq.atlassian.net/browse/APPSEC-9858)

[APPSEC-9858]: https://datadoghq.atlassian.net/browse/APPSEC-9858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ