### PR TITLE
Fixed `Error` handling for trace interceptors.

### DIFF
--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/ApiVerification.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/ApiVerification.java
@@ -8,12 +8,17 @@ import java.util.Collection;
 public final class ApiVerification {
   private ApiVerification() {}
 
-  public static void verifyInterceptors(Tracer otTracer) {
+  public static void verifyInterceptors(Tracer otTracer, boolean throwError) {
     TraceInterceptor interceptor =
         new TraceInterceptor() {
           @Override
           public Collection<? extends MutableSpan> onTraceComplete(
               Collection<? extends MutableSpan> trace) {
+            // Emulates situation when user code will throw an Error.
+            if (throwError) {
+              throw new AssertionError();
+            }
+
             return trace;
           }
 
@@ -23,6 +28,6 @@ public final class ApiVerification {
           }
         };
 
-    ((datadog.trace.api.Tracer) otTracer).addTraceInterceptor(interceptor);
+    otTracer.addTraceInterceptor(interceptor);
   }
 }

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
@@ -12,10 +12,11 @@ public class OTWithAgentApplication {
   public static void main(final String[] args) throws InterruptedException {
     final Tracer tracer = GlobalTracer.get();
 
-    ApiVerification.verifyInterceptors(datadog.trace.api.GlobalTracer.get());
+    boolean throwError = args != null && args.length > 0 && Boolean.parseBoolean(args[0]);
+    ApiVerification.verifyInterceptors(datadog.trace.api.GlobalTracer.get(), throwError);
 
     final Span span = tracer.buildSpan("someOperation").start();
-    try (final Scope scope = tracer.activateSpan(span)) {
+    try (final Scope ignored = tracer.activateSpan(span)) {
       span.setTag(DDTags.SERVICE_NAME, "someService");
       // Verify that the returned object is wrapped correctly.
       Span root = (Span) ((MutableSpan) tracer.activeSpan()).getLocalRootSpan();

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithoutAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithoutAgentApplication.java
@@ -13,7 +13,7 @@ public class OTWithoutAgentApplication {
     // register the same tracer with the Datadog API
     datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
-    ApiVerification.verifyInterceptors(tracer);
+    ApiVerification.verifyInterceptors(tracer, false);
 
     final Span span = tracer.buildSpan("someOperation").start();
     try (final Scope scope = tracer.activateSpan(span)) {

--- a/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/OpenTracingSmokeTest.groovy
+++ b/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/OpenTracingSmokeTest.groovy
@@ -9,8 +9,6 @@ import static java.util.concurrent.TimeUnit.SECONDS
 abstract class OpenTracingSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation, plus request, plus some extra
   public static final int TIMEOUT_SECS = 30
-  // Timeout for individual requests
-  public static final int REQUEST_TIMEOUT = 5
 
   List<String> baseCommand() {
     List<String> command = new ArrayList<>()
@@ -48,6 +46,18 @@ class OTWithAgentTest extends OpenTracingSmokeTest {
   ProcessBuilder createProcessBuilder() {
     List<String> command = baseCommand()
     command.add(OTWithAgentApplication.name)
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+  }
+}
+
+class OTWithAgentAssertionErrorTest extends OpenTracingSmokeTest {
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    List<String> command = baseCommand()
+    command.add(OTWithAgentApplication.name)
+    command.add("true")
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1040,7 +1040,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         try {
           // If one TraceInterceptor throws an exception, then continue with the next one
           interceptedTrace = interceptor.onTraceComplete(interceptedTrace);
-        } catch (Exception e) {
+        } catch (Throwable e) {
           String interceptorName = interceptor.getClass().getName();
           rlLog.warn("Exception in TraceInterceptor {}", interceptorName, e);
         }


### PR DESCRIPTION
# What Does This Do
Improved error handling for custom `TraceInterceptor` to gracefully handle cases where user code throws an `Error`.

# Motivation
This PR addresses an issue where user code may throw a base Error instead of an Exception. Since Error is not a subclass of Exception, such cases are not caught by standard exception handling logic. As a result, this can lead to the application hanging on exit, due to unhandled errors disrupting proper shutdown procedures.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
