### PR TITLE
Add error priorities for dynamic instrumentation and manual instrumentation

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -15,6 +15,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -105,11 +107,11 @@ public class OtelSpan implements Span, WithAgentSpan {
     if (this.recording) {
       if (this.statusCode == UNSET) {
         this.statusCode = statusCode;
-        this.delegate.setError(statusCode == ERROR);
+        this.delegate.setError(statusCode == ERROR, ErrorPriorities.MANUAL_INSTRUMENTATION);
         this.delegate.setErrorMessage(statusCode == ERROR ? description : null);
       } else if (this.statusCode == ERROR && statusCode == OK) {
         this.statusCode = statusCode;
-        this.delegate.setError(false);
+        this.delegate.setError(false, ErrorPriorities.MANUAL_INSTRUMENTATION);
         this.delegate.setErrorMessage(null);
       }
     }
@@ -132,7 +134,7 @@ public class OtelSpan implements Span, WithAgentSpan {
   @Override
   public Span updateName(String name) {
     if (this.recording) {
-      this.delegate.setResourceName(name);
+      this.delegate.setResourceName(name, ResourceNamePriorities.MANUAL_INSTRUMENTATION);
     }
     return this;
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing31;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
@@ -73,7 +74,7 @@ class OTSpan implements Span, MutableSpan, WithAgentSpan {
 
   @Override
   public OTSpan setError(final boolean value) {
-    delegate.setError(value);
+    delegate.setError(value, ErrorPriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing32;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
@@ -74,7 +75,7 @@ class OTSpan implements Span, MutableSpan, WithAgentSpan {
 
   @Override
   public OTSpan setError(final boolean value) {
-    delegate.setError(value);
+    delegate.setError(value, ErrorPriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -262,7 +262,7 @@ public class TagInterceptor {
   }
 
   private boolean interceptError(DDSpanContext span, Object value) {
-    span.setErrorFlag(asBoolean(value), ErrorPriorities.DEFAULT);
+    span.setErrorFlag(asBoolean(value), ErrorPriorities.TAG_INTERCEPTOR);
     return true;
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.opentracing;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
@@ -73,7 +74,7 @@ class OTSpan implements Span, MutableSpan, WithAgentSpan {
 
   @Override
   public OTSpan setError(final boolean value) {
-    delegate.setError(value);
+    delegate.setError(value, ErrorPriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ErrorPriorities.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ErrorPriorities.java
@@ -5,4 +5,6 @@ public class ErrorPriorities {
   public static final byte HTTP_SERVER_DECORATOR = -1;
 
   public static final byte DEFAULT = 0;
+  public static final byte TAG_INTERCEPTOR = 1;
+  public static final byte MANUAL_INSTRUMENTATION = 2;
 }


### PR DESCRIPTION
# What Does This Do

Adds error priorities for dynamic instrumentation and manual instrumentation, similar to what exists for priorities for resource name today.

It also sets the priority for manual instrumentation from otel spans for both resource name and error.

# Motivation

Reliably override error status set by automatic instrumentation from dynamic instrumentation and manual instrumentation.

# Additional Notes

No tests have been added yet. If the change generally seems good, I'm happy to write tests.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
