### PR TITLE
Remove telemetry markers from log output

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
@@ -15,25 +15,25 @@ public class DDTelemetryLogger extends DDLogger {
   @Override
   public void formatLog(LogLevel level, Marker marker, String format, Object arg) {
     telemetryLog(level, marker, format, getIfThrowable(arg));
-    super.formatLog(level, marker, format, arg);
+    super.formatLog(level, filterTelemetryLogMarkers(marker), format, arg);
   }
 
   @Override
   public void formatLog(LogLevel level, Marker marker, String format, Object arg1, Object arg2) {
     telemetryLog(level, marker, format, getIfThrowable(arg2));
-    super.formatLog(level, marker, format, arg1, arg2);
+    super.formatLog(level, filterTelemetryLogMarkers(marker), format, arg1, arg2);
   }
 
   @Override
   public void formatLog(LogLevel level, Marker marker, String format, Object... arguments) {
     telemetryLog(level, marker, format, MessageFormatter.getThrowableCandidate(arguments));
-    super.formatLog(level, marker, format, arguments);
+    super.formatLog(level, filterTelemetryLogMarkers(marker), format, arguments);
   }
 
   @Override
   protected void log(LogLevel level, Marker marker, String msg, Throwable t) {
     telemetryLog(level, marker, msg, t);
-    super.log(level, marker, msg, t);
+    super.log(level, filterTelemetryLogMarkers(marker), msg, t);
   }
 
   private void telemetryLog(LogLevel level, Marker marker, String msgOrgFormat, Throwable t) {
@@ -46,6 +46,14 @@ public class DDTelemetryLogger extends DDLogger {
       return;
     }
     LogCollector.get().addLogMessage(level.name(), msgOrgFormat, t);
+  }
+
+  private Marker filterTelemetryLogMarkers(Marker marker) {
+    if (marker == LogCollector.EXCLUDE_TELEMETRY || marker == LogCollector.SEND_TELEMETRY) {
+      // Do not log telemetry markers
+      return null;
+    }
+    return marker;
   }
 
   private Throwable getIfThrowable(final Object obj) {


### PR DESCRIPTION
# What Does This Do
Remove telemetry markers from log calls after they've been forwarded to telemetry. This avoids telemetry markers showing up as log levels in the output format.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-53169](https://datadoghq.atlassian.net/browse/APPSEC-53169)