### PR TITLE
Add source file tracking enable option

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
@@ -111,4 +111,8 @@ public class ClassesToRetransformFinder {
     String simpleName = extractSimpleName(clazz);
     return changedClasses.contains(reverseStr(simpleName));
   }
+
+  ConcurrentMap<String, String> getClassNamesBySourceFile() {
+    return classNamesBySourceFile;
+  }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -324,6 +324,10 @@ public class DebuggerAgent {
 
   private static void setupSourceFileTracking(
       Instrumentation instrumentation, ClassesToRetransformFinder finder) {
+    if (!Config.get().isDebuggerSourceFileTrackingEnabled()) {
+      LOGGER.debug("Source file tracking is disabled");
+      return;
+    }
     SourceFileTrackingTransformer sourceFileTrackingTransformer =
         new SourceFileTrackingTransformer(finder);
     sourceFileTrackingTransformer.start();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
@@ -75,12 +75,22 @@ public class SourceFileTrackingTransformer implements ClassFileTransformer {
     if (sourceFile == null) {
       return;
     }
+    if (!isExtensionAllowed(sourceFile)) {
+      return;
+    }
     String simpleClassName = stripPackagePath(className);
     String simpleSourceFile = removeExtension(sourceFile);
     if (simpleClassName.equals(simpleSourceFile)) {
       return;
     }
     finder.register(sourceFile, className);
+  }
+
+  private boolean isExtensionAllowed(String sourceFile) {
+    return sourceFile.endsWith(".java")
+        || sourceFile.endsWith(".kt")
+        || sourceFile.endsWith(".scala")
+        || sourceFile.endsWith(".groovy");
   }
 
   private static class SourceFileItem {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -207,6 +207,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES = 3;
   static final int DEFAULT_DEBUGGER_EXCEPTION_CAPTURE_INTERVAL_SECONDS = 60 * 60;
   static final boolean DEFAULT_DISTRIBUTED_DEBUGGER_ENABLED = false;
+  static final boolean DEFAULT_DEBUGGER_SOURCE_FILE_TRACKING_ENABLED = true;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -61,6 +61,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_EXCEPTION_CAPTURE_INTERMEDIATE_SPANS_ENABLED =
       "exception.replay.capture.intermediate.spans.enabled";
   public static final String DISTRIBUTED_DEBUGGER_ENABLED = "distributed.debugger.enabled";
+  public static final String DEBUGGER_SOURCE_FILE_TRACKING_ENABLED =
+      "dynamic.instrumentation.source.file.tracking.enabled";
   public static final String THIRD_PARTY_INCLUDES = "third.party.includes";
   public static final String THIRD_PARTY_EXCLUDES = "third.party.excludes";
   public static final String THIRD_PARTY_SHADING_IDENTIFIERS = "third.party.shading.identifiers";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -60,6 +60,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ENABLE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_SOURCE_FILE_TRACKING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DISTRIBUTED_DEBUGGER_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
@@ -281,6 +282,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_EXCEPTION_PER_SECOND;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SOURCE_FILE_TRACKING_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DISTRIBUTED_DEBUGGER_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_CAPTURE_TIMEOUT;
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_CLASSFILE_DUMP_ENABLED;
@@ -1048,6 +1050,7 @@ public class Config {
   private final boolean debuggerCodeOriginEnabled;
   private final int debuggerCodeOriginMaxUserFrames;
   private final boolean distributedDebuggerEnabled;
+  private final boolean debuggerSourceFileTrackingEnabled;
 
   private final Set<String> debuggerThirdPartyIncludes;
   private final Set<String> debuggerThirdPartyExcludes;
@@ -2385,6 +2388,9 @@ public class Config {
         configProvider.getInteger(
             DEBUGGER_EXCEPTION_CAPTURE_INTERVAL_SECONDS,
             DEFAULT_DEBUGGER_EXCEPTION_CAPTURE_INTERVAL_SECONDS);
+    debuggerSourceFileTrackingEnabled =
+        configProvider.getBoolean(
+            DEBUGGER_SOURCE_FILE_TRACKING_ENABLED, DEFAULT_DEBUGGER_SOURCE_FILE_TRACKING_ENABLED);
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
@@ -3986,6 +3992,10 @@ public class Config {
 
   public boolean isDistributedDebuggerEnabled() {
     return distributedDebuggerEnabled;
+  }
+
+  public boolean isDebuggerSourceFileTrackingEnabled() {
+    return debuggerSourceFileTrackingEnabled;
   }
 
   public Set<String> getThirdPartyIncludes() {


### PR DESCRIPTION
# What Does This Do
By default, source file tracking is enabled, but add an option to disable it if there are any issue wit it.
only allow java, kotlin, scala and groovy files to be tracked.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4125]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4125]: https://datadoghq.atlassian.net/browse/DEBUG-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ