### PR TITLE
Use token to access Akka secure repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,6 +160,8 @@ default:
       policy: $BUILD_CACHE_POLICY
   before_script:
     - source .gitlab/gitlab-utils.sh
+    # Akka token added to SSM from https://account.akka.io/token
+    - export AKKA_REPO_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.akka_repo_token --with-decryption --query "Parameter.Value" --out text)
     - mkdir -p .gradle
     - export GRADLE_USER_HOME=$(pwd)/.gradle
     - |
@@ -167,6 +169,7 @@ default:
       cat << EOF > $GRADLE_USER_HOME/gradle.properties
       mavenRepositoryProxy=$MAVEN_REPOSITORY_PROXY
       gradlePluginProxy=$GRADLE_PLUGIN_PROXY
+      akkaRepositoryToken=$AKKA_REPO_TOKEN
       EOF
     - |
       # replace maven central part by MAVEN_REPOSITORY_PROXY in .mvn/wrapper/maven-wrapper.properties

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/build.gradle
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/build.gradle
@@ -15,15 +15,27 @@ muzzle {
     versions = "[10.6.0,)"
     javaVersion = "11"
     extraDependency 'com.typesafe.akka:akka-stream_2.13:2.9.0'
-    extraRepository('akka', 'https://repo.akka.io/maven')
+
+    if (project.rootProject.hasProperty("akkaRepositoryToken")) {
+      extraRepository('akka', "https://repo.akka.io/${project.rootProject.property("akkaRepositoryToken")}/secure")
+    } else {
+      extraRepository('akka', 'https://repo.akka.io/maven')
+    }
+
     assertInverse = true
   }
 
 }
 
 repositories {
-  maven {
-    url "https://repo.akka.io/maven"
+  if (project.rootProject.hasProperty("akkaRepositoryToken")) {
+    maven {
+      url "https://repo.akka.io/${project.rootProject.property("akkaRepositoryToken")}/secure"
+    }
+  } else {
+    maven {
+      url "https://repo.akka.io/maven"
+    }
   }
 }
 


### PR DESCRIPTION
# What Does This Do
Use a secure URL for akka dependencies.

# Motivation
Akka recently requires this: https://doc.akka.io/libraries/akka-core/current/project/migration-guide-2.8.x-2.9.x.html

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
