### PR TITLE
Fix environment unit tests related to IBM / J9

### DIFF
--- a/components/environment/src/test/java/datadog/environment/CommandLineTest.java
+++ b/components/environment/src/test/java/datadog/environment/CommandLineTest.java
@@ -7,7 +7,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import datadog.environment.CommandLineHelper.Result;
@@ -99,7 +99,7 @@ class CommandLineTest {
       }
     }
     if (useArgFile) {
-      assumeFalse(System.getProperty("java.home").matches(".*[-/]8[./].*"));
+      assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(9));
     }
   }
 

--- a/components/environment/src/test/java/datadog/environment/JavaVirtualMachineTest.java
+++ b/components/environment/src/test/java/datadog/environment/JavaVirtualMachineTest.java
@@ -114,7 +114,7 @@ class JavaVirtualMachineTest {
   void onlyOnIbm8() {
     assertFalse(JavaVirtualMachine.isGraalVM());
     assertTrue(JavaVirtualMachine.isIbm8());
-    assertFalse(JavaVirtualMachine.isJ9());
+    assertTrue(JavaVirtualMachine.isJ9());
     assertFalse(JavaVirtualMachine.isOracleJDK8());
   }
 
@@ -122,7 +122,6 @@ class JavaVirtualMachineTest {
   @EnabledIfSystemProperty(named = "java.vm.name", matches = ".*J9.*")
   void onlyOnJ9() {
     assertFalse(JavaVirtualMachine.isGraalVM());
-    assertFalse(JavaVirtualMachine.isIbm8());
     assertTrue(JavaVirtualMachine.isJ9());
     assertFalse(JavaVirtualMachine.isOracleJDK8());
   }


### PR DESCRIPTION
# What Does This Do

This PR fixes environment unit tests related to IBM / J9

# Motivation

# Additional Notes

I missed those tests as they aren't running on PR check

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
