### PR TITLE
Make client stats reliable in case of downgrade

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -325,11 +325,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     features.discover();
     if (!features.supportsMetrics()) {
       log.debug("Disabling metric reporting because an agent downgrade was detected");
-      AgentTaskScheduler.Scheduled<?> cancellation = this.cancellation;
-      if (null != cancellation) {
-        cancellation.cancel();
-      }
-      this.thread.interrupt();
       this.pending.clear();
       this.batchPool.clear();
       this.inbox.clear();

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
@@ -1,0 +1,117 @@
+package datadog.trace.common.metrics
+
+import datadog.communication.ddagent.SharedCommunicationObjects
+import datadog.trace.api.Config
+import datadog.trace.core.test.DDCoreSpecification
+
+import java.util.concurrent.CountDownLatch
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class MetricsReliabilityTest extends DDCoreSpecification {
+
+  static class State {
+    boolean agentMetricsAvailable
+    boolean receivedStats
+    boolean receivedClientComputedHeader
+    CountDownLatch latch
+    def reset(agentMetricsAvailable) {
+      this.agentMetricsAvailable = agentMetricsAvailable
+      receivedStats = false
+      receivedClientComputedHeader = false
+      latch = new CountDownLatch(1)
+    }
+  }
+
+  static newAgent(State state) {
+    httpServer {
+      handlers {
+        get("/info") {
+          response.send('{"endpoints":[' + (state.agentMetricsAvailable ? '"/v0.6/stats", ' : '')
+            + '"/v0.4/traces"]}')
+          state.latch.countDown()
+        }
+        post("/v0.6/stats", {
+          state.receivedStats = true
+          response.status(state.agentMetricsAvailable ? 200 : 404).send()
+        })
+        put("/v0.4/traces", {
+          state.receivedClientComputedHeader = "true" == request.getHeader('Datadog-Client-Computed-Stats')
+          response.status(200).send()
+        })
+      }
+    }
+  }
+
+  def "metrics should reliably handle momentary downgrades"() {
+    setup:
+    def state = new State()
+    state.reset(true)
+    def agent = newAgent(state)
+    agent.start()
+    def props = new Properties()
+    props.put("trace.agent.url", agent.getAddress().toString())
+    props.put("trace.tracer.metrics.enabled", "true")
+    def config = Config.get(props)
+    def sharedComm = new SharedCommunicationObjects()
+    sharedComm.createRemaining(config)
+    def featuresDiscovery = sharedComm.featuresDiscovery(config)
+    def tracer = tracerBuilder().sharedCommunicationObjects(sharedComm).config(config).build()
+
+    when: "metrics enabled and discovery is performed"
+    featuresDiscovery.discover()
+
+    then: "should support metrics"
+    state.latch.await()
+    assert featuresDiscovery.supportsMetrics()
+
+    when: "a span is published"
+    tracer.startSpan("test", "test").finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "should have sent statistics and informed the agent that we calculate the stats"
+    assert state.receivedClientComputedHeader
+    assert state.receivedStats
+
+    when: "simulate an agent downgrade"
+    state.reset(false)
+    tracer.startSpan("test", "test").finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "a discovery should have done - we do not support anymore stats calculation"
+    state.latch.await()
+    assert !featuresDiscovery.supportsMetrics()
+
+    when: "a span is published"
+    tracer.startSpan("test", "test").finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "should have not sent statistics and informed the agent that we don't calculate the stats anymore"
+    assert !state.receivedClientComputedHeader
+    assert !state.receivedStats
+
+    when: "we detect that the agent can calculate the stats again"
+    state.reset(true)
+    featuresDiscovery.discover()
+
+    then: "we should understand it"
+    state.latch.await()
+    assert featuresDiscovery.supportsMetrics()
+
+    when: "a span is published"
+    tracer.startSpan("test", "test").finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "we should have sent the stats and informed the agent to not calculate the stats on the trace payload"
+    assert state.receivedClientComputedHeader
+    assert state.receivedStats
+
+    cleanup:
+    tracer.close()
+    agent.stop()
+  }
+}


### PR DESCRIPTION
# What Does This Do

In case of downgrade the client stats thread is interrupted. However the `DDAgentFeatureDiscovery` maintains a state based on the info endpoint that is then driving the fact that we inform the agent we are calculating or not the client stats (header `Datadog-Client-Stats-Computed`)

If the client stats thread exit, and we discover again that the agent supports the client stats, we will end up in a situation where nobody will calculate the stats (since the thread is exited).

This PR avoid shutting down that thread. In any case there is always a guard (features.clientStatsSupported) in any metric writer method. 

It also adds reliability test for this scenario

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
