### PR TITLE
Give more time to structured concurrency tests

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/previewTest/groovy/StructuredConcurrencyTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/previewTest/groovy/StructuredConcurrencyTest.groovy
@@ -26,7 +26,7 @@ class StructuredConcurrencyTest extends AgentTestRunner {
             return true
           }
         })
-      taskScope.joinUntil(now() + 1) // Wait for a second at maximum
+      taskScope.joinUntil(now() + 10) // Wait for 10 seconds at maximum
       result = task.get()
     }
     taskScope.close()
@@ -73,7 +73,7 @@ class StructuredConcurrencyTest extends AgentTestRunner {
       taskScope.fork {
         runnableUnderTrace("child3") {}
       }
-      taskScope.joinUntil(now() + 2) // Wait for two seconds at maximum
+      taskScope.joinUntil(now() + 10) // Wait for 10 seconds at maximum
     }
     taskScope.close()
 
@@ -132,7 +132,7 @@ class StructuredConcurrencyTest extends AgentTestRunner {
       taskScope.fork {
         runnableUnderTrace("child2") {}
       }
-      taskScope.joinUntil(now() + 2) // Wait for two seconds at maximum
+      taskScope.joinUntil(now() + 10) // Wait for 10 seconds at maximum
     }
     taskScope.close()
 


### PR DESCRIPTION
# What Does This Do

Fixes the structured concurrency test that is failing quite often (expecially on 24.x)

I observed locally that the wait can time out. hence the parent span is reported before the child are finished and spans are dropped because of the strict write policy. Hence the test times out

We just give more time to the join (better always give a larger timeout even if it won't be reached...)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
