### PR TITLE
Ignore jboss and quarkus smoke tests for JDK 24+

### DIFF
--- a/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/JBossModulesV1SmokeTest.groovy
+++ b/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/JBossModulesV1SmokeTest.groovy
@@ -1,9 +1,9 @@
 package datadog.smoketest
 
+import datadog.environment.JavaVirtualMachine
 import spock.lang.IgnoreIf
 
-@IgnoreIf({
-  // JBoss Modules 1.x doesn't support Java 17
-  new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)
+@IgnoreIf(reason = "JBoss Modules 1.x doesn't support Java 17", value = {
+  JavaVirtualMachine.isJavaVersionAtLeast(17)
 })
 class JBossModulesV1SmokeTest extends AbstractModulesSmokeTest {}

--- a/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/JBossModulesV2SmokeTest.groovy
+++ b/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/JBossModulesV2SmokeTest.groovy
@@ -3,7 +3,7 @@ package datadog.smoketest
 import datadog.environment.JavaVirtualMachine
 import spock.lang.IgnoreIf
 
-@IgnoreIf(reason = "Failing on Java 24. Skip until we have a fix.", value = {
+@IgnoreIf(reason = "JBoss Modules does not support Java 24+", value = {
   JavaVirtualMachine.isJavaVersionAtLeast(24)
 })
 class JBossModulesV2SmokeTest extends AbstractModulesSmokeTest {}

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -1,3 +1,7 @@
+ext {
+  // Quarkus is only supported up to Java 21: https://github.com/quarkusio/quarkus
+  maxJavaVersionForTests = JavaVersion.VERSION_21
+}
 
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusJBossLoggingSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusJBossLoggingSmokeTest.groovy
@@ -1,11 +1,5 @@
 package datadog.smoketest
 
-import datadog.environment.JavaVirtualMachine
-import spock.lang.IgnoreIf
-
-@IgnoreIf(reason = "Failing on Java 24. Skip until we have a fix.", value = {
-  JavaVirtualMachine.isJavaVersionAtLeast(24)
-})
 class QuarkusJBossLoggingSmokeTest extends QuarkusSmokeTest {
   @Override
   String helloEndpointName() {

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSlf4jSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSlf4jSmokeTest.groovy
@@ -1,11 +1,5 @@
 package datadog.smoketest
 
-import datadog.environment.JavaVirtualMachine
-import spock.lang.IgnoreIf
-
-@IgnoreIf(reason = "Failing on Java 24. Skip until we have a fix.", value = {
-  JavaVirtualMachine.isJavaVersionAtLeast(24)
-})
 class QuarkusSlf4jSmokeTest extends QuarkusSmokeTest {
   @Override
   String helloEndpointName() {


### PR DESCRIPTION
# What Does This Do

Ignore jboss and quarkus smoke tests for JDK 24+

# Motivation

They do not support JDK 24+

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
