### PR TITLE
Specify junit version for llmobs agent

### DIFF
--- a/dd-java-agent/agent-llmobs/build.gradle
+++ b/dd-java-agent/agent-llmobs/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation project(':internal-api')
 
   testImplementation project(":utils:test-utils")
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.0'
 
   testFixturesApi project(':dd-java-agent:testing')
   testFixturesApi project(':utils:test-utils')


### PR DESCRIPTION
# What Does This Do

Specify the version for `junit-platform-launcher` in the `:dd-java-agent:agent-llmobs` project

# Motivation

Address the failure on `master`:
```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':dd-java-agent:agent-llmobs:resolveAndLockAll'.
> Could not resolve all files for configuration ':dd-java-agent:agent-llmobs:testRuntimeOnlyDependenciesMetadata'.
   > Could not find org.junit.platform:junit-platform-launcher:.
     Required by:
         project :dd-java-agent:agent-llmobs
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
