### PR TITLE
Don't update jmxfetch integrations submodule during build

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -130,6 +130,14 @@ _Action:_ Build the Java Client Library and runs [the system tests](https://gith
 
 _Recovery:_ Manually trigger the action on the desired branch.
 
+### update-jmxfetch-submodule [🔗](update-jmxfetch-submodule.yaml)
+
+_Trigger:_ Monthly or manually
+
+_Action:_ Creates a PR updating the git submodule at dd-java-agent/agent-jmxfetch/integrations-core
+
+_Recovery:_ Manually trigger the action again.
+
 ## Maintenance
 
 GitHub actions should be part of the [repository allowed actions to run](https://github.com/DataDog/dd-trace-java/settings/actions).

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -1,0 +1,63 @@
+name: Update Docker Build Image
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Update Submodule
+        run: |
+          GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G'" \
+          JAVA_HOME=$JAVA_HOME_8_X64 \
+          JAVA_8_HOME=$JAVA_HOME_8_X64 \
+          JAVA_11_HOME=$JAVA_HOME_11_X64 \
+          JAVA_17_HOME=$JAVA_HOME_17_X64 \
+          JAVA_21_HOME=$JAVA_HOME_21_X64 \
+          ./gradlew :dd-java-agent:agent-jmxfetch:submodulesUpdate
+      - name: Download ghcommit CLI
+        run: |
+          curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
+          chmod +x /usr/local/bin/ghcommit
+      - name: Pick a branch name
+        id: define-branch
+        run: echo "branch=ci/update-jmxfetch-submodule-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Create branch
+        run: |
+          git checkout -b ${{ steps.define-branch.outputs.branch }}
+          git push -u origin ${{ steps.define-branch.outputs.branch }} --force
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          ghcommit --repository ${{ github.repository }} --branch ${{ steps.define-branch.outputs.branch }} --add dd-java-agent/agent-jmxfetch/integrations-core --message "Update agent-jmxfetch submodule"
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create --title "Update agent-jmxfetch submodule" \
+            --base master \
+            --head ${{ steps.define-branch.outputs.branch }} \
+            --label "comp: tooling" \
+            --label "type: enhancement" \
+            --label "tag: no release notes" \
+            --body "This PR updates the agent-jmxfetch submodule."

--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -97,7 +97,6 @@ tasks.register('copyMetricConfigs', CopyMetricConfigsTask) {
   description 'Copy metrics.yaml files from integrations-core into resources'
   inputDirectory = file("$projectDir/integrations-core")
   outputDirectory = file("$buildDir/integrations-core-resources")
-  dependsOn 'submodulesUpdate'
 }
 
 processResources {


### PR DESCRIPTION
# What Does This Do
Removes updating the integrations git submodule from the build and creates a github action to update monthly

# Motivation
Updating the submodule takes 30+ seconds and is not worth doing on every build every time.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
