### PR TITLE
Implement APIGW Inferred Proxy Spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -213,9 +213,9 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
         tracer()
             .startSpan(instrumentationName, spanName(), inferredProxySpan.context())
             .setMeasured(true);
-    
+
     serverSpan.setServiceName(Config.get().getServiceName());
-    
+
     // run the same IG/header logic we normally execute in startSpan(..)
     Flow<Void> flow = callIGCallbackRequestHeaders(serverSpan, carrier);
     if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/InferredProxySpanGroupDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/InferredProxySpanGroupDecorator.java
@@ -1,0 +1,389 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
+import java.util.Map;
+
+public class InferredProxySpanGroupDecorator implements AgentSpan {
+  private final AgentSpan inferredProxySpan;
+  private final AgentSpan serverSpan;
+
+  InferredProxySpanGroupDecorator(AgentSpan inferredProxySpan, AgentSpan serverSpan) {
+    this.inferredProxySpan = inferredProxySpan;
+    this.serverSpan = serverSpan;
+  }
+
+  @Override
+  public DDTraceId getTraceId() {
+    return serverSpan.getTraceId();
+  }
+
+  @Override
+  public long getSpanId() {
+    return serverSpan.getSpanId();
+  }
+
+  @Override
+  public AgentSpan setTag(String key, boolean value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, int value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, long value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, double value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, String value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, CharSequence value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setTag(String key, Object value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  /**
+   * @param map
+   * @return
+   */
+  @Override
+  public AgentSpan setAllTags(Map<String, ?> map) {
+    return null;
+  }
+
+  @Override
+  public AgentSpan setTag(String key, Number value) {
+    return serverSpan.setTag(key, value);
+  }
+
+  @Override
+  public AgentSpan setMetric(CharSequence key, int value) {
+    return serverSpan.setMetric(key, value);
+  }
+
+  @Override
+  public AgentSpan setMetric(CharSequence key, long value) {
+    return serverSpan.setMetric(key, value);
+  }
+
+  @Override
+  public AgentSpan setMetric(CharSequence key, double value) {
+    return serverSpan.setMetric(key, value);
+  }
+
+  @Override
+  public AgentSpan setSpanType(CharSequence type) {
+    return serverSpan.setSpanType(type);
+  }
+
+  @Override
+  public Object getTag(String key) {
+    return serverSpan.getTag(key);
+  }
+
+  @Override
+  public AgentSpan setError(boolean error) {
+    serverSpan.setError(error);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.setError(error);
+    }
+    return this;
+  }
+
+  @Override
+  public AgentSpan setError(boolean error, byte priority) {
+    serverSpan.setError(error, priority);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.setError(error, priority);
+    }
+    return this;
+  }
+
+  @Override
+  public AgentSpan setMeasured(boolean measured) {
+    return serverSpan.setMeasured(measured);
+  }
+
+  @Override
+  public AgentSpan setErrorMessage(String errorMessage) {
+    return serverSpan.setErrorMessage(errorMessage);
+  }
+
+  @Override
+  public AgentSpan addThrowable(Throwable throwable) {
+    serverSpan.addThrowable(throwable);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.addThrowable(throwable);
+    }
+    return this;
+  }
+
+  @Override
+  public AgentSpan addThrowable(Throwable throwable, byte errorPriority) {
+    serverSpan.addThrowable(throwable, errorPriority);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.addThrowable(throwable, errorPriority);
+    }
+    return this;
+  }
+
+  @Override
+  public AgentSpan getLocalRootSpan() {
+    return serverSpan.getLocalRootSpan();
+  }
+
+  @Override
+  public boolean isSameTrace(AgentSpan otherSpan) {
+    return serverSpan.isSameTrace(otherSpan);
+  }
+
+  @Override
+  public AgentSpanContext context() {
+    return serverSpan.context();
+  }
+
+  @Override
+  public String getBaggageItem(String key) {
+    return serverSpan.getBaggageItem(key);
+  }
+
+  @Override
+  public AgentSpan setBaggageItem(String key, String value) {
+    return serverSpan.setBaggageItem(key, value);
+  }
+
+  @Override
+  public AgentSpan setHttpStatusCode(int statusCode) {
+    serverSpan.setHttpStatusCode(statusCode);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.setHttpStatusCode(statusCode);
+    }
+    return this;
+  }
+
+  @Override
+  public short getHttpStatusCode() {
+    return serverSpan.getHttpStatusCode();
+  }
+
+  @Override
+  public void finish() {
+    serverSpan.finish();
+    if (inferredProxySpan != null) {
+      inferredProxySpan.finish();
+    }
+  }
+
+  @Override
+  public void finish(long finishMicros) {
+    serverSpan.finish(finishMicros);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.finish(finishMicros);
+    }
+  }
+
+  @Override
+  public void finishWithDuration(long durationNanos) {
+    serverSpan.finishWithDuration(durationNanos);
+    if (inferredProxySpan != null) {
+      inferredProxySpan.finishWithDuration(durationNanos);
+    }
+  }
+
+  @Override
+  public void beginEndToEnd() {
+    serverSpan.beginEndToEnd();
+  }
+
+  @Override
+  public void finishWithEndToEnd() {
+    serverSpan.finishWithEndToEnd();
+    if (inferredProxySpan != null) {
+      inferredProxySpan.finishWithEndToEnd();
+    }
+  }
+
+  @Override
+  public boolean phasedFinish() {
+    final boolean ret = serverSpan.phasedFinish();
+    if (inferredProxySpan != null) {
+      inferredProxySpan.phasedFinish();
+    }
+    return ret;
+  }
+
+  @Override
+  public void publish() {
+    serverSpan.publish();
+  }
+
+  @Override
+  public CharSequence getSpanName() {
+    return serverSpan.getSpanName();
+  }
+
+  @Override
+  public void setSpanName(CharSequence spanName) {
+    serverSpan.setSpanName(spanName);
+  }
+
+  @Deprecated
+  @Override
+  public boolean hasResourceName() {
+    return serverSpan.hasResourceName();
+  }
+
+  @Override
+  public byte getResourceNamePriority() {
+    return serverSpan.getResourceNamePriority();
+  }
+
+  @Override
+  public AgentSpan setResourceName(CharSequence resourceName) {
+    return serverSpan.setResourceName(resourceName);
+  }
+
+  @Override
+  public AgentSpan setResourceName(CharSequence resourceName, byte priority) {
+    return serverSpan.setResourceName(resourceName, priority);
+  }
+
+  @Override
+  public RequestContext getRequestContext() {
+    return serverSpan.getRequestContext();
+  }
+
+  @Override
+  public Integer forceSamplingDecision() {
+    return serverSpan.forceSamplingDecision();
+  }
+
+  @Override
+  public AgentSpan setSamplingPriority(int newPriority, int samplingMechanism) {
+    return serverSpan.setSamplingPriority(newPriority, samplingMechanism);
+  }
+
+  @Override
+  public TraceConfig traceConfig() {
+    return serverSpan.traceConfig();
+  }
+
+  @Override
+  public void addLink(AgentSpanLink link) {
+    serverSpan.addLink(link);
+  }
+
+  @Override
+  public AgentSpan setMetaStruct(String field, Object value) {
+    return serverSpan.setMetaStruct(field, value);
+  }
+
+  @Override
+  public boolean isOutbound() {
+    return serverSpan.isOutbound();
+  }
+
+  @Override
+  public AgentSpan asAgentSpan() {
+    return serverSpan.asAgentSpan();
+  }
+
+  @Override
+  public long getStartTime() {
+    return serverSpan.getStartTime();
+  }
+
+  @Override
+  public long getDurationNano() {
+    return serverSpan.getDurationNano();
+  }
+
+  @Override
+  public CharSequence getOperationName() {
+    return serverSpan.getOperationName();
+  }
+
+  @Override
+  public MutableSpan setOperationName(CharSequence serviceName) {
+    return serverSpan.setOperationName(serviceName);
+  }
+
+  @Override
+  public String getServiceName() {
+    return serverSpan.getServiceName();
+  }
+
+  @Override
+  public MutableSpan setServiceName(String serviceName) {
+    return serverSpan.setServiceName(serviceName);
+  }
+
+  @Override
+  public CharSequence getResourceName() {
+    return serverSpan.getResourceName();
+  }
+
+  @Override
+  public Integer getSamplingPriority() {
+    return serverSpan.getSamplingPriority();
+  }
+
+  @Deprecated
+  @Override
+  public MutableSpan setSamplingPriority(int newPriority) {
+    return serverSpan.setSamplingPriority(newPriority);
+  }
+
+  @Override
+  public String getSpanType() {
+    return serverSpan.getSpanType();
+  }
+
+  @Override
+  public Map<String, Object> getTags() {
+    return serverSpan.getTags();
+  }
+
+  @Override
+  public boolean isError() {
+    return serverSpan.isError();
+  }
+
+  @Deprecated
+  @Override
+  public MutableSpan getRootSpan() {
+    return serverSpan.getRootSpan();
+  }
+
+  @Override
+  public void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba) {
+    serverSpan.setRequestBlockingAction(rba);
+  }
+
+  @Override
+  public Flow.Action.RequestBlockingAction getRequestBlockingAction() {
+    return serverSpan.getRequestBlockingAction();
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -84,6 +84,7 @@ public final class ConfigDefaults {
       new LinkedHashSet<>(asList(PropagationStyle.DATADOG));
   static final int DEFAULT_TRACE_BAGGAGE_MAX_ITEMS = 64;
   static final int DEFAULT_TRACE_BAGGAGE_MAX_BYTES = 8192;
+  static final boolean DEFAULT_TRACE_INFERRED_PROXY_SERVICES_ENABLED = false;
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -99,6 +99,9 @@ public final class TracerConfig {
   public static final String TRACE_BAGGAGE_MAX_ITEMS = "trace.baggage.max.items";
   public static final String TRACE_BAGGAGE_MAX_BYTES = "trace.baggage.max.bytes";
 
+  public static final String TRACE_INFERRED_PROXY_SERVICES_ENABLED =
+      "trace.inferred.proxy.services.enabled";
+
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
 
   public static final String CLIENT_IP_ENABLED = "trace.client-ip.enabled";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -7,6 +7,7 @@ import static datadog.trace.api.DDTags.PROFILING_CONTEXT_ENGINE;
 import static datadog.trace.api.TracePropagationBehaviorExtract.IGNORE;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.BAGGAGE_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.DSM_CONCERN;
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.INFERRED_PROXY_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.TRACING_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.XRAY_TRACING_CONCERN;
 import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetricsAggregator;
@@ -77,6 +78,7 @@ import datadog.trace.common.writer.Writer;
 import datadog.trace.common.writer.WriterFactory;
 import datadog.trace.common.writer.ddintake.DDIntakeTraceInterceptor;
 import datadog.trace.context.TraceScope;
+import datadog.trace.core.apigw.InferredProxyPropagator;
 import datadog.trace.core.baggage.BaggagePropagator;
 import datadog.trace.core.datastreams.DataStreamsMonitoring;
 import datadog.trace.core.datastreams.DefaultDataStreamsMonitoring;
@@ -719,6 +721,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (config.isBaggagePropagationEnabled()
         && config.getTracePropagationBehaviorExtract() != IGNORE) {
       Propagators.register(BAGGAGE_CONCERN, new BaggagePropagator(config));
+    }
+    if (config.isTraceInferredProxyServicesEnabled()) {
+      Propagators.register(INFERRED_PROXY_CONCERN, new InferredProxyPropagator());
     }
 
     this.tagInterceptor =

--- a/dd-trace-core/src/main/java/datadog/trace/core/apigw/InferredProxyPropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/apigw/InferredProxyPropagator.java
@@ -5,11 +5,11 @@ import datadog.context.propagation.CarrierSetter;
 import datadog.context.propagation.CarrierVisitor;
 import datadog.context.propagation.Propagator;
 import datadog.trace.bootstrap.instrumentation.api.InferredProxyContext;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.HashMap;
-import java.util.Map;
 
 public class InferredProxyPropagator implements Propagator {
   private static final Logger log = LoggerFactory.getLogger(InferredProxyPropagator.class);
@@ -22,6 +22,7 @@ public class InferredProxyPropagator implements Propagator {
 
   // Supported proxies mapping (header value -> canonical component name)
   static final Map<String, String> SUPPORTED_PROXIES;
+
   static {
     SUPPORTED_PROXIES = new HashMap<>();
     SUPPORTED_PROXIES.put("aws-apigateway", "aws.apigateway");

--- a/dd-trace-core/src/main/java/datadog/trace/core/apigw/InferredProxyPropagator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/apigw/InferredProxyPropagator.java
@@ -1,0 +1,105 @@
+package datadog.trace.core.apigw;
+
+import datadog.context.Context;
+import datadog.context.propagation.CarrierSetter;
+import datadog.context.propagation.CarrierVisitor;
+import datadog.context.propagation.Propagator;
+import datadog.trace.bootstrap.instrumentation.api.InferredProxyContext;
+import datadog.trace.core.CoreTracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.BiConsumer;
+
+public class InferredProxyPropagator implements Propagator {
+  private static final Logger log = LoggerFactory.getLogger(InferredProxyPropagator.class);
+  static final String INFERRED_PROXY_KEY = "x-dd-proxy";
+  static final String REQUEST_TIME_KEY = "x-dd-proxy-request-time-ms";
+  static final String DOMAIN_NAME_KEY = "x-dd-proxy-domain-name";
+  static final String HTTP_METHOD_KEY = "x-dd-proxy-httpmethod";
+  static final String PATH_KEY = "x-dd-proxy-path";
+  static final String STAGE_KEY = "x-dd-proxy-stage";
+
+  /**
+   * METHOD STUB: InferredProxy is currently not meant to be injected to downstream services
+   *
+   * @param context the context containing the values to be injected.
+   * @param carrier the instance that will receive the key/value pairs to propagate.
+   * @param setter the callback to set key/value pairs into the carrier.
+   */
+  @Override
+  public <C> void inject(Context context, C carrier, CarrierSetter<C> setter) {}
+
+  /**
+   * Extracts an InferredProxyContext from un upstream service and stores it as part of the Context object
+   *
+   * @param context the base context to store the extracted values on top, use {@link
+   *     Context#root()} for a default base context.
+   * @param carrier the instance to fetch the propagated key/value pairs from.
+   * @param visitor the callback to walk over the carrier and extract its key/value pais.
+   * @return A context with the extracted values on top of the given base context.
+   */
+  @Override
+  public <C> Context extract(Context context, C carrier, CarrierVisitor<C> visitor) {
+    if (context == null || carrier == null || visitor == null) {
+      return context;
+    }
+    InferredProxyContextExtractor extractor = new InferredProxyContextExtractor();
+    visitor.forEachKeyValue(carrier, extractor);
+
+    InferredProxyContext extractedContext = extractor.extractedContext;
+    // Mandatory headers for APIGW
+    if (extractedContext == null || !extractedContext.validContext()) {
+      return context;
+    }
+    return context.with(extractedContext);
+  }
+
+  public static class InferredProxyContextExtractor implements BiConsumer<String, String> {
+    private InferredProxyContext extractedContext;
+
+    InferredProxyContextExtractor() {}
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param key the first input argument from an http header
+     * @param value the second input argument from an http header
+     */
+    @Override
+    public void accept(String key, String value) {
+      if (key == null || key.isEmpty() || !key.startsWith(INFERRED_PROXY_KEY)) {
+        return;
+      }
+
+      if (extractedContext == null) {
+        extractedContext = new InferredProxyContext();
+      }
+
+      switch (key) {
+        case INFERRED_PROXY_KEY:
+          if (value.equals("aws.apigateway")){
+            extractedContext.setProxyName(value);
+          }
+          break;
+        case REQUEST_TIME_KEY:
+          extractedContext.setStartTime(value);
+          break;
+        case DOMAIN_NAME_KEY:
+          extractedContext.setDomainName(value);
+          break;
+        case HTTP_METHOD_KEY:
+          extractedContext.setHttpMethod(value);
+          break;
+        case PATH_KEY:
+          extractedContext.setPath(value);
+          break;
+        case STAGE_KEY:
+          extractedContext.setStage(value);
+          break;
+        default:
+          log.info("Extracting Inferred Proxy header that doesn't match accepted Inferred Proxy keys");
+      }
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1719,7 +1719,9 @@ public class Config {
         configProvider.getBoolean(
             TRACE_PROPAGATION_EXTRACT_FIRST, DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST);
 
-    traceInferredProxyServicesEnabled = configProvider.getBoolean(TRACE_INFERRED_PROXY_SERVICES_ENABLED, DEFAULT_TRACE_INFERRED_PROXY_SERVICES_ENABLED);
+    traceInferredProxyServicesEnabled =
+        configProvider.getBoolean(
+            TRACE_INFERRED_PROXY_SERVICES_ENABLED, DEFAULT_TRACE_INFERRED_PROXY_SERVICES_ENABLED);
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -154,6 +154,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_CLOUD_PAYLOAD_TAGGING_SERVICES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXPERIMENTAL_FEATURES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_INFERRED_PROXY_SERVICES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_KEEP_LATENCY_THRESHOLD_MS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL;
@@ -597,6 +598,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOU
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_INFERRED_PROXY_SERVICES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_KEEP_LATENCY_THRESHOLD_MS;
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_FLUSH_INTERVAL;
@@ -823,6 +825,7 @@ public class Config {
   private final boolean tracePropagationExtractFirst;
   private final int traceBaggageMaxItems;
   private final int traceBaggageMaxBytes;
+  private final boolean traceInferredProxyServicesEnabled;
   private final int clockSyncPeriod;
   private final boolean logsInjectionEnabled;
 
@@ -1715,6 +1718,8 @@ public class Config {
     tracePropagationExtractFirst =
         configProvider.getBoolean(
             TRACE_PROPAGATION_EXTRACT_FIRST, DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST);
+
+    traceInferredProxyServicesEnabled = configProvider.getBoolean(TRACE_INFERRED_PROXY_SERVICES_ENABLED, DEFAULT_TRACE_INFERRED_PROXY_SERVICES_ENABLED);
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
 
@@ -3096,6 +3101,10 @@ public class Config {
 
   public int getTraceBaggageMaxBytes() {
     return traceBaggageMaxBytes;
+  }
+
+  public boolean isTraceInferredProxyServicesEnabled() {
+    return traceInferredProxyServicesEnabled;
   }
 
   public int getClockSyncPeriod() {
@@ -5345,6 +5354,8 @@ public class Config {
         + tracePropagationBehaviorExtract
         + ", tracePropagationExtractFirst="
         + tracePropagationExtractFirst
+        + ", traceInferredProxyServicesEnabled="
+        + traceInferredProxyServicesEnabled
         + ", clockSyncPeriod="
         + clockSyncPeriod
         + ", jmxFetchEnabled="

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -15,6 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class AgentPropagation {
   public static final Concern TRACING_CONCERN = named("tracing");
   public static final Concern BAGGAGE_CONCERN = named("baggage");
+  public static final Concern INFERRED_PROXY_CONCERN = named("inferred_proxy");
   public static final Concern XRAY_TRACING_CONCERN = named("tracing-xray");
 
   // TODO DSM propagator should run after the other propagators as it stores the pathway context

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InferredProxyContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InferredProxyContext.java
@@ -3,7 +3,6 @@ package datadog.trace.bootstrap.instrumentation.api;
 import datadog.context.Context;
 import datadog.context.ContextKey;
 import datadog.context.ImplicitContextKeyed;
-
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -23,55 +22,55 @@ public class InferredProxyContext implements ImplicitContextKeyed {
 
   public InferredProxyContext() {}
 
-  public void setProxyName(String name){
+  public void setProxyName(String name) {
     this.proxyName = name;
   }
 
-  public String getProxyName(){
+  public String getProxyName() {
     return this.proxyName;
   }
 
-  public void setStartTime(String time){
+  public void setStartTime(String time) {
     this.startTime = time;
   }
 
-  public String getStartTime(){
+  public String getStartTime() {
     return this.startTime;
   }
 
-  public void setDomainName(String name){
+  public void setDomainName(String name) {
     this.domainName = name;
   }
 
-  public String getDomainName(){
+  public String getDomainName() {
     return this.domainName;
   }
 
-  public void setHttpMethod(String httpMethod){
+  public void setHttpMethod(String httpMethod) {
     this.httpMethod = httpMethod;
   }
 
-  public String getHttpMethod(){
+  public String getHttpMethod() {
     return this.httpMethod;
   }
 
-  public void setPath(String path){
+  public void setPath(String path) {
     this.path = path;
   }
 
-  public String getPath(){
+  public String getPath() {
     return this.path;
   }
 
-  public void setStage(String stage){
+  public void setStage(String stage) {
     this.stage = stage;
   }
 
-  public String getStage(){
+  public String getStage() {
     return this.stage;
   }
 
-  public boolean validContext(){
+  public boolean validContext() {
     return Stream.of(proxyName, startTime, domainName, httpMethod, path, stage)
         .allMatch(Objects::nonNull);
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InferredProxyContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InferredProxyContext.java
@@ -1,0 +1,90 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.context.Context;
+import datadog.context.ContextKey;
+import datadog.context.ImplicitContextKeyed;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class InferredProxyContext implements ImplicitContextKeyed {
+  public static final ContextKey<InferredProxyContext> CONTEXT_KEY =
+      ContextKey.named("inferred-proxy-key");
+  private String proxyName;
+  private String startTime;
+  private String domainName;
+  private String httpMethod;
+  private String path;
+  private String stage;
+
+  public static InferredProxyContext fromContext(Context context) {
+    return context.get(CONTEXT_KEY);
+  }
+
+  public InferredProxyContext() {}
+
+  public void setProxyName(String name){
+    this.proxyName = name;
+  }
+
+  public String getProxyName(){
+    return this.proxyName;
+  }
+
+  public void setStartTime(String time){
+    this.startTime = time;
+  }
+
+  public String getStartTime(){
+    return this.startTime;
+  }
+
+  public void setDomainName(String name){
+    this.domainName = name;
+  }
+
+  public String getDomainName(){
+    return this.domainName;
+  }
+
+  public void setHttpMethod(String httpMethod){
+    this.httpMethod = httpMethod;
+  }
+
+  public String getHttpMethod(){
+    return this.httpMethod;
+  }
+
+  public void setPath(String path){
+    this.path = path;
+  }
+
+  public String getPath(){
+    return this.path;
+  }
+
+  public void setStage(String stage){
+    this.stage = stage;
+  }
+
+  public String getStage(){
+    return this.stage;
+  }
+
+  public boolean validContext(){
+    return Stream.of(proxyName, startTime, domainName, httpMethod, path, stage)
+        .allMatch(Objects::nonNull);
+  }
+
+  /**
+   * Creates a new context with this value under its chosen key.
+   *
+   * @param context the context to copy the original values from.
+   * @return the new context with the implicitly keyed value.
+   * @see Context#with(ImplicitContextKeyed)
+   */
+  @Override
+  public Context storeInto(Context context) {
+    return context.with(CONTEXT_KEY, this);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds an inferred proxy span as the parent of http request spans if http headers with x-dd-proxy are detected

# Motivation
We want to have observability of router/ proxy services like AWS API Gateway, that redirect client calls to various targets. There is distinct http header metadata available to us from http requests that can allow us to "infer" the presence of these proxy services.

# Additional Notes
- Add tests
- Check telemetry
- Update system tests

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
