### PR TITLE
Backpropagate container tags hash coming from the info endpoint

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -1,5 +1,7 @@
 package datadog.communication.ddagent;
 
+import static datadog.communication.http.OkHttpUtils.DATADOG_CONTAINER_ID;
+import static datadog.communication.http.OkHttpUtils.DATADOG_CONTAINER_TAGS_HASH;
 import static datadog.communication.serialization.msgpack.MsgPackWriter.FIXARRAY;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -8,6 +10,7 @@ import static java.util.Collections.unmodifiableList;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datadog.common.container.ContainerInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.communication.monitor.Monitoring;
@@ -157,11 +160,15 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     // 3. fallback if the endpoint couldn't be found or the response couldn't be parsed
     try (Recording recording = discoveryTimer.start()) {
       boolean fallback = true;
-      try (Response response =
-          client
-              .newCall(new Request.Builder().url(agentBaseUrl.resolve("info").url()).build())
-              .execute()) {
+      final Request.Builder requestBuilder =
+          new Request.Builder().url(agentBaseUrl.resolve("info").url());
+      final String containerId = ContainerInfo.get().getContainerId();
+      if (containerId != null) {
+        requestBuilder.header(DATADOG_CONTAINER_ID, containerId);
+      }
+      try (Response response = client.newCall(requestBuilder.build()).execute()) {
         if (response.isSuccessful()) {
+          processInfoResponseHeaders(response);
           fallback = !processInfoResponse(response.body().string());
         }
       } catch (Throwable error) {
@@ -220,6 +227,10 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       }
     }
     return V3_ENDPOINT;
+  }
+
+  private void processInfoResponseHeaders(Response response) {
+    ContainerInfo.get().setContainerTagsHash(response.header(DATADOG_CONTAINER_TAGS_HASH));
   }
 
   @SuppressWarnings("unchecked")

--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -43,8 +43,9 @@ public final class OkHttpUtils {
   private static final String DATADOG_META_LANG_INTERPRETER = "Datadog-Meta-Lang-Interpreter";
   private static final String DATADOG_META_LANG_INTERPRETER_VENDOR =
       "Datadog-Meta-Lang-Interpreter-Vendor";
-  private static final String DATADOG_CONTAINER_ID = "Datadog-Container-ID";
+  public static final String DATADOG_CONTAINER_ID = "Datadog-Container-ID";
   private static final String DATADOG_ENTITY_ID = "Datadog-Entity-ID";
+  public static final String DATADOG_CONTAINER_TAGS_HASH = "Datadog-Container-Tags-Hash";
 
   private static final String DD_API_KEY = "DD-API-KEY";
 

--- a/utils/container-utils/src/main/java/datadog/common/container/ContainerInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ContainerInfo.java
@@ -54,6 +54,7 @@ public class ContainerInfo {
   private static final String ENTITY_ID;
 
   public String containerId;
+  public String containerTagsHash;
   public String podId;
   public List<CGroupInfo> cGroups = new ArrayList<>();
 
@@ -63,6 +64,14 @@ public class ContainerInfo {
 
   public void setContainerId(String containerId) {
     this.containerId = containerId;
+  }
+
+  public String getContainerTagsHash() {
+    return containerTagsHash;
+  }
+
+  public void setContainerTagsHash(String containerTagsHash) {
+    this.containerTagsHash = containerTagsHash;
   }
 
   public String getPodId() {


### PR DESCRIPTION
# What Does This Do

Send the container ID when discovering (calling the agent on the info endpoint) and fetch the container tags hash in the response headers.
The information is made available then on the ContainerInfo class and will be used by DSM/DBM for future features.

See the agent PR https://github.com/DataDog/datadog-agent/pull/38515

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
