### PR TITLE
Calculate client stats also if the span kind is eligible

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -1,9 +1,9 @@
 package datadog.communication.ddagent;
 
 import static datadog.communication.serialization.msgpack.MsgPackWriter.FIXARRAY;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -88,8 +88,8 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private volatile String evpProxyEndpoint;
   private volatile String version;
   private volatile String telemetryProxyEndpoint;
-  private volatile List<String> peerTags = emptyList();
-  private volatile List<String> spanKindsToComputedStats = emptyList();
+  private volatile Set<String> peerTags = emptySet();
+  private volatile Set<String> spanKindsToComputedStats = emptySet();
 
   private long lastTimeDiscovered;
 
@@ -123,8 +123,8 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     version = null;
     lastTimeDiscovered = 0;
     telemetryProxyEndpoint = null;
-    peerTags = emptyList();
-    spanKindsToComputedStats = emptyList();
+    peerTags = emptySet();
+    spanKindsToComputedStats = emptySet();
   }
 
   /** Run feature discovery, unconditionally. */
@@ -295,11 +295,16 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
                     || Boolean.TRUE.equals(canDrop));
 
         Object peer_tags = map.get("peer_tags");
-        peerTags = peer_tags == null ? emptyList() : unmodifiableList((List<String>) peer_tags);
+        peerTags =
+            peer_tags instanceof List
+                ? unmodifiableSet(new HashSet<>((List<String>) peer_tags))
+                : emptySet();
 
         Object span_kinds = map.get("span_kinds_stats_computed");
         spanKindsToComputedStats =
-            span_kinds == null ? emptyList() : unmodifiableList((List<String>) span_kinds);
+            span_kinds instanceof List
+                ? unmodifiableSet(new HashSet<>((List<String>) span_kinds))
+                : emptySet();
       }
       try {
         state = Strings.sha256(response);
@@ -357,11 +362,11 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     return supportsLongRunning;
   }
 
-  public List<String> peerTags() {
+  public Set<String> peerTags() {
     return peerTags;
   }
 
-  public List<String> spanKindsToComputedStats() {
+  public Set<String> spanKindsToComputedStats() {
     return spanKindsToComputedStats;
   }
 


### PR DESCRIPTION
# What Does This Do

The datadog agent already calculates the stats not only if the span is top level or measured but also if its span kind is among the one eligible.

Those span kinds are returned by the agent through the info endpoint response. 
This PR enable including span with eligible kind in the stats computation

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
