### PR TITLE
Fix flaky out of order comparison for http client test

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -330,6 +330,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     status == 500
     assertTraces(2) {
       trace(size(2)) {
+        sortSpansByStart()
         basicSpan(it, "parent")
         clientSpan(it, span(0), method, false, false, uri, 500, false) // not an error.
       }
@@ -368,6 +369,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     status == 401
     assertTraces(2) {
       trace(size(2)) {
+        sortSpansByStart()
         basicSpan(it, "parent")
         clientSpan(it, span(0), method, false, false, uri, 401, true)
       }


### PR DESCRIPTION
# What Does This Do

Apache http client tests are quite flaky. Especially those couple with parent and errors.
This PR just try to remove the flakiness by sorting the spans by start in order to make the assertions reliable

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
