### PR TITLE
Fix AppSec play.mvc.StatusHeader instrumentation for play 2.6

### DIFF
--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/appsec/StatusHeaderInstrumentation.java
@@ -97,10 +97,10 @@ public class StatusHeaderInstrumentation extends InstrumenterModule.AppSec
         throw new BlockingException("Blocked request (for StatusHeader/sendJson)");
       }
     }
-  }
 
-  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  static void after() {
-    CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    static void after() {
+      CallDepthThreadLocalMap.decrementCallDepth(StatusHeader.class);
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
Fix the AppSec instrumentation issue with `play.mvc.StatusHeader` that was causing failures in `PlayAsyncServerTest`. The `OnMethodExit` hook was incorrectly placed, leading to the callback not always being called.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
