### PR TITLE
Unify truncation limits between ObjectIntrospection and WAFModule

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
@@ -69,9 +69,9 @@ import org.slf4j.LoggerFactory;
 public class WAFModule implements AppSecModule {
   private static final Logger log = LoggerFactory.getLogger(WAFModule.class);
 
-  private static final int MAX_DEPTH = 10;
-  private static final int MAX_ELEMENTS = 150;
-  private static final int MAX_STRING_SIZE = 4096;
+  public static final int MAX_DEPTH = 20;
+  public static final int MAX_ELEMENTS = 256;
+  public static final int MAX_STRING_SIZE = 4096;
   private static volatile Waf.Limits LIMITS;
   private static final Class<?> PROXY_CLASS =
       Proxy.getProxyClass(WAFModule.class.getClassLoader(), Set.class);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/ObjectIntrospection.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/ObjectIntrospection.java
@@ -1,5 +1,9 @@
 package com.datadog.appsec.event.data;
 
+import static com.datadog.appsec.ddwaf.WAFModule.MAX_DEPTH;
+import static com.datadog.appsec.ddwaf.WAFModule.MAX_ELEMENTS;
+import static com.datadog.appsec.ddwaf.WAFModule.MAX_STRING_SIZE;
+
 import com.datadog.appsec.gateway.AppSecRequestContext;
 import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.telemetry.WafMetricCollector;
@@ -20,9 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class ObjectIntrospection {
-  private static final int MAX_DEPTH = 20;
-  private static final int MAX_ELEMENTS = 256;
-  private static final int MAX_STRING_LENGTH = 4096;
+
   private static final Logger log = LoggerFactory.getLogger(ObjectIntrospection.class);
 
   private static final Method trySetAccessible;
@@ -337,9 +339,9 @@ public final class ObjectIntrospection {
   }
 
   private static String checkStringLength(final String str, final State state) {
-    if (str.length() > MAX_STRING_LENGTH) {
+    if (str.length() > MAX_STRING_SIZE) {
       state.stringTooLong = true;
-      return str.substring(0, MAX_STRING_LENGTH);
+      return str.substring(0, MAX_STRING_SIZE);
     }
     return str;
   }


### PR DESCRIPTION
# What Does This Do

Unifies truncation limits to prevent using different thresholds, it also aligns them with what is specified in the [API Security RFC](https://docs.google.com/document/d/1VK_A63izyRR1vHRxOevCELSZ2yvTy93WxhJfBS0ep3k/edit?tab=t.0#heading=h.8d3o7vtyu1y1).

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
