### PR TITLE
Only inject ot-baggage-* into the HTTP headers once.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -98,10 +98,12 @@ public class HttpCodec {
       Set<TracePropagationStyle> propagationStyles,
       Map<String, String> reverseBaggageMapping) {
     EnumMap<TracePropagationStyle, Injector> result = new EnumMap<>(TracePropagationStyle.class);
+    boolean isInjectOtBaggage = true;
     for (TracePropagationStyle style : propagationStyles) {
       switch (style) {
         case DATADOG:
-          result.put(style, DatadogHttpCodec.newInjector(reverseBaggageMapping));
+          result.put(style, DatadogHttpCodec.newInjector(reverseBaggageMapping, isInjectOtBaggage));
+          isInjectOtBaggage = false;
           break;
         case B3SINGLE:
           result.put(
@@ -123,7 +125,8 @@ public class HttpCodec {
           result.put(style, NoneCodec.INJECTOR);
           break;
         case TRACECONTEXT:
-          result.put(style, W3CHttpCodec.newInjector(reverseBaggageMapping));
+          result.put(style, W3CHttpCodec.newInjector(reverseBaggageMapping, isInjectOtBaggage));
+          isInjectOtBaggage = false;
           break;
         case BAGGAGE:
           break;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -48,17 +48,20 @@ class W3CHttpCodec {
     // This class should not be created. This also makes code coverage checks happy.
   }
 
-  public static HttpCodec.Injector newInjector(Map<String, String> invertedBaggageMapping) {
-    return new Injector(invertedBaggageMapping);
+  public static HttpCodec.Injector newInjector(
+      Map<String, String> invertedBaggageMapping, boolean isInjectBaggage) {
+    return new Injector(invertedBaggageMapping, isInjectBaggage);
   }
 
   private static class Injector implements HttpCodec.Injector {
 
     private final Map<String, String> invertedBaggageMapping;
+    private final boolean isInjectBaggage;
 
-    public Injector(Map<String, String> invertedBaggageMapping) {
+    public Injector(Map<String, String> invertedBaggageMapping, boolean isInjectBaggage) {
       assert invertedBaggageMapping != null;
       this.invertedBaggageMapping = invertedBaggageMapping;
+      this.isInjectBaggage = isInjectBaggage;
     }
 
     @Override
@@ -66,7 +69,9 @@ class W3CHttpCodec {
         final DDSpanContext context, final C carrier, final CarrierSetter<C> setter) {
       injectTraceParent(context, carrier, setter);
       injectTraceState(context, carrier, setter);
-      injectBaggage(context, carrier, setter);
+      if (isInjectBaggage) {
+        injectBaggage(context, carrier, setter);
+      }
     }
 
     private <C> void injectTraceParent(DDSpanContext context, C carrier, CarrierSetter<C> setter) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -17,7 +17,7 @@ import static datadog.trace.core.propagation.DatadogHttpCodec.*
 
 class DatadogHttpInjectorTest extends DDCoreSpecification {
 
-  HttpCodec.Injector injector = newInjector(["some-baggage-key":"SOME_CUSTOM_HEADER"])
+  HttpCodec.Injector injector = newInjector(["some-baggage-key": "SOME_CUSTOM_HEADER"], true)
 
   def "inject http headers"() {
     setup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
@@ -21,7 +21,7 @@ import static datadog.trace.core.propagation.W3CHttpCodec.newInjector
 
 class W3CHttpInjectorTest extends DDCoreSpecification {
 
-  HttpCodec.Injector injector = newInjector(["some-baggage-key":"SOME_CUSTOM_HEADER"])
+  HttpCodec.Injector injector = newInjector(["some-baggage-key":"SOME_CUSTOM_HEADER"], true)
 
   def "inject http headers"() {
     setup:


### PR DESCRIPTION
# What Does This Do

Only inject `ot-baggage-*` into the HTTP headers once.

# Motivation

This resolves the issue that occurs when both `DATADOG`and `TRACECONTEXT` propagation styles are active and the carrier injects the same key multiple times (e.g.`GrpcHttp2OutboundHeaders`).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-16280]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-16280]: https://datadoghq.atlassian.net/browse/APMS-16280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ