### PR TITLE
Make rum injector stream/writer more resilient to errors

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
@@ -154,7 +154,7 @@ public class InjectingPipeOutputStream extends OutputStream {
 
   private void drain() throws IOException {
     if (count > 0) {
-      boolean tmpFilter = filter;
+      boolean wasFiltering = filter;
       filter = false;
       wasDraining = true;
       int start = (pos - count + lookbehind.length) % lookbehind.length;
@@ -163,7 +163,7 @@ public class InjectingPipeOutputStream extends OutputStream {
         downstream.write(lookbehind[(start + i) % lookbehind.length]);
         count--;
       }
-      filter = tmpFilter;
+      filter = wasFiltering;
       wasDraining = false;
     }
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
@@ -5,16 +5,19 @@ import java.io.OutputStream;
 
 /**
  * An OutputStream containing a circular buffer with a lookbehind buffer of n bytes. The first time
- * that the latest n bytes matches the marker, a content is injected before.
+ * that the latest n bytes matches the marker, a content is injected before. In case of IOException
+ * thrown by the downstream, the buffer will be lost unless the error occurred when draining it. In
+ * this case the draining will be resumed.
  */
 public class InjectingPipeOutputStream extends OutputStream {
   private final byte[] lookbehind;
   private int pos;
-  private boolean bufferFilled;
+  private int count;
   private final byte[] marker;
   private final byte[] contentToInject;
-  private boolean found = false;
-  private int matchingPos = 0;
+  private boolean filter;
+  private boolean wasDraining;
+  private int matchingPos;
   private final Runnable onContentInjected;
   private final int bulkWriteThreshold;
   private final OutputStream downstream;
@@ -34,6 +37,11 @@ public class InjectingPipeOutputStream extends OutputStream {
     this.marker = marker;
     this.lookbehind = new byte[marker.length];
     this.pos = 0;
+    this.count = 0;
+    this.matchingPos = 0;
+    this.wasDraining = false;
+    // should filter the stream to potentially inject into it.
+    this.filter = true;
     this.contentToInject = contentToInject;
     this.onContentInjected = onContentInjected;
     this.bulkWriteThreshold = marker.length * 2 - 2;
@@ -41,25 +49,27 @@ public class InjectingPipeOutputStream extends OutputStream {
 
   @Override
   public void write(int b) throws IOException {
-    if (found) {
+    if (!filter) {
+      if (wasDraining) {
+        // continue draining
+        drain();
+      }
       downstream.write(b);
       return;
     }
 
-    if (bufferFilled) {
+    if (count == lookbehind.length) {
       downstream.write(lookbehind[pos]);
+    } else {
+      count++;
     }
 
     lookbehind[pos] = (byte) b;
     pos = (pos + 1) % lookbehind.length;
 
-    if (!bufferFilled) {
-      bufferFilled = pos == 0;
-    }
-
     if (marker[matchingPos++] == b) {
       if (matchingPos == marker.length) {
-        found = true;
+        filter = false;
         downstream.write(contentToInject);
         if (onContentInjected != null) {
           onContentInjected.run();
@@ -73,10 +83,15 @@ public class InjectingPipeOutputStream extends OutputStream {
 
   @Override
   public void write(byte[] array, int off, int len) throws IOException {
-    if (found) {
+    if (!filter) {
+      if (wasDraining) {
+        // needs drain
+        drain();
+      }
       downstream.write(array, off, len);
       return;
     }
+
     if (len > bulkWriteThreshold) {
       // if the content is large enough, we can bulk write everything but the N trail and tail.
       // This because the buffer can already contain some byte from a previous single write.
@@ -84,7 +99,7 @@ public class InjectingPipeOutputStream extends OutputStream {
       int idx = arrayContains(array, off, len, marker);
       if (idx >= 0) {
         // we have a full match. just write everything
-        found = true;
+        filter = false;
         drain();
         downstream.write(array, off, idx);
         downstream.write(contentToInject);
@@ -99,7 +114,13 @@ public class InjectingPipeOutputStream extends OutputStream {
           write(array[i]);
         }
         drain();
+        boolean tmpFilter = filter;
+
+        // will be reset if no errors after the following write
+        filter = false;
         downstream.write(array, off + marker.length - 1, len - bulkWriteThreshold);
+        filter = tmpFilter;
+
         for (int i = len - marker.length + 1; i < len; i++) {
           write(array[i]);
         }
@@ -133,16 +154,19 @@ public class InjectingPipeOutputStream extends OutputStream {
   }
 
   private void drain() throws IOException {
-    if (bufferFilled) {
-      for (int i = 0; i < lookbehind.length; i++) {
-        downstream.write(lookbehind[(pos + i) % lookbehind.length]);
+    if (count > 0) {
+      boolean tmpFilter = filter;
+      filter = false;
+      wasDraining = true;
+      int start = (pos - count + lookbehind.length) % lookbehind.length;
+      int cnt = count;
+      for (int i = 0; i < cnt; i++) {
+        downstream.write(lookbehind[(start + i) % lookbehind.length]);
+        count--;
       }
-    } else {
-      downstream.write(this.lookbehind, 0, pos);
+      filter = tmpFilter;
+      wasDraining = false;
     }
-    pos = 0;
-    matchingPos = 0;
-    bufferFilled = false;
   }
 
   @Override
@@ -152,9 +176,12 @@ public class InjectingPipeOutputStream extends OutputStream {
 
   @Override
   public void close() throws IOException {
-    if (!found) {
-      drain();
+    try {
+      if (filter || wasDraining) {
+        drain();
+      }
+    } finally {
+      downstream.close();
     }
-    downstream.close();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStream.java
@@ -114,13 +114,12 @@ public class InjectingPipeOutputStream extends OutputStream {
           write(array[i]);
         }
         drain();
-        boolean tmpFilter = filter;
+        boolean wasFiltering = filter;
 
         // will be reset if no errors after the following write
         filter = false;
         downstream.write(array, off + marker.length - 1, len - bulkWriteThreshold);
-        filter = tmpFilter;
-
+        filter = wasFiltering;
         for (int i = len - marker.length + 1; i < len; i++) {
           write(array[i]);
         }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriter.java
@@ -114,12 +114,12 @@ public class InjectingPipeWriter extends Writer {
           write(array[i]);
         }
         drain();
-        boolean tmpFilter = filter;
+        boolean wasFiltering = filter;
 
         // will be reset if no errors after the following write
         filter = false;
         downstream.write(array, off + marker.length - 1, len - bulkWriteThreshold);
-        filter = tmpFilter;
+        filter = wasFiltering;
 
         for (int i = len - marker.length + 1; i < len; i++) {
           write(array[i]);
@@ -155,7 +155,7 @@ public class InjectingPipeWriter extends Writer {
 
   private void drain() throws IOException {
     if (count > 0) {
-      boolean tmpFilter = filter;
+      boolean wasFiltering = filter;
       filter = false;
       wasDraining = true;
       int start = (pos - count + lookbehind.length) % lookbehind.length;
@@ -164,7 +164,7 @@ public class InjectingPipeWriter extends Writer {
         downstream.write(lookbehind[(start + i) % lookbehind.length]);
         count--;
       }
-      filter = tmpFilter;
+      filter = wasFiltering;
       wasDraining = false;
     }
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriter.java
@@ -5,16 +5,19 @@ import java.io.Writer;
 
 /**
  * A Writer containing a circular buffer with a lookbehind buffer of n bytes. The first time that
- * the latest n bytes matches the marker, a content is injected before.
+ * the latest n bytes matches the marker, a content is injected before. In case of IOException
+ * thrown by the downstream, the buffer will be lost unless the error occurred when draining it. In
+ * this case the draining will be resumed.
  */
 public class InjectingPipeWriter extends Writer {
   private final char[] lookbehind;
   private int pos;
-  private boolean bufferFilled;
+  private int count;
   private final char[] marker;
   private final char[] contentToInject;
-  private boolean found = false;
-  private int matchingPos = 0;
+  private boolean filter;
+  private boolean wasDraining;
+  private int matchingPos;
   private final Runnable onContentInjected;
   private final int bulkWriteThreshold;
   private final Writer downstream;
@@ -34,6 +37,11 @@ public class InjectingPipeWriter extends Writer {
     this.marker = marker;
     this.lookbehind = new char[marker.length];
     this.pos = 0;
+    this.count = 0;
+    this.matchingPos = 0;
+    this.wasDraining = false;
+    // should filter the stream to potentially inject into it.
+    this.filter = true;
     this.contentToInject = contentToInject;
     this.onContentInjected = onContentInjected;
     this.bulkWriteThreshold = marker.length * 2 - 2;
@@ -41,25 +49,27 @@ public class InjectingPipeWriter extends Writer {
 
   @Override
   public void write(int c) throws IOException {
-    if (found) {
+    if (!filter) {
+      if (wasDraining) {
+        // continue draining
+        drain();
+      }
       downstream.write(c);
       return;
     }
 
-    if (bufferFilled) {
+    if (count == lookbehind.length) {
       downstream.write(lookbehind[pos]);
+    } else {
+      count++;
     }
 
     lookbehind[pos] = (char) c;
     pos = (pos + 1) % lookbehind.length;
 
-    if (!bufferFilled) {
-      bufferFilled = pos == 0;
-    }
-
     if (marker[matchingPos++] == c) {
       if (matchingPos == marker.length) {
-        found = true;
+        filter = false;
         downstream.write(contentToInject);
         if (onContentInjected != null) {
           onContentInjected.run();
@@ -72,16 +82,16 @@ public class InjectingPipeWriter extends Writer {
   }
 
   @Override
-  public void flush() throws IOException {
-    downstream.flush();
-  }
-
-  @Override
   public void write(char[] array, int off, int len) throws IOException {
-    if (found) {
+    if (!filter) {
+      if (wasDraining) {
+        // needs drain
+        drain();
+      }
       downstream.write(array, off, len);
       return;
     }
+
     if (len > bulkWriteThreshold) {
       // if the content is large enough, we can bulk write everything but the N trail and tail.
       // This because the buffer can already contain some byte from a previous single write.
@@ -89,7 +99,7 @@ public class InjectingPipeWriter extends Writer {
       int idx = arrayContains(array, off, len, marker);
       if (idx >= 0) {
         // we have a full match. just write everything
-        found = true;
+        filter = false;
         drain();
         downstream.write(array, off, idx);
         downstream.write(contentToInject);
@@ -104,7 +114,13 @@ public class InjectingPipeWriter extends Writer {
           write(array[i]);
         }
         drain();
+        boolean tmpFilter = filter;
+
+        // will be reset if no errors after the following write
+        filter = false;
         downstream.write(array, off + marker.length - 1, len - bulkWriteThreshold);
+        filter = tmpFilter;
+
         for (int i = len - marker.length + 1; i < len; i++) {
           write(array[i]);
         }
@@ -138,23 +154,34 @@ public class InjectingPipeWriter extends Writer {
   }
 
   private void drain() throws IOException {
-    if (bufferFilled) {
-      for (int i = 0; i < lookbehind.length; i++) {
-        downstream.write(lookbehind[(pos + i) % lookbehind.length]);
+    if (count > 0) {
+      boolean tmpFilter = filter;
+      filter = false;
+      wasDraining = true;
+      int start = (pos - count + lookbehind.length) % lookbehind.length;
+      int cnt = count;
+      for (int i = 0; i < cnt; i++) {
+        downstream.write(lookbehind[(start + i) % lookbehind.length]);
+        count--;
       }
-    } else {
-      downstream.write(this.lookbehind, 0, pos);
+      filter = tmpFilter;
+      wasDraining = false;
     }
-    pos = 0;
-    matchingPos = 0;
-    bufferFilled = false;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    downstream.flush();
   }
 
   @Override
   public void close() throws IOException {
-    if (!found) {
-      drain();
+    try {
+      if (filter || wasDraining) {
+        drain();
+      }
+    } finally {
+      downstream.close();
     }
-    downstream.close();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
@@ -6,9 +6,11 @@ class InjectingPipeOutputStreamTest extends DDSpecification {
   static class GlitchedOutputStream extends FilterOutputStream {
     int glitchesPos
     int count
+    final OutputStream out
 
     GlitchedOutputStream(OutputStream out, int glitchesPos) {
       super(out)
+      this.out = out
       this.glitchesPos = glitchesPos
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.buffer
 
 import datadog.trace.test.util.DDSpecification
-import org.apache.commons.io.IOUtils
 
 class InjectingPipeOutputStreamTest extends DDSpecification {
   static class GlitchedOutputStream extends FilterOutputStream {
@@ -67,7 +66,11 @@ class InjectingPipeOutputStreamTest extends DDSpecification {
         }
       }
     } finally {
-      IOUtils.closeQuietly(piped) // it can throw when draining at close
+      // it can throw when draining at close
+      try {
+        piped.close()
+      } catch (IOException ignored) {
+      }
     }
     then:
     assert baos.toByteArray() == expected.getBytes("UTF-8")

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeOutputStreamTest.groovy
@@ -1,8 +1,37 @@
 package datadog.trace.bootstrap.instrumentation.buffer
 
 import datadog.trace.test.util.DDSpecification
+import org.apache.commons.io.IOUtils
 
 class InjectingPipeOutputStreamTest extends DDSpecification {
+  static class GlitchedOutputStream extends FilterOutputStream {
+    int glitchesPos
+    int count
+
+    GlitchedOutputStream(OutputStream out, int glitchesPos) {
+      super(out)
+      this.glitchesPos = glitchesPos
+    }
+
+    @Override
+    void write(byte[] b, int off, int len) throws IOException {
+      count += len
+      if (count >= glitchesPos) {
+        glitchesPos = Integer.MAX_VALUE
+        throw new IOException("Glitched after $count bytes")
+      }
+      out.write(b, off, len)
+    }
+
+    @Override
+    void write(int b) throws IOException {
+      if (++count == glitchesPos) {
+        throw new IOException("Glitched after $glitchesPos bytes")
+      }
+      out.write(b)
+    }
+  }
+
   def 'should filter a buffer and inject if found #found'() {
     setup:
     def downstream = new ByteArrayOutputStream()
@@ -19,5 +48,38 @@ class InjectingPipeOutputStreamTest extends DDSpecification {
     "<html><head><foo/></head><body/></html>" | "</head>"         | "<script>true</script>" | true  | "<html><head><foo/><script>true</script></head><body/></html>"
     "<html><body/></html>"                    | "</head>"         | "<something/>"          | false | "<html><body/></html>"
     "<foo/>"                                  | "<longerThanFoo>" | "<nothing>"             | false | "<foo/>"
+  }
+
+  def 'should be resilient to exceptions when writing #body'() {
+    setup:
+    def baos = new ByteArrayOutputStream()
+    def downstream = new GlitchedOutputStream(baos, glichesAt)
+    def piped = new InjectingPipeOutputStream(downstream, marker.getBytes("UTF-8"), contentToInject.getBytes("UTF-8"), null)
+    when:
+    try {
+      for (String line : body) {
+        final bytes = line.getBytes("UTF-8")
+        try {
+          piped.write(bytes)
+        } catch (IOException ioe) {
+          ioe.printStackTrace()
+          piped.write(bytes)
+        }
+      }
+    } finally {
+      IOUtils.closeQuietly(piped) // it can throw when draining at close
+    }
+    then:
+    assert baos.toByteArray() == expected.getBytes("UTF-8")
+    where:
+    body                                                            | marker            | contentToInject         | glichesAt | expected
+    // write fails after the content has been injected
+    ["<html>", "<head>", "<foo/>", "</head>", "<body/>", "</html>"] | "</head>"         | "<script>true</script>" | 60        | "<html><head><foo/><script>true</script></head><body/></html>"
+    // write fails before the content has been injected
+    ["<html>", "<head>", "<foo/>", "</head>", "<body/>", "</html>"] | "</head>"         | "<script>true</script>" | 20        | "<html><head><foo/></head><body/></html>"
+    // write fails after having filled the buffer. The last line is written twice
+    ["<html>", "<body/>", "</html>"]                                | "</head>"         | "<something/>"          | 10        | "<html><body/></h</html>"
+    // expected broken since the real write happens at close (drain) being the content smaller than the buffer. And retry on close is not a common practice. Hence, we suppose loosing content
+    ["<foo/>"]                                                      | "<longerThanFoo>" | "<nothing>"             | 3         | "<f"
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
@@ -1,8 +1,37 @@
 package datadog.trace.bootstrap.instrumentation.buffer
 
 import datadog.trace.test.util.DDSpecification
+import org.apache.commons.io.IOUtils
 
 class InjectingPipeWriterTest extends DDSpecification {
+  static class GlitchedWriter extends FilterWriter {
+    int glitchesPos
+    int count
+
+    GlitchedWriter(Writer out, int glitchesPos) {
+      super(out)
+      this.glitchesPos = glitchesPos
+    }
+
+    @Override
+    void write(char[] c, int off, int len) throws IOException {
+      count += len
+      if (count >= glitchesPos) {
+        glitchesPos = Integer.MAX_VALUE
+        throw new IOException("Glitched after $count bytes")
+      }
+      out.write(c, off, len)
+    }
+
+    @Override
+    void write(int c) throws IOException {
+      if (++count == glitchesPos) {
+        throw new IOException("Glitched after $glitchesPos bytes")
+      }
+      out.write(c)
+    }
+  }
+
   def 'should filter a buffer and inject if found #found using write'() {
     setup:
     def downstream = new StringWriter()
@@ -35,5 +64,38 @@ class InjectingPipeWriterTest extends DDSpecification {
     "<html><head><foo/></head><body/></html>" | "</head>"         | "<script>true</script>" | true  | "<html><head><foo/><script>true</script></head><body/></html>"
     "<html><body/></html>"                    | "</head>"         | "<something/>"          | false | "<html><body/></html>"
     "<foo/>"                                  | "<longerThanFoo>" | "<nothing>"             | false | "<foo/>"
+  }
+
+  def 'should be resilient to exceptions when writing #body'() {
+    setup:
+    def writer = new StringWriter()
+    def downstream = new GlitchedWriter(writer, glichesAt)
+    def piped = new InjectingPipeWriter(downstream, marker.toCharArray(), contentToInject.toCharArray(), null)
+    when:
+    try {
+      for (String line : body) {
+        final chars = line.toCharArray()
+        try {
+          piped.write(chars)
+        } catch (IOException ioe) {
+          ioe.printStackTrace()
+          piped.write(chars)
+        }
+      }
+    } finally {
+      IOUtils.closeQuietly(piped) // it can throw when draining at close
+    }
+    then:
+    assert writer.toString() == expected
+    where:
+    body                                                            | marker            | contentToInject         | glichesAt | expected
+    // write fails after the content has been injected
+    ["<html>", "<head>", "<foo/>", "</head>", "<body/>", "</html>"] | "</head>"         | "<script>true</script>" | 60        | "<html><head><foo/><script>true</script></head><body/></html>"
+    // write fails before the content has been injected
+    ["<html>", "<head>", "<foo/>", "</head>", "<body/>", "</html>"] | "</head>"         | "<script>true</script>" | 20        | "<html><head><foo/></head><body/></html>"
+    // write fails after having filled the buffer. The last line is written twice
+    ["<html>", "<body/>", "</html>"]                                | "</head>"         | "<something/>"          | 10        | "<html><body/></h</html>"
+    // expected broken since the real write happens at close (drain) being the content smaller than the buffer. And retry on close is not a common practice. Hence, we suppose loosing content
+    ["<foo/>"]                                                      | "<longerThanFoo>" | "<nothing>"             | 3         | "<f"
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
@@ -6,9 +6,11 @@ class InjectingPipeWriterTest extends DDSpecification {
   static class GlitchedWriter extends FilterWriter {
     int glitchesPos
     int count
+    final Writer out
 
     GlitchedWriter(Writer out, int glitchesPos) {
       super(out)
+      this.out = out
       this.glitchesPos = glitchesPos
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/buffer/InjectingPipeWriterTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.buffer
 
 import datadog.trace.test.util.DDSpecification
-import org.apache.commons.io.IOUtils
 
 class InjectingPipeWriterTest extends DDSpecification {
   static class GlitchedWriter extends FilterWriter {
@@ -83,7 +82,11 @@ class InjectingPipeWriterTest extends DDSpecification {
         }
       }
     } finally {
-      IOUtils.closeQuietly(piped) // it can throw when draining at close
+      // it can throw when draining at close
+      try {
+        piped.close()
+      } catch (IOException ignored) {
+      }
     }
     then:
     assert writer.toString() == expected


### PR DESCRIPTION
# What Does This Do

Make `InjectingPipeOutStream` and `InjectingPipeWriter` more deterministic when an `IOException` is thrown by the downstream.

In this particular case, the wrappers stop trying to inject to the downstream and just delegate the writes since the underlying  buffer is now in an inconsistent state (we do not know in advance which portion of the buffer has been eventually written and what will be the retry policy of the user). This implies that eventually data can be corrupted or lost (but this would also have happened without this wrapper)

However, if the error arose when draining, the draining is resumed from the position that broke.


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
