### PR TITLE
Improve environment component null values handling

### DIFF
--- a/components/environment/src/main/java/datadog/environment/EnvironmentVariables.java
+++ b/components/environment/src/main/java/datadog/environment/EnvironmentVariables.java
@@ -16,7 +16,8 @@ public final class EnvironmentVariables {
    * Gets an environment variable value.
    *
    * @param name The environment variable name.
-   * @return The environment variable value, {@code null} if missing or can't be retrieved.
+   * @return The environment variable value, {@code null} if missing, can't be retrieved, or the
+   *     environment variable name is {@code null}.
    */
   public static @Nullable String get(String name) {
     return getOrDefault(name, null);
@@ -28,9 +29,13 @@ public final class EnvironmentVariables {
    * @param name The environment variable name.
    * @param defaultValue The default value to return if the environment variable is missing or can't
    *     be retrieved.
-   * @return The environment variable value, {@code defaultValue} if missing or can't be retrieved.
+   * @return The environment variable value, {@code defaultValue} if missing, can't be retrieved or
+   *     the environment variable name is {@code null}.
    */
   public static String getOrDefault(@Nonnull String name, String defaultValue) {
+    if (name == null) {
+      return defaultValue;
+    }
     try {
       String value = System.getenv(name);
       return value == null ? defaultValue : value;

--- a/components/environment/src/main/java/datadog/environment/SystemProperties.java
+++ b/components/environment/src/main/java/datadog/environment/SystemProperties.java
@@ -1,5 +1,7 @@
 package datadog.environment;
 
+import javax.annotation.Nonnull;
+
 /**
  * Safely queries system properties against security manager.
  *
@@ -13,7 +15,8 @@ public final class SystemProperties {
    * Gets a system property value.
    *
    * @param property The system property name.
-   * @return The system property value, {@code null} if missing or can't be retrieved.
+   * @return The system property value, {@code null} if missing, can't be retrieved, or the system
+   *     property name is {@code null}.
    */
   public static String get(String property) {
     return getOrDefault(property, null);
@@ -25,9 +28,13 @@ public final class SystemProperties {
    * @param property The system property name.
    * @param defaultValue The default value to return if the system property is missing or can't be
    *     retrieved.
-   * @return The system property value, {@code defaultValue} if missing or can't be retrieved.
+   * @return The system property value, {@code defaultValue} if missing, can't be retrieved, or the
+   *     system property name is {@code null}.
    */
-  public static String getOrDefault(String property, String defaultValue) {
+  public static String getOrDefault(@Nonnull String property, String defaultValue) {
+    if (property == null) {
+      return defaultValue;
+    }
     try {
       return System.getProperty(property, defaultValue);
     } catch (SecurityException ignored) {

--- a/components/environment/src/test/java/datadog/environment/EnvironmentVariablesTest.java
+++ b/components/environment/src/test/java/datadog/environment/EnvironmentVariablesTest.java
@@ -1,27 +1,39 @@
 package datadog.environment;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 class EnvironmentVariablesTest {
   private static final String EXISTING_ENV_VAR = "JAVA_8_HOME";
   private static final String MISSING_ENV_VAR = "UNDEFINED_ENV_VAR";
+  private static final String DEFAULT_VALUE = "DEFAULT";
 
   @Test
   void testGet() {
+    // Existing environment variable
     assertNotNull(EnvironmentVariables.get(EXISTING_ENV_VAR));
+    // Missing environment variable
     assertNull(EnvironmentVariables.get(MISSING_ENV_VAR));
-    assertThrows(NullPointerException.class, () -> EnvironmentVariables.get(null));
+    // Null values
+    assertDoesNotThrow(() -> EnvironmentVariables.get(null));
+    assertNull(EnvironmentVariables.get(null));
   }
 
   @Test
   void testGetOrDefault() {
+    // Existing environment variable
     assertNotNull(EnvironmentVariables.getOrDefault(EXISTING_ENV_VAR, null));
-
-    assertEquals("", EnvironmentVariables.getOrDefault(MISSING_ENV_VAR, ""));
+    // Missing environment variable
+    assertEquals(DEFAULT_VALUE, EnvironmentVariables.getOrDefault(MISSING_ENV_VAR, DEFAULT_VALUE));
     assertNull(EnvironmentVariables.getOrDefault(MISSING_ENV_VAR, null));
-
-    assertThrows(NullPointerException.class, () -> EnvironmentVariables.getOrDefault(null, ""));
+    // Null values
+    assertDoesNotThrow(() -> EnvironmentVariables.getOrDefault(null, DEFAULT_VALUE));
+    assertEquals(DEFAULT_VALUE, EnvironmentVariables.getOrDefault(null, DEFAULT_VALUE));
+    assertDoesNotThrow(() -> EnvironmentVariables.getOrDefault(MISSING_ENV_VAR, null));
+    assertNull(EnvironmentVariables.getOrDefault(MISSING_ENV_VAR, null));
   }
 }

--- a/components/environment/src/test/java/datadog/environment/SystemPropertiesTest.java
+++ b/components/environment/src/test/java/datadog/environment/SystemPropertiesTest.java
@@ -8,22 +8,32 @@ import org.junit.jupiter.api.Test;
 class SystemPropertiesTest {
   private static final String EXISTING_SYSTEM_PROPERTY = "java.home";
   private static final String MISSING_SYSTEM_PROPERTY = "undefined.system.property";
+  private static final String DEFAULT_VALUE = "DEFAULT";
 
   @Test
   void testGet() {
+    // Existing system properties
     assertNotNull(SystemProperties.get(EXISTING_SYSTEM_PROPERTY));
+    // Missing system properties
     assertNull(SystemProperties.get(MISSING_SYSTEM_PROPERTY));
-    assertThrows(NullPointerException.class, () -> SystemProperties.get(null));
+    // Null values
+    assertDoesNotThrow(() -> SystemProperties.get(null));
+    assertNull(SystemProperties.get(null));
   }
 
   @Test
   void testGetOrDefault() {
+    // Existing system properties
     assertNotNull(SystemProperties.getOrDefault(EXISTING_SYSTEM_PROPERTY, null));
-
-    assertEquals("", SystemProperties.getOrDefault(MISSING_SYSTEM_PROPERTY, ""));
+    // Missing system properties
+    assertEquals(
+        DEFAULT_VALUE, SystemProperties.getOrDefault(MISSING_SYSTEM_PROPERTY, DEFAULT_VALUE));
     assertNull(SystemProperties.getOrDefault(MISSING_SYSTEM_PROPERTY, null));
-
-    assertThrows(NullPointerException.class, () -> SystemProperties.getOrDefault(null, ""));
+    // Null values
+    assertDoesNotThrow(() -> SystemProperties.getOrDefault(null, DEFAULT_VALUE));
+    assertEquals(DEFAULT_VALUE, SystemProperties.getOrDefault(null, DEFAULT_VALUE));
+    assertDoesNotThrow(() -> SystemProperties.getOrDefault(MISSING_SYSTEM_PROPERTY, null));
+    assertNull(SystemProperties.getOrDefault(MISSING_SYSTEM_PROPERTY, null));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

This PR improves null values handling of environment component.

# Motivation

Following feedback on #9170 from @sarahchen6 

# Additional Notes


Environment component related stacked PRs:

* https://github.com/DataDog/dd-trace-java/pull/9071
* https://github.com/DataDog/dd-trace-java/pull/9072
* https://github.com/DataDog/dd-trace-java/pull/9091
* https://github.com/DataDog/dd-trace-java/pull/9093
* https://github.com/DataDog/dd-trace-java/pull/9100
* https://github.com/DataDog/dd-trace-java/pull/9188
* https://github.com/DataDog/dd-trace-java/pull/9190
* https://github.com/DataDog/dd-trace-java/pull/9191

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-458]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-458]: https://datadoghq.atlassian.net/browse/LANGPLAT-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ