### PR TITLE
Exclude akka http build outside the CI

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
@@ -3,90 +3,88 @@ ext {
   minJavaVersionForTests = JavaVersion.VERSION_11
 }
 
-apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'scala'
-apply plugin: 'call-site-instrumentation'
+if (project.rootProject.hasProperty("akkaRepositoryToken")) {
+
+  apply from: "$rootDir/gradle/java.gradle"
+  apply plugin: 'scala'
+  apply plugin: 'call-site-instrumentation'
 
 
-muzzle {
-  pass {
-    group = 'com.typesafe.akka'
-    module = 'akka-http_2.13'
-    versions = "[10.6.0,)"
-    javaVersion = "11"
-    extraDependency 'com.typesafe.akka:akka-stream_2.13:2.9.0'
+  muzzle {
+    pass {
+      group = 'com.typesafe.akka'
+      module = 'akka-http_2.13'
+      versions = "[10.6.0,)"
+      javaVersion = "11"
+      extraDependency 'com.typesafe.akka:akka-stream_2.13:2.9.0'
 
-    if (project.rootProject.hasProperty("akkaRepositoryToken")) {
       extraRepository('akka', "https://repo.akka.io/${project.rootProject.property("akkaRepositoryToken")}/secure")
+      assertInverse = true
+    }
+
+  }
+
+  repositories {
+    if (project.rootProject.hasProperty("akkaRepositoryToken")) {
+      maven {
+        url "https://repo.akka.io/${project.rootProject.property("akkaRepositoryToken")}/secure"
+      }
     } else {
-      extraRepository('akka', 'https://repo.akka.io/maven')
-    }
-
-    assertInverse = true
-  }
-
-}
-
-repositories {
-  if (project.rootProject.hasProperty("akkaRepositoryToken")) {
-    maven {
-      url "https://repo.akka.io/${project.rootProject.property("akkaRepositoryToken")}/secure"
-    }
-  } else {
-    maven {
-      url "https://repo.akka.io/maven"
+      maven {
+        url "https://repo.akka.io/maven"
+      }
     }
   }
-}
 
-addTestSuiteForDir('latestDepTest', 'test')
+  addTestSuiteForDir('latestDepTest', 'test')
 
-[compileMain_java11Java, compileTestScala, compileLatestDepTestScala].each {
-  it.configure {
-    setJavaVersion(it, 11)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+  [compileMain_java11Java, compileTestScala, compileLatestDepTestScala].each {
+    it.configure {
+      setJavaVersion(it, 11)
+      sourceCompatibility = JavaVersion.VERSION_1_8
+      targetCompatibility = JavaVersion.VERSION_1_8
+    }
   }
-}
 
-compileTestGroovy {
-  javaLauncher = getJavaLauncherFor(11)
-  dependsOn compileTestScala
-  classpath += files(compileTestScala.destinationDirectory)
-}
+  compileTestGroovy {
+    javaLauncher = getJavaLauncherFor(11)
+    dependsOn compileTestScala
+    classpath += files(compileTestScala.destinationDirectory)
+  }
 
-compileLatestDepTestGroovy {
-  javaLauncher = getJavaLauncherFor(11)
-  dependsOn compileLatestDepTestScala
-  classpath += files(compileLatestDepTestScala.destinationDirectory)
-}
+  compileLatestDepTestGroovy {
+    javaLauncher = getJavaLauncherFor(11)
+    dependsOn compileLatestDepTestScala
+    classpath += files(compileLatestDepTestScala.destinationDirectory)
+  }
 
-dependencies {
-  main_java11CompileOnly libs.scala213
-  main_java11CompileOnly group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.6.0'
-  main_java11CompileOnly group: 'com.typesafe.akka', name: 'akka-actor_2.13', version: '2.9.0'
+  dependencies {
+    main_java11CompileOnly libs.scala213
+    main_java11CompileOnly group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.6.0'
+    main_java11CompileOnly group: 'com.typesafe.akka', name: 'akka-actor_2.13', version: '2.9.0'
 
-  //testImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
-  testImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.6.0'
-  testImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.9.0'
-  testImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '10.6.0'
-  testImplementation group: 'com.typesafe.akka', name: 'akka-http-spray-json_2.13', version: '10.6.0'
-  testImplementation libs.scala213
-  testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
-  testImplementation project(':dd-java-agent:instrumentation:akka:akka-actor-2.5')
-  testImplementation project(':dd-java-agent:instrumentation:scala-concurrent')
-  testImplementation project(':dd-java-agent:instrumentation:akka:akka-http:akka-http-10.0')
-  testImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
+    //testImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+    testImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.6.0'
+    testImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.9.0'
+    testImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '10.6.0'
+    testImplementation group: 'com.typesafe.akka', name: 'akka-http-spray-json_2.13', version: '10.6.0'
+    testImplementation libs.scala213
+    testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+    testImplementation project(':dd-java-agent:instrumentation:akka:akka-actor-2.5')
+    testImplementation project(':dd-java-agent:instrumentation:scala-concurrent')
+    testImplementation project(':dd-java-agent:instrumentation:akka:akka-http:akka-http-10.0')
+    testImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
 
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '+'
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '+'
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-pki_2.13', version: '+'
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-protobuf-v3_2.13', version: '+'
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '+'
-  latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http-spray-json_2.13', version: '+'
-  latestDepTestImplementation group: 'org.scala-lang.modules', name: 'scala-java8-compat_2.13', version: '1.0.+'
-}
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '+'
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '+'
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-pki_2.13', version: '+'
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-protobuf-v3_2.13', version: '+'
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '+'
+    latestDepTestImplementation group: 'com.typesafe.akka', name: 'akka-http-spray-json_2.13', version: '+'
+    latestDepTestImplementation group: 'org.scala-lang.modules', name: 'scala-java8-compat_2.13', version: '1.0.+'
+  }
 
-configurations.getByName("latestDepTestRuntimeClasspath").resolutionStrategy {
-  it.force libs.slf4j
+  configurations.getByName("latestDepTestRuntimeClasspath").resolutionStrategy {
+    it.force libs.slf4j
+  }
 }


### PR DESCRIPTION
# What Does This Do

When the akka repo token is not available it excludes the build for akka http 10+ that requires a token

I checked that the gitlab generated artifact contains the instrumentations

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
