### PR TITLE
Move JSON generation to sender thread to improve startup time.

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/BootstrapInitializationTelemetryTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/BootstrapInitializationTelemetryTest.groovy
@@ -1,56 +1,56 @@
 package datadog.trace.bootstrap
 
-import groovy.json.JsonBuilder
 import spock.lang.Specification
 
-import static java.nio.charset.StandardCharsets.UTF_8
-
 class BootstrapInitializationTelemetryTest extends Specification {
-  def initTelemetry, capture
+  Capture capture
+  def initTelemetry
 
   def setup() {
-    def capture = new Capture()
-    def initTelemetry = new BootstrapInitializationTelemetry.JsonBased(capture)
+    capture = new Capture()
 
     // There's an annoying interaction between our bootstrap injection
     // and the GroovyClassLoader class resolution.  Groovy resolves the import
     // against the application ClassLoader, but when a method invocation
     // happens it resolves the invocation against the bootstrap classloader.
-
+    //
     // To side step this problem, put a Groovy Proxy around the object under test
-
     // codeNarc was incorrectly flagging "import groovy.util.Proxy" as unnecessary,
     // since groovy.util is imported implicitly.  However, java.util is also
     // implicitly imported and also contains a Proxy class, so need to use the
     // full name inline to disambiguate and pass codeNarc.
     def initTelemetryProxy = new groovy.util.Proxy()
-    initTelemetryProxy.setAdaptee(initTelemetry)
-
+    initTelemetryProxy.setAdaptee(new BootstrapInitializationTelemetry.JsonBased(capture))
     this.initTelemetry = initTelemetryProxy
-    this.initTelemetry.initMetaInfo("runtime_name", "java")
-    this.initTelemetry.initMetaInfo("runtime_version", "1.8.0_382")
-    this.capture = capture
   }
 
-  def "test success"() {
+  def "test happy path"() {
     when:
     initTelemetry.finish()
 
     then:
-    capture.json() == json("success", "success", "Successfully configured ddtrace package",
-      [[name: "library_entrypoint.complete"]])
+    assertMeta("success", "success", "Successfully configured ddtrace package")
+    assertPoints(true, "library_entrypoint.complete", [])
   }
 
-  def "real example"() {
+  def "test non fatal error as text"() {
     when:
-    initTelemetry.onError(new Exception("foo"))
+    initTelemetry.onError("some reason")
     initTelemetry.finish()
 
     then:
-    capture.json() == json("error", "internal_error", "foo", [
-      [name: "library_entrypoint.error", tags: ["error_type:java.lang.Exception"]],
-      [name: "library_entrypoint.complete"]
-    ])
+    assertMeta("error", "unknown", "some reason")
+    assertPoints(true, "library_entrypoint.error", ["error_type:some reason"])
+  }
+
+  def "test non fatal error as exception"() {
+    when:
+    initTelemetry.onError(new Exception("non fatal error"))
+    initTelemetry.finish()
+
+    then:
+    assertMeta("error", "internal_error", "non fatal error")
+    assertPoints(true, "library_entrypoint.error", ["error_type:java.lang.Exception"])
   }
 
   def "test abort"() {
@@ -59,8 +59,8 @@ class BootstrapInitializationTelemetryTest extends Specification {
     initTelemetry.finish()
 
     then:
-    capture.json() == json("abort", resultClass, reasonCode,
-      [[name: "library_entrypoint.abort", tags: ["reason:${reasonCode}"]]])
+    assertMeta("abort", resultClass, reasonCode)
+    assertPoints(false, "library_entrypoint.abort", ["reason:${reasonCode}"])
 
     where:
     reasonCode            | resultClass
@@ -70,68 +70,52 @@ class BootstrapInitializationTelemetryTest extends Specification {
     "foo"                 | "unknown"
   }
 
-  def "trivial completion check"() {
+  def "test fatal error"() {
     when:
+    initTelemetry.onFatalError(new Exception("fatal error"))
     initTelemetry.finish()
 
     then:
-    capture.json().contains("library_entrypoint.complete")
+    assertMeta("error", "internal_error", "fatal error")
+    assertPoints(false, "library_entrypoint.error", ["error_type:java.lang.Exception"])
   }
 
-  def "trivial incomplete check"() {
-    when:
-    initTelemetry.markIncomplete()
-    initTelemetry.finish()
-
-    then:
-    !capture.json().contains("library_entrypoint.complete")
-  }
-
-  def "incomplete on fatal error"() {
-    when:
-    initTelemetry.onFatalError(new Exception("foo"))
-    initTelemetry.finish()
-
-    then:
-    !capture.json().contains("library_entrypoint.complete")
-    capture.json() == json("error", "internal_error", "foo",
-      [[name: "library_entrypoint.error", tags: ["error_type:java.lang.Exception"]]])
-  }
-
-  def "incomplete on abort"() {
-    when:
-    initTelemetry.onAbort("reason")
-    initTelemetry.finish()
-
-    then:
-    !capture.json().contains("library_entrypoint.complete")
-  }
-
-  def "unwind root cause"() {
+  def "test unwind root cause"() {
     when:
     initTelemetry.onError(new Exception("top cause", new FileNotFoundException("root cause")))
     initTelemetry.finish()
 
     then:
-    capture.json() == json("error", "internal_error", "top cause", [
-      [name: "library_entrypoint.error", tags: ["error_type:java.io.FileNotFoundException", "error_type:java.lang.Exception"]],
-      [name: "library_entrypoint.complete"]
-    ])
+    assertMeta("error", "internal_error", "top cause")
+    assertPoints(true, "library_entrypoint.error", ["error_type:java.io.FileNotFoundException", "error_type:java.lang.Exception"])
   }
 
-  private static String json(String result, String resultClass, String resultReason, List points) {
-    return """{"metadata":{"runtime_name":"java","runtime_version":"1.8.0_382","result":"${result}","result_class":"${resultClass}","result_reason":"${resultReason}"},"points":${new JsonBuilder(points)}}"""
+  def assertMeta(String result, String resultClass, String resultReason) {
+    def meta = capture.meta
+
+    assert meta.get("result") == result
+    assert meta.get("result_class") == resultClass
+    assert meta.get("result_reason") == resultReason
+
+    return true
+  }
+
+  def assertPoints(boolean complete, String point, List<String> tags) {
+    def points = capture.points
+
+    assert points.containsKey("library_entrypoint.complete") == complete
+    assert points.get(point) == tags
+
+    return true
   }
 
   static class Capture implements BootstrapInitializationTelemetry.JsonSender {
-    String json
+    Map<String, String> meta
+    Map<String, List<String>> points
 
-    void send(byte[] payload) {
-      this.json = new String(payload, UTF_8)
-    }
-
-    String json() {
-      return this.json
+    void send(Map<String, String> meta, Map<String, List<String>> points) {
+      this.meta = meta
+      this.points = points
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Move JSON generation to sender thread to improve startup time.

# Motivation
Improve agent startup time by offloading JSON generation to separate thread.
