### PR TITLE
Add dd-octo-sts trust policy

### DIFF
--- a/.github/chainguard/self.gitlab.release.sts.yaml
+++ b/.github/chainguard/self.gitlab.release.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-java:ref_type:tag:ref:v.*"
+
+claim_pattern:
+  project_path: "DataDog/apm-reliability/dd-trace-java"
+  ref_type: "tag"
+  ref: "v.*"
+
+permissions:
+  contents: "write"


### PR DESCRIPTION
# What Does This Do

This PR adds the trust policy for `dd-octo-sts` usage.

# Motivation

We want to use `dd-octo-sts` for github PATs instead of our current fine-grained tokens. Since trust policies must be read from the `master` branch to be valid, the policy needs to be merged in before we can test the token workflow.

# Additional Notes

The github release token is needed when we tag a release, so the policy is tailored for git tags. The policy is tested to work with [this dd-octo-sts-sandbox example run](https://gitlab.ddbuild.io/DataDog/dd-octo-sts-sandbox/-/jobs/1033180338).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-696

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
