### PR TITLE
Test dd-octo-sts workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -852,10 +852,10 @@ test_deploy_artifacts_to_github:
     - gh auth status
     - export VERSION=TEST_VERSION
     - cp workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
-    - gh release upload --clobber --repo DataDog/dd-trace-java vTEST_RELEASE_TAG workspace/dd-java-agent/build/libs/dd-java-agent.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java vTEST_RELEASE_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java vTEST_RELEASE_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${VERSION}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java vTEST_RELEASE_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${VERSION}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java v0 workspace/dd-java-agent/build/libs/dd-java-agent.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java v0 workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java v0 workspace/dd-trace-api/build/libs/dd-trace-api-${VERSION}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java v0 workspace/dd-trace-ot/build/libs/dd-trace-ot-${VERSION}.jar
 
   after_script:
     # Revoke the token after usage


### PR DESCRIPTION
# What Does This Do

Creates a temporary job that tests that uploading artifacts to github still works with the `dd-octo-sts` token.

# Motivation

Test the `dd-octo-sts` workflow on a tagged branch without triggering an actual release.

# Additional Notes

Depends on #9198. We would test by:
* tagging the most recent commit on this branch with `vTEST_RELEASE_TAG`. **DOES NOT WORK: build steps require tags that are prefixed with `v` to be formatted "correctly"**
* pushing the tag
* manually creating a pre-release with the tag `vTEST_RELEASE_TAG` e.g. 
<img width="465" height="458.5" alt="image" src="https://github.com/user-attachments/assets/f8704485-ce77-43a7-8bce-f6ea2a47b469" />

* manually triggering the job that uploads to this test release
* checking that github artifacts were successfully uploaded to the test release
* deleting the test release and tag

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-696

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
