### PR TITLE
Enhance Service Representation for Serverless

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -85,12 +85,13 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     final AmazonWebServiceRequest originalRequest = request.getOriginalRequest();
     final Class<?> awsOperation = originalRequest.getClass();
     final GetterAccess access = GetterAccess.of(originalRequest);
+    final String endpoint = request.getEndpoint().toString();
 
     span.setTag(InstrumentationTags.AWS_AGENT, COMPONENT_NAME);
     span.setTag(InstrumentationTags.AWS_SERVICE, awsServiceName);
     span.setTag(InstrumentationTags.TOP_LEVEL_AWS_SERVICE, awsSimplifiedServiceName);
     span.setTag(InstrumentationTags.AWS_OPERATION, awsOperation.getSimpleName());
-    span.setTag(InstrumentationTags.AWS_ENDPOINT, request.getEndpoint().toString());
+    span.setTag(InstrumentationTags.AWS_ENDPOINT, endpoint);
 
     CharSequence awsRequestName = AwsNameCache.getQualifiedName(request);
     span.setResourceName(awsRequestName, RPC_COMMAND_NAME);
@@ -184,11 +185,16 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
       bestPeerService = tableName;
     }
 
-    // for aws we can calculate this eagerly without needing to have to looking up tags in the peer
-    // service interceptor
-    if (bestPrecursor != null && SpanNaming.instance().namingSchema().peerService().supports()) {
-      span.setTag(Tags.PEER_SERVICE, bestPeerService);
-      span.setTag(DDTags.PEER_SERVICE_SOURCE, bestPrecursor);
+    String serverlessFunction = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
+    // Set peer.service based on environment
+    if (serverlessFunction != null && !serverlessFunction.isEmpty()) {
+      String hostname = endpoint.replaceFirst("^https?://", "").split("/")[0];
+      span.setTag(Tags.PEER_SERVICE, hostname);
+    } else {
+      if (bestPrecursor != null && SpanNaming.instance().namingSchema().peerService().supports()) {
+        span.setTag(Tags.PEER_SERVICE, bestPeerService);
+        span.setTag(DDTags.PEER_SERVICE_SOURCE, bestPrecursor);
+      }
     }
 
     // DSM

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -214,6 +214,15 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
       }
     }
 
+    // Set peer.service based on environment for serverless functions
+    String serverlessFunction = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
+    if (serverlessFunction != null && !serverlessFunction.isEmpty()) {
+      String endpoint = httpRequest.getUri().toString();
+      // Extract just the hostname from the endpoint URL
+      String hostname = endpoint.replaceFirst("^https?://", "").split("/")[0];
+      span.setTag(Tags.PEER_SERVICE, hostname);
+    }
+
     return span;
   }
 


### PR DESCRIPTION
# What Does This Do

Rollout of span naming changes to align tracer with serverless product to create streamlined Service Representation for Serverless

Key Changes:

- Apply all changes ONLY in a Serverless scenario

- Apply explicit peer.service tag equal to the hostname based on aws service type and region grouping all spans underneath one explicitly defined inferred service

# Motivation

Improve Service Map for Serverless

# Additional Notes

Only the sdk v1 and v2 need to be changed since those affect all spans before other instrumentation enriches based on service. This is a generic change so no need for specific instrumentation behavior

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
