### PR TITLE
Add dependency on Maven Central deployment to OCI publish jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ include:
 stages:
   - build
   - shared-pipeline
+  - publish-oci-images
   - publish
   - benchmarks
   - macrobenchmarks
@@ -837,6 +838,49 @@ requirements_json_test:
 
 package-oci:
   needs: [ build ]
+
+# "needs" parameters are taken from the one-pipeline template: https://github.com/DataDog/libdatadog-build/blob/main/templates/one-pipeline.yml
+# but with an additional dependency on the deploy_to_maven_central job.
+internal-publish-lib-init-tags:
+  stage: publish-oci-images
+  needs:
+    - job: deploy_to_maven_central
+    - job: generate-lib-init-pinned-tag-values
+      artifacts: true
+    - job: create-multiarch-lib-injection-image
+
+promote-oci-to-prod:
+  stage: publish-oci-images
+  needs:
+    - job: deploy_to_maven_central
+    - job: package-oci
+      artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
+
+promote-oci-to-prod-beta:
+  stage: publish-oci-images
+  needs:
+    - job: package-oci
+      artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
+
+promote-oci-to-staging:
+  stage: publish-oci-images
+  needs:
+    - job: package-oci
+      artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
+
+publish-lib-init-pinned-tags:
+  stage: publish-oci-images
+  needs:
+    - job: deploy_to_maven_central
+    - job: generate-lib-init-pinned-tag-values
+      artifacts: true
+    - job: create-multiarch-lib-injection-image
 
 configure_system_tests:
   variables:


### PR DESCRIPTION
# What Does This Do

OCI publishing jobs now depend on the `deploy_to_maven_central` job to succeed before continuing. The dependency is added to jobs `internal-publish-lib-init-tags`, `promote-oci-to-prod`, and `publish-lib-init-pinned-tags`.

# Motivation

Previously, all OCI-related jobs were triggered as soon as the `build` step was successful. This gave little buffer between when a release begins and when OCI images are published. The additional dependency added in this PR helps to avoid prematurely publishing OCI images. The images can still be created (`create-arch-specific-lib-injection-image`, `create-multiarch-lib-injection-image`), internally published (`oci-internal-publish`), and internally tested (`oci-internal-test-publish`) as soon as the `build` step succeeds. However, the publishing steps will only begin after the release artifacts are successfully deployed to Maven Central. In case something happens with the release and the Maven Central deployment fails, we don't want to release our OCI images and tags into customer prod envs either.

# Additional Notes

Also considered was to add another layer of security by making these publishing jobs manually triggered. However, that's not included in order to keep the release automated. Of course open to other ideas though.

Example of release pipeline before this PR's changes: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/70610397. Select `Group jobs by: Job dependencies` and `Show dependencies`. Note the dependencies for the jobs below: 
<img width="295" height="290" alt="image" src="https://github.com/user-attachments/assets/cb3c99b5-32f2-44c1-80da-002b266243c6" />

Example pipeline for this PR: . Again, select `Group jobs by: Job dependencies` and `Show dependencies`. Note that the publishing jobs above now depend on `deploy_to_maven_central` as well.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
