### PR TITLE
Add third-party filtering in SourceFile tracking

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -4,79 +4,106 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static utils.TestClassFileHelper.getClassFileBytes;
 
 import com.datadog.debugger.probe.LogProbe;
+import datadog.trace.api.Config;
 import java.lang.instrument.IllegalClassFormatException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import utils.TestHelper;
 
 class SourceFileTrackingTransformerTest {
   @Test
   void transformTopLevel() throws IllegalClassFormatException {
-    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
-    SourceFileTrackingTransformer sourceFileTrackingTransformer =
-        new SourceFileTrackingTransformer(finder);
-    ConfigurationComparer comparer = createComparer("TopLevelHelper.java");
-    sourceFileTrackingTransformer.transform(
-        null,
-        getInternalName(TopLevelHelper.class),
-        null,
-        null,
-        getClassFileBytes(TopLevelHelper.class));
-    List<Class<?>> changedClasses =
-        finder.getAllLoadedChangedClasses(new Class[] {TopLevelHelper.class}, comparer);
-    assertEquals(1, changedClasses.size());
-    assertEquals(TopLevelHelper.class, changedClasses.get(0));
-    sourceFileTrackingTransformer.transform(
-        null,
-        getInternalName(MyTopLevelClass.class),
-        null,
-        null,
-        getClassFileBytes(MyTopLevelClass.class));
-    sourceFileTrackingTransformer.flush();
-    changedClasses =
-        finder.getAllLoadedChangedClasses(
-            new Class[] {TopLevelHelper.class, MyTopLevelClass.class}, comparer);
-    assertEquals(2, changedClasses.size());
-    assertEquals(TopLevelHelper.class, changedClasses.get(0));
-    assertEquals(MyTopLevelClass.class, changedClasses.get(1));
+    TestHelper.setFieldInConfig(
+        Config.get(),
+        "debuggerThirdPartyExcludes",
+        new HashSet<>(Arrays.asList("com.datadog.debugger.agent")));
+    try {
+      ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
+      SourceFileTrackingTransformer sourceFileTrackingTransformer =
+          new SourceFileTrackingTransformer(finder);
+      ConfigurationComparer comparer = createComparer("TopLevelHelper.java");
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(TopLevelHelper.class),
+          null,
+          null,
+          getClassFileBytes(TopLevelHelper.class));
+      List<Class<?>> changedClasses =
+          finder.getAllLoadedChangedClasses(new Class[] {TopLevelHelper.class}, comparer);
+      assertEquals(1, changedClasses.size());
+      assertEquals(TopLevelHelper.class, changedClasses.get(0));
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(MyTopLevelClass.class),
+          null,
+          null,
+          getClassFileBytes(MyTopLevelClass.class));
+      sourceFileTrackingTransformer.flush();
+      changedClasses =
+          finder.getAllLoadedChangedClasses(
+              new Class[] {TopLevelHelper.class, MyTopLevelClass.class}, comparer);
+      assertEquals(2, changedClasses.size());
+      assertEquals(TopLevelHelper.class, changedClasses.get(0));
+      assertEquals(MyTopLevelClass.class, changedClasses.get(1));
+    } finally {
+      TestHelper.setFieldInConfig(
+          Config.get(), "debuggerThirdPartyExcludes", Collections.emptySet());
+    }
   }
 
   @Test
   void transformInner() throws IllegalClassFormatException {
-    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
-    SourceFileTrackingTransformer sourceFileTrackingTransformer =
-        new SourceFileTrackingTransformer(finder);
-    ConfigurationComparer comparer = createComparer("InnerHelper.java");
-    sourceFileTrackingTransformer.transform(
-        null, getInternalName(InnerHelper.class), null, null, getClassFileBytes(InnerHelper.class));
-    sourceFileTrackingTransformer.flush();
-    List<Class<?>> changedClasses =
-        finder.getAllLoadedChangedClasses(new Class[] {InnerHelper.class}, comparer);
-    assertEquals(1, changedClasses.size());
-    assertEquals(InnerHelper.class, changedClasses.get(0));
-    sourceFileTrackingTransformer.transform(
-        null,
-        getInternalName(InnerHelper.MyInner.class),
-        null,
-        null,
-        getClassFileBytes(InnerHelper.MyInner.class));
-    sourceFileTrackingTransformer.transform(
-        null,
-        getInternalName(InnerHelper.MySecondInner.class),
-        null,
-        null,
-        getClassFileBytes(InnerHelper.MySecondInner.class));
-    sourceFileTrackingTransformer.flush();
-    changedClasses =
-        finder.getAllLoadedChangedClasses(
-            new Class[] {
-              InnerHelper.class, InnerHelper.MyInner.class, InnerHelper.MySecondInner.class
-            },
-            comparer);
-    assertEquals(3, changedClasses.size());
-    assertEquals(InnerHelper.class, changedClasses.get(0));
-    assertEquals(InnerHelper.MyInner.class, changedClasses.get(1));
-    assertEquals(InnerHelper.MySecondInner.class, changedClasses.get(2));
+    TestHelper.setFieldInConfig(
+        Config.get(),
+        "debuggerThirdPartyExcludes",
+        new HashSet<>(Arrays.asList("com.datadog.debugger.agent")));
+    try {
+      ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
+      SourceFileTrackingTransformer sourceFileTrackingTransformer =
+          new SourceFileTrackingTransformer(finder);
+      ConfigurationComparer comparer = createComparer("InnerHelper.java");
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(InnerHelper.class),
+          null,
+          null,
+          getClassFileBytes(InnerHelper.class));
+      sourceFileTrackingTransformer.flush();
+      List<Class<?>> changedClasses =
+          finder.getAllLoadedChangedClasses(new Class[] {InnerHelper.class}, comparer);
+      assertEquals(1, changedClasses.size());
+      assertEquals(InnerHelper.class, changedClasses.get(0));
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(InnerHelper.MyInner.class),
+          null,
+          null,
+          getClassFileBytes(InnerHelper.MyInner.class));
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(InnerHelper.MySecondInner.class),
+          null,
+          null,
+          getClassFileBytes(InnerHelper.MySecondInner.class));
+      sourceFileTrackingTransformer.flush();
+      changedClasses =
+          finder.getAllLoadedChangedClasses(
+              new Class[] {
+                InnerHelper.class, InnerHelper.MyInner.class, InnerHelper.MySecondInner.class
+              },
+              comparer);
+      assertEquals(3, changedClasses.size());
+      assertEquals(InnerHelper.class, changedClasses.get(0));
+      assertEquals(InnerHelper.MyInner.class, changedClasses.get(1));
+      assertEquals(InnerHelper.MySecondInner.class, changedClasses.get(2));
+    } finally {
+      TestHelper.setFieldInConfig(
+          Config.get(), "debuggerThirdPartyExcludes", Collections.emptySet());
+    }
   }
 
   @Test
@@ -92,6 +119,22 @@ class SourceFileTrackingTransformerTest {
     sourceFileTrackingTransformer.flush();
     List<Class<?>> changedClasses =
         finder.getAllLoadedChangedClasses(new Class[] {InnerHelper.class}, comparer);
+    assertEquals(0, finder.getClassNamesBySourceFile().size());
+  }
+
+  @Test
+  void thirdPartyExcludes() throws IllegalClassFormatException {
+    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
+    SourceFileTrackingTransformer sourceFileTrackingTransformer =
+        new SourceFileTrackingTransformer(finder);
+    ConfigurationComparer comparer = createComparer("TopLevelHelper.java");
+    sourceFileTrackingTransformer.transform(
+        null,
+        getInternalName(TopLevelHelper.class),
+        null,
+        null,
+        getClassFileBytes(TopLevelHelper.class));
+    sourceFileTrackingTransformer.flush();
     assertEquals(0, finder.getClassNamesBySourceFile().size());
   }
 

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -40,6 +40,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   @Test
   @DisplayName("testDynamicInstrumentationEnablementWithLineProbe")
   void testDynamicInstrumentationEnablementWithLineProbe() throws Exception {
+    additionalJvmArgs.add("-Ddd.third.party.excludes=datadog.smoketest");
     appUrl = startAppAndAndGetUrl();
     setConfigOverrides(createConfigOverrides(true, false));
     LogProbe probe =


### PR DESCRIPTION
# What Does This Do
Initialize ClassNameFiltering in background thread to avoid startup latency

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4187]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4187]: https://datadoghq.atlassian.net/browse/DEBUG-4187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ