### PR TITLE
Fixed flaky test

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
@@ -247,7 +247,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
           "type:kafka"
           )
       }
-      def sorted = new ArrayList<DataStreamsTags>(TEST_DATA_STREAMS_WRITER.backlogs).sort()
+      def sorted = new ArrayList<DataStreamsTags>(TEST_DATA_STREAMS_WRITER.backlogs).sort({it.type+it.partition})
       verifyAll(sorted) {
         size() == 2
         get(0).hasAllTags("consumer_group:sender",

--- a/dd-java-agent/instrumentation/kafka-connect-0.11/src/test/groovy/ConnectWorkerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-connect-0.11/src/test/groovy/ConnectWorkerInstrumentationTest.groovy
@@ -280,12 +280,12 @@ class ConnectWorkerInstrumentationTest extends AgentTestRunner {
 
     StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
     verifyAll(first) {
-      tags.hasAllTags("direction:out", "topic:test-topic", "type:kafka", "kafka_cluster_id:" + clusterId)
+      tags.hasAllTags("direction:out", "topic:test-topic", "type:kafka")
     }
 
     StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
     verifyAll(second) {
-      tags.hasAllTags("direction:in", "group:connect-file-sink-connector", "topic:test-topic", "type:kafka", "kafka_cluster_id:" + clusterId)
+      tags.hasAllTags("direction:in", "group:connect-file-sink-connector", "topic:test-topic", "type:kafka")
     }
     TEST_DATA_STREAMS_WRITER.getServices().contains('file-sink-connector')
 


### PR DESCRIPTION
# What Does This Do
Fix for a flaky test

# Details
Elements in the collection were not sorted properly. Now this test should work as expected. 
The issue was introduced in [this](https://github.com/DataDog/dd-trace-java/pull/9151) PR.