### PR TITLE
Clean dd-octo-sts workflow and add pre-release check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,11 +193,10 @@ default:
   after_script:
     - *cgroup_info
 
-# TODO: Add a pre-release check to see if the dd-octo-sts token is working.
-# Checks and fail early if central credentials are incorrect, indeed, when a new token is generated
-# on the central publisher protal, it invalidates the old one. This checks prevents going further.
+# Check and fail early if maven central credentials are incorrect. When a new token is generated
+# on the central publisher portal, it invalidates the old one. This check prevents going further.
 # See https://datadoghq.atlassian.net/wiki/x/Oog5OgE
-pre-release-checks:
+maven-central-pre-release-check:
   image: ghcr.io/datadog/dd-trace-java-docker-build:${BUILDER_IMAGE_VERSION_PREFIX}base
   stage: .pre
   rules:
@@ -216,9 +215,37 @@ pre-release-checks:
         exit 1
       fi
 
+dd-octo-sts-pre-release-check:
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  stage: .pre
+  tags: [ "arch:amd64" ]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: on_success
+      allow_failure: false
+  before_script:
+    - dd-octo-sts version
+    - dd-octo-sts debug --scope DataDog/dd-trace-java --policy self.gitlab.release
+    - dd-octo-sts token --scope DataDog/dd-trace-java --policy self.gitlab.release > test-github-token.txt
+  script:
+    - gh auth login --with-token < test-github-token.txt
+    - gh auth status
+  after_script:
+    - dd-octo-sts revoke -t $(cat test-github-token.txt)
+  retry:
+    max: 2
+    when: always
+
 build:
   needs:
-    - job: pre-release-checks
+    - job: maven-central-pre-release-check
+      optional: true
+    - job: dd-octo-sts-pre-release-check
       optional: true
   extends: .gradle_build
   variables:
@@ -822,51 +849,20 @@ deploy_artifacts_to_github:
       # The deploy_to_maven_central job is not run for release candidate versions
       optional: true
   before_script:
-    # Get token
     - dd-octo-sts version
     - dd-octo-sts debug --scope DataDog/dd-trace-java --policy self.gitlab.release
     - dd-octo-sts token --scope DataDog/dd-trace-java --policy self.gitlab.release > github-token.txt
   script:
     - gh auth login --with-token < github-token.txt
-    - gh auth status  # Maybe helpful to have this output in logs?
+    - gh auth status
     - export VERSION=${CI_COMMIT_TAG##v} # remove "v" from front of tag to get version
-    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
+    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # upload two filenames
     - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent.jar
     - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar
     - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${VERSION}.jar
     - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${VERSION}.jar
   after_script:
     - dd-octo-sts revoke -t $(cat github-token.txt)
-  retry:
-    max: 2
-    when: always
-
-# This is the original job that uses the AWS SSM token retrieval method. Allow manual triggering in case the dd-octo-sts token is not working.
-# TODO: Remove this job once the dd-octo-sts token is provably working.
-deploy_artifacts_to_github_old:
-  stage: publish
-  image: registry.ddbuild.io/github-cli:v27480869-eafb11d-2.43.0
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: manual
-  # Requires the deploy_to_maven_central job to have run first (the UP-TO-DATE gradle check across jobs is broken)
-  # This will deploy the artifacts built from the publishToSonatype task to the GitHub release
-  needs:
-    - job: deploy_to_maven_central
-      # The deploy_to_maven_central job is not run for release candidate versions
-      optional: true
-  script:
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh_release_token --with-decryption --query "Parameter.Value" --out text > github-token.txt
-    - gh auth login --with-token < github-token.txt
-    - gh auth status  # Maybe helpful to have this output in logs?
-    - export VERSION=${CI_COMMIT_TAG##v} # remove "v" from front of tag to get version
-    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${VERSION}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${VERSION}.jar
   retry:
     max: 2
     when: always


### PR DESCRIPTION
# What Does This Do

Cleans up the `dd-octo-sts` workflow that retrieves a github token for publishing during releases. This also adds a pre-release check to ensure that the trust policy and token work before proceeding.

# Motivation

The workflow was proven successful during the `1.51.2` patch release, so no need for a back up job anymore.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-696

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
