### PR TITLE
Fix debugger test for stable JVM

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
 
@@ -521,7 +522,7 @@ class SymbolExtractionTransformerTest {
         19);
     Scope supplierClosureScope = classScope.getScopes().get(3);
     assertScope(
-        supplierClosureScope, ScopeType.CLOSURE, "lambda$process$1", 20, 21, SOURCE_FILE, 1, 0);
+        supplierClosureScope, ScopeType.CLOSURE, "lambda$process$*", 20, 21, SOURCE_FILE, 1, 0);
     Scope supplierClosureLocalScope = supplierClosureScope.getScopes().get(0);
     assertScope(supplierClosureLocalScope, ScopeType.LOCAL, null, 20, 21, SOURCE_FILE, 0, 1);
     assertSymbol(
@@ -676,7 +677,7 @@ class SymbolExtractionTransformerTest {
         fooMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 17);
     Scope lambdaFoo3MethodScope = classScope.getScopes().get(3);
     assertScope(
-        lambdaFoo3MethodScope, ScopeType.CLOSURE, "lambda$foo$3", 19, 19, SOURCE_FILE, 0, 1);
+        lambdaFoo3MethodScope, ScopeType.CLOSURE, "lambda$foo$*", 19, 19, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaFoo3MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -685,7 +686,7 @@ class SymbolExtractionTransformerTest {
         19);
     Scope lambdaFoo2MethodScope = classScope.getScopes().get(4);
     assertScope(
-        lambdaFoo2MethodScope, ScopeType.CLOSURE, "lambda$foo$2", 19, 19, SOURCE_FILE, 0, 1);
+        lambdaFoo2MethodScope, ScopeType.CLOSURE, "lambda$foo$*", 19, 19, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaFoo2MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -856,7 +857,7 @@ class SymbolExtractionTransformerTest {
   }
 
   @Test
-  @EnabledOnJre({JRE.JAVA_17, JRE.JAVA_21})
+  @EnabledOnJre({JRE.JAVA_17, JRE.JAVA_21, JRE.JAVA_24})
   @DisabledIf(
       value = "datadog.environment.JavaVirtualMachine#isJ9",
       disabledReason = "Flaky on J9 JVMs")
@@ -991,7 +992,12 @@ class SymbolExtractionTransformerTest {
       int nbScopes,
       int nbSymbols) {
     assertEquals(scopeType, scope.getScopeType());
-    assertEquals(name, scope.getName());
+    if (name != null && name.endsWith("*")) {
+      name = name.substring(0, name.length() - 1);
+      assertTrue(scope.getName().startsWith(name));
+    } else {
+      assertEquals(name, scope.getName());
+    }
     assertEquals(startLine, scope.getStartLine());
     assertEquals(endLine, scope.getEndLine());
     assertEquals(sourceFile, scope.getSourceFile());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileLinesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileLinesTest.java
@@ -71,10 +71,10 @@ class ClassFileLinesTest {
     assertEquals("multiLambda", methods58.get(0).name);
     assertEquals("(Ljava/lang/String;)I", methods58.get(0).desc);
     // filter
-    assertEquals("lambda$multiLambda$3", methods58.get(1).name);
+    assertTrue(methods58.get(1).name.startsWith("lambda$multiLambda$"));
     assertEquals("(Ljava/lang/String;)Z", methods58.get(1).desc);
     // map
-    assertEquals("lambda$multiLambda$2", methods58.get(2).name);
+    assertTrue(methods58.get(2).name.startsWith("lambda$multiLambda$"));
     assertEquals("(Ljava/lang/String;)Ljava/lang/String;", methods58.get(2).desc);
   }
 


### PR DESCRIPTION
# What Does This Do
Since JDK 24, lambdas are renumbered from the local scope and not
from the whole classfile

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
