### PR TITLE
Unlimit latestdep for spark 3.x

### DIFF
--- a/dd-java-agent/instrumentation/spark-executor/build.gradle
+++ b/dd-java-agent/instrumentation/spark-executor/build.gradle
@@ -37,10 +37,9 @@ dependencies {
   baseTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: "2.4.0"
   baseTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: "2.4.0"
 
-  // FIXME: 3.6.0 seems missing from central
-  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: '3.5.5'
-  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: '3.5.5'
+  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: '3.+'
+  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: '3.+'
 
-  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.13", version: '3.5.5'
-  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.13", version: '3.5.5'
+  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.13", version: '3.+'
+  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.13", version: '3.+'
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -52,10 +52,9 @@ dependencies {
   test_spark32Implementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: "3.2.4"
 
   // FIXME: Currently not working on Spark 4.0.0 preview releases.
-  // FIXME: 3.6.0 seems missing from central
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-core_$scalaVersion", version: '3.5.5'
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-sql_$scalaVersion", version: '3.5.5'
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '3.5.5'
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-core_$scalaVersion", version: '3.+'
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-sql_$scalaVersion", version: '3.+'
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '3.+'
 }
 
 tasks.named("test").configure {


### PR DESCRIPTION
Basically reverts https://github.com/DataDog/dd-trace-java/pull/8895
This closes https://datadoghq.atlassian.net/browse/DJM-841 
The previous PR had limited spark deps to 3.5.6 bcz some artifacts for scala 2.13 and 3.5.6 were not available. 