### PR TITLE
Add workflow retry to fix Resource not accessible by integration error

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yaml
+++ b/.github/workflows/add-milestone-to-pull-requests.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Add milestone to merged pull requests
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401
           script: |
             // Get project milestones
             const response = await github.rest.issues.listMilestones({


### PR DESCRIPTION
# What Does This Do

This PR adds retry to the workflow in charge of assigning milestone to PR to fix Resource not accessible by integration error

# Motivation

This sometimes fails due to GH API request error like https://github.com/DataDog/dd-trace-java/actions/runs/16317277156/job/46086120541#step:2:84

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
