### PR TITLE
Adding Config Inversion Telemetry component

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/telemetry/ConfigInversionMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/ConfigInversionMetricCollector.java
@@ -1,0 +1,70 @@
+package datadog.trace.api.telemetry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigInversionMetricCollector
+    implements MetricCollector<ConfigInversionMetricCollector.ConfigInversionMetric> {
+  private static final Logger log = LoggerFactory.getLogger(ConfigInversionMetricCollector.class);
+  private static final String CONFIG_INVERSION_KEY_TAG = "config_name:";
+  private static final String CONFIG_INVERSION_METRIC_NAME = "untracked.config.detected";
+  private static final String NAMESPACE = "tracers";
+  private static final ConfigInversionMetricCollector INSTANCE =
+      new ConfigInversionMetricCollector();
+
+  private final BlockingQueue<ConfigInversionMetricCollector.ConfigInversionMetric> metricsQueue;
+
+  private ConfigInversionMetricCollector() {
+    this.metricsQueue = new ArrayBlockingQueue<>(RAW_QUEUE_SIZE);
+  }
+
+  public static ConfigInversionMetricCollector getInstance() {
+    return INSTANCE;
+  }
+
+  public void setUndocumentedEnvVarMetric(String configName) {
+    setMetricConfigInversionMetric(CONFIG_INVERSION_KEY_TAG + configName);
+  }
+
+  private void setMetricConfigInversionMetric(final String... tags) {
+    if (!metricsQueue.offer(
+        new ConfigInversionMetricCollector.ConfigInversionMetric(
+            NAMESPACE, true, CONFIG_INVERSION_METRIC_NAME, "count", 1, tags))) {
+      log.debug("Unable to add telemetry metric {} for {}", CONFIG_INVERSION_METRIC_NAME, tags[0]);
+    }
+  }
+
+  @Override
+  public void prepareMetrics() {
+    // Nothing to do here
+  }
+
+  @Override
+  public Collection<ConfigInversionMetricCollector.ConfigInversionMetric> drain() {
+    if (this.metricsQueue.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<ConfigInversionMetricCollector.ConfigInversionMetric> drained =
+        new ArrayList<>(this.metricsQueue.size());
+    this.metricsQueue.drainTo(drained);
+    return drained;
+  }
+
+  public static class ConfigInversionMetric extends MetricCollector.Metric {
+    public ConfigInversionMetric(
+        String namespace,
+        boolean common,
+        String metricName,
+        String type,
+        Number value,
+        final String... tags) {
+      super(namespace, common, metricName, type, value, tags);
+    }
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/ConfigInversionMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/ConfigInversionMetricCollectorTest.groovy
@@ -1,0 +1,28 @@
+package datadog.trace.api.telemetry
+
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.telemetry.ConfigInversionMetricCollector.CONFIG_INVERSION_METRIC_NAME
+
+class ConfigInversionMetricCollectorTest extends DDSpecification {
+
+  def "should emit metric when unsupported env var is used"() {
+    setup:
+    def collector = ConfigInversionMetricCollector.getInstance()
+
+    when:
+    ConfigInversionMetricCollectorTestHelper.checkAndEmitUnsupported("DD_UNKNOWN_FEATURE")
+    collector.prepareMetrics()
+    def metrics = collector.drain()
+
+    then:
+    metrics.size() == 1
+    def metric = metrics[0]
+    metric.type == 'count'
+    metric.value == 1
+    metric.namespace == 'tracers'
+    metric.metricName == CONFIG_INVERSION_METRIC_NAME
+    metric.tags.size() == 1
+    metric.tags[0] == 'config_name:DD_UNKNOWN_FEATURE'
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/ConfigInversionMetricCollectorTestHelper.java
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/ConfigInversionMetricCollectorTestHelper.java
@@ -1,0 +1,21 @@
+package datadog.trace.api.telemetry;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+// Lightweight helper class to simulate Config Inversion ConfigHelper scenario where telemetry
+// metrics are emitted for "unknown" environment variables.
+public class ConfigInversionMetricCollectorTestHelper {
+  private static final Set<String> SUPPORTED_ENV_VARS =
+      new HashSet<>(Arrays.asList("DD_ENV", "DD_SERVICE"));
+
+  private static final ConfigInversionMetricCollector configInversionMetricCollector =
+      ConfigInversionMetricCollector.getInstance();
+
+  public static void checkAndEmitUnsupported(String envVarName) {
+    if (!SUPPORTED_ENV_VARS.contains(envVarName)) {
+      configInversionMetricCollector.setUndocumentedEnvVarMetric(envVarName);
+    }
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -10,6 +10,7 @@ import datadog.telemetry.endpoint.EndpointPeriodicAction;
 import datadog.telemetry.integration.IntegrationPeriodicAction;
 import datadog.telemetry.log.LogPeriodicAction;
 import datadog.telemetry.metric.CiVisibilityMetricPeriodicAction;
+import datadog.telemetry.metric.ConfigInversionMetricPeriodicAction;
 import datadog.telemetry.metric.CoreMetricsPeriodicAction;
 import datadog.telemetry.metric.IastMetricPeriodicAction;
 import datadog.telemetry.metric.OtelEnvMetricPeriodicAction;
@@ -51,6 +52,7 @@ public class TelemetrySystem {
     if (telemetryMetricsEnabled) {
       actions.add(new CoreMetricsPeriodicAction());
       actions.add(new OtelEnvMetricPeriodicAction());
+      actions.add(new ConfigInversionMetricPeriodicAction());
       actions.add(new IntegrationPeriodicAction());
       actions.add(new WafMetricPeriodicAction());
       if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {

--- a/telemetry/src/main/java/datadog/telemetry/metric/ConfigInversionMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/ConfigInversionMetricPeriodicAction.java
@@ -1,0 +1,13 @@
+package datadog.telemetry.metric;
+
+import datadog.trace.api.telemetry.ConfigInversionMetricCollector;
+import datadog.trace.api.telemetry.MetricCollector;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ConfigInversionMetricPeriodicAction extends MetricPeriodicAction {
+  @Override
+  @NonNull
+  public MetricCollector collector() {
+    return ConfigInversionMetricCollector.getInstance();
+  }
+}


### PR DESCRIPTION
# What Does This Do
As part of Config Inversion, we want to emit Telemetry metrics for all environment variables set that are DD related but not documented in the `supported-configurations.json` file. This PR introduces the Telemetry metrics component for Config Inversion. Given that the `ConfigHelper` and `supported-configurations.json` file do not exist yet, testing is done with a lightweight "Mock" helper that has a list of "supported configurations", and emits a telemetry metric if an environment variable is passed in that is not "supported".
# Motivation
[Config Inversion RFC](https://docs.google.com/document/d/1FzBcbvjiReuHolPSP-hhpfuqYL7ewJ3YHM3ERrHqHRo/edit?pli=1&tab=t.0)
# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
