### PR TITLE
Add capping on SourceFile tracking queue

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -478,7 +478,9 @@ public class DebuggerAgent {
             "SymbolDB stats:",
             symbolDBStats,
             "Exception Fingerprints:",
-            exceptionFingerprints);
+            exceptionFingerprints,
+            "SourceFile tracking entries:",
+            String.valueOf(classesToRetransformFinder.getClassNamesBySourceFile().size()));
     TracerFlare.addText(zip, "dynamic_instrumentation.txt", content);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
@@ -6,6 +6,7 @@ import static com.datadog.debugger.util.ClassFileHelper.stripPackagePath;
 import com.datadog.debugger.util.ClassFileHelper;
 import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.api.Config;
+import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.Strings;
 import java.lang.instrument.ClassFileTransformer;
@@ -14,6 +15,7 @@ import java.security.ProtectionDomain;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,10 +26,15 @@ import org.slf4j.LoggerFactory;
  */
 public class SourceFileTrackingTransformer implements ClassFileTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(SourceFileTrackingTransformer.class);
+  private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
+  static final int MAX_QUEUE_SIZE = 4096;
 
+  private final RatelimitedLogger ratelimitedLogger =
+      new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES);
   private final ClassesToRetransformFinder finder;
   private final Queue<SourceFileItem> queue = new ConcurrentLinkedQueue<>();
   private final AgentTaskScheduler scheduler = AgentTaskScheduler.INSTANCE;
+  private final AtomicInteger queueSize = new AtomicInteger(0);
   private AgentTaskScheduler.Scheduled<Runnable> scheduled;
   // this field MUST only be used in flush() calling thread
   private ClassNameFiltering classNameFilter;
@@ -55,14 +62,23 @@ public class SourceFileTrackingTransformer implements ClassFileTransformer {
     if (queue.isEmpty()) {
       return;
     }
-    int size = queue.size();
+    int itemCount = 0;
     long start = System.nanoTime();
     SourceFileItem item;
     while ((item = queue.poll()) != null) {
+      queueSize.decrementAndGet();
       registerSourceFile(item.className, item.classfileBuffer);
+      itemCount++;
     }
     LOGGER.debug(
-        "flushing {} source file items in {}ms", size, (System.nanoTime() - start) / 1_000_000);
+        "flushing {} source file items in {}ms, totalentries: {}",
+        itemCount,
+        (System.nanoTime() - start) / 1_000_000,
+        finder.getClassNamesBySourceFile().size());
+  }
+
+  int getQueueSize() {
+    return queueSize.get();
   }
 
   @Override
@@ -76,7 +92,12 @@ public class SourceFileTrackingTransformer implements ClassFileTransformer {
     if (className == null) {
       return null;
     }
+    if (queueSize.get() >= MAX_QUEUE_SIZE) {
+      ratelimitedLogger.warn("SourceFile Tracking queue full, dropping class: {}", className);
+      return null;
+    }
     queue.add(new SourceFileItem(className, classfileBuffer));
+    queueSize.incrementAndGet();
     return null;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.agent.SourceFileTrackingTransformer.MAX_QUEUE_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static utils.TestClassFileHelper.getClassFileBytes;
 
@@ -136,6 +137,22 @@ class SourceFileTrackingTransformerTest {
         getClassFileBytes(TopLevelHelper.class));
     sourceFileTrackingTransformer.flush();
     assertEquals(0, finder.getClassNamesBySourceFile().size());
+  }
+
+  @Test
+  void maxQueue() throws IllegalClassFormatException {
+    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
+    SourceFileTrackingTransformer sourceFileTrackingTransformer =
+        new SourceFileTrackingTransformer(finder);
+    for (int i = 0; i < MAX_QUEUE_SIZE + 10; i++) {
+      sourceFileTrackingTransformer.transform(
+          null,
+          getInternalName(TopLevelHelper.class),
+          null,
+          null,
+          getClassFileBytes(TopLevelHelper.class));
+    }
+    assertEquals(MAX_QUEUE_SIZE, sourceFileTrackingTransformer.getQueueSize());
   }
 
   private static void replaceInByteArray(byte[] buffer, byte[] oldBytes, byte[] newBytes) {


### PR DESCRIPTION
# What Does This Do
tracks number of item put into the queue and dequeued. limits to 4096 items.
Avoid using queue.size that is O(n) and keep the size in AtomicInteger dump the number of entries in the SourceFile map into tracer flare

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4189]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
