### PR TITLE
Fix notify-slo-breaches interaction with POPULATE_CACHE

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -136,6 +136,9 @@ notify-slo-breaches:
   extends: .notify-slo-breaches
   stage: macrobenchmarks
   needs: ["check-slo-breaches"]
-  when: always
+  rules:
+    - if: $POPULATE_CACHE
+      when: never
+    - when: always
   variables:
     CHANNEL: "apm-release-platform"


### PR DESCRIPTION
# What Does This Do

I missed a job in #9243 . This add a rule not to run `notify-slo-breaches` during `POPULATE_CACHE`

# Motivation

During POPULATE_CACHE pipelines, none of the jobs that the slo check depends on are run and the pipeline is broken. This PR aligns the slo check with the benchmark runs

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
