### PR TITLE
Add script to clean up old Gradle modules

### DIFF
--- a/tooling/cleanup-gradle-module.sh
+++ b/tooling/cleanup-gradle-module.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: cleanup-gradle-module.sh [--backup]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+BACKUP_MODE=0
+BACKUP_DIR="$SCRIPT_DIR/backup"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --backup)
+      BACKUP_MODE=1
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--backup]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+
+if [[ $BACKUP_MODE -eq 1 ]]; then
+  mkdir -p "$BACKUP_DIR"
+fi
+
+echo "Searching for old Gradle modules in $ROOT_DIR..."
+find "$ROOT_DIR" -type d | sort -r | while read -r dir; do
+  # Skip the root directory itself
+  [ "$dir" = "$ROOT_DIR" ] && continue
+  # Check if the directory contains only a 'build' directory
+  if [ -d "$dir/build" ]; then
+    # List all items except 'build'
+    OTHERS=$(find "$dir" -mindepth 1 -maxdepth 1 ! -name 'build')
+    if [ -z "$OTHERS" ]; then
+      if [[ $BACKUP_MODE -eq 1 ]]; then
+        # Move to backup dir, preserving relative path
+        RELATIVE_PATH="${dir#$ROOT_DIR/}"
+        DEST="$BACKUP_DIR/$RELATIVE_PATH"
+        mkdir -p "$(dirname "$DEST")"
+        mv "$dir" "$DEST"
+        echo "Moved to backup: $dir -> $DEST"
+      else
+        rm -rf "$dir"
+        echo "Removed: $dir"
+      fi
+    fi
+  fi
+done
+
+# At the end, if in backup mode and backup folder exists, prompt to remove it
+if [[ $BACKUP_MODE -eq 1 && -d "$BACKUP_DIR" ]]; then
+  read -r -p "Remove backup folder '$BACKUP_DIR'? [y/N] " confirm
+  case $confirm in
+    [yY][eE][sS]|[yY])
+      rm -rf "$BACKUP_DIR"
+      echo "Removed backup folder."
+      ;;
+    *)
+      echo "Backup folder retained at $BACKUP_DIR."
+      ;;
+  esac
+fi


### PR DESCRIPTION
# What Does This Do

This script cleans up the old Gradle modules.

# Motivation

When relocating Gradle modules, working copy ends up with empty folders, only containing `build` output. This script will find and remove them. 
There is also a `--backup` option that will remove them from repo to move them near the script if you would like to check what will be clean up. It can be restored by moving the backup at the root of the working copy.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
