### PR TITLE
Fix VM options parsing from /proc/fs

### DIFF
--- a/components/environment/src/test/java/datadog/environment/JvmOptionsTest.java
+++ b/components/environment/src/test/java/datadog/environment/JvmOptionsTest.java
@@ -135,12 +135,12 @@ class JvmOptionsTest {
         arguments(
             "Java from class and options",
             new String[]{"java", "-Xmx512m", "-Xms256m", "-cp", "app.jar", "Main"},
-            asList("-Xmx512m", "-Xms256m", "-cp", "app.jar")
+            asList("-Xmx512m", "-Xms256m")
         ),
         arguments(
             "Java from class and options, mixed",
             new String[]{"java", "-Xms256m", "-cp", "app.jar", "-Xmx512m", "Main"},
-            asList("-Xms256m", "-cp", "app.jar", "-Xmx512m")
+            asList("-Xms256m", "-Xmx512m")
         ),
         arguments(
             "Args from file",
@@ -167,10 +167,9 @@ class JvmOptionsTest {
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("procFsCmdLine")
-  void testFindVmOptionsWithProcFsCmdLine(
-      String useCase, String[] procfsCmdline, List<String> expected) throws Exception {
+  void testFindVmOptionsFromProcFs(String useCase, String[] procfsCmdline, List<String> expected) {
     JvmOptions vmOptions = new JvmOptions();
-    List<String> found = vmOptions.findVmOptions(procfsCmdline);
+    List<String> found = vmOptions.findVmOptionsFromProcFs(procfsCmdline);
     assertEquals(expected, found);
   }
 


### PR DESCRIPTION
# What Does This Do

Fix VM options on Linux platform when parsing /proc/fs 

# Motivation

The classpath argument is not part of the VM option and must be excluded.
In addition, the path from classpath can lead to premature parsing end, leading to missed VM options.

# Additional Notes

This is a follow up fix from the discussion with @jbachorik on #9130

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-699]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-699]: https://datadoghq.atlassian.net/browse/LANGPLAT-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ