### PR TITLE
Add `ci.job.id` tag

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
@@ -29,6 +29,7 @@ class AwsCodePipelineInfo implements CIProviderInfo {
     return CIInfo.builder(environment)
         .ciProviderName(AWS_CODEPIPELINE_PROVIDER_NAME)
         .ciPipelineId(environment.get(AWS_CODEPIPELINE_EXECUTION_ID))
+        .ciJobId(environment.get(AWS_CODEPIPELINE_ACTION_EXECUTION_ID))
         .ciEnvVars(
             AWS_CODEPIPELINE_EXECUTION_ID,
             AWS_CODEPIPELINE_ACTION_EXECUTION_ID,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
@@ -77,6 +77,7 @@ class AzurePipelinesInfo implements CIProviderInfo {
         .ciPipelineNumber(buildId)
         .ciPipelineUrl(buildCiPipelineUrl(uri, project, buildId))
         .ciStageName(environment.get(AZURE_SYSTEM_STAGEDISPLAYNAME))
+        .ciJobId(jobId)
         .ciJobName(environment.get(AZURE_SYSTEM_JOBDISPLAYNAME))
         .ciJobUrl(buildCiJobUrl(uri, project, buildId, jobId, taskId))
         .ciWorkspace(expandTilde(environment.get(AZURE_WORKSPACE_PATH)))

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
@@ -70,6 +70,7 @@ class BuildkiteInfo implements CIProviderInfo {
         .ciPipelineName(environment.get(BUILDKITE_PIPELINE_NAME))
         .ciPipelineNumber(environment.get(BUILDKITE_PIPELINE_NUMBER))
         .ciPipelineUrl(ciPipelineUrl)
+        .ciJobId(environment.get(BUILDKITE_JOB_ID))
         .ciJobUrl(String.format("%s#%s", ciPipelineUrl, environment.get(BUILDKITE_JOB_ID)))
         .ciWorkspace(expandTilde(environment.get(BUILDKITE_WORKSPACE_PATH)))
         .ciNodeName(environment.get(BUILDKITE_AGENT_ID))

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIInfo.java
@@ -23,6 +23,7 @@ public class CIInfo {
     private String ciPipelineId;
     private String ciPipelineName;
     private String ciStageName;
+    private String ciJobId;
     private String ciJobName;
     private String ciPipelineNumber;
     private String ciPipelineUrl;
@@ -72,6 +73,11 @@ public class CIInfo {
       return this;
     }
 
+    public Builder ciJobId(String ciJobId) {
+      this.ciJobId = ciJobId;
+      return this;
+    }
+
     public Builder ciJobUrl(String ciJobUrl) {
       this.ciJobUrl = ciJobUrl;
       return this;
@@ -118,6 +124,7 @@ public class CIInfo {
           ciPipelineId,
           ciPipelineName,
           ciStageName,
+          ciJobId,
           ciJobName,
           ciPipelineNumber,
           ciPipelineUrl,
@@ -134,6 +141,7 @@ public class CIInfo {
   private final String ciPipelineId;
   private final String ciPipelineName;
   private final String ciStageName;
+  private final String ciJobId;
   private final String ciJobName;
   private final String ciPipelineNumber;
   private final String ciPipelineUrl;
@@ -145,7 +153,7 @@ public class CIInfo {
   private final Map<String, String> additionalTags;
 
   public CIInfo() {
-    this(null, null, null, null, null, null, null, null, null, null, null, null, null);
+    this(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public CIInfo(
@@ -153,6 +161,7 @@ public class CIInfo {
       String ciPipelineId,
       String ciPipelineName,
       String ciStageName,
+      String ciJobId,
       String ciJobName,
       String ciPipelineNumber,
       String ciPipelineUrl,
@@ -166,6 +175,7 @@ public class CIInfo {
     this.ciPipelineId = ciPipelineId;
     this.ciPipelineName = ciPipelineName;
     this.ciStageName = ciStageName;
+    this.ciJobId = ciJobId;
     this.ciJobName = ciJobName;
     this.ciPipelineNumber = ciPipelineNumber;
     this.ciPipelineUrl = ciPipelineUrl;
@@ -191,6 +201,10 @@ public class CIInfo {
 
   public String getCiStageName() {
     return ciStageName;
+  }
+
+  public String getCiJobId() {
+    return ciJobId;
   }
 
   public String getCiJobName() {
@@ -252,6 +266,7 @@ public class CIInfo {
         && Objects.equals(ciPipelineId, ciInfo.ciPipelineId)
         && Objects.equals(ciPipelineName, ciInfo.ciPipelineName)
         && Objects.equals(ciStageName, ciInfo.ciStageName)
+        && Objects.equals(ciJobId, ciInfo.ciJobId)
         && Objects.equals(ciJobName, ciInfo.ciJobName)
         && Objects.equals(ciPipelineNumber, ciInfo.ciPipelineNumber)
         && Objects.equals(ciPipelineUrl, ciInfo.ciPipelineUrl)
@@ -270,6 +285,7 @@ public class CIInfo {
     hash = 31 * hash + (ciPipelineId == null ? 0 : ciPipelineId.hashCode());
     hash = 31 * hash + (ciPipelineName == null ? 0 : ciPipelineName.hashCode());
     hash = 31 * hash + (ciStageName == null ? 0 : ciStageName.hashCode());
+    hash = 31 * hash + (ciJobId == null ? 0 : ciJobId.hashCode());
     hash = 31 * hash + (ciJobName == null ? 0 : ciJobName.hashCode());
     hash = 31 * hash + (ciPipelineNumber == null ? 0 : ciPipelineNumber.hashCode());
     hash = 31 * hash + (ciPipelineUrl == null ? 0 : ciPipelineUrl.hashCode());
@@ -296,6 +312,9 @@ public class CIInfo {
         + '\''
         + ", ciStageName='"
         + ciStageName
+        + '\''
+        + ", ciJobId='"
+        + ciJobId
         + '\''
         + ", ciJobName='"
         + ciJobName

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CITagsProvider.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CITagsProvider.java
@@ -31,6 +31,7 @@ public class CITagsProvider {
         .withCiPipelineName(ciInfo.getCiPipelineName())
         .withCiStageName(ciInfo.getCiStageName())
         .withCiJobName(ciInfo.getCiJobName())
+        .withCiJobId(ciInfo.getCiJobId())
         .withCiPipelineNumber(ciInfo.getCiPipelineNumber())
         .withCiPipelineUrl(ciInfo.getCiPipelineUrl())
         .withCiJorUrl(ciInfo.getCiJobUrl())
@@ -90,6 +91,10 @@ public class CITagsProvider {
 
     public CITagsBuilder withCiStageName(final String ciStageName) {
       return putTagValue(Tags.CI_STAGE_NAME, ciStageName);
+    }
+
+    public CITagsBuilder withCiJobId(final String ciJobId) {
+      return putTagValue(Tags.CI_JOB_ID, ciJobId);
     }
 
     public CITagsBuilder withCiJobName(final String ciJobName) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
@@ -51,6 +51,7 @@ class CircleCIInfo implements CIProviderInfo {
         .ciPipelineId(pipelineId)
         .ciPipelineName(environment.get(CIRCLECI_PIPELINE_NAME))
         .ciPipelineUrl(buildPipelineUrl(pipelineId))
+        .ciJobId(environment.get(CIRCLECI_BUILD_NUM))
         .ciJobName(environment.get(CIRCLECI_JOB_NAME))
         .ciJobUrl(environment.get(CIRCLECI_BUILD_URL))
         .ciWorkspace(expandTilde(environment.get(CIRCLECI_WORKSPACE_PATH)))

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
@@ -73,6 +73,7 @@ class GitLabInfo implements CIProviderInfo {
         .ciPipelineNumber(environment.get(GITLAB_PIPELINE_NUMBER))
         .ciPipelineUrl(environment.get(GITLAB_PIPELINE_URL))
         .ciStageName(environment.get(GITLAB_STAGE_NAME))
+        .ciJobId(environment.get(GITLAB_JOB_ID))
         .ciJobName(environment.get(GITLAB_JOB_NAME))
         .ciJobUrl(environment.get(GITLAB_JOB_URL))
         .ciWorkspace(expandTilde(environment.get(GITLAB_WORKSPACE_PATH)))

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
@@ -82,6 +82,7 @@ class GithubActionsInfo implements CIProviderInfo {
         .ciPipelineName(environment.get(GHACTIONS_PIPELINE_NAME))
         .ciPipelineNumber(environment.get(GHACTIONS_PIPELINE_NUMBER))
         .ciPipelineUrl(pipelineUrl)
+        .ciJobId(environment.get(GHACTIONS_JOB))
         .ciJobName(environment.get(GHACTIONS_JOB))
         .ciJobUrl(jobUrl)
         .ciWorkspace(expandTilde(environment.get(GHACTIONS_WORKSPACE_PATH)))

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/awscodepipeline.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/awscodepipeline.json
@@ -18,6 +18,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CODEBUILD_BUILD_ARN\":\"arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19\",\"DD_PIPELINE_EXECUTION_ID\":\"bb1f15ed-fde2-494d-8e13-88785bca9cc0\",\"DD_ACTION_EXECUTION_ID\":\"35519dc3-7c45-493c-9ba6-cd78ea11f69d\"}",
+      "ci.job.id": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
       "ci.pipeline.id": "bb1f15ed-fde2-494d-8e13-88785bca9cc0",
       "ci.provider.name": "awscodepipeline",
       "git.branch": "user-supplied-branch",

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/azurepipelines.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/azurepipelines.json
@@ -18,6 +18,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -53,6 +54,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -87,6 +89,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -123,6 +126,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -159,6 +163,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -195,6 +200,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -231,6 +237,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -267,6 +274,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -301,6 +309,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -335,6 +344,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -369,6 +379,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -403,6 +414,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -437,6 +449,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -473,6 +486,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -510,6 +524,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -548,6 +563,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.name": "azure-pipelines-job-name",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
@@ -589,6 +605,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -632,6 +649,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -667,6 +685,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -696,6 +715,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -724,6 +744,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -752,6 +773,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -780,6 +802,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -808,6 +831,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -836,6 +860,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -864,6 +889,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -892,6 +918,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -920,6 +947,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -949,6 +977,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/buildkite.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/buildkite.json
@@ -20,6 +20,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -56,6 +57,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -92,6 +94,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -128,6 +131,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -166,6 +170,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -204,6 +209,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -242,6 +248,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -278,6 +285,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -314,6 +322,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -350,6 +359,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -386,6 +396,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -422,6 +433,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -458,6 +470,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -494,6 +507,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -530,6 +544,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -566,6 +581,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -602,6 +618,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -646,6 +663,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -693,6 +711,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -732,6 +751,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -766,6 +786,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -799,6 +820,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -832,6 +854,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -865,6 +888,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -898,6 +922,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -931,6 +956,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -964,6 +990,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -997,6 +1024,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -1030,6 +1058,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -1065,6 +1094,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.node.labels": "[\"mytag:my-value\",\"myothertag:my-other-value\"]",
       "ci.node.name": "1a222222-e999-3636-8ddd-802222222222",
@@ -1098,6 +1128,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/circleci.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/circleci.json
@@ -14,6 +14,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -41,6 +42,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -68,6 +70,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -95,6 +98,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -124,6 +128,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -153,6 +158,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -182,6 +188,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -209,6 +216,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -236,6 +244,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -264,6 +273,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -292,6 +302,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -319,6 +330,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -346,6 +358,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -373,6 +386,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -400,6 +414,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -427,6 +442,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -461,6 +477,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -501,6 +518,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -533,6 +551,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -557,6 +576,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -580,6 +600,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -603,6 +624,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -626,6 +648,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -649,6 +672,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -672,6 +696,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -695,6 +720,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -718,6 +744,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -741,6 +768,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -764,6 +792,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/github.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/github.json
@@ -15,6 +15,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -44,6 +45,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -73,6 +75,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -102,6 +105,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -131,6 +135,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -162,6 +167,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -193,6 +199,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -224,6 +231,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -253,6 +261,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -282,6 +291,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -311,6 +321,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -340,6 +351,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -369,6 +381,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -399,6 +412,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -429,6 +443,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -459,6 +474,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -497,6 +513,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -542,6 +559,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -575,6 +593,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -600,6 +619,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -625,6 +645,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -650,6 +671,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com:1234/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -675,6 +697,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://1.1.1.1/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -700,6 +723,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://1.1.1.1:1234/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -726,6 +750,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/gitlab.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/gitlab.json
@@ -21,6 +21,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -61,6 +62,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -101,6 +103,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -143,6 +146,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -185,6 +189,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -227,6 +232,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -267,6 +273,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -307,6 +314,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -348,6 +356,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -390,6 +399,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -432,6 +442,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -474,6 +485,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -515,6 +527,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -555,6 +568,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -595,6 +609,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -635,6 +650,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -675,6 +691,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -715,6 +732,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -755,6 +773,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -795,6 +814,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -835,6 +855,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -875,6 +896,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -925,6 +947,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -978,6 +1001,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -1024,6 +1048,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.node.labels": "[\"arch:arm64\",\"linux\"]",
@@ -1068,6 +1093,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -113,6 +113,7 @@ public class Tags {
   public static final String CI_PIPELINE_NUMBER = "ci.pipeline.number";
   public static final String CI_PIPELINE_URL = "ci.pipeline.url";
   public static final String CI_STAGE_NAME = "ci.stage.name";
+  public static final String CI_JOB_ID = "ci.job.id";
   public static final String CI_JOB_NAME = "ci.job.name";
   public static final String CI_JOB_URL = "ci.job.url";
   public static final String CI_WORKSPACE_PATH = "ci.workspace_path";


### PR DESCRIPTION
# What Does This Do

- Adds the `ci.job.id` tag for the following CI providers:
  - AWS
  - Azure
  - Buildkite
  - CircleCI
  - Gitlab
  - GHA

# Motivation

- Previously the values were sent only in `_dd.ci.env_vars`

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-2285]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-2285]: https://datadoghq.atlassian.net/browse/SDTEST-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ