### PR TITLE
Fix base branch SHA usage in GitHub Actions

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
@@ -131,7 +131,8 @@ public class CiVisibilityRepoServices {
       // if head sha present try to populate author, committer and message info through git client
       try {
         CommitInfo commitInfo = gitClient.getCommitInfo(headSha, true);
-        return PullRequestInfo.merge(ciInfo, new PullRequestInfo(null, null, commitInfo, null));
+        return PullRequestInfo.merge(
+            ciInfo, new PullRequestInfo(null, null, null, commitInfo, null));
       } catch (Exception ignored) {
       }
     }
@@ -145,6 +146,7 @@ public class CiVisibilityRepoServices {
         new PullRequestInfo(
             config.getGitPullRequestBaseBranch(),
             config.getGitPullRequestBaseBranchSha(),
+            null,
             new CommitInfo(config.getGitCommitHeadSha()),
             null);
 
@@ -164,6 +166,7 @@ public class CiVisibilityRepoServices {
         new PullRequestInfo(
             null,
             mergeBase,
+            null,
             new CommitInfo(environment.get(Constants.DDCI_PULL_REQUEST_SOURCE_SHA)),
             null);
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AppVeyorInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AppVeyorInfo.java
@@ -91,6 +91,7 @@ class AppVeyorInfo implements CIProviderInfo {
       return new PullRequestInfo(
           normalizeBranch(environment.get(APPVEYOR_REPO_BRANCH)),
           null,
+          null,
           new CommitInfo(environment.get(APPVEYOR_PR_HEAD_COMMIT)),
           environment.get(APPVEYOR_PR_NUMBER));
     } else {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
@@ -90,6 +90,7 @@ class AzurePipelinesInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(AZURE_PR_TARGET_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(AZURE_PR_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitBucketInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitBucketInfo.java
@@ -79,6 +79,7 @@ class BitBucketInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(BITBUCKET_PR_DESTINATION_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(BITBUCKET_PR_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitriseInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitriseInfo.java
@@ -76,6 +76,7 @@ class BitriseInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(BITRISE_GIT_BRANCH_DEST)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(BITRISE_PR_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuddyInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuddyInfo.java
@@ -67,6 +67,7 @@ class BuddyInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(BUDDY_RUN_PR_BASE_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(BUDDY_RUN_PR_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
@@ -85,6 +85,7 @@ class BuildkiteInfo implements CIProviderInfo {
       return new PullRequestInfo(
           normalizeBranch(environment.get(BUILDKITE_PULL_REQUEST_BASE_BRANCH)),
           null,
+          null,
           CommitInfo.NOOP,
           environment.get(BUILDKITE_PULL_REQUEST_NUMBER));
     }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CITagsProvider.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CITagsProvider.java
@@ -41,6 +41,7 @@ public class CITagsProvider {
         .withAdditionalTags(ciInfo.getAdditionalTags())
         .withPullRequestBaseBranch(pullRequestInfo)
         .withPullRequestBaseBranchSha(pullRequestInfo)
+        .withPullRequestBaseBranchHeadSha(pullRequestInfo)
         .withGitCommitHeadSha(pullRequestInfo)
         .withGitCommitHeadAuthorName(pullRequestInfo)
         .withGitCommitHeadAuthorEmail(pullRequestInfo)
@@ -130,13 +131,16 @@ public class CITagsProvider {
     }
 
     public CITagsBuilder withPullRequestBaseBranch(final PullRequestInfo pullRequestInfo) {
-      return putTagValue(
-          Tags.GIT_PULL_REQUEST_BASE_BRANCH, pullRequestInfo.getPullRequestBaseBranch());
+      return putTagValue(Tags.GIT_PULL_REQUEST_BASE_BRANCH, pullRequestInfo.getBaseBranch());
     }
 
     public CITagsBuilder withPullRequestBaseBranchSha(final PullRequestInfo pullRequestInfo) {
+      return putTagValue(Tags.GIT_PULL_REQUEST_BASE_BRANCH_SHA, pullRequestInfo.getBaseBranchSha());
+    }
+
+    public CITagsBuilder withPullRequestBaseBranchHeadSha(final PullRequestInfo pullRequestInfo) {
       return putTagValue(
-          Tags.GIT_PULL_REQUEST_BASE_BRANCH_SHA, pullRequestInfo.getPullRequestBaseBranchSha());
+          Tags.GIT_PULL_REQUEST_BASE_BRANCH_HEAD_SHA, pullRequestInfo.getBaseBranchHeadSha());
     }
 
     public CITagsBuilder withGitCommitHeadSha(final PullRequestInfo pullRequestInfo) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
@@ -61,7 +61,8 @@ class CircleCIInfo implements CIProviderInfo {
   @Nonnull
   @Override
   public PullRequestInfo buildPullRequestInfo() {
-    return new PullRequestInfo(null, null, CommitInfo.NOOP, environment.get(CIRCLECI_PR_NUMBER));
+    return new PullRequestInfo(
+        null, null, null, CommitInfo.NOOP, environment.get(CIRCLECI_PR_NUMBER));
   }
 
   private String buildPipelineUrl(final String pipelineId) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CodefreshInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CodefreshInfo.java
@@ -51,6 +51,7 @@ public class CodefreshInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(CF_PULL_REQUEST_TARGET_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(CF_PULL_REQUEST_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/DroneInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/DroneInfo.java
@@ -68,6 +68,7 @@ public class DroneInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(DRONE_PULL_REQUEST_TARGET_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(DRONE_PULL_REQUEST_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
@@ -88,6 +88,7 @@ class GitLabInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(GITLAB_PULL_REQUEST_BASE_BRANCH)),
         null,
+        null,
         new CommitInfo(environment.get(GITLAB_PULL_REQUEST_COMMIT_HEAD_SHA)),
         environment.get(GITLAB_PULL_REQUEST_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
@@ -107,7 +107,7 @@ class GithubActionsInfo implements CIProviderInfo {
           moshi.adapter(Types.newParameterizedType(Map.class, String.class, Object.class));
       Map<String, Object> eventJson = mapJsonAdapter.fromJson(event);
 
-      String baseSha = null;
+      String baseBranchHeadSha = null;
       String headSha = null;
       String prNumber = null;
 
@@ -120,7 +120,7 @@ class GithubActionsInfo implements CIProviderInfo {
 
         Map<String, Object> base = (Map<String, Object>) pullRequest.get("base");
         if (base != null) {
-          baseSha = (String) base.get("sha");
+          baseBranchHeadSha = (String) base.get("sha");
         }
 
         Double number = (Double) pullRequest.get("number");
@@ -129,11 +129,12 @@ class GithubActionsInfo implements CIProviderInfo {
         }
       }
 
-      return new PullRequestInfo(baseRef, baseSha, new CommitInfo(headSha), prNumber);
+      return new PullRequestInfo(
+          baseRef, null, baseBranchHeadSha, new CommitInfo(headSha), prNumber);
 
     } catch (Exception e) {
       LOGGER.warn("Error while parsing GitHub event", e);
-      return new PullRequestInfo(baseRef, null, CommitInfo.NOOP, null);
+      return new PullRequestInfo(baseRef, null, null, CommitInfo.NOOP, null);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/JenkinsInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/JenkinsInfo.java
@@ -77,6 +77,7 @@ class JenkinsInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(JENKINS_PR_BASE_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(JENKINS_PR_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/PullRequestInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/PullRequestInfo.java
@@ -8,30 +8,37 @@ import javax.annotation.Nonnull;
 public class PullRequestInfo {
 
   public static final PullRequestInfo EMPTY =
-      new PullRequestInfo(null, null, CommitInfo.NOOP, null);
+      new PullRequestInfo(null, null, null, CommitInfo.NOOP, null);
 
-  private final String pullRequestBaseBranch;
-  private final String pullRequestBaseBranchSha;
+  private final String baseBranch;
+  private final String baseBranchSha;
+  private final String baseBranchHeadSha;
   @Nonnull private final CommitInfo headCommit;
   private final String pullRequestNumber;
 
   public PullRequestInfo(
-      String pullRequestBaseBranch,
-      String pullRequestBaseBranchSha,
+      String baseBranch,
+      String baseBranchSha,
+      String baseBranchHeadSha,
       @Nonnull CommitInfo headCommit,
       String pullRequestNumber) {
-    this.pullRequestBaseBranch = pullRequestBaseBranch;
-    this.pullRequestBaseBranchSha = pullRequestBaseBranchSha;
+    this.baseBranch = baseBranch;
+    this.baseBranchSha = baseBranchSha;
+    this.baseBranchHeadSha = baseBranchHeadSha;
     this.headCommit = headCommit;
     this.pullRequestNumber = pullRequestNumber;
   }
 
-  public String getPullRequestBaseBranch() {
-    return pullRequestBaseBranch;
+  public String getBaseBranch() {
+    return baseBranch;
   }
 
-  public String getPullRequestBaseBranchSha() {
-    return pullRequestBaseBranchSha;
+  public String getBaseBranchSha() {
+    return baseBranchSha;
+  }
+
+  public String getBaseBranchHeadSha() {
+    return baseBranchHeadSha;
   }
 
   @Nonnull
@@ -44,15 +51,17 @@ public class PullRequestInfo {
   }
 
   public boolean isEmpty() {
-    return Strings.isBlank(pullRequestBaseBranch)
-        && Strings.isBlank(pullRequestBaseBranchSha)
+    return Strings.isBlank(baseBranch)
+        && Strings.isBlank(baseBranchSha)
+        && Strings.isBlank(baseBranchHeadSha)
         && headCommit.isEmpty()
         && Strings.isBlank(pullRequestNumber);
   }
 
   public boolean isComplete() {
-    return Strings.isNotBlank(pullRequestBaseBranch)
-        && Strings.isNotBlank(pullRequestBaseBranchSha)
+    return Strings.isNotBlank(baseBranch)
+        && Strings.isNotBlank(baseBranchSha)
+        && Strings.isNotBlank(baseBranchHeadSha)
         && headCommit.isComplete()
         && Strings.isNotBlank(pullRequestNumber);
   }
@@ -66,12 +75,11 @@ public class PullRequestInfo {
    */
   public static PullRequestInfo merge(PullRequestInfo info, PullRequestInfo fallback) {
     return new PullRequestInfo(
-        Strings.isNotBlank(info.pullRequestBaseBranch)
-            ? info.pullRequestBaseBranch
-            : fallback.pullRequestBaseBranch,
-        Strings.isNotBlank(info.pullRequestBaseBranchSha)
-            ? info.pullRequestBaseBranchSha
-            : fallback.pullRequestBaseBranchSha,
+        Strings.isNotBlank(info.baseBranch) ? info.baseBranch : fallback.baseBranch,
+        Strings.isNotBlank(info.baseBranchSha) ? info.baseBranchSha : fallback.baseBranchSha,
+        Strings.isNotBlank(info.baseBranchHeadSha)
+            ? info.baseBranchHeadSha
+            : fallback.baseBranchHeadSha,
         CommitInfo.merge(info.headCommit, fallback.headCommit),
         Strings.isNotBlank(info.pullRequestNumber)
             ? info.pullRequestNumber
@@ -87,26 +95,29 @@ public class PullRequestInfo {
       return false;
     }
     PullRequestInfo that = (PullRequestInfo) o;
-    return Objects.equals(pullRequestBaseBranch, that.pullRequestBaseBranch)
-        && Objects.equals(pullRequestBaseBranchSha, that.pullRequestBaseBranchSha)
+    return Objects.equals(baseBranch, that.baseBranch)
+        && Objects.equals(baseBranchSha, that.baseBranchSha)
+        && Objects.equals(baseBranchHeadSha, that.baseBranchHeadSha)
         && Objects.equals(headCommit, that.headCommit)
         && Objects.equals(pullRequestNumber, that.pullRequestNumber);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        pullRequestBaseBranch, pullRequestBaseBranchSha, headCommit, pullRequestNumber);
+    return Objects.hash(baseBranch, baseBranchSha, headCommit, pullRequestNumber);
   }
 
   @Override
   public String toString() {
     return "PR{"
         + "baseBranch='"
-        + pullRequestBaseBranch
+        + baseBranch
         + '\''
         + ", baseSHA='"
-        + pullRequestBaseBranchSha
+        + baseBranchSha
+        + '\''
+        + ", baseHeadSHA='"
+        + baseBranchHeadSha
         + '\''
         + ", headCommit='"
         + headCommit

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TeamcityInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TeamcityInfo.java
@@ -43,6 +43,7 @@ public class TeamcityInfo implements CIProviderInfo {
     return new PullRequestInfo(
         normalizeBranch(environment.get(TEAMCITY_PULL_REQUEST_TARGET_BRANCH)),
         null,
+        null,
         CommitInfo.NOOP,
         environment.get(TEAMCITY_PULL_REQUEST_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TravisInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TravisInfo.java
@@ -71,6 +71,7 @@ class TravisInfo implements CIProviderInfo {
       return new PullRequestInfo(
           normalizeBranch(environment.get(TRAVIS_GIT_BRANCH)),
           null,
+          null,
           new CommitInfo(environment.get(TRAVIS_PR_HEAD_SHA)),
           environment.get(TRAVIS_PR_NUMBER));
     }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ExecutionSettingsFactoryImpl.java
@@ -423,10 +423,16 @@ public class ExecutionSettingsFactoryImpl implements ExecutionSettingsFactory {
         // ensure repo is not shallow before attempting to get git diff
         gitRepoUnshallow.unshallow();
 
-        String baseCommitSha = pullRequestInfo.getPullRequestBaseBranchSha();
+        String baseCommitSha = pullRequestInfo.getBaseBranchSha();
+        if (baseCommitSha == null && pullRequestInfo.getBaseBranchHeadSha() != null) {
+          baseCommitSha =
+              gitClient.getMergeBase(
+                  pullRequestInfo.getBaseBranchHeadSha(), pullRequestInfo.getHeadCommit().getSha());
+        }
+
         if (baseCommitSha == null) {
           baseCommitSha =
-              gitClient.getBaseCommitSha(pullRequestInfo.getPullRequestBaseBranch(), defaultBranch);
+              gitClient.getBaseCommitSha(pullRequestInfo.getBaseBranch(), defaultBranch);
         }
 
         Diff diff = gitClient.getGitDiff(baseCommitSha, pullRequestInfo.getHeadCommit().getSha());

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/CiVisibilityRepoServicesTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/CiVisibilityRepoServicesTest.groovy
@@ -36,7 +36,7 @@ class CiVisibilityRepoServicesTest extends Specification {
     setup:
     def expectedInfo = new PullRequestInfo(
       "master",
-      "baseSha",
+      "baseSha", null,
       new CommitInfo(
       "sourceSha",
       new PersonInfo("john", "john@doe.com", "never"),
@@ -47,7 +47,7 @@ class CiVisibilityRepoServicesTest extends Specification {
       )
 
     def config = Stub(Config)
-    config.getGitPullRequestBaseBranch() >> expectedInfo.getPullRequestBaseBranch()
+    config.getGitPullRequestBaseBranch() >> expectedInfo.getBaseBranch()
 
     def environment = Stub(CiEnvironment)
     environment.get(Constants.DDCI_PULL_REQUEST_TARGET_SHA) >> "targetSha"
@@ -55,10 +55,10 @@ class CiVisibilityRepoServicesTest extends Specification {
 
     def repoUnshallow = Stub(GitRepoUnshallow)
     def ciProviderInfo = Stub(CIProviderInfo)
-    ciProviderInfo.buildPullRequestInfo() >> new PullRequestInfo(null, null, CommitInfo.NOOP, expectedInfo.getPullRequestNumber())
+    ciProviderInfo.buildPullRequestInfo() >> new PullRequestInfo(null, null, null, CommitInfo.NOOP, expectedInfo.getPullRequestNumber())
 
     def gitClient = Stub(GitClient)
-    gitClient.getMergeBase("targetSha", "sourceSha") >> expectedInfo.getPullRequestBaseBranchSha()
+    gitClient.getMergeBase("targetSha", "sourceSha") >> expectedInfo.getBaseBranchSha()
     gitClient.getCommitInfo("sourceSha", true) >> expectedInfo.getHeadCommit()
 
     expect:

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/GithubActionsInfoTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/GithubActionsInfoTest.groovy
@@ -40,8 +40,9 @@ class GithubActionsInfoTest extends CITagsProviderTest {
     def pullRequestInfo = new GithubActionsInfo(new CiEnvironmentImpl(System.getenv())).buildPullRequestInfo()
 
     then:
-    pullRequestInfo.getPullRequestBaseBranch() == "base-ref"
-    pullRequestInfo.getPullRequestBaseBranchSha() == "52e0974c74d41160a03d59ddc73bb9f5adab054b"
+    pullRequestInfo.getBaseBranch() == "base-ref"
+    pullRequestInfo.getBaseBranchSha() == null
+    pullRequestInfo.getBaseBranchHeadSha() == "52e0974c74d41160a03d59ddc73bb9f5adab054b"
     pullRequestInfo.getHeadCommit().getSha() == "df289512a51123083a8e6931dd6f57bb3883d4c4"
     pullRequestInfo.getPullRequestNumber() == "1"
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/PullRequestInfoTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/PullRequestInfoTest.groovy
@@ -8,8 +8,10 @@ class PullRequestInfoTest extends Specification {
   private static final PersonInfo PERSON_A = new PersonInfo("nameA", "emailA", "dateA")
   private static final PersonInfo PERSON_B = new PersonInfo("nameB", "emailB", "dateB")
   private static final PersonInfo EMPTY_PERSON = new PersonInfo(null, null, null)
-  private static final CommitInfo COMMIT_A = new CommitInfo("shaA", PERSON_A, PERSON_A, "msgA")
-  private static final CommitInfo COMMIT_B = new CommitInfo("shaB", PERSON_B, PERSON_B, "msgB")
+  private static final String SHA_A = "shaA"
+  private static final String SHA_B = "shaB"
+  private static final CommitInfo COMMIT_A = new CommitInfo(SHA_A, PERSON_A, PERSON_A, "msgA")
+  private static final CommitInfo COMMIT_B = new CommitInfo(SHA_B, PERSON_B, PERSON_B, "msgB")
   private static final CommitInfo EMPTY_COMMIT = new CommitInfo(null, EMPTY_PERSON, EMPTY_PERSON, null)
 
   def "test isEmpty"() {
@@ -17,11 +19,11 @@ class PullRequestInfoTest extends Specification {
     info.isEmpty() == empty
 
     where:
-    info                                                     | empty
-    new PullRequestInfo(null, null, EMPTY_COMMIT, null)      | true
-    new PullRequestInfo("", "", EMPTY_COMMIT, "")            | true
-    new PullRequestInfo(null, "", COMMIT_A, "42")            | false
-    new PullRequestInfo("branch", "baseSha", COMMIT_A, "42") | false
+    info                                                            | empty
+    new PullRequestInfo(null, null, null, EMPTY_COMMIT, null)       | true
+    new PullRequestInfo("", "", null, EMPTY_COMMIT, "")             | true
+    new PullRequestInfo(null, "", null, COMMIT_A, "42")             | false
+    new PullRequestInfo("branch", "baseSha", SHA_A, COMMIT_A, "42") | false
   }
 
   def "test isComplete"() {
@@ -29,11 +31,11 @@ class PullRequestInfoTest extends Specification {
     info.isComplete() == empty
 
     where:
-    info                                                     | empty
-    new PullRequestInfo(null, null, EMPTY_COMMIT, null)      | false
-    new PullRequestInfo("", "", EMPTY_COMMIT, "")            | false
-    new PullRequestInfo(null, "", COMMIT_A, "42")            | false
-    new PullRequestInfo("branch", "baseSha", COMMIT_A, "42") | true
+    info                                                            | empty
+    new PullRequestInfo(null, null, null, EMPTY_COMMIT, null)       | false
+    new PullRequestInfo("", "", null, EMPTY_COMMIT, "")             | false
+    new PullRequestInfo("branch", "", null, COMMIT_A, "42")         | false
+    new PullRequestInfo("branch", "baseSha", SHA_A, COMMIT_A, "42") | true
   }
 
   def "test info merge"() {
@@ -41,10 +43,10 @@ class PullRequestInfoTest extends Specification {
     PullRequestInfo.merge(infoA, infoB) == result
 
     where:
-    infoA                                                      | infoB                                                      | result
-    new PullRequestInfo("branchA", "baseShaA", COMMIT_A, "42") | new PullRequestInfo("branchB", "baseShaB", COMMIT_B, "28") | new PullRequestInfo("branchA", "baseShaA", COMMIT_A, "42")
-    new PullRequestInfo(null, null, EMPTY_COMMIT, null)        | new PullRequestInfo("branchB", "baseShaB", COMMIT_B, "28") | new PullRequestInfo("branchB", "baseShaB", COMMIT_B, "28")
-    new PullRequestInfo("branchA", null, EMPTY_COMMIT, "42")   | new PullRequestInfo("branchB", "baseShaB", COMMIT_B, null) | new PullRequestInfo("branchA", "baseShaB", COMMIT_B, "42")
-    new PullRequestInfo("branchA", null, EMPTY_COMMIT, "42")   | new PullRequestInfo(null, null, EMPTY_COMMIT, null)        | new PullRequestInfo("branchA", null, EMPTY_COMMIT, "42")
+    infoA                                                             | infoB                                                             | result
+    new PullRequestInfo("branchA", "baseShaA", SHA_A, COMMIT_A, "42") | new PullRequestInfo("branchB", "baseShaB", SHA_B, COMMIT_B, "28") | new PullRequestInfo("branchA", "baseShaA", SHA_A, COMMIT_A, "42")
+    new PullRequestInfo(null, null, null, EMPTY_COMMIT, null)         | new PullRequestInfo("branchB", "baseShaB", SHA_B, COMMIT_B, "28") | new PullRequestInfo("branchB", "baseShaB", SHA_B, COMMIT_B, "28")
+    new PullRequestInfo("branchA", null, SHA_A, EMPTY_COMMIT, "42")   | new PullRequestInfo("branchB", "baseShaB", null, COMMIT_B, null)  | new PullRequestInfo("branchA", "baseShaB", SHA_A, COMMIT_B, "42")
+    new PullRequestInfo("branchA", null, null, EMPTY_COMMIT, "42")    | new PullRequestInfo(null, null, null, EMPTY_COMMIT, null)         | new PullRequestInfo("branchA", null, null, EMPTY_COMMIT, "42")
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -132,6 +132,8 @@ public class Tags {
   public static final String GIT_TAG = "git.tag";
   public static final String GIT_PULL_REQUEST_BASE_BRANCH = "git.pull_request.base_branch";
   public static final String GIT_PULL_REQUEST_BASE_BRANCH_SHA = "git.pull_request.base_branch_sha";
+  public static final String GIT_PULL_REQUEST_BASE_BRANCH_HEAD_SHA =
+      "git.pull_request.base_branch_head_sha";
   public static final String GIT_COMMIT_HEAD_SHA = "git.commit.head.sha";
   public static final String GIT_COMMIT_HEAD_AUTHOR_NAME = "git.commit.head.author.name";
   public static final String GIT_COMMIT_HEAD_AUTHOR_EMAIL = "git.commit.head.author.email";


### PR DESCRIPTION
# What Does This Do

- Sets the `pull_request.base.sha` value provided by GitHub Actions as `git.pull_request.base_branch_head_sha` instead of `git.pull_request.base_branch_sha`
- When calculating the PR diff and `base_branch_sha` is not present, tries to use the merge base with `base_branch_head_sha` to compute it

# Motivation

- Using `pull_request.base.sha`, which is the head commit SHA for the base branch, meant that the git diff calculated was inaccurate (base branch head sha - head sha, instead of base commit sha - head sha)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-2351]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
