### PR TITLE
Specify how to get graalvm version on macos in setup instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,8 +69,8 @@ Download and install JDK versions 8, 11, 17, 21 and 24, and GraalVM 17 for your 
   ```shell
   brew install --cask zulu@8 zulu@11 zulu@17 zulu@21 zulu graalvm/tap/graalvm-ce-java17
   ```
-* Identify your local version of graalvm:
-  ```shell
+* Identify your local version of GraalVM:
+  ```
   ls /Library/Java/JavaVirtualMachines | grep graalvm
   ```
   Example: `graalvm-ce-java17-22.3.1`


### PR DESCRIPTION
# What Does This Do
Adds a bullet point to get the current graalvm version on macos before using this version in the xattrs command

# Motivation
I couldn't find my graalvm version and was lost 😃 

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
