### PR TITLE
Use mirrored agent image in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -606,6 +606,7 @@ agent_integration_tests:
       variables:
         DD_APM_ENABLED: "true"
         DD_BIND_HOST: "0.0.0.0"
+        DD_HOSTNAME: "local-agent"
         DD_API_KEY: "invalid_key_but_this_is_fine"
 
 test_base:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -601,7 +601,7 @@ agent_integration_tests:
     GRADLE_TARGET: "traceAgentTest"
     CACHE_TYPE: "base"
   services:
-    - name: datadog/agent:7.34.0
+    - name: registry.ddbuild.io/images/mirror/datadog/agent:7.40.1
       alias: local-agent
       variables:
         DD_APM_ENABLED: "true"

--- a/dd-trace-core/src/traceAgentTest/groovy/AbstractTraceAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/AbstractTraceAgentTest.groovy
@@ -18,7 +18,7 @@ abstract class AbstractTraceAgentTest extends DDSpecification {
      and we use 'testcontainers' for this.
      */
     if ("true" != System.getenv("CI")) {
-      agentContainer = new GenericContainer("datadog/agent:7.34.0")
+      agentContainer = new GenericContainer("datadog/agent:7.40.1")
         .withEnv(["DD_APM_ENABLED": "true",
           "DD_BIND_HOST"  : "0.0.0.0",
           "DD_API_KEY"    : "invalid_key_but_this_is_fine",

--- a/dd-trace-core/src/traceAgentTest/groovy/AbstractTraceAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/AbstractTraceAgentTest.groovy
@@ -22,6 +22,7 @@ abstract class AbstractTraceAgentTest extends DDSpecification {
         .withEnv(["DD_APM_ENABLED": "true",
           "DD_BIND_HOST"  : "0.0.0.0",
           "DD_API_KEY"    : "invalid_key_but_this_is_fine",
+          "DD_HOSTNAME"   : "doesnotexist",
           "DD_LOGS_STDOUT": "yes"])
         .withExposedPorts(datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT)
         .withStartupTimeout(Duration.ofSeconds(120))


### PR DESCRIPTION
# What Does This Do
Use an datadog agent image that's mirrored internally

# Motivation
docker rate limits (rarely). I also changed the image used to run locally so that they match

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
