### PR TITLE
Bump ddprof to 1.29.0

### DIFF
--- a/dd-java-agent/ddprof-lib/build.gradle
+++ b/dd-java-agent/ddprof-lib/build.gradle
@@ -13,7 +13,10 @@ dependencies {
 }
 
 shadowJar {
-  dependencies deps.excludeShared
+  dependencies {
+    deps.excludeShared
+    exclude '**/*.debug'
+  }
   archiveClassifier = 'all'
   include {
     def rslt = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,14 +51,14 @@ ddprof = { module = "com.datadoghq:ddprof", version.ref = "ddprof" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asmcommons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 dogstatsd = { module = "com.datadoghq:java-dogstatsd-client", version.ref = "dogstatsd" }
-jnr-unixsocket = { module = "com.github.jnr:jnr-unixsocket", version.ref = "jnr-unixsocket" }
+jnr-unixsocket = { module = "com.github.jnr:jnr-unixsocket", version.ref = "jnr-unixsocket"}
 
 cafe-crypto-ed25519 = { module = "cafe.cryptography:ed25519-elisabeth", version.ref = "cafe_crypto" }
 cafe-crypto-curve25519 = { module = "cafe.cryptography:curve25519-elisabeth", version.ref = "cafe_crypto" }
 
 lz4 = { module = "org.lz4:lz4-java", version.ref = "lz4" }
 # aircompressor v3 requires Java 22
-aircompressor = { module = 'io.airlift:aircompressor', version = '2.0.2' }
+aircompressor = { module = 'io.airlift:aircompressor', version = '2.0.2'}
 
 # Testing
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ moshi = '1.11.0'
 testcontainers = '1.20.1'
 jmc = "8.1.0"
 autoservice = "1.0-rc7"
-ddprof = "1.27.0"
+ddprof = "1.29.0"
 asm = "9.8"
 cafe_crypto = "0.1.0"
 lz4 = "1.7.1"
@@ -51,14 +51,14 @@ ddprof = { module = "com.datadoghq:ddprof", version.ref = "ddprof" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asmcommons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 dogstatsd = { module = "com.datadoghq:java-dogstatsd-client", version.ref = "dogstatsd" }
-jnr-unixsocket = { module = "com.github.jnr:jnr-unixsocket", version.ref = "jnr-unixsocket"}
+jnr-unixsocket = { module = "com.github.jnr:jnr-unixsocket", version.ref = "jnr-unixsocket" }
 
 cafe-crypto-ed25519 = { module = "cafe.cryptography:ed25519-elisabeth", version.ref = "cafe_crypto" }
 cafe-crypto-curve25519 = { module = "cafe.cryptography:curve25519-elisabeth", version.ref = "cafe_crypto" }
 
 lz4 = { module = "org.lz4:lz4-java", version.ref = "lz4" }
 # aircompressor v3 requires Java 22
-aircompressor = { module = 'io.airlift:aircompressor', version = '2.0.2'}
+aircompressor = { module = 'io.airlift:aircompressor', version = '2.0.2' }
 
 # Testing
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }


### PR DESCRIPTION
# What Does This Do
Bump ddprof to 1.29.0

# Motivation
Improve performance and stability

# Additional Notes
## What's Changed
* Split debug by @r1viollet in https://github.com/DataDog/java-profiler/pull/233
* Add the micro-benchmark for thread filtering by @jbachorik in https://github.com/DataDog/java-profiler/pull/237
* Flaky test - j9 OSR by @r1viollet in https://github.com/DataDog/java-profiler/pull/239
* Fix flaky allocation test by @r1viollet in https://github.com/DataDog/java-profiler/pull/241
* Remove debugging code from ActiveBitmap by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/242
* Potential memory leak and race with the JVMTI wallclock sampler by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/234
* Stresstest fix - Add limits to the graph mutation stress test by @r1viollet in https://github.com/DataDog/java-profiler/pull/244
* Split debug - publish debug info by @r1viollet in https://github.com/DataDog/java-profiler/pull/240
* Relax benchmark commandline restriction by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/243
* Downport async-profiler no-allocation changes by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/245
* Adopt openjdk safefetch by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/246
* Safe fetch 64-bit value and pointer by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/247
* Exclude BoundMethodHandleMetadataSizeTest from running on IBM JDK 8 by @jbachorik in https://github.com/DataDog/java-profiler/pull/248
* Fix the async-profiler re-fetch by @jbachorik in https://github.com/DataDog/java-profiler/pull/249
* Fix typo PR #274 by @zhengyu123 in https://github.com/DataDog/java-profiler/pull/250
* Rebase on Async-Profiler 4.1 by @jbachorik in https://github.com/DataDog/java-profiler/pull/252
* Remove gtest during build by @r1viollet in https://github.com/DataDog/java-profiler/pull/251


# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
