### PR TITLE
Use proxy for forbiddenapi plugin dependencies

### DIFF
--- a/gradle/forbiddenapis.gradle
+++ b/gradle/forbiddenapis.gradle
@@ -1,9 +1,22 @@
 buildscript {
   repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
+    mavenLocal()
+    if (project.rootProject.hasProperty("gradlePluginProxy")) {
+      maven {
+        url project.rootProject.property("gradlePluginProxy")
+        allowInsecureProtocol true
+      }
     }
+    if (project.rootProject.hasProperty("mavenRepositoryProxy")) {
+      maven {
+        url project.rootProject.property("mavenRepositoryProxy")
+        allowInsecureProtocol true
+      }
+    }
+    gradlePluginPortal()
+    mavenCentral()
   }
+
   dependencies {
     classpath "de.thetaphi:forbiddenapis:3.8"
   }


### PR DESCRIPTION
# What Does This Do
Use proxy for dependencies.

# Motivation
Not using the proxy leads to rate limits. Worse yet, this particular case doesn't even check `mavenLocal()` first. Yet another PR in the line of #9099 #8979 #8976 #8775 #8592 #8554

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
