### PR TITLE
Do not rely on timeout when testing smap entry cache

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCache.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCache.java
@@ -62,6 +62,11 @@ final class SmapEntryCache {
     this.smapsPath = smapsPath;
   }
 
+  // @VisibleForTesting
+  void invalidate() {
+    UPDATER.getAndSet(this, System.nanoTime() - (2 * ttl));
+  }
+
   @SuppressWarnings("unchecked")
   public List<SmapEntryEvent> getEvents() {
     long prevTimestamp = lastTimestamp;
@@ -296,9 +301,9 @@ final class SmapEntryCache {
     return Collections.emptyMap();
   }
 
-  private static void collectEvents(List<SmapEntryEvent> events) {
+  private void collectEvents(List<SmapEntryEvent> events) {
     try (BufferedReader br =
-        new BufferedReader(new InputStreamReader(Files.newInputStream(SMAPS_PATH)), 64 * 1024)) {
+        new BufferedReader(new InputStreamReader(Files.newInputStream(smapsPath)), 64 * 1024)) {
       readEvents(br, events);
       Map<Long, String> regions = getAnnotatedRegions();
       for (SmapEntryEvent e : events) {

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCacheTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCacheTest.java
@@ -18,16 +18,13 @@ class SmapEntryCacheTest {
     assumeTrue(OperatingSystem.isLinux());
     // We need at least Java 22 for the annotated regions
     assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(22));
-    SmapEntryCache smapEntryCache = new SmapEntryCache(Duration.ofMillis(100));
+    SmapEntryCache smapEntryCache = new SmapEntryCache(Duration.ofHours(1)); // set up a really long expiration duration
     List<SmapEntryEvent> events1 = smapEntryCache.getEvents();
     List<SmapEntryEvent> events2 = smapEntryCache.getEvents();
     // the cache is using double buffered event list so we can use identity comparison
     assertSame(events1, events2);
 
-    long ts = System.nanoTime();
-    while (System.nanoTime() - ts < 150_000_000L) { // make sure the cache is expired
-      Thread.sleep(200);
-    }
+    smapEntryCache.invalidate(); // pretend expiring the cache
     events1 = smapEntryCache.getEvents();
     assertNotSame(events1, events2);
   }


### PR DESCRIPTION
# What Does This Do
Adds support to explicitly invalidate the smap entry cache for testing.

# Motivation
Stop flaky test. Relying on exact timing is always troublesome.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
