### PR TITLE
Upgrade gradle to v8.14.3

### DIFF
--- a/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# What Does This Do
Upgrade gradle to v8.14.3

# Motivation
Using the same Gradle version across builds minimizes binary downloads and leads to faster CI execution.

# Additional Notes
For some reason, these files don't appear in IntelliJ IDEA's search results — I had to locate them using a direct file system search.

