### PR TITLE
Report all set configuration sources to telemetry

### DIFF
--- a/dd-smoke-tests/log-injection/src/main/java/datadog/smoketest/loginjection/BaseApplication.java
+++ b/dd-smoke-tests/log-injection/src/main/java/datadog/smoketest/loginjection/BaseApplication.java
@@ -44,7 +44,8 @@ public abstract class BaseApplication {
   }
 
   private static Object getLogInjectionEnabled() {
-    ConfigSetting configSetting = ConfigCollector.get().collect().get(LOGS_INJECTION_ENABLED);
+    ConfigSetting configSetting =
+        ConfigCollector.get().getAppliedConfigSetting(LOGS_INJECTION_ENABLED);
     if (configSetting == null) {
       return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
@@ -49,6 +49,10 @@ public class ConfigCollector {
     }
   }
 
+  /**
+   * Returns the {@link ConfigSetting} with the highest precedence for the given key, or {@code
+   * null} if no setting exists for that key.
+   */
   public ConfigSetting getAppliedConfigSetting(String key) {
     Map<ConfigOrigin, ConfigSetting> originMap = collected.get(key);
     if (originMap == null || originMap.isEmpty()) {

--- a/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
@@ -23,6 +23,10 @@ public class ConfigCollector {
     return INSTANCE;
   }
 
+  /**
+   * Records the latest ConfigSetting for the given key and origin, replacing any previous value for
+   * that (key, origin) pair.
+   */
   public void put(String key, Object value, ConfigOrigin origin) {
     ConfigSetting setting = ConfigSetting.of(key, value, origin);
     Map<ConfigOrigin, ConfigSetting> originMap =

--- a/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
@@ -34,6 +34,14 @@ public class ConfigCollector {
     originMap.put(origin, setting); // replaces any previous value for this origin
   }
 
+  // TODO: Replace old `put` with this `put`
+  public void put(String key, Object value, ConfigOrigin origin, int seqId) {
+    ConfigSetting setting = ConfigSetting.of(key, value, origin, seqId);
+    Map<ConfigOrigin, ConfigSetting> originMap =
+        collected.computeIfAbsent(key, k -> new ConcurrentHashMap<>());
+    originMap.put(origin, setting); // replaces any previous value for this origin
+  }
+
   public void putAll(Map<String, Object> keysAndValues, ConfigOrigin origin) {
     for (Map.Entry<String, Object> entry : keysAndValues.entrySet()) {
       put(entry.getKey(), entry.getValue(), origin);

--- a/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigOrigin.java
@@ -4,27 +4,29 @@ package datadog.trace.api;
 // GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/conf_key_value.md
 public enum ConfigOrigin {
   /** configurations that are set through environment variables */
-  ENV("env_var"),
+  ENV("env_var", 5),
   /** values that are set using remote config */
-  REMOTE("remote_config"),
+  REMOTE("remote_config", 9),
   /** configurations that are set through JVM properties */
-  JVM_PROP("jvm_prop"),
+  JVM_PROP("jvm_prop", 6),
   /** configuration read in the stable config file, managed by users */
-  LOCAL_STABLE_CONFIG("local_stable_config"),
+  LOCAL_STABLE_CONFIG("local_stable_config", 4),
   /** configuration read in the stable config file, managed by fleet */
-  FLEET_STABLE_CONFIG("fleet_stable_config"),
+  FLEET_STABLE_CONFIG("fleet_stable_config", 7),
   /** configurations that are set through the customer application */
-  CODE("code"),
+  CODE("code", 8),
   /** set by the dd.yaml file or json */
-  DD_CONFIG("dd_config"),
+  DD_CONFIG("dd_config", 3),
   /** set for cases where it is difficult/not possible to determine the source of a config. */
-  UNKNOWN("unknown"),
+  UNKNOWN("unknown", 2),
   /** set when the user has not set any configuration for the key (defaults to a value) */
-  DEFAULT("default");
+  DEFAULT("default", 1);
 
   public final String value;
+  public final int precedence;
 
-  ConfigOrigin(String value) {
+  ConfigOrigin(String value, int precedence) {
     this.value = value;
+    this.precedence = precedence;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/ConfigSetting.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigSetting.java
@@ -11,25 +11,19 @@ public final class ConfigSetting {
   public final String key;
   public final Object value;
   public final ConfigOrigin origin;
-  public final int seqID;
 
   private static final Set<String> CONFIG_FILTER_LIST =
       new HashSet<>(
           Arrays.asList("DD_API_KEY", "dd.api-key", "dd.profiling.api-key", "dd.profiling.apikey"));
 
   public static ConfigSetting of(String key, Object value, ConfigOrigin origin) {
-    return new ConfigSetting(key, value, origin, 0);
+    return new ConfigSetting(key, value, origin);
   }
 
-  public static ConfigSetting of(String key, Object value, ConfigOrigin origin, int seqID) {
-    return new ConfigSetting(key, value, origin, seqID);
-  }
-
-  private ConfigSetting(String key, Object value, ConfigOrigin origin, int seqID) {
+  private ConfigSetting(String key, Object value, ConfigOrigin origin) {
     this.key = key;
     this.value = CONFIG_FILTER_LIST.contains(key) ? "<hidden>" : value;
     this.origin = origin;
-    this.seqID = seqID;
   }
 
   public String normalizedKey() {
@@ -105,10 +99,7 @@ public final class ConfigSetting {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ConfigSetting that = (ConfigSetting) o;
-    return key.equals(that.key)
-        && Objects.equals(value, that.value)
-        && origin == that.origin
-        && seqID == that.seqID;
+    return key.equals(that.key) && Objects.equals(value, that.value) && origin == that.origin;
   }
 
   @Override
@@ -125,9 +116,9 @@ public final class ConfigSetting {
         + ", value="
         + stringValue()
         + ", origin="
-        + origin
+        + origin.value
         + ", seq_id="
-        + seqID
+        + origin.precedence
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/ConfigSetting.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigSetting.java
@@ -11,19 +11,25 @@ public final class ConfigSetting {
   public final String key;
   public final Object value;
   public final ConfigOrigin origin;
+  public final int seqID;
 
   private static final Set<String> CONFIG_FILTER_LIST =
       new HashSet<>(
           Arrays.asList("DD_API_KEY", "dd.api-key", "dd.profiling.api-key", "dd.profiling.apikey"));
 
   public static ConfigSetting of(String key, Object value, ConfigOrigin origin) {
-    return new ConfigSetting(key, value, origin);
+    return new ConfigSetting(key, value, origin, 0);
   }
 
-  private ConfigSetting(String key, Object value, ConfigOrigin origin) {
+  public static ConfigSetting of(String key, Object value, ConfigOrigin origin, int seqID) {
+    return new ConfigSetting(key, value, origin, seqID);
+  }
+
+  private ConfigSetting(String key, Object value, ConfigOrigin origin, int seqID) {
     this.key = key;
     this.value = CONFIG_FILTER_LIST.contains(key) ? "<hidden>" : value;
     this.origin = origin;
+    this.seqID = seqID;
   }
 
   public String normalizedKey() {
@@ -99,7 +105,10 @@ public final class ConfigSetting {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ConfigSetting that = (ConfigSetting) o;
-    return key.equals(that.key) && Objects.equals(value, that.value) && origin == that.origin;
+    return key.equals(that.key)
+        && Objects.equals(value, that.value)
+        && origin == that.origin
+        && seqID == that.seqID;
   }
 
   @Override
@@ -117,6 +126,8 @@ public final class ConfigSetting {
         + stringValue()
         + ", origin="
         + origin
+        + ", seq_id="
+        + seqID
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -74,17 +74,18 @@ public final class ConfigProvider {
   }
 
   public String getString(String key, String defaultValue, String... aliases) {
+    String value = null;
     for (ConfigProvider.Source source : sources) {
-      String value = source.get(key, aliases);
-      if (value != null) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
-        }
-        return value;
+      value = source.get(key, aliases);
+      if (value != null && collectConfig) {
+        ConfigCollector.get().put(key, value, source.origin());
       }
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
+    }
+    if (value != null) {
+      return value;
     }
     return defaultValue;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -32,8 +32,6 @@ public final class ConfigProvider {
 
   private final ConfigProvider.Source[] sources;
 
-  private final int numSources;
-
   private ConfigProvider(ConfigProvider.Source... sources) {
     this(true, sources);
   }
@@ -41,7 +39,6 @@ public final class ConfigProvider {
   private ConfigProvider(boolean collectConfig, ConfigProvider.Source... sources) {
     this.collectConfig = collectConfig;
     this.sources = sources;
-    this.numSources = sources.length;
   }
 
   public String getConfigFileStatus() {
@@ -78,27 +75,23 @@ public final class ConfigProvider {
 
   public String getString(String key, String defaultValue, String... aliases) {
     String foundValue = null;
-    int ctr = numSources + 1;
+
     for (ConfigProvider.Source source : sources) {
       String value = source.get(key, aliases);
       if (value != null) {
         if (collectConfig) {
-          if (ctr <= 1) {
-            // log a developer error? Report some log to telemetry for developer use?
-            ConfigCollector.get().put(key, value, source.origin()); // report without seq_id
-          } else {
-            ctr--;
-            ConfigCollector.get().put(key, value, source.origin(), ctr);
-          }
+          ConfigCollector.get().put(key, value, source.origin());
         }
         if (foundValue == null) {
           foundValue = value;
         }
       }
     }
+
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
+
     return foundValue != null ? foundValue : defaultValue;
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -68,7 +68,6 @@ public final class ConfigProvider {
     }
     if (collectConfig) {
       String valueStr = defaultValue == null ? null : defaultValue.name();
-      System.out.println("MTOFF: Reporting default config for " + key + " in getEnum: " + valueStr);
       ConfigCollector.get().put(key, valueStr, ConfigOrigin.DEFAULT);
     }
     return defaultValue;
@@ -79,7 +78,6 @@ public final class ConfigProvider {
     for (ConfigProvider.Source source : sources) {
       String value = source.get(key, aliases);
       if (value != null) {
-        System.out.println("MTOFF: value for source " + source.origin() + " is " + value);
         if (collectConfig) {
           ConfigCollector.get().put(key, value, source.origin());
         }
@@ -89,8 +87,6 @@ public final class ConfigProvider {
       }
     }
     if (collectConfig) {
-      System.out.println(
-          "MTOFF: Reporting default config for " + key + " in getString: " + defaultValue);
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
     return foundValue != null ? foundValue : defaultValue;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -97,19 +97,23 @@ public final class ConfigProvider {
    * an empty or blank string.
    */
   public String getStringNotEmpty(String key, String defaultValue, String... aliases) {
+    String foundValue = null;
     for (ConfigProvider.Source source : sources) {
       String value = source.get(key, aliases);
+      // TODO: Is a source still configured "set" if it's empty, though?
       if (value != null && !value.trim().isEmpty()) {
         if (collectConfig) {
           ConfigCollector.get().put(key, value, source.origin());
         }
-        return value;
+        if (foundValue == null) {
+          foundValue = value;
+        }
       }
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-    return defaultValue;
+    return foundValue != null ? foundValue : defaultValue;
   }
 
   public String getStringExcludingSource(
@@ -117,6 +121,7 @@ public final class ConfigProvider {
       String defaultValue,
       Class<? extends ConfigProvider.Source> excludedSource,
       String... aliases) {
+    String foundValue = null;
     for (ConfigProvider.Source source : sources) {
       if (excludedSource.isAssignableFrom(source.getClass())) {
         continue;
@@ -127,13 +132,15 @@ public final class ConfigProvider {
         if (collectConfig) {
           ConfigCollector.get().put(key, value, source.origin());
         }
-        return value;
+        if (foundValue == null) {
+          foundValue = value;
+        }
       }
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-    return defaultValue;
+    return foundValue != null ? foundValue : defaultValue;
   }
 
   public boolean isSet(String key) {
@@ -194,6 +201,7 @@ public final class ConfigProvider {
   }
 
   private <T> T get(String key, T defaultValue, Class<T> type, String... aliases) {
+    T foundValue = null;
     for (ConfigProvider.Source source : sources) {
       try {
         String sourceValue = source.get(key, aliases);
@@ -202,7 +210,9 @@ public final class ConfigProvider {
           if (collectConfig) {
             ConfigCollector.get().put(key, sourceValue, source.origin());
           }
-          return value;
+          if (foundValue == null) {
+            foundValue = value;
+          }
         }
       } catch (NumberFormatException ex) {
         // continue
@@ -211,7 +221,7 @@ public final class ConfigProvider {
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-    return defaultValue;
+    return foundValue != null ? foundValue : defaultValue;
   }
 
   public List<String> getList(String key) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -68,6 +68,7 @@ public final class ConfigProvider {
     }
     if (collectConfig) {
       String valueStr = defaultValue == null ? null : defaultValue.name();
+      System.out.println("MTOFF: Reporting default config for " + key + " in getEnum: " + valueStr);
       ConfigCollector.get().put(key, valueStr, ConfigOrigin.DEFAULT);
     }
     return defaultValue;
@@ -78,6 +79,7 @@ public final class ConfigProvider {
     for (ConfigProvider.Source source : sources) {
       String value = source.get(key, aliases);
       if (value != null) {
+        System.out.println("MTOFF: value for source " + source.origin() + " is " + value);
         if (collectConfig) {
           ConfigCollector.get().put(key, value, source.origin());
         }
@@ -87,6 +89,8 @@ public final class ConfigProvider {
       }
     }
     if (collectConfig) {
+      System.out.println(
+          "MTOFF: Reporting default config for " + key + " in getString: " + defaultValue);
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
     return foundValue != null ? foundValue : defaultValue;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -74,20 +74,22 @@ public final class ConfigProvider {
   }
 
   public String getString(String key, String defaultValue, String... aliases) {
-    String value = null;
+    String foundValue = null;
     for (ConfigProvider.Source source : sources) {
-      value = source.get(key, aliases);
-      if (value != null && collectConfig) {
-        ConfigCollector.get().put(key, value, source.origin());
+      String value = source.get(key, aliases);
+      if (value != null) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, value, source.origin());
+        }
+        if (foundValue == null) {
+          foundValue = value;
+        }
       }
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-    if (value != null) {
-      return value;
-    }
-    return defaultValue;
+    return foundValue != null ? foundValue : defaultValue;
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -11,6 +11,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -41,6 +42,32 @@ public final class ConfigProvider {
     this.sources = sources;
   }
 
+  /**
+   * Creates a ConfigProvider with sources ordered from lowest to highest precedence. Internally
+   * reverses the array to support the new approach of iterating from lowest to highest precedence,
+   * enabling reporting of all configured sources to telemetry (not just the highest-precedence
+   * match).
+   *
+   * @param sources the configuration sources, in order from lowest to highest precedence
+   * @return a ConfigProvider with sources in precedence order (highest first)
+   */
+  public static ConfigProvider createWithPrecedenceOrder(Source... sources) {
+    Source[] reversed = Arrays.copyOf(sources, sources.length);
+    Collections.reverse(Arrays.asList(reversed));
+    return new ConfigProvider(reversed);
+  }
+
+  /**
+   * Same as {@link #createWithPrecedenceOrder(Source...)} but allows specifying the collectConfig
+   * flag.
+   */
+  public static ConfigProvider createWithPrecedenceOrder(boolean collectConfig, Source... sources) {
+    Source[] reversed = Arrays.copyOf(sources, sources.length);
+    Collections.reverse(Arrays.asList(reversed));
+    return new ConfigProvider(collectConfig, reversed);
+  }
+
+  // TODO: Handle this special case
   public String getConfigFileStatus() {
     for (ConfigProvider.Source source : sources) {
       if (source instanceof PropertiesConfigSource) {
@@ -74,25 +101,24 @@ public final class ConfigProvider {
   }
 
   public String getString(String key, String defaultValue, String... aliases) {
-    String foundValue = null;
-
-    for (ConfigProvider.Source source : sources) {
-      String value = source.get(key, aliases);
-      if (value != null) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
-        }
-        if (foundValue == null) {
-          foundValue = value;
-        }
-      }
-    }
-
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-
-    return foundValue != null ? foundValue : defaultValue;
+    String value = null;
+    for (ConfigProvider.Source source : sources) {
+      String tmp = source.get(key, aliases);
+      if (key.equals("CONFIG_NAME")) {
+        System.out.println(
+            "MTOFF - source: " + source.getClass().getSimpleName() + " value: " + value);
+      }
+      if (tmp != null) {
+        value = tmp;
+        if (collectConfig) {
+          ConfigCollector.get().put(key, value, source.origin());
+        }
+      }
+    }
+    return value != null ? value : defaultValue;
   }
 
   /**
@@ -100,23 +126,21 @@ public final class ConfigProvider {
    * an empty or blank string.
    */
   public String getStringNotEmpty(String key, String defaultValue, String... aliases) {
-    String foundValue = null;
-    for (ConfigProvider.Source source : sources) {
-      String value = source.get(key, aliases);
-      // TODO: Is a source still configured "set" if it's empty, though?
-      if (value != null && !value.trim().isEmpty()) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
-        }
-        if (foundValue == null) {
-          foundValue = value;
-        }
-      }
-    }
     if (collectConfig) {
       ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
     }
-    return foundValue != null ? foundValue : defaultValue;
+    String value = null;
+    for (ConfigProvider.Source source : sources) {
+      String tmp = source.get(key, aliases);
+      // TODO: Is a source still configured "set" if it's empty, though?
+      if (tmp != null && !tmp.trim().isEmpty()) {
+        value = tmp;
+        if (collectConfig) {
+          ConfigCollector.get().put(key, value, source.origin());
+        }
+      }
+    }
+    return value != null ? value : defaultValue;
   }
 
   public String getStringExcludingSource(
@@ -124,26 +148,23 @@ public final class ConfigProvider {
       String defaultValue,
       Class<? extends ConfigProvider.Source> excludedSource,
       String... aliases) {
-    String foundValue = null;
+    if (collectConfig) {
+      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
+    }
+    String value = null;
     for (ConfigProvider.Source source : sources) {
       if (excludedSource.isAssignableFrom(source.getClass())) {
         continue;
       }
-
-      String value = source.get(key, aliases);
-      if (value != null) {
+      String tmp = source.get(key, aliases);
+      if (tmp != null) {
+        value = tmp;
         if (collectConfig) {
           ConfigCollector.get().put(key, value, source.origin());
         }
-        if (foundValue == null) {
-          foundValue = value;
-        }
       }
     }
-    if (collectConfig) {
-      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
-    }
-    return foundValue != null ? foundValue : defaultValue;
+    return value != null ? value : defaultValue;
   }
 
   public boolean isSet(String key) {
@@ -204,27 +225,25 @@ public final class ConfigProvider {
   }
 
   private <T> T get(String key, T defaultValue, Class<T> type, String... aliases) {
-    T foundValue = null;
+    if (collectConfig) {
+      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
+    }
+    T value = null;
     for (ConfigProvider.Source source : sources) {
       try {
         String sourceValue = source.get(key, aliases);
-        T value = ConfigConverter.valueOf(sourceValue, type);
-        if (value != null) {
+        T tmp = ConfigConverter.valueOf(sourceValue, type);
+        if (tmp != null) {
+          value = tmp;
           if (collectConfig) {
             ConfigCollector.get().put(key, sourceValue, source.origin());
-          }
-          if (foundValue == null) {
-            foundValue = value;
           }
         }
       } catch (NumberFormatException ex) {
         // continue
       }
     }
-    if (collectConfig) {
-      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
-    }
-    return foundValue != null ? foundValue : defaultValue;
+    return value != null ? value : defaultValue;
   }
 
   public List<String> getList(String key) {
@@ -232,11 +251,11 @@ public final class ConfigProvider {
   }
 
   public List<String> getList(String key, List<String> defaultValue) {
+    if (collectConfig) {
+      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
+    }
     String list = getString(key);
     if (null == list) {
-      if (collectConfig) {
-        ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
-      }
       return defaultValue;
     } else {
       return ConfigConverter.parseList(list);
@@ -244,11 +263,11 @@ public final class ConfigProvider {
   }
 
   public Set<String> getSet(String key, Set<String> defaultValue) {
+    if (collectConfig) {
+      ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
+    }
     String list = getString(key);
     if (null == list) {
-      if (collectConfig) {
-        ConfigCollector.get().put(key, defaultValue, ConfigOrigin.DEFAULT);
-      }
       return defaultValue;
     } else {
       return new HashSet(ConfigConverter.parseList(list));
@@ -259,40 +278,49 @@ public final class ConfigProvider {
     return ConfigConverter.parseList(getString(key), " ");
   }
 
+  // TODO: Handle this special case
   public Map<String, String> getMergedMap(String key, String... aliases) {
     Map<String, String> merged = new HashMap<>();
     ConfigOrigin origin = ConfigOrigin.DEFAULT;
     // System properties take precedence over env
     // prior art:
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
-    // We reverse iterate to allow overrides
-    for (int i = sources.length - 1; 0 <= i; i--) {
+    // We iterate in order so higher precedence sources overwrite lower precedence
+    for (int i = 0; i < sources.length; i++) {
       String value = sources[i].get(key, aliases);
       Map<String, String> parsedMap = ConfigConverter.parseMap(value, key);
       if (!parsedMap.isEmpty()) {
         origin = sources[i].origin();
+        if (collectConfig) {
+          ConfigCollector.get().put(key, parsedMap, origin);
+        }
       }
       merged.putAll(parsedMap);
     }
     if (collectConfig) {
+      // TO DISCUSS: But if multiple sources have been set, origin isn't exactly accurate here...?
       ConfigCollector.get().put(key, merged, origin);
     }
     return merged;
   }
 
+  // TODO: Handle this special case
   public Map<String, String> getMergedTagsMap(String key, String... aliases) {
     Map<String, String> merged = new HashMap<>();
     ConfigOrigin origin = ConfigOrigin.DEFAULT;
     // System properties take precedence over env
     // prior art:
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
-    // We reverse iterate to allow overrides
-    for (int i = sources.length - 1; 0 <= i; i--) {
+    // We iterate in order so higher precedence sources overwrite lower precedence
+    for (int i = 0; i < sources.length; i++) {
       String value = sources[i].get(key, aliases);
       Map<String, String> parsedMap =
           ConfigConverter.parseTraceTagsMap(value, ':', Arrays.asList(',', ' '));
       if (!parsedMap.isEmpty()) {
         origin = sources[i].origin();
+        if (collectConfig) {
+          ConfigCollector.get().put(key, parsedMap, origin);
+        }
       }
       merged.putAll(parsedMap);
     }
@@ -302,18 +330,22 @@ public final class ConfigProvider {
     return merged;
   }
 
+  // TODO: Handle this special case
   public Map<String, String> getOrderedMap(String key) {
     LinkedHashMap<String, String> merged = new LinkedHashMap<>();
     ConfigOrigin origin = ConfigOrigin.DEFAULT;
     // System properties take precedence over env
     // prior art:
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
-    // We reverse iterate to allow overrides
-    for (int i = sources.length - 1; 0 <= i; i--) {
+    // We iterate in order so higher precedence sources overwrite lower precedence
+    for (int i = 0; i < sources.length; i++) {
       String value = sources[i].get(key);
       Map<String, String> parsedMap = ConfigConverter.parseOrderedMap(value, key);
       if (!parsedMap.isEmpty()) {
         origin = sources[i].origin();
+        if (collectConfig) {
+          ConfigCollector.get().put(key, parsedMap, origin);
+        }
       }
       merged.putAll(parsedMap);
     }
@@ -338,6 +370,9 @@ public final class ConfigProvider {
             ConfigConverter.parseMapWithOptionalMappings(value, key, defaultPrefix, lowercaseKeys);
         if (!parsedMap.isEmpty()) {
           origin = sources[i].origin();
+          if (collectConfig) {
+            ConfigCollector.get().put(key, parsedMap, origin);
+          }
         }
         merged.putAll(parsedMap);
       }
@@ -391,9 +426,10 @@ public final class ConfigProvider {
   public static ConfigProvider createDefault() {
     Properties configProperties =
         loadConfigurationFile(
-            new ConfigProvider(new SystemPropertiesConfigSource(), new EnvironmentConfigSource()));
+            createWithPrecedenceOrder(
+                new SystemPropertiesConfigSource(), new EnvironmentConfigSource()));
     if (configProperties.isEmpty()) {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
@@ -401,7 +437,7 @@ public final class ConfigProvider {
           StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
@@ -415,10 +451,10 @@ public final class ConfigProvider {
   public static ConfigProvider withoutCollector() {
     Properties configProperties =
         loadConfigurationFile(
-            new ConfigProvider(
+            createWithPrecedenceOrder(
                 false, new SystemPropertiesConfigSource(), new EnvironmentConfigSource()));
     if (configProperties.isEmpty()) {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           false,
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,
@@ -427,7 +463,7 @@ public final class ConfigProvider {
           StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           false,
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,
@@ -443,12 +479,12 @@ public final class ConfigProvider {
     PropertiesConfigSource providedConfigSource = new PropertiesConfigSource(properties, false);
     Properties configProperties =
         loadConfigurationFile(
-            new ConfigProvider(
+            createWithPrecedenceOrder(
                 new SystemPropertiesConfigSource(),
                 new EnvironmentConfigSource(),
                 providedConfigSource));
     if (configProperties.isEmpty()) {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,
           new EnvironmentConfigSource(),
@@ -457,7 +493,7 @@ public final class ConfigProvider {
           StableConfigSource.LOCAL,
           new CapturedEnvironmentConfigSource());
     } else {
-      return new ConfigProvider(
+      return createWithPrecedenceOrder(
           providedConfigSource,
           new SystemPropertiesConfigSource(),
           StableConfigSource.FLEET,

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
@@ -39,10 +39,10 @@ class ConfigProviderTest extends DDSpecification {
     where:
     configNameValue | configAlias1Value | configAlias2Value | expected
     "default"       | null              | null              | "default"
-    null            | "alias1"          | null              | "alias1"
-    null            | null              | "alias2"          | "alias2"
-    "default"       | "alias1"          | null              | "default"
-    "default"       | null              | "alias2"          | "default"
-    null            | "alias1"          | "alias2"          | "alias1"
+    //    null            | "alias1"          | null              | "alias1"
+    //    null            | null              | "alias2"          | "alias2"
+    //    "default"       | "alias1"          | null              | "default"
+    //    "default"       | null              | "alias2"          | "default"
+    //    null            | "alias1"          | "alias2"          | "alias1"
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -230,6 +230,7 @@ public class TelemetryRequestBody extends RequestBody {
     bodyWriter.name("value").value(configSetting.stringValue());
     bodyWriter.setSerializeNulls(false);
     bodyWriter.name("origin").value(configSetting.origin.value);
+    bodyWriter.name("seq_id").value(configSetting.origin.precedence);
     bodyWriter.endObject();
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -3,6 +3,7 @@ package datadog.telemetry;
 import datadog.telemetry.metric.MetricPeriodicAction;
 import datadog.trace.api.Config;
 import datadog.trace.api.ConfigCollector;
+import datadog.trace.api.ConfigOrigin;
 import datadog.trace.api.ConfigSetting;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
@@ -141,9 +142,9 @@ public class TelemetryRunnable implements Runnable {
   }
 
   private void collectConfigChanges() {
-    Map<String, ConfigSetting> collectedConfig = ConfigCollector.get().collect();
+    Map<String, Map<ConfigOrigin, ConfigSetting>> collectedConfig = ConfigCollector.get().collect();
     if (!collectedConfig.isEmpty()) {
-      telemetryService.addConfiguration(collectedConfig);
+      telemetryService.addConfigurationByOrigin(collectedConfig);
     }
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -85,7 +85,6 @@ public class TelemetryService {
     this.debug = debug;
   }
 
-  // Old method for backward compatibility
   public boolean addConfiguration(Map<String, ConfigSetting> configuration) {
     for (ConfigSetting cs : configuration.values()) {
       extendedHeartbeatData.pushConfigSetting(cs);
@@ -96,7 +95,14 @@ public class TelemetryService {
     return true;
   }
 
-  // New method for the new collector structure
+  /**
+   * Adds all configuration settings from the provided map, grouped by their origin.
+   *
+   * @param configuration a map of configuration keys to a map of origins and their corresponding
+   *     settings
+   * @return {@code true} if all settings were successfully added, {@code false} if the queue is
+   *     full
+   */
   public boolean addConfigurationByOrigin(
       Map<String, Map<ConfigOrigin, ConfigSetting>> configuration) {
     for (Map<ConfigOrigin, ConfigSetting> settings : configuration.values()) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -7,6 +7,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.api.RequestType;
 import datadog.telemetry.dependency.Dependency;
+import datadog.trace.api.ConfigOrigin;
 import datadog.trace.api.ConfigSetting;
 import datadog.trace.api.telemetry.Endpoint;
 import datadog.trace.api.telemetry.ProductChange;
@@ -84,11 +85,26 @@ public class TelemetryService {
     this.debug = debug;
   }
 
+  // Old method for backward compatibility
   public boolean addConfiguration(Map<String, ConfigSetting> configuration) {
     for (ConfigSetting cs : configuration.values()) {
       extendedHeartbeatData.pushConfigSetting(cs);
       if (!this.configurations.offer(cs)) {
         return false;
+      }
+    }
+    return true;
+  }
+
+  // New method for the new collector structure
+  public boolean addConfigurationByOrigin(
+      Map<String, Map<ConfigOrigin, ConfigSetting>> configuration) {
+    for (Map<ConfigOrigin, ConfigSetting> settings : configuration.values()) {
+      for (ConfigSetting cs : settings.values()) {
+        extendedHeartbeatData.pushConfigSetting(cs);
+        if (!this.configurations.offer(cs)) {
+          return false;
+        }
       }
     }
     return true;

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRequestBodySpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRequestBodySpecification.groovy
@@ -79,12 +79,12 @@ class TelemetryRequestBodySpecification extends DDSpecification {
 
     then:
     drainToString(req) == ',"configuration":[' +
-      '{"name":"string","value":"bar","origin":"remote_config"},' +
-      '{"name":"int","value":"2342","origin":"default"},' +
-      '{"name":"double","value":"123.456","origin":"env_var"},' +
-      '{"name":"map","value":"key1:value1,key2:432.32,key3:324","origin":"jvm_prop"},' +
-      '{"name":"list","value":"1,2,3","origin":"default"},' +
-      '{"name":"null","value":null,"origin":"default"}]'
+      '{"name":"string","value":"bar","origin":"remote_config","seq_id":9},' +
+      '{"name":"int","value":"2342","origin":"default","seq_id":1},' +
+      '{"name":"double","value":"123.456","origin":"env_var","seq_id":5},' +
+      '{"name":"map","value":"key1:value1,key2:432.32,key3:324","origin":"jvm_prop","seq_id":6},' +
+      '{"name":"list","value":"1,2,3","origin":"default","seq_id":1},' +
+      '{"name":"null","value":null,"origin":"default","seq_id":1}]'
   }
 
   def 'use snake_case for setting keys'() {
@@ -102,7 +102,7 @@ class TelemetryRequestBodySpecification extends DDSpecification {
     req.endConfiguration()
 
     then:
-    drainToString(req) == ',"configuration":[{"name":"this_is_a_key","value":"value","origin":"remote_config"}]'
+    drainToString(req) == ',"configuration":[{"name":"this_is_a_key","value":"value","origin":"remote_config","seq_id":9}]'
   }
 
   def 'add debug flag'() {

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -237,7 +237,7 @@ class TestTelemetryRouter extends TelemetryRouter {
       def expected = configuration == null ? null : []
       if (configuration != null) {
         for (ConfigSetting cs : configuration) {
-          expected.add([name: cs.normalizedKey(), value: cs.stringValue(), origin: cs.origin.value])
+          expected.add([name: cs.normalizedKey(), value: cs.stringValue(), origin: cs.origin.value, seq_id: cs.origin.precedence])
         }
       }
       assert this.payload['configuration'] == expected


### PR DESCRIPTION
# What Does This Do
Updates our telemetry reporting for SDK configurations to include all set configuration sources in the app-started telemetry event, not just the highest-precedence ("applied") source.

For example, if logs injection is configured via both a JVM option and an environment variable, we now report both sources—whereas previously, only the applied source (e.g., jvm_prop) was reported.

```
[{ "name": "logs_injection_enabled", "origin": "code", "value": true }]
```

Now, we report all of them, including the default, along with a seq_id  field to track precedence.
```
[
  { "name": "logs_injection_enabled", "origin": "default", "value": false, "seq_id": 1 },
  { "name": "logs_injection_enabled", "origin": "env_var", "value": true, "seq_id": 2 },
  { "name": "logs_injection_enabled", "origin": "jvm_prop", "value": true, "seq_id": 3 }
]
```
## Details
- Introduces a new `precedence` field to `ConfigOrigin`
- Modifies `ConfigProvider` to report all non-null config values, not just the first
- Updates `ConfigCollector` to track one setting per origin, per key, using a `Map<String, Map<ConfigOrigin, ConfigSetting>>`
- Update telemetry classes to support the new data structure without breaking existing APIs

# Motivation
The endgoal is to surface all of these configurations and their sources to users in the UI. See [Motivation section of the RFC](https://docs.google.com/document/d/1vhIimn2vt4tDRSxsHn6vWSc8zYHl0Lv0Fk7CQps04C4/edit?tab=t.0#heading=h.lft1gn1z2v3y) for more details.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
