### PR TITLE
Fix master failure after adding JDK 25 EA testing

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -436,11 +436,30 @@ public class CapturingTestBase {
       String compilerOutputDir = "/tmp/" + CapturedSnapshotTest.class.getSimpleName() + "-kotlin";
       args.setDestination(compilerOutputDir);
       args.setClasspath(System.getProperty("java.class.path"));
-      ExitCode exitCode =
-          compiler.execImpl(
-              new PrintingMessageCollector(System.out, MessageRenderer.WITHOUT_PATHS, true),
-              Services.EMPTY,
-              args);
+      // We are currently testing JDK 25-ea, which is not yet generally available. This is causing
+      // Kotlin compilation issues for "25-ea" and "25". Temporarily override java.version "25-ea"
+      // to be the latest generally available JDK version "24".
+      // TODO: Revert this change once JDK 25 is generally available and tested.
+      String originalJavaVersion = System.getProperty("java.version");
+      boolean overrideEAJavaVersion =
+          originalJavaVersion != null && originalJavaVersion.contains("-ea");
+      ExitCode exitCode;
+      try {
+        if (overrideEAJavaVersion) {
+          System.setProperty("java.version", "24");
+        }
+        exitCode =
+            compiler.execImpl(
+                new PrintingMessageCollector(System.out, MessageRenderer.WITHOUT_PATHS, true),
+                Services.EMPTY,
+                args);
+      } finally {
+        // Restore the original java.version if it was overridden (25-ea)
+        if (overrideEAJavaVersion) {
+          System.setProperty("java.version", originalJavaVersion);
+        }
+      }
+
       if (exitCode.getCode() != 0) {
         throw new RuntimeException("Kotlin compilation failed");
       }


### PR DESCRIPTION
# What Does This Do

Kotlin compilation fails for JDK 25 EA and JDK 25 (unreleased). So, temporarily override the `java.version` to be the latest JDK general release `24` until `25` is GA-ed and tested.

# Motivation

Fix master

# Additional Notes

Master failure: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1053846178
Running `./gradlew :dd-java-agent:agent-debugger:test -PtestJvm=25` was failing but now passes locally.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
