### PR TITLE
Update GitLab provided tags

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
@@ -41,6 +41,9 @@ class GitLabInfo implements CIProviderInfo {
   public static final String GITLAB_CI_RUNNER_TAGS = "CI_RUNNER_TAGS";
   public static final String GITLAB_PULL_REQUEST_BASE_BRANCH =
       "CI_MERGE_REQUEST_TARGET_BRANCH_NAME";
+  public static final String GITLAB_PULL_REQUEST_BASE_SHA = "CI_MERGE_REQUEST_DIFF_BASE_SHA";
+  public static final String GITLAB_PULL_REQUEST_BASE_HEAD_SHA =
+      "CI_MERGE_REQUEST_TARGET_BRANCH_SHA";
   public static final String GITLAB_PULL_REQUEST_COMMIT_HEAD_SHA =
       "CI_MERGE_REQUEST_SOURCE_BRANCH_SHA";
   public static final String GITLAB_PULL_REQUEST_NUMBER = "CI_MERGE_REQUEST_IID";
@@ -88,8 +91,8 @@ class GitLabInfo implements CIProviderInfo {
   public PullRequestInfo buildPullRequestInfo() {
     return new PullRequestInfo(
         normalizeBranch(environment.get(GITLAB_PULL_REQUEST_BASE_BRANCH)),
-        null,
-        null,
+        environment.get(GITLAB_PULL_REQUEST_BASE_SHA),
+        environment.get(GITLAB_PULL_REQUEST_BASE_HEAD_SHA),
         new CommitInfo(environment.get(GITLAB_PULL_REQUEST_COMMIT_HEAD_SHA)),
         environment.get(GITLAB_PULL_REQUEST_NUMBER));
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/gitlab.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/gitlab.json
@@ -1080,8 +1080,10 @@
       "CI_JOB_NAME": "gitlab-job-name",
       "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_MERGE_REQUEST_DIFF_BASE_SHA": "bf6c156e8c1ec9cf43239162bca38cad22a3f4d2",
       "CI_MERGE_REQUEST_IID": 42,
       "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "target-branch",
+      "CI_MERGE_REQUEST_TARGET_BRANCH_SHA": "eb6dda23983998409db832ad675ec18ec32a8205",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
       "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
@@ -1110,6 +1112,8 @@
       "git.commit.message": "gitlab-git-commit-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.pull_request.base_branch": "target-branch",
+      "git.pull_request.base_branch_head_sha": "eb6dda23983998409db832ad675ec18ec32a8205",
+      "git.pull_request.base_branch_sha": "bf6c156e8c1ec9cf43239162bca38cad22a3f4d2",
       "git.repository_url": "https://gitlab.com/repo/myrepo.git",
       "pr.number": "42"
     }


### PR DESCRIPTION
# What Does This Do

- Adds support for the following tags in GitLab:
  - `git.pull_request.base_branch_sha` - `CI_MERGE_REQUEST_DIFF_BASE_SHA`
  - `git.pull_request.base_branch_head_sha` - `CI_MERGE_REQUEST_TARGET_BRANCH_SHA`

# Motivation

#9257 introduced the `git.pull_request.base_branch_head_sha` tag, which is also supported by environment variables provided by GitLab. Also, `CI_MERGE_REQUEST_DIFF_BASE_SHA` provides the base PR commit, which can be used by the impacted tests feature to skip the computation for the base commit.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-2351]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
