### PR TITLE
Align the Groovy version in project.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
   implementation("org.ow2.asm", "asm-tree", "9.8")
 
   testImplementation(libs.spock.core)
-  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")
+  testImplementation(libs.groovy)
 }
 
 tasks.compileKotlin {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   testImplementation("net.bytebuddy", "byte-buddy", "1.17.5")
   testImplementation(libs.spock.core)
   testImplementation("org.objenesis", "objenesis", "3.0.1")
-  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")
+  testImplementation(libs.groovy)
   testImplementation("javax.servlet", "javax.servlet-api", "3.0.1")
   testImplementation("com.github.spotbugs", "spotbugs-annotations", "4.2.0")
 }

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -56,7 +56,7 @@ dependencies {
   testFixturesApi project(':utils:test-utils')
   testImplementation libs.bytebuddy
   testImplementation('org.skyscreamer:jsonassert:1.5.1')
-  testImplementation('org.codehaus.groovy:groovy-yaml:3.0.17')
+  testImplementation libs.groovy.yaml
   testImplementation libs.guava
 
   testImplementation group: 'io.grpc', name: 'grpc-core', version: grpcVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ spock24-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "sp
 spock24-spring = { module = "org.spockframework:spock-spring", version = "spock24" }
 
 groovy = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy" }
+groovy-yaml = { module = "org.codehaus.groovy:groovy-yaml", version.ref = "groovy" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 


### PR DESCRIPTION
# What Does This Do
Align the Groovy version in project.

# Motivation
Using the same Groovy version throughout the project minimizes discrepancies in transitive dependencies.
Simplify future updates.
