### PR TITLE
Align the JMH version in project.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
   id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 
   id("com.gradleup.shadow") version "8.3.6" apply false
-  id("me.champeau.jmh") version "0.7.0" apply false
+  id("me.champeau.jmh") version "0.7.3" apply false
   id("org.gradle.playframework") version "0.13" apply false
   id("info.solidsoft.pitest") version "1.9.11" apply false
 }

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -63,7 +63,7 @@ idea {
 }
 
 jmh {
-  jmhVersion = '1.32'
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -112,7 +112,7 @@ spotless {
 }
 
 jmh {
-  jmhVersion = '1.28'
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 }
 
 jmh {
-  jmhVersion = '1.32'
+  jmhVersion = libs.versions.jmh.get()
   includeTests = true
 }
 compileJmhJava.dependsOn compileTestJava

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -51,7 +51,7 @@ processResources {
 }
 
 jmh {
-  jmhVersion = '1.32'
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
   jvmArgs = ['-Ddd.appsec.enabled=true -Xms64m -Xmx64m']
   failOnError = false

--- a/dd-java-agent/benchmark/build.gradle
+++ b/dd-java-agent/benchmark/build.gradle
@@ -35,7 +35,7 @@ jmh {
   // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
 
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
-  jmhVersion = '1.23' // Specifies JMH version
+  jmhVersion = libs.versions.jmh.get()
 }
 
 tasks.named('jmh').configure {

--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -87,6 +87,6 @@ tasks.withType(Test).configureEach {
 }
 
 jmh {
-  jmhVersion = '1.28'
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -101,6 +101,6 @@ dependencies {
 }
 
 jmh {
-  jmhVersion = '1.28'
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/dd-trace-ot/build.gradle.kts
+++ b/dd-trace-ot/build.gradle.kts
@@ -194,7 +194,7 @@ jmh {
   //  warmupBenchmarks = ['.*Warmup'] // Warmup benchmarks to include in the run in addition to already selected. JMH will not measure these benchmarks, but only use them for the warmup.
 
   //  zip64 = true // Use ZIP64 format for bigger archives
-  jmhVersion = "1.23" // Specifies JMH version
+  jmhVersion = libs.versions.jmh.get()
   //  includeTests = true // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
   //  duplicateClassesStrategy = 'warn' // Strategy to apply when encountring duplicate classes during creation of the fat jar (i.e. while executing jmhJar task)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ ddprof = "1.29.0"
 asm = "9.8"
 cafe_crypto = "0.1.0"
 lz4 = "1.7.1"
+jmh = "1.37"
 
 [libraries]
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -290,6 +290,6 @@ dependencies {
 }
 
 jmh {
-  jmhVersion = "1.32"
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/internal-api/internal-api-9/build.gradle.kts
+++ b/internal-api/internal-api-9/build.gradle.kts
@@ -54,7 +54,7 @@ idea {
 }
 
 jmh {
-  jmhVersion = "1.28"
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
   jvm = System.getenv("JAVA_11_HOME") + "/bin/java"
 }

--- a/telemetry/build.gradle.kts
+++ b/telemetry/build.gradle.kts
@@ -54,6 +54,6 @@ dependencies {
 }
 
 jmh {
-  jmhVersion = "1.28"
+  jmhVersion = libs.versions.jmh.get()
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
# What Does This Do
Align the JMH version in project.

# Motivation
Align the JMH (Java Microbenchmark Harness) version across the project to ensure consistency in benchmarking behavior and results. Simplify future updates.
