### PR TITLE
Add URI in string primitives

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -107,6 +107,7 @@ public class WellKnownClasses {
               "java.time.LocalDate",
               "java.time.LocalDateTime",
               "java.util.UUID",
+              "java.net.URI",
               "java.io.File",
               "sun.nio.fs.UnixPath",
               "sun.nio.fs.WindowsPath"));

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
@@ -20,15 +20,27 @@ public class SubStringExpression implements ValueExpression<Value<String>> {
   @Override
   public Value<String> evaluate(ValueReferenceResolver valueRefResolver) {
     Value<?> sourceValue = source != null ? source.evaluate(valueRefResolver) : Value.nullValue();
+    if (sourceValue.isUndefined()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (sourceValue.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
+    }
     if (sourceValue.getValue() instanceof String) {
       String sourceStr = (String) sourceValue.getValue();
-      try {
-        return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex));
-      } catch (StringIndexOutOfBoundsException ex) {
-        throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
-      }
+      return internalEvaluate(sourceStr);
     }
     return Value.undefined();
+  }
+
+  private Value<String> internalEvaluate(String sourceStr) {
+    try {
+      return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex));
+    } catch (StringIndexOutOfBoundsException ex) {
+      throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
+    }
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
@@ -12,10 +12,13 @@ import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class EndsWithExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
+  // used to ref lookup
+  URI uri = URI.create("https://www.datadoghq.com");
 
   @Test
   void nullExpression() {
@@ -45,5 +48,12 @@ class EndsWithExpressionTest {
     expression = new EndsWithExpression(DSL.value("abc"), new StringValue("ab"));
     assertFalse(expression.evaluate(resolver));
     assertEquals("endsWith(\"abc\", \"ab\")", print(expression));
+  }
+
+  @Test
+  void stringPrimitives() {
+    EndsWithExpression expression = new EndsWithExpression(DSL.ref("uri"), new StringValue(".com"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("endsWith(uri, \".com\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
@@ -9,10 +9,13 @@ import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class MatchesExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
+  // used to ref lookup
+  URI uri = URI.create("https://www.datadoghq.com");
 
   @Test
   void nullExpression() {
@@ -48,5 +51,13 @@ class MatchesExpressionTest {
     expression = new MatchesExpression(DSL.value("abc"), new StringValue("[def]+"));
     assertFalse(expression.evaluate(resolver));
     assertEquals("matches(\"abc\", \"[def]+\")", print(expression));
+  }
+
+  @Test
+  void stringPrimitives() {
+    MatchesExpression expression =
+        new MatchesExpression(DSL.ref("uri"), new StringValue("^https?://w{3}\\.datadoghq\\.com$"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("matches(uri, \"^https?://w{3}\\.datadoghq\\.com$\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
@@ -9,10 +9,13 @@ import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class StartsWithExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
+  // used to ref lookup
+  URI uri = URI.create("https://www.datadoghq.com");
 
   @Test
   void nullExpression() {
@@ -43,5 +46,13 @@ class StartsWithExpressionTest {
     expression = new StartsWithExpression(DSL.value("abc"), new StringValue("bc"));
     assertFalse(expression.evaluate(resolver));
     assertEquals("startsWith(\"abc\", \"bc\")", print(expression));
+  }
+
+  @Test
+  void stringPrimitives() {
+    StartsWithExpression expression =
+        new StartsWithExpression(DSL.ref("uri"), new StringValue("https"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("startsWith(uri, \"https\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
@@ -3,31 +3,40 @@ package com.datadog.debugger.el.expressions;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 public class SubStringExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
+  // used to ref lookup
+  URI uri = URI.create("https://www.datadoghq.com");
+  Object nullValue = null;
 
   @Test
   void nullExpression() {
-    SubStringExpression expression = new SubStringExpression(null, 0, 0);
-    assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(null, 0, 0)", print(expression));
+    SubStringExpression expression1 = new SubStringExpression(null, 0, 0);
+    EvaluationException evaluationException =
+        assertThrows(EvaluationException.class, () -> expression1.evaluate(resolver));
+    assertEquals("substring(null, 0, 0)", evaluationException.getExpr());
+    SubStringExpression expression2 = new SubStringExpression(DSL.ref("nullValue"), 0, 0);
+    evaluationException =
+        assertThrows(EvaluationException.class, () -> expression2.evaluate(resolver));
+    assertEquals("substring(nullValue, 0, 0)", evaluationException.getExpr());
   }
 
   @Test
   void undefinedExpression() {
     SubStringExpression expression =
         new SubStringExpression(DSL.value(Values.UNDEFINED_OBJECT), 0, 0);
-    assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(UNDEFINED, 0, 0)", print(expression));
+    EvaluationException evaluationException =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("substring(UNDEFINED, 0, 0)", evaluationException.getExpr());
   }
 
   @Test
@@ -43,5 +52,12 @@ public class SubStringExpressionTest {
     EvaluationException evaluationException =
         assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
     assertEquals("substring(\"abc\", 0, 10)", evaluationException.getExpr());
+  }
+
+  @Test
+  void stringPrimitives() {
+    SubStringExpression expression = new SubStringExpression(DSL.ref("uri"), 0, 5);
+    assertEquals("https", expression.evaluate(resolver).getValue());
+    assertEquals("substring(uri, 0, 5)", print(expression));
   }
 }


### PR DESCRIPTION
# What Does This Do
To be able to use substring and string predicates on URI variables

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4169]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4169]: https://datadoghq.atlassian.net/browse/DEBUG-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ