### PR TITLE
Avoid using GITHUB_TOKEN for PR creation

### DIFF
--- a/.github/chainguard/self.update-docker-build-image.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-docker-build-image.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:ref:refs/heads/master
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/update-docker-build-image\.yaml@refs/heads/master
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/self.update-gradle-dependencies.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-gradle-dependencies.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:ref:refs/heads/master
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/update-gradle-dependencies\.yaml@refs/heads/master
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -3,21 +3,27 @@ name: Update Docker Build Image
 on:
   schedule:
     # A day after creating the tag from https://github.com/DataDog/dd-trace-java-docker-build/blob/master/.github/workflows/docker-tag.yml
-    - cron: '0 0 1 2,5,8,11 *'
+    - cron: "0 0 1 2,5,8,11 *"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag to use for the Docker build image'
+        description: "The tag to use for the Docker build image"
         required: true
-        default: 'vYY.MM'
-    
+        default: "vYY.MM"
+
 jobs:
   update-docker-build-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Required to commit and push changes to a new branch
-      pull-requests: write # Required to create a pull request
+      contents: write # Required to create and push branch
+      id-token: write # Required for OIDC token federation
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-java
+          policy: self.update-docker-build-image.create-pr
+
       - name: Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Download ghcommit CLI
@@ -55,12 +61,12 @@ jobs:
           sed -i '' -E 's|(BUILDER_IMAGE_VERSION_PREFIX:)[^#]*([#].*)|\1 "${{ steps.define-tag.outputs.tag }}-" \2|' .gitlab-ci.yml
       - name: Commit and push changes
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           ghcommit --repository ${{ github.repository }} --branch ${{ steps.define-branch.outputs.branch }} --add .gitlab-ci.yml --message "feat(ci): Update Docker build image"
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           gh pr create --title "Update Docker build image" \
             --base master \

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -1,7 +1,7 @@
 name: Update Gradle dependencies
 on:
   schedule:
-    - cron: '0 4 * * 0'
+    - cron: "0 4 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -9,13 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Update Gradle dependencies
     permissions:
-      contents: write # Required to commit and push changes to a new branch
-      pull-requests: write # Required to create a pull request
+      contents: write # Required to create new branch
+      id-token: write # Required for OIDC token federation
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-java
+          policy: self.update-gradle-dependencies.create-pr
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Download ghcommit CLI
         run: |
           curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
@@ -37,7 +43,7 @@ jobs:
           ./gradlew resolveAndLockAll --write-locks --parallel --stacktrace --no-daemon --max-workers=4
       - name: Commit changes
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           GH_ADD_ARGS=""
           COUNT=0
@@ -69,7 +75,7 @@ jobs:
           fi
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           # use echo to set a multiline body for the PR
           echo -e "This PR updates the Gradle dependencies. ⚠️ Don't forget to squash commits before merging. ⚠️\n\n- [ ] Update PR title if a code change is needed to support one of those new dependencies" | \


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
