### PR TITLE
Switch profile compression to zstd default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -39,13 +39,6 @@ public final class ProfilingConfig {
    */
   @Deprecated
   public static final String PROFILING_UPLOAD_COMPRESSION = "profiling.upload.compression";
-  /**
-   * Default compression value. Supported values are: - "on": equivalent to "lz4", will later be
-   * "zstd" - "off": disables compression - "lz4": uses LZ4 compression (fast with moderate
-   * compression ratio) - "gzip": uses GZIP compression (higher compression ratio but slower) -
-   * "zstd": uses ZSTD compression (high compression ratio with reasonable performance)
-   */
-  public static final String PROFILING_DEBUG_UPLOAD_COMPRESSION_DEFAULT = "lz4";
 
   public static final String PROFILING_PROXY_HOST = "profiling.proxy.host";
   public static final String PROFILING_PROXY_PORT = "profiling.proxy.port";
@@ -204,14 +197,22 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_DEBUG_DUMP_PATH = "profiling.debug.dump_path";
   public static final String PROFILING_DEBUG_JFR_DISABLED = "profiling.debug.jfr.disabled";
+  // spotless:off
   /**
-   * Configuration for profile upload compression. Supported values are: - "on": equivalent to "lz4"
-   * - "off": disables compression - "lz4": uses LZ4 compression (fast with moderate compression
-   * ratio) - "gzip": uses GZIP compression (higher compression ratio but slower) - "zstd": uses
-   * ZSTD compression (high compression ratio with reasonable performance)
+   * Configuration for profile upload compression.<br><br> Supported values are:
+   * <ul>
+   * <li><b>on</b>: equivalent to <b>zstd</b></li>
+   * <li><b>off</b>: disables compression</li>
+   * <li><b>lz4</b>: uses LZ4 compression (fast with moderate compression ratio)</li>
+   * <li><b>gzip</b>: uses GZIP compression (higher compression ratio but slower)</li>
+   * <li><b>zstd</b>: uses ZSTD compression (high compression ratio with reasonable performance)</li>
+   * </ul>
    */
+  // spotless:on
   public static final String PROFILING_DEBUG_UPLOAD_COMPRESSION =
       "profiling.debug.upload.compression";
+
+  public static final String PROFILING_DEBUG_UPLOAD_COMPRESSION_DEFAULT = "zstd";
 
   public static final String PROFILING_CONTEXT_ATTRIBUTES = "profiling.context.attributes";
 


### PR DESCRIPTION
# What Does This Do
It changes the default compressor for profiles.

# Motivation
Lower the transmission rates for profiler data.

# Additional Notes
We have been running our services with this compressor for more than a month with no observable issues. 
It should be safe to roll out the global change of the default compression mechanism.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11854]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11854]: https://datadoghq.atlassian.net/browse/PROF-11854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ