### PR TITLE
Fix `FootprintForkedTest` that was also measuring Spock mock

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
   testImplementation project(':remote-config:remote-config-core')
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
-  testImplementation group: 'org.openjdk.jol', name: 'jol-core', version: '0.16'
+  testImplementation group: 'org.openjdk.jol', name: 'jol-core', version: '0.17'
   testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.3'
   testImplementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version:'3.11.0'
   testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -25,8 +25,9 @@ class FootprintForkedTest extends DDSpecification {
     setup:
     CountDownLatch latch = new CountDownLatch(1)
     ValidatingSink sink = new ValidatingSink(latch)
-    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
-    features.supportsMetrics() >> true
+    DDAgentFeaturesDiscovery features = Stub(DDAgentFeaturesDiscovery) {
+      it.supportsMetrics() >> true
+    }
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("runtimeid","hostname", "env", "service", "version","language"),
       [].toSet() as Set<String>,
@@ -35,8 +36,10 @@ class FootprintForkedTest extends DDSpecification {
       1000,
       1000,
       100,
-      SECONDS)
-    long baseline = footprint(aggregator)
+      SECONDS
+      )
+    // Removing the 'features' as it's a mock, and mocks are heavyweight, e.g. around 22MiB
+    def baseline = footprint(aggregator, features)
     aggregator.start()
 
     when: "lots of traces are published"
@@ -70,7 +73,8 @@ class FootprintForkedTest extends DDSpecification {
     assert latch.await(30, SECONDS)
 
     then:
-    footprint(aggregator) - baseline <= 10 * 1024 * 1024
+    def layout = footprint(aggregator, features)
+    layout.totalSize() - baseline.totalSize() <= 10 * 1024 * 1024
 
     cleanup:
     aggregator.close()
@@ -134,9 +138,14 @@ class FootprintForkedTest extends DDSpecification {
   }
 
 
-  static long footprint(Object o) {
-    GraphLayout layout = GraphLayout.parseInstance(o)
-    System.err.println(layout.toFootprint())
-    return layout.totalSize()
+  static GraphLayout footprint(Object root, Object... excludedRootFieldInstance) {
+    GraphLayout layout = GraphLayout.parseInstance(root)
+
+    excludedRootFieldInstance.each {
+      layout = layout.subtract(GraphLayout.parseInstance(it))
+    }
+
+    println layout.toFootprint()
+    return layout
   }
 }


### PR DESCRIPTION
# What Does This Do

Removes the 'features' mock that made the test a bit unpredictable. 

This is a cherry pick from 

* https://github.com/DataDog/dd-trace-java/pull/9178/commits/b7aa90dbf3f2a27271943665842590742b0005d0
* https://github.com/DataDog/dd-trace-java/pull/9178

# Motivation

The memory footprint of `aggregator` was including the `features` Spock mock which included its stubs and its recorded invocations. This single mock could amount to ~22 MiB.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
