### PR TITLE
Fix small gradle mistakes

### DIFF
--- a/dd-java-agent/instrumentation/liberty-20/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-20/build.gradle
@@ -37,8 +37,7 @@ dependencies {
   webappCompileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   // compileOnly to avoid bringing all the test dependencies to the test app
   // these are to be provided by the system classloader on test time
-  webappCompileOnly project(':dd-java-agent:instrumentation:servlet:request-3')
-    .tasks['compileTestFixturesJava'].classpath
+  webappCompileOnly testFixtures(project(':dd-java-agent:instrumentation:servlet:request-3'))
   // only the testFixtures jar (not its dependencies) and groovy should be included in the webapp
   webappImplementation files(
     project(':dd-java-agent:instrumentation:servlet:request-3')

--- a/dd-java-agent/instrumentation/liberty-23/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-23/build.gradle
@@ -41,8 +41,7 @@ dependencies {
   webappCompileOnly group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '5.0.0'
   // compileOnly to avoid bringing all the test dependencies to the test app
   // these are to be provided by the system classloader on test time
-  webappCompileOnly project(':dd-java-agent:instrumentation:servlet:request-5')
-    .tasks['compileTestFixturesJava'].classpath
+  webappCompileOnly testFixtures(project(':dd-java-agent:instrumentation:servlet:request-5'))
   // only the testFixtures jar (not its dependencies) and groovy should be included in the webapp
   webappImplementation files(
     project(':dd-java-agent:instrumentation:servlet:request-5')

--- a/dd-java-agent/instrumentation/servlet/request-3/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   implementation project(':dd-java-agent:instrumentation:servlet-common')
 
-  testFixturesImplementation(project(':dd-java-agent:testing')) {
+  testFixturesApi(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
   testFixturesCompileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'

--- a/dd-java-agent/instrumentation/servlet/request-5/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-5/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     transitive = false
   }
 
-  testFixturesImplementation(project(':dd-java-agent:testing')) {
+  testFixturesApi(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
   testFixturesCompileOnly group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '5.0.0'

--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -19,9 +19,9 @@ repositories {
     url 'https://archive.apache.org/dist'
     patternLayout {
       artifact '/[organisation]/[module]/v[revision]/bin/apache-[organisation]-[revision].[ext]'
-      metadataSources {
-        artifact()
-      }
+    }
+    metadataSources {
+      it.artifact()
     }
   }
 }

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -14,9 +14,9 @@ repositories {
       // artifact '/[organisation]/[revision]/[module]/[organisation]-[module]-[revision].[ext]'
       // we download the full EE profile and not the servlet minimal one
       artifact '/[organisation]/[revision]/[organisation]-[revision].[ext]'
-      metadataSources {
-        artifact()
-      }
+    }
+    metadataSources {
+      it.artifact()
     }
   }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -111,8 +111,8 @@ configurations {
   }
 }
 
-tasks.withType(AbstractPublishToMaven).configureEach {
+tasks.withType(AbstractPublishToMaven).configureEach { task ->
   rootProject.subprojects {
-    mustRunAfter tasks.matching { it instanceof VerificationTask }
+    task.mustRunAfter tasks.matching { it instanceof VerificationTask }
   }
 }


### PR DESCRIPTION
# What Does This Do

Fix misplaced API usage, confusing API usage, and misuse of testFixtures API.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
