### PR TITLE
Fix docker build update workflow

### DIFF
--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "::notice::Using Docker build image tag: ${TAG}"
       - name: Update the Docker build image in GitLab CI config
         run: |
-          sed -i '' -E 's|(BUILDER_IMAGE_VERSION_PREFIX:)[^#]*([#].*)|\1 "${{ steps.define-tag.outputs.tag }}-" \2|' .gitlab-ci.yml
+          sed -i -E 's|(BUILDER_IMAGE_VERSION_PREFIX:)[^#]*([#].*)|\1 "${{ steps.define-tag.outputs.tag }}-" \2|' .gitlab-ci.yml
       - name: Commit and push changes
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
# What Does This Do

The extra `''` is only needed for macOS environments.

# Motivation

Fix failing GHA workflow.

# Additional Notes

See `Update the Docker build image in GitLab CI config` step in this failing GHA workflow: https://github.com/DataDog/dd-trace-java/actions/runs/16662709587/job/47163137648

VS. the step in a previously successful one: https://github.com/DataDog/dd-trace-java/actions/runs/15004105028/job/42158228806

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
