### PR TITLE
Fix jmxfetch workflow

### DIFF
--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -24,10 +24,6 @@ jobs:
       - name: Update Submodule
         run: |
           git submodule update --remote -- dd-java-agent/agent-jmxfetch/integrations-core
-      - name: Download ghcommit CLI
-        run: |
-          curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
-          chmod +x /usr/local/bin/ghcommit
       - name: Pick a branch name
         id: define-branch
         run: echo "branch=ci/update-jmxfetch-submodule-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# What Does This Do

Avoid using https://github.com/planetscale/ghcommit because `ghcommit` can only add files whereas this workflow needs to add a directory. Also use a `dd-octo-sts` token instead of `GITHUB_TOKEN` for PR creation (e.g. #9288). The policy for this workflow corresponds to #9303, which is already merged to `master`.

# Motivation

Fix failing workflow: https://github.com/DataDog/dd-trace-java/actions/runs/16732671104/job/47364223082

# Additional Notes

Because we're not using `ghcommit`, I expect the commits created in this PR to be unsigned. They will need to be manually signed before merging until #9302 is resolved.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-722

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
