### PR TITLE
Add Forwarded header as a source to client IP resolution

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/ClientIpAddressResolverSpecification.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/ClientIpAddressResolverSpecification.groovy
@@ -70,6 +70,14 @@ class ClientIpAddressResolverSpecification extends Specification {
     'fastly-client-ip' | '3.3.3.3' | '3.3.3.3'
     'cf-connecting-ip' | '4.4.4.4' | '4.4.4.4'
     'cf-connecting-ipv6' | '2001::2' | '2001::2'
+
+    'forwarded' | 'for=192.0.2.60;proto=http;by=203.0.113.43' | '192.0.2.60'
+    'forwarded' | 'For="[2001:db8:cafe::17]:4711"' | '2001:db8:cafe::17'
+    'forwarded' | 'for=192.0.2.43, for=198.51.100.17' | '198.51.100.17'
+    'forwarded' | 'for=192.0.2.43;proto=https;by=203.0.113.43' | '192.0.2.43'
+    'forwarded' | 'for="_gazonk"' | null
+    'forwarded' | 'for=unknown, for=8.8.8.8' | '8.8.8.8'
+    'forwarded' | 'for="[::ffff:192.0.2.128]";proto=http' | '192.0.2.128'
   }
 
   void 'test recognition strategy with custom header'() {
@@ -112,6 +120,9 @@ class ClientIpAddressResolverSpecification extends Specification {
 
     then:
     1 * context.getForwardedFor() >> null
+
+    then:
+    1 * context.getForwarded() >> null
 
     then:
     1 * context.getXClusterClientIp() >> null


### PR DESCRIPTION
# What Does This Do

Updates the resolver to include Forwarded as one of the evaluated headers

Modify the ParseForwarded implementation, now splits the Forwarded header on commas and iterates entries right-to-left, selecting the first valid public IP. This fixes incorrect behavior in cases like:
	
`Forwarded: for=192.0.2.43, for=198.51.100.17`
	
which previously returned the first (private) IP.

# Motivation

# Additional Notes

According to [RFC 7239, Section 4](https://datatracker.ietf.org/doc/html/rfc7239#section-4), the Forwarded header may contain a list of values, separated by commas, each representing a proxy that the request has passed through.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-58258]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
