### PR TITLE
Update GHA workflows to avoid creating PRs if no changes to commit

### DIFF
--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -26,18 +26,7 @@ jobs:
 
       - name: Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Download ghcommit CLI
-        run: |
-          curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
-          chmod +x /usr/local/bin/ghcommit
-      - name: Pick a branch name
-        id: define-branch
-        run: echo "branch=ci/update-docker-build-image-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Create branch
-        run: |
-          git checkout -b ${{ steps.define-branch.outputs.branch }}
-          git push -u origin ${{ steps.define-branch.outputs.branch }} --force
-      - name: Define the Docker build image tage to use
+      - name: Define the Docker build image tag to use
         id: define-tag
         run: |
           if [ -n "${{ github.event.inputs.tag }}" ]; then
@@ -59,12 +48,38 @@ jobs:
       - name: Update the Docker build image in GitLab CI config
         run: |
           sed -i -E 's|(BUILDER_IMAGE_VERSION_PREFIX:)[^#]*([#].*)|\1 "${{ steps.define-tag.outputs.tag }}-" \2|' .gitlab-ci.yml
+      - name: Check if changes should be committed
+        id: check-changes
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "No changes to commit, exiting."
+            echo "commit_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            echo "commit_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Download ghcommit CLI
+        if: steps.check-changes.outputs.commit_changes == 'true'
+        run: |
+          curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
+          chmod +x /usr/local/bin/ghcommit
+      - name: Pick a branch name
+        if: steps.check-changes.outputs.commit_changes == 'true'
+        id: define-branch
+        run: echo "branch=ci/update-docker-build-image-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Create branch
+        if: steps.check-changes.outputs.commit_changes == 'true'
+        run: |
+          git checkout -b ${{ steps.define-branch.outputs.branch }}
+          git push -u origin ${{ steps.define-branch.outputs.branch }} --force
       - name: Commit and push changes
+        if: steps.check-changes.outputs.commit_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           ghcommit --repository ${{ github.repository }} --branch ${{ steps.define-branch.outputs.branch }} --add .gitlab-ci.yml --message "feat(ci): Update Docker build image"
       - name: Create pull request
+        if: steps.check-changes.outputs.commit_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -24,28 +24,37 @@ jobs:
       - name: Update Submodule
         run: |
           git submodule update --remote -- dd-java-agent/agent-jmxfetch/integrations-core
+      - name: Check if changes should be committed
+        id: check-changes
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "No changes to commit, exiting."
+            echo "commit_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            echo "commit_changes=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Pick a branch name
+        if: steps.check-changes.outputs.commit_changes == 'true'
         id: define-branch
         run: echo "branch=ci/update-jmxfetch-submodule-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Create branch
+        if: steps.check-changes.outputs.commit_changes == 'true'
         run: |
           git checkout -b ${{ steps.define-branch.outputs.branch }}
           git push -u origin ${{ steps.define-branch.outputs.branch }} --force
       - name: Commit and push changes
+        if: steps.check-changes.outputs.commit_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [[ -z "$(git status -s)" ]]; then
-            echo "No changes to commit, exiting."
-            exit 0;
-          fi
-          git checkout -b ${{ steps.define-branch.outputs.branch }}
           git add dd-java-agent/agent-jmxfetch/integrations-core
           git commit -m "Update agent-jmxfetch submodule"
           git push origin ${{ steps.define-branch.outputs.branch }}
       - name: Create pull request
+        if: steps.check-changes.outputs.commit_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |


### PR DESCRIPTION
# What Does This Do

Following @AlexeyKuznetsov-DD 's recommendation in #9305, this PR updates the `update-docker-build-image` and `update-jmxfetch-submodule` workflows such that they only create PRs if there are changes to commit.

# Motivation

The `update-docker-build-image` created a PR with no changes: https://github.com/DataDog/dd-trace-java/pull/9305

The `update-jmxfetch-submodule` failed to create a PR because there were no commits made: https://github.com/DataDog/dd-trace-java/actions/runs/16737254881/job/47378527957

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
