### PR TITLE
chore: Revert adding log file and updating `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ replay_pid*
 .bsp/
 **/src/*/generated/*
 !dd-java-agent/benchmark/releases/*.jar
+**/errors/*.log
 
 # Magic for local JMC built
 /vendor/jmc-libs

--- a/buildSrc/.kotlin/errors/errors-1754401818862.log
+++ b/buildSrc/.kotlin/errors/errors-1754401818862.log
@@ -1,4 +1,0 @@
-kotlin version: 2.0.21
-error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
-    1. Kotlin compile daemon is ready
-


### PR DESCRIPTION
# What Does This Do
Revert adding error log from #9244 and updating `.gitignore` to ignore error logs.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
