### PR TITLE
ConfigProvider.Source bubbles up parsing errors to ConfigProvider with ConfigSourceException

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -76,12 +76,18 @@ public final class ConfigProvider {
 
   public String getString(String key, String defaultValue, String... aliases) {
     for (ConfigProvider.Source source : sources) {
-      String value = source.get(key, aliases);
-      if (value != null) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
+      try {
+        String value = source.get(key, aliases);
+        if (value != null) {
+          if (collectConfig) {
+            ConfigCollector.get().put(key, value, source.origin());
+          }
+          return value;
         }
-        return value;
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), source.origin());
+        }
       }
     }
     if (collectConfig) {
@@ -96,12 +102,18 @@ public final class ConfigProvider {
    */
   public String getStringNotEmpty(String key, String defaultValue, String... aliases) {
     for (ConfigProvider.Source source : sources) {
-      String value = source.get(key, aliases);
-      if (value != null && !value.trim().isEmpty()) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
+      try {
+        String value = source.get(key, aliases);
+        if (value != null && !value.trim().isEmpty()) {
+          if (collectConfig) {
+            ConfigCollector.get().put(key, value, source.origin());
+          }
+          return value;
         }
-        return value;
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), source.origin());
+        }
       }
     }
     if (collectConfig) {
@@ -119,13 +131,18 @@ public final class ConfigProvider {
       if (excludedSource.isAssignableFrom(source.getClass())) {
         continue;
       }
-
-      String value = source.get(key, aliases);
-      if (value != null) {
-        if (collectConfig) {
-          ConfigCollector.get().put(key, value, source.origin());
+      try {
+        String value = source.get(key, aliases);
+        if (value != null) {
+          if (collectConfig) {
+            ConfigCollector.get().put(key, value, source.origin());
+          }
+          return value;
         }
-        return value;
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), source.origin());
+        }
       }
     }
     if (collectConfig) {
@@ -202,6 +219,10 @@ public final class ConfigProvider {
           }
           return value;
         }
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), source.origin());
+        }
       } catch (NumberFormatException ex) {
         // continue
       }
@@ -252,12 +273,18 @@ public final class ConfigProvider {
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
     // We reverse iterate to allow overrides
     for (int i = sources.length - 1; 0 <= i; i--) {
-      String value = sources[i].get(key, aliases);
-      Map<String, String> parsedMap = ConfigConverter.parseMap(value, key);
-      if (!parsedMap.isEmpty()) {
-        origin = sources[i].origin();
+      try {
+        String value = sources[i].get(key, aliases);
+        Map<String, String> parsedMap = ConfigConverter.parseMap(value, key);
+        if (!parsedMap.isEmpty()) {
+          origin = sources[i].origin();
+        }
+        merged.putAll(parsedMap);
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), sources[i].origin());
+        }
       }
-      merged.putAll(parsedMap);
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, merged, origin);
@@ -273,13 +300,19 @@ public final class ConfigProvider {
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
     // We reverse iterate to allow overrides
     for (int i = sources.length - 1; 0 <= i; i--) {
-      String value = sources[i].get(key, aliases);
-      Map<String, String> parsedMap =
-          ConfigConverter.parseTraceTagsMap(value, ':', Arrays.asList(',', ' '));
-      if (!parsedMap.isEmpty()) {
-        origin = sources[i].origin();
+      try {
+        String value = sources[i].get(key, aliases);
+        Map<String, String> parsedMap =
+            ConfigConverter.parseTraceTagsMap(value, ':', Arrays.asList(',', ' '));
+        if (!parsedMap.isEmpty()) {
+          origin = sources[i].origin();
+        }
+        merged.putAll(parsedMap);
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), sources[i].origin());
+        }
       }
-      merged.putAll(parsedMap);
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, merged, origin);
@@ -295,12 +328,18 @@ public final class ConfigProvider {
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
     // We reverse iterate to allow overrides
     for (int i = sources.length - 1; 0 <= i; i--) {
-      String value = sources[i].get(key);
-      Map<String, String> parsedMap = ConfigConverter.parseOrderedMap(value, key);
-      if (!parsedMap.isEmpty()) {
-        origin = sources[i].origin();
+      try {
+        String value = sources[i].get(key);
+        Map<String, String> parsedMap = ConfigConverter.parseOrderedMap(value, key);
+        if (!parsedMap.isEmpty()) {
+          origin = sources[i].origin();
+        }
+        merged.putAll(parsedMap);
+      } catch (ConfigSourceException e) {
+        if (collectConfig) {
+          ConfigCollector.get().put(key, e.getRawValue(), sources[i].origin());
+        }
       }
-      merged.putAll(parsedMap);
     }
     if (collectConfig) {
       ConfigCollector.get().put(key, merged, origin);
@@ -318,13 +357,20 @@ public final class ConfigProvider {
     // We reverse iterate to allow overrides
     for (String key : keys) {
       for (int i = sources.length - 1; 0 <= i; i--) {
-        String value = sources[i].get(key);
-        Map<String, String> parsedMap =
-            ConfigConverter.parseMapWithOptionalMappings(value, key, defaultPrefix, lowercaseKeys);
-        if (!parsedMap.isEmpty()) {
-          origin = sources[i].origin();
+        try {
+          String value = sources[i].get(key);
+          Map<String, String> parsedMap =
+              ConfigConverter.parseMapWithOptionalMappings(
+                  value, key, defaultPrefix, lowercaseKeys);
+          if (!parsedMap.isEmpty()) {
+            origin = sources[i].origin();
+          }
+          merged.putAll(parsedMap);
+        } catch (ConfigSourceException e) {
+          if (collectConfig) {
+            ConfigCollector.get().put(key, e.getRawValue(), sources[i].origin());
+          }
         }
-        merged.putAll(parsedMap);
       }
       if (collectConfig) {
         ConfigCollector.get().put(key, merged, origin);
@@ -500,7 +546,7 @@ public final class ConfigProvider {
   }
 
   public abstract static class Source {
-    public final String get(String key, String... aliases) {
+    public final String get(String key, String... aliases) throws ConfigSourceException {
       String value = get(key);
       if (value != null) {
         return value;
@@ -514,7 +560,7 @@ public final class ConfigProvider {
       return null;
     }
 
-    protected abstract String get(String key);
+    protected abstract String get(String key) throws ConfigSourceException;
 
     public abstract ConfigOrigin origin();
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigSourceException.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigSourceException.java
@@ -1,0 +1,23 @@
+package datadog.trace.bootstrap.config.provider;
+
+/**
+ * Exception thrown when a ConfigProvider.Source encounters an error (e.g., parsing, IO, or format
+ * error) while retrieving a configuration value.
+ */
+public class ConfigSourceException extends Exception {
+  private final Object rawValue;
+
+  public ConfigSourceException(String message, Object rawValue, Throwable cause) {
+    super(message, cause);
+    this.rawValue = rawValue;
+  }
+
+  public ConfigSourceException(Object rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  /** Returns the raw value that caused the exception, if available. */
+  public Object getRawValue() {
+    return rawValue;
+  }
+}


### PR DESCRIPTION
…d throw this exception, and introduce tests

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
