### PR TITLE
Update Spock to 2.4-M6.

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/build.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/build.gradle
@@ -46,7 +46,11 @@ tasks.named("check").configure {
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
-  testImplementation libs.bundles.spock24
+
+  // Using Spock 2.4-M6 because it contains fix for deadlock when blocking in mock response generators.
+  // See: https://github.com/spockframework/spock/pull/1910
+  testImplementation libs.spock24.core
+  testImplementation libs.spock24.junit4
 }
 
 // Set all compile tasks to use JDK21 but let instrumentation code targets 1.8 compatibility

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ objenesis = { module = "org.objenesis:objenesis", version = "3.3" } # Used by Sp
 spock24-core = { module = "org.spockframework:spock-core", version.ref = "spock24" }
 spock24-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spock24" }
 spock24-spring = { module = "org.spockframework:spock-spring", version.ref = "spock24" }
-objenesis34 = { module = "org.objenesis:objenesis", version = "3.4" }
 
 groovy = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy" }
 groovy-yaml = { module = "org.codehaus.groovy:groovy-yaml", version.ref = "groovy" }
@@ -108,7 +107,6 @@ asm = ["asm", "asmcommons"]
 cafe-crypto = ["cafe-crypto-curve25519", "cafe-crypto-ed25519"]
 # Testing
 spock = ["spock-core", "spock-junit4", "objenesis"]
-spock24 = ["spock24-core", "spock24-junit4", "objenesis34"]
 spock24-spring = ["spock24-core", "spock24-junit4", "spock24-spring"]
 junit5 = ["junit-jupiter", "junit-jupiter-params"]
 mockito = ["mokito-core", "mokito-junit-jupiter", "byte-buddy", "byte-buddy-agent"]


### PR DESCRIPTION
# What Does This Do

Update module `java-concurrent-21` to use Spock 2.4 to mitigate issue with hanging test on GitLab.
Spock 2.4 contains fix for possible deadlock, when blocking in mock response generators.
See: [Spock release notes](https://github.com/spockframework/spock/blob/master/docs/release_notes.adoc#misc-2)

# Motivation
Green CI

# Additional Notes
This change addresses test hangs observed in this module, which appear to be similar to issues seen in several other modules. If this fix proves effective in resolving the freezing behavior on GitLab, we will apply similar updates to the remaining affected modules.

NOTE, that we are not upgrading the entire project to Spock 2.4 at this time. Initial attempts to do so resulted in widespread test failures without clear root causes. A full upgrade will require further investigation and will be handled separately.

