### PR TITLE
Allow `testJvm` property to receive paths

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -1,6 +1,9 @@
 import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
 
+import java.nio.file.Files
+import java.nio.file.Paths
+
 apply plugin: 'java-library'
 
 apply from: "$rootDir/gradle/codenarc.gradle"
@@ -164,17 +167,22 @@ project.afterEvaluate {
     testJvm = javaVersions.max().toString()
   }
   if (testJvm) {
-    def matcher = testJvm =~ /([a-zA-Z]*)([0-9]+)/
-    if (!matcher.matches()) {
-      throw new GradleException("Unable to find launcher for Java '$testJvm'. It needs to match '([a-zA-Z]*)([0-9]+)'.")
+    def testJvmHomePath
+    if (Files.exists(Paths.get(testJvm))) {
+      testJvmHomePath = getJavaHomePath(testJvm)
+    } else {
+      def matcher = testJvm =~ /([a-zA-Z]*)([0-9]+)/
+      if (!matcher.matches()) {
+        throw new GradleException("Unable to find launcher for Java '$testJvm'. It needs to match '([a-zA-Z]*)([0-9]+)'.")
+      }
+      def testJvmLanguageVersion = matcher.group(2) as Integer
+      def testJvmEnv = "JAVA_${testJvm}_HOME"
+      def testJvmHome = System.getenv(testJvmEnv)
+      if (!testJvmHome) {
+        throw new GradleException("Unable to find launcher for Java '$testJvm'. Have you set '$testJvmEnv'?")
+      }
+      testJvmHomePath = getJavaHomePath(testJvmHome)
     }
-    def testJvmLanguageVersion = matcher.group(2) as Integer
-    def testJvmEnv = "JAVA_${testJvm}_HOME"
-    def testJvmHome = System.getenv(testJvmEnv)
-    if (!testJvmHome) {
-      throw new GradleException("Unable to find launcher for Java '$testJvm'. Have you set '$testJvmEnv'?")
-    }
-    def testJvmHomePath = getJavaHomePath(testJvmHome)
     // Only change test JVM if it's not the one we are running the gradle build with
     if (currentJavaHomePath != testJvmHomePath) {
       def jvmSpec = new SpecificInstallationToolchainSpec(project.services.get(PropertyFactory), file(testJvmHomePath))


### PR DESCRIPTION
# What Does This Do

Allow `testJvm` property to have paths.

# Motivation

Locally this allows to easily use a different JVM from the IDE, without having to set-up an environment variable before. In practice this allows to use either `-PtestJvm=JAVAMY_JVM_HOME` or `-PtestJvm=/path/to-/my-jvm`

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
