### PR TITLE
Improves CSS peer tag aggregation

### DIFF
--- a/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
@@ -1,0 +1,102 @@
+package datadog.trace.common.metrics;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
+import datadog.communication.monitor.Monitoring;
+import datadog.trace.api.WellKnownTags;
+import datadog.trace.core.CoreSpan;
+import datadog.trace.util.Strings;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 30, timeUnit = SECONDS)
+@Measurement(iterations = 3, time = 30, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+public class ConflatingMetricsAggregatorBenchmark {
+  private final DDAgentFeaturesDiscovery featuresDiscovery =
+      new FixedAgentFeaturesDiscovery(
+          Collections.singleton("peer.hostname"), Collections.emptySet());
+  private final ConflatingMetricsAggregator aggregator =
+      new ConflatingMetricsAggregator(
+          new WellKnownTags("", "", "", "", "", ""),
+          Collections.emptySet(),
+          featuresDiscovery,
+          new NullSink(),
+          2048,
+          2048);
+  private final List<CoreSpan<?>> spans = generateTrace(64);
+
+  static List<CoreSpan<?>> generateTrace(int len) {
+    final List<CoreSpan<?>> trace = new ArrayList<>();
+    for (int i = 0; i < len; i++) {
+      SimpleSpan span = new SimpleSpan("", "", "", "", true, true, false, 0, 10, -1);
+      span.setTag("peer.hostname", Strings.random(10));
+      trace.add(span);
+    }
+    return trace;
+  }
+
+  static class NullSink implements Sink {
+
+    @Override
+    public void register(EventListener listener) {}
+
+    @Override
+    public void accept(int messageCount, ByteBuffer buffer) {}
+  }
+
+  static class FixedAgentFeaturesDiscovery extends DDAgentFeaturesDiscovery {
+    private final Set<String> peerTags;
+    private final Set<String> spanKinds;
+
+    public FixedAgentFeaturesDiscovery(Set<String> peerTags, Set<String> spanKinds) {
+      // create a fixed discovery with metrics enabled
+      super(null, Monitoring.DISABLED, null, false, true);
+      this.peerTags = peerTags;
+      this.spanKinds = spanKinds;
+    }
+
+    @Override
+    public void discover() {
+      // do nothing
+    }
+
+    @Override
+    public boolean supportsMetrics() {
+      return true;
+    }
+
+    @Override
+    public Set<String> peerTags() {
+      return peerTags;
+    }
+
+    @Override
+    public Set<String> spanKindsToComputedStats() {
+      return spanKinds;
+    }
+  }
+
+  @Benchmark
+  public void benchmark(Blackhole blackhole) {
+    blackhole.consume(aggregator.publish(spans));
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -15,6 +15,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
+import datadog.trace.api.Pair;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -24,8 +25,8 @@ import datadog.trace.common.writer.ddagent.DDAgentApi;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.DDTraceCoreInfo;
 import datadog.trace.util.AgentTaskScheduler;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.jctools.maps.NonBlockingHashMap;
 import org.jctools.queues.MpscCompoundQueue;
 import org.jctools.queues.SpmcArrayQueue;
@@ -49,6 +51,20 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   private static final DDCache<String, UTF8BytesString> SERVICE_NAMES =
       DDCaches.newFixedSizeCache(32);
 
+  private static final DDCache<String, UTF8BytesString> SPAN_KINDS = DDCaches.newFixedSizeCache(16);
+  private static final DDCache<
+          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
+      PEER_TAGS_CACHE =
+          DDCaches.newUnboundedCache(
+              64); // it can be unbounded since those values are returned by the agent and should be
+  // under control.
+  private static final Function<
+          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
+      PEER_TAGS_CACHE_ADDER =
+          key ->
+              Pair.of(
+                  DDCaches.newFixedSizeCache(512),
+                  value -> UTF8BytesString.create(key + ":" + value));
   private static final CharSequence SYNTHETICS_ORIGIN = "synthetics";
 
   private final Set<String> ignoredResources;
@@ -288,12 +304,14 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     return isNewKey || span.getError() > 0;
   }
 
-  private Map<String, String> getPeerTags(CoreSpan<?> span) {
-    Map<String, String> peerTags = new HashMap<>();
+  private List<UTF8BytesString> getPeerTags(CoreSpan<?> span) {
+    List<UTF8BytesString> peerTags = new ArrayList<>();
     for (String peerTag : features.peerTags()) {
       Object value = span.getTag(peerTag);
       if (value != null) {
-        peerTags.put(peerTag, value.toString());
+        final Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> pair =
+            PEER_TAGS_CACHE.computeIfAbsent(peerTag, PEER_TAGS_CACHE_ADDER);
+        peerTags.add(pair.getLeft().computeIfAbsent(value.toString(), pair.getRight()));
       }
     }
     return peerTags;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -268,7 +268,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             span.getHttpStatusCode(),
             isSynthetic(span),
             span.isTopLevel(),
-            span.getTag(SPAN_KIND, ""),
+            SPAN_KINDS.computeIfAbsent(span.getTag(SPAN_KIND, ""), UTF8_ENCODE),
             getPeerTags(span));
     boolean isNewKey = false;
     MetricKey key = keys.putIfAbsent(newKey, newKey);

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -27,7 +27,7 @@ public final class MetricKey {
       int httpStatusCode,
       boolean synthetics,
       boolean isTraceRoot,
-      UTF8BytesString spanKind,
+      CharSequence spanKind,
       List<UTF8BytesString> peerTags) {
     this.resource = null == resource ? EMPTY : UTF8BytesString.create(resource);
     this.service = null == service ? EMPTY : UTF8BytesString.create(service);
@@ -36,7 +36,7 @@ public final class MetricKey {
     this.httpStatusCode = httpStatusCode;
     this.synthetics = synthetics;
     this.isTraceRoot = isTraceRoot;
-    this.spanKind = spanKind;
+    this.spanKind = null == spanKind ? EMPTY : UTF8BytesString.create(spanKind);
     this.peerTags = peerTags == null ? Collections.emptyList() : peerTags;
 
     // Unrolled polynomial hashcode to avoid varargs allocation

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -27,7 +27,7 @@ public final class MetricKey {
       int httpStatusCode,
       boolean synthetics,
       boolean isTraceRoot,
-      CharSequence spanKind,
+      UTF8BytesString spanKind,
       List<UTF8BytesString> peerTags) {
     this.resource = null == resource ? EMPTY : UTF8BytesString.create(resource);
     this.service = null == service ? EMPTY : UTF8BytesString.create(service);
@@ -36,7 +36,7 @@ public final class MetricKey {
     this.httpStatusCode = httpStatusCode;
     this.synthetics = synthetics;
     this.isTraceRoot = isTraceRoot;
-    this.spanKind = null == spanKind ? EMPTY : UTF8BytesString.create(spanKind);
+    this.spanKind = spanKind;
     this.peerTags = peerTags == null ? Collections.emptyList() : peerTags;
 
     // Unrolled polynomial hashcode to avoid varargs allocation

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -4,7 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.UTF8BytesString.EMPTY;
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 /** The aggregation key for tracked metrics. */
 public final class MetricKey {
@@ -17,7 +17,7 @@ public final class MetricKey {
   private final int hash;
   private final boolean isTraceRoot;
   private final UTF8BytesString spanKind;
-  private final Map<String, String> peerTags;
+  private final List<UTF8BytesString> peerTags;
 
   public MetricKey(
       CharSequence resource,
@@ -28,7 +28,7 @@ public final class MetricKey {
       boolean synthetics,
       boolean isTraceRoot,
       CharSequence spanKind,
-      Map<String, String> peerTags) {
+      List<UTF8BytesString> peerTags) {
     this.resource = null == resource ? EMPTY : UTF8BytesString.create(resource);
     this.service = null == service ? EMPTY : UTF8BytesString.create(service);
     this.operationName = null == operationName ? EMPTY : UTF8BytesString.create(operationName);
@@ -37,7 +37,7 @@ public final class MetricKey {
     this.synthetics = synthetics;
     this.isTraceRoot = isTraceRoot;
     this.spanKind = null == spanKind ? EMPTY : UTF8BytesString.create(spanKind);
-    this.peerTags = peerTags == null ? Collections.emptyMap() : peerTags;
+    this.peerTags = peerTags == null ? Collections.emptyList() : peerTags;
 
     // Unrolled polynomial hashcode to avoid varargs allocation
     // and eliminate data dependency between iterations as in Arrays.hashCode.
@@ -90,7 +90,7 @@ public final class MetricKey {
     return spanKind;
   }
 
-  public Map<String, String> getPeerTags() {
+  public List<UTF8BytesString> getPeerTags() {
     return peerTags;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -1,7 +1,6 @@
 package datadog.trace.common.metrics;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.WritableFormatter;
@@ -9,8 +8,7 @@ import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.util.TraceUtils;
-import java.util.Map;
+import java.util.List;
 
 public final class SerializingMetricWriter implements MetricWriter {
 
@@ -126,19 +124,11 @@ public final class SerializingMetricWriter implements MetricWriter {
     writer.writeUTF8(key.getSpanKind());
 
     writer.writeUTF8(PEER_TAGS);
-    Map<String, String> peerTags = key.getPeerTags();
+    final List<UTF8BytesString> peerTags = key.getPeerTags();
     writer.startArray(peerTags.size());
 
-    StringBuilder peerTagBuilder = new StringBuilder();
-    for (Map.Entry<String, String> peerTag : peerTags.entrySet()) {
-      peerTagBuilder.setLength(0);
-      String toWrite =
-          peerTagBuilder
-              .append(peerTag.getKey())
-              .append(':')
-              .append(TraceUtils.normalizeTag(peerTag.getValue()))
-              .toString();
-      writer.writeUTF8(toWrite.getBytes(UTF_8));
+    for (UTF8BytesString peerTag : peerTags) {
+      writer.writeUTF8(peerTag);
     }
 
     writer.writeUTF8(HITS);

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics
 
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.test.util.DDSpecification
 
 import java.util.concurrent.BlockingDeque
@@ -51,7 +52,7 @@ class AggregateMetricTest extends DDSpecification {
     given:
     AggregateMetric aggregate = new AggregateMetric().recordDurations(3, new AtomicLongArray(0L, 0L, 0L | ERROR_TAG | TOP_LEVEL_TAG))
 
-    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", "type", 0, false, true, "corge", ["grault":"quux"]))
+    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")]))
     batch.add(0L, 10)
     batch.add(0L, 10)
     batch.add(0L, 10)
@@ -126,7 +127,7 @@ class AggregateMetricTest extends DDSpecification {
   def "consistent under concurrent attempts to read and write"() {
     given:
     AggregateMetric aggregate = new AggregateMetric()
-    MetricKey key = new MetricKey("foo", "bar", "qux", "type", 0, false, true, "corge", ["grault":"quux"])
+    MetricKey key = new MetricKey("foo", "bar", "qux", "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")])
     BlockingDeque<Batch> queue = new LinkedBlockingDeque<>(1000)
     ExecutorService reader = Executors.newSingleThreadExecutor()
     int writerCount = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -125,7 +125,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       true,
       "baz",
-      [:]
+      []
       ), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
       }
@@ -168,7 +168,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       false,
       kind,
-      [:]
+      []
       ), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
@@ -221,7 +221,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       false,
       "grault",
-      ["country":"france"]
+      [UTF8BytesString.create("country:france")]
       ), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
@@ -235,7 +235,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       false,
       "grault",
-      ["country":"france", "georegion":"europe"]
+      [UTF8BytesString.create("country:france"), UTF8BytesString.create("georegion:europe")]
       ), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
@@ -277,7 +277,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       topLevel,
       "baz",
-      [:]
+      []
       ), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getTopLevelCount() == topLevelCount && value.getDuration() == 100
       })
@@ -333,7 +333,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       false,
       "baz",
-      [:]
+      []
       ), { AggregateMetric value ->
         value.getHitCount() == count && value.getDuration() == count * duration
       })
@@ -346,7 +346,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       false,
       "baz",
-      [:]
+      []
       ), { AggregateMetric value ->
         value.getHitCount() == count && value.getDuration() == count * duration * 2
       })
@@ -396,7 +396,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         false,
         true,
         "baz",
-        [:]
+        []
         ), _) >> { MetricKey key, AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         }
@@ -410,7 +410,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       true,
       "baz",
-      [:]
+      []
       ), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
@@ -456,7 +456,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         false,
         true,
         "baz",
-        [:]
+        []
         ), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
@@ -487,7 +487,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         false,
         true,
         "baz",
-        [:]
+        []
         ),{ AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
@@ -501,7 +501,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       false,
       true,
       "baz",
-      [:]
+      []
       ), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
@@ -547,7 +547,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         false,
         true,
         "quux",
-        [:]
+        []
         ), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
@@ -603,7 +603,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         false,
         true,
         "garply",
-        [:]
+        []
         ), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -2,6 +2,7 @@ import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.communication.http.OkHttpUtils
 import datadog.trace.api.Config
 import datadog.trace.api.WellKnownTags
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.metrics.AggregateMetric
 import datadog.trace.common.metrics.EventListener
 import datadog.trace.common.metrics.MetricKey
@@ -34,11 +35,11 @@ class MetricsIntegrationTest extends AbstractTraceAgentTest {
       )
     writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))
     writer.add(
-      new MetricKey("resource1", "service1", "operation1", "sql", 0, false, true, "xyzzy", ["grault":"quux"]),
+      new MetricKey("resource1", "service1", "operation1", "sql", 0, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")]),
       new AggregateMetric().recordDurations(5, new AtomicLongArray(2, 1, 2, 250, 4, 5))
       )
     writer.add(
-      new MetricKey("resource2", "service2", "operation2", "web", 200, false, true, "xyzzy", ["grault":"quux"]),
+      new MetricKey("resource2", "service2", "operation2", "web", 200, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")]),
       new AggregateMetric().recordDurations(10, new AtomicLongArray(1, 1, 200, 2, 3, 4, 5, 6, 7, 8, 9))
       )
     writer.finishBucket()


### PR DESCRIPTION
# What Does This Do

Improves CSS serializer performances by caching peer tags creations (avoids also utf8 conversions)

The cache has been choosen big enough to contains high cardinality tag values like (peer.hostname). -> tested with org2

A JMH test shows that in case of cache hit (obviously) performs better (see below).

The peer tags cache is unbounded since those tags have low cardinality (they are fixed and returned by the agent).


```

Benchmark  (NO CACHE)                                                        Mode  Cnt      Score     Error   Units
ConflatingMetricsAggregatorBenchmark.benchmark                     avgt    3      9.223 ±   0.622   us/op
ConflatingMetricsAggregatorBenchmark.benchmark:gc.alloc.rate       avgt    3   2177.221 ± 147.254  MB/sec
ConflatingMetricsAggregatorBenchmark.benchmark:gc.alloc.rate.norm  avgt    3  21056.002 ±   0.103    B/op
ConflatingMetricsAggregatorBenchmark.benchmark:gc.count            avgt    3    840.000            counts
ConflatingMetricsAggregatorBenchmark.benchmark:gc.time             avgt    3    573.000                ms
❯

Benchmark  (WITH CACHE)                                                        Mode  Cnt      Score     Error   Units
ConflatingMetricsAggregatorBenchmark.benchmark                     avgt    3      7.951 ±   0.986   us/op
ConflatingMetricsAggregatorBenchmark.benchmark:gc.alloc.rate       avgt    3   1788.643 ± 221.065  MB/sec
ConflatingMetricsAggregatorBenchmark.benchmark:gc.alloc.rate.norm  avgt    3  14911.998 ±   0.052    B/op
ConflatingMetricsAggregatorBenchmark.benchmark:gc.count            avgt    3    897.000            counts
ConflatingMetricsAggregatorBenchmark.benchmark:gc.time             avgt    3    537.000                ms
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
