### PR TITLE
🍒 9334 - Properly handle trace agent IPv6 URL in profiling

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4746,7 +4746,7 @@ public class Config {
       return "https://intake.profile." + site + "/api/v2/profile";
     } else {
       // when profilingUrl and agentless are not set we send to the dd trace agent running locally
-      return "http://" + agentHost + ":" + agentPort + "/profiling/v1/input";
+      return getAgentUrl() + "/profiling/v1/input";
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1652,6 +1652,19 @@ class ConfigTest extends DDSpecification {
     config.getFinalProfilingUrl() == "https://some.new.url/goes/here"
   }
 
+  def "ipv6 profiling url"() {
+    setup:
+    def configuredUrl = "http://[2600:1f14:1cfc:5f07::38d4]:8126"
+    def props = new Properties()
+    props.setProperty(TRACE_AGENT_URL, configuredUrl)
+
+    when:
+    Config config = Config.get(props)
+
+    then:
+    config.getFinalProfilingUrl() == configuredUrl + "/profiling/v1/input"
+  }
+
   def "fallback to DD_TAGS"() {
     setup:
     environmentVariables.set(DD_TAGS_ENV, "a:1,b:2,c:3")


### PR DESCRIPTION
Backport #9334 to release/v1.52.x