### PR TITLE
Detect dirtiness only if gradle property is enabled

### DIFF
--- a/buildSrc/src/integTest/kotlin/datadog/gradle/plugin/version/TracerVersionIntegrationTest.kt
+++ b/buildSrc/src/integTest/kotlin/datadog/gradle/plugin/version/TracerVersionIntegrationTest.kt
@@ -2,12 +2,12 @@ package datadog.gradle.plugin.version
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.IOException
-
 
 class TracerVersionIntegrationTest {
 
@@ -89,6 +89,13 @@ class TracerVersionIntegrationTest {
       projectDir,
       "1.53.0-SNAPSHOT-DIRTY",
       beforeGradle = {
+        println("Setting up git repository in $projectDir")
+        File(projectDir, "gradle.properties").writeText(
+          """
+          tracerVersion.dirtiness=true
+          """.trimIndent()
+        )
+
         exec(projectDir, "git", "init", "--initial-branch", "main")
         exec(projectDir, "git", "config", "user.email", "test@datadoghq.com")
         exec(projectDir, "git", "config", "user.name", "Test")
@@ -101,29 +108,6 @@ class TracerVersionIntegrationTest {
           // uncommitted change this file, 
         """.trimIndent())
       }
-    )
-  }
-
-  @Test
-  fun `should ignore dirtiness if CI env`(@TempDir projectDir: File) { // CI patch some tracked files
-    assertTracerVersion(
-      projectDir,
-      "1.52.0",
-      beforeGradle = {
-        exec(projectDir, "git", "init", "--initial-branch", "main")
-        exec(projectDir, "git", "config", "user.email", "test@datadoghq.com")
-        exec(projectDir, "git", "config", "user.name", "Test")
-        exec(projectDir, "git", "add", "-A")
-        exec(projectDir, "git", "commit", "-m", "A commit")
-        exec(projectDir, "git", "tag", "v1.52.0", "-m", "")
-
-        // dirty file ignored
-        File(projectDir, "settings.gradle.kts").appendText("""
-          
-          // uncommitted change this file, 
-        """.trimIndent())
-      },
-      additionalEnv = mapOf("CI" to "true")
     )
   }
 
@@ -157,6 +141,12 @@ class TracerVersionIntegrationTest {
       projectDir,
       "1.53.0-SNAPSHOT-DIRTY",
       beforeGradle = {
+        File(projectDir, "gradle.properties").writeText(
+          """
+          tracerVersion.dirtiness=true
+          """.trimIndent()
+        )
+
         exec(projectDir, "git", "init", "--initial-branch", "main")
         exec(projectDir, "git", "config", "user.email", "test@datadoghq.com")
         exec(projectDir, "git", "config", "user.name", "Test")
@@ -268,7 +258,6 @@ class TracerVersionIntegrationTest {
     expectedVersion: String,
     beforeGradle: () -> Unit = {},
     workingDirectory: File = projectDir,
-    additionalEnv: Map<String, String> = mapOf("CI" to "false"),
   ) {
     File(projectDir, "settings.gradle.kts").writeText(
       """
@@ -296,7 +285,6 @@ class TracerVersionIntegrationTest {
       // .withGradleVersion(gradleVersion)  // Use current gradle version
       .withPluginClasspath()
       .withArguments("printVersion", "--quiet")
-      .withEnvironment(System.getenv() + additionalEnv)
       .withProjectDir(workingDirectory)
       // .withDebug(true)
       .build()

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/TracerVersionPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/TracerVersionPlugin.kt
@@ -23,7 +23,9 @@ class TracerVersionPlugin @Inject constructor(
     val extension = targetProject.extensions.getByType(TracerVersionExtension::class.java)
 
     extension.detectDirty.set(
-      providerFactory.environmentVariable("CI").map { it != "true" }.orElse(true)
+       providerFactory.gradleProperty("tracerVersion.dirtiness")
+         .map { it.trim().toBoolean() }
+         .orElse(false)
     )
 
     val versionProvider = versionProvider(targetProject, extension)


### PR DESCRIPTION
# What Does This Do

Detect the dirtyness only of the property `tracerVersion.dirtiness` is true.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
