### PR TITLE
🍒 9355 - Fix NullPointerException log in AppSec

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/ddwaf/WAFModule.java
@@ -1,5 +1,6 @@
 package com.datadog.appsec.ddwaf;
 
+import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static datadog.trace.util.stacktrace.StackTraceEvent.DEFAULT_LANGUAGE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -557,6 +558,10 @@ public class WAFModule implements AppSecModule {
   }
 
   private Collection<AppSecEvent> buildEvents(Waf.ResultWithData actionWithData) {
+    if (actionWithData.data == null) {
+      log.debug(SEND_TELEMETRY, "WAF result data is null");
+      return Collections.emptyList();
+    }
     Collection<WAFResultData> listResults;
     try {
       listResults = RES_JSON_ADAPTER.fromJson(actionWithData.data);

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/ddwaf/WAFModuleSpecification.groovy
@@ -1682,6 +1682,19 @@ class WAFModuleSpecification extends DDSpecification {
     internal == libddwaf
   }
 
+  void 'ResultWithData - null data'() {
+    def waf = new WAFModule()
+    Waf.ResultWithData rwd = new Waf.ResultWithData(null, null, null, null)
+    Collection ret
+
+    when:
+    ret = waf.buildEvents(rwd)
+
+    then:
+    noExceptionThrown()
+    ret.isEmpty()
+  }
+
   /**
    * Helper to return a concrete Waf exception for each WafErrorCode
    */


### PR DESCRIPTION
What Does This Do
Backport https://github.com/DataDog/dd-trace-java/pull/9355 to release/v1.52.x

Motivation

Additional Notes

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
