### PR TITLE
Update ddapm-test-agent to latest 1.31.1.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -580,7 +580,7 @@ muzzle-dep-report:
     CI_USE_TEST_AGENT: "true"
     CI_AGENT_HOST: local-agent
   services:
-    - name: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.27.1
+    - name: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1
       alias: local-agent
       variables:
         LOG_LEVEL: "DEBUG"


### PR DESCRIPTION
# What Does This Do
Update ddapm-test-agent to latest 1.31.1.

# Motivation
Dogfood the latest deps and stay current.

