### PR TITLE
Improve stability of FixedSizeCacheTest identity/weak tests

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
@@ -112,7 +112,7 @@ class FixedSizeCacheTest extends DDSpecification {
 
   def "identity cache should store and retrieve values"() {
     setup:
-    def fsCache = DDCaches.newFixedSizeIdentityCache(15)
+    def fsCache = DDCaches.newFixedSizeIdentityCache(256)
     def creationCount = new AtomicInteger(0)
     def tvc = new TVC(creationCount)
     fsCache.computeIfAbsent(id1, tvc)
@@ -140,7 +140,7 @@ class FixedSizeCacheTest extends DDSpecification {
 
   def "weak key cache should store and retrieve values"() {
     setup:
-    def fsCache = DDCaches.newFixedSizeWeakKeyCache(15)
+    def fsCache = DDCaches.newFixedSizeWeakKeyCache(256)
     def creationCount = new AtomicInteger(0)
     def tvc = new TVC(creationCount)
     fsCache.computeIfAbsent(id1, tvc)


### PR DESCRIPTION
# What Does This Do

Improve stability of `FixedSizeCacheTest` identity/weak tests by eliminating the chance identity hash might collide even after 3 rehashes - the easiest way to do this is to bump the size of the cache used in testing.

# Motivation

Note this is only necessary because we want to keep both keys in the cache to test the 'visit' method - otherwise we could just relax that assertion.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
