### PR TITLE
Add policy for add-release-to-cloudfoundry

### DIFF
--- a/.github/chainguard/self.add-release-to-cloudfoundry.sts.yaml
+++ b/.github/chainguard/self.add-release-to-cloudfoundry.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:ref:refs/heads/master
+
+claim_pattern:
+  event_name: release
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/add-release-to-cloudfoundry\.yaml@refs/heads/master
+
+permissions:
+  contents: write


### PR DESCRIPTION
# What Does This Do

Add trust policy for `add-release-to-cloudfoundry` workflow

# Motivation

Update `add-release-to-cloudfoundry` to use a `dd-octo-sts` token to sign and push the commit made in the workflow.

# Additional Notes

Checked this policy with the [#sdlc-security](https://dd.enterprise.slack.com/archives/C027P1CK07N) team for the `add-release-to-cloudfoundry` workflow. TY!

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-701

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
