### PR TITLE
Fix nightly pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -953,10 +953,10 @@ publishing-gate:
   stage: publish
   needs:
     - job: verify_maven_central_deployment
-      optional: true
+      optional: true # Required for releases only
   rules:
     - if: '$POPULATE_CACHE'
-      when: never
+      when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
     - when: manual


### PR DESCRIPTION
# What Does This Do

Allow `publishing-gate` job to run when `POPULATE_CACHE` is true because we promote OCI artifacts to staging during nightly builds: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipeline_schedules?scope=ALL

# Motivation

Fix the nightly pipeline failure: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/73766389

# Additional Notes

I re-ran the nightly pipeline after this PR was merged, and it was successful: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/73812480

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
