### PR TITLE
Fix release script

### DIFF
--- a/tooling/perform-release.sh
+++ b/tooling/perform-release.sh
@@ -61,7 +61,7 @@ echo "✅ Working copy is clean and up-to-date."
 # Check the git log history
 LAST_RELEASE_TAG=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
 echo "ℹ️ Last release version: $LAST_RELEASE_TAG"
-SUSPICIOUS_COMMITS=$(git log --oneline --first-parent "$LAST_RELEASE_TAG"..HEAD | grep -E -v "Merge pull request #" | grep -E -v "\(#")
+SUSPICIOUS_COMMITS=$(git log --oneline --first-parent "$LAST_RELEASE_TAG"..HEAD | grep -E -v "Merge pull request #" | grep -E -v "\(#" || true)
 if [ -n "$SUSPICIOUS_COMMITS" ]; then
     echo "❌ The following commits are not merge commits and may not be suitable for a release:"
     echo "$SUSPICIOUS_COMMITS"
@@ -72,7 +72,7 @@ else
 fi
 
 # Get the next release version
-VERSION=$(echo "$LAST_RELEASE_TAG" | grep -E '^v[0-9]+\.[0-9]+\.0$' | sed 's/^v//')
+VERSION=$(echo "$LAST_RELEASE_TAG" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' || true)
 if [ -z "$VERSION" ]; then
     echo "❌ Unable to determine the next release version from the last release tag: $LAST_RELEASE_TAG"
     exit 1


### PR DESCRIPTION
# What Does This Do

This PR improves the release script:
* Do not stop on git log check
* Fix next patch release version compute

# Motivation

Improvement following @nayeem-kamal / @sarahchen6 feedback on last patch release

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-737]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-737]: https://datadoghq.atlassian.net/browse/LANGPLAT-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ