### PR TITLE
Increase timeout for :dd-java-agent:agent-ci-visibility:

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -1,3 +1,6 @@
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
 buildscript {
   repositories {
     mavenLocal()
@@ -71,4 +74,8 @@ shadowJar {
 
 jar {
   archiveClassifier = 'unbundled'
+}
+
+tasks.withType(Test).configureEach {
+  timeout = Duration.of(12, ChronoUnit.MINUTES)
 }


### PR DESCRIPTION
# What Does This Do

- Increase the timeout for `:dd-java-agent:agent-ci-visibility:` from the default 9m to 12m

# Motivation

The test has failed previously a couple of times with timeouts. This causes the tests to not be reported. Increasing the timeout a bit will hopefully provide better feedback on big fluctuations in execution times.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
