### PR TITLE
Use mockito mocks in Runtime CSI tests

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/build.gradle
@@ -11,4 +11,6 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testImplementation libs.bundles.mockito
+  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.11.0'
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
@@ -1,17 +1,12 @@
 package datadog.trace.instrumentation.java.lang
 
-import datadog.environment.JavaVirtualMachine
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.CommandInjectionModule
 import foo.bar.TestRuntimeSuite
-import groovy.transform.CompileDynamic
-import spock.lang.IgnoreIf
 
-@CompileDynamic
-@IgnoreIf(reason = "TODO: Fix for Java 25.", value = {
-  JavaVirtualMachine.isJavaVersionAtLeast(25)
-})
+import static org.mockito.Mockito.mock
+
 class RuntimeCallSiteTest extends AgentTestRunner {
 
   @Override
@@ -21,7 +16,7 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
   def 'test exec with command string'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = 'ls'
     InstrumentationBridge.registerIastModule(iastModule)
@@ -31,13 +26,12 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(command)
-    1 * runtime.exec(command)
     0 * _
   }
 
   def 'test exec with command string and env array'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = 'ls'
     final env = ['DD_TRACE_DEBUG=true'] as String[]
@@ -48,13 +42,12 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(env, command)
-    1 * runtime.exec(command, env)
     0 * _
   }
 
   def 'test exec with command string array'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = ['ls', '-lah'] as String[]
     InstrumentationBridge.registerIastModule(iastModule)
@@ -64,13 +57,12 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(command)
-    1 * runtime.exec(command)
     0 * _
   }
 
   def 'test exec with command string array and env array'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = ['ls', '-lah'] as String[]
     final env = ['DD_TRACE_DEBUG=true'] as String[]
@@ -81,13 +73,12 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(env, command)
-    1 * runtime.exec(command, env)
     0 * _
   }
 
   def 'test exec with command string and env array and dir'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = 'ls'
     final env = ['DD_TRACE_DEBUG=true'] as String[]
@@ -99,13 +90,12 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(env, command)
-    1 * runtime.exec(command, env, file)
     0 * _
   }
 
   def 'test exec with command string array and env array and dir'() {
     setup:
-    final runtime = Mock(Runtime)
+    final runtime = mock(Runtime)
     CommandInjectionModule iastModule = Mock(CommandInjectionModule)
     final command = ['ls', '-lah'] as String[]
     final env = ['DD_TRACE_DEBUG=true'] as String[]
@@ -117,7 +107,6 @@ class RuntimeCallSiteTest extends AgentTestRunner {
 
     then:
     1 * iastModule.onRuntimeExec(env, command)
-    1 * runtime.exec(command, env, file)
     0 * _
   }
 }


### PR DESCRIPTION
# What Does This Do?

Replaces Spock mocks with Mockito inline mocks.
This change is necessary because Mockito supports mocking `final` classes, which Spock’s default mocking does not.

# Motivation

Starting with JDK 25, `java.lang.Runtime` has been made `final`.
This prevents the use of Spock’s default mocking mechanism, breaking tests that rely on mocking `Runtime`.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-705]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-705]: https://datadoghq.atlassian.net/browse/LANGPLAT-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ