### PR TITLE
Implement health metrics for client stats

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -365,7 +365,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     return debuggerDiagnosticsEndpoint != null;
   }
 
-  boolean supportsDropping() {
+  public boolean supportsDropping() {
     return supportsDropping;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
@@ -2,6 +2,7 @@ package datadog.trace.common.metrics;
 
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
+import datadog.trace.core.monitor.HealthMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,10 +10,12 @@ public class MetricsAggregatorFactory {
   private static final Logger log = LoggerFactory.getLogger(MetricsAggregatorFactory.class);
 
   public static MetricsAggregator createMetricsAggregator(
-      Config config, SharedCommunicationObjects sharedCommunicationObjects) {
+      Config config,
+      SharedCommunicationObjects sharedCommunicationObjects,
+      HealthMetrics healthMetrics) {
     if (config.isTracerMetricsEnabled()) {
       log.debug("tracer metrics enabled");
-      return new ConflatingMetricsAggregator(config, sharedCommunicationObjects);
+      return new ConflatingMetricsAggregator(config, sharedCommunicationObjects, healthMetrics);
     }
     log.debug("tracer metrics disabled");
     return NoOpMetricsAggregator.INSTANCE;

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -73,6 +73,24 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {}
 
+  /**
+   * Report that a trace has been used to compute client stats.
+   *
+   * @param countedSpan the number of spans used for the stat computation
+   * @param totalSpan the number of total spans in the trace
+   * @param dropped true if the trace can be dropped. Note: the PayloadDispatcher also count this.
+   *     However, this counter will report how many p0 dropped we could achieve before that the span
+   *     got sampled.
+   */
+  public void onClientStatTraceComputed(
+      final int countedSpan, final int totalSpan, boolean dropped) {}
+
+  public void onClientStatPayloadSent() {}
+
+  public void onClientStatErrorReceived() {}
+
+  public void onClientStatDowngraded() {}
+
   /** @return Human-readable summary of the current health metrics. */
   public String summary() {
     return "";

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -529,31 +529,18 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             target.statsd, "long-running.expired", target.longRunningTracesExpired, NO_TAGS);
 
         reportIfChanged(
-            target.statsd,
-            "client-stats.processed.traces",
-            target.clientStatsProcessedTraces,
-            NO_TAGS);
+            target.statsd, "stats.traces_in", target.clientStatsProcessedTraces, NO_TAGS);
 
+        reportIfChanged(target.statsd, "stats.spans_in", target.clientStatsProcessedSpans, NO_TAGS);
         reportIfChanged(
-            target.statsd,
-            "client-stats.processed.spans",
-            target.clientStatsProcessedSpans,
-            NO_TAGS);
+            target.statsd, "stats.p0_dropped_traces", target.clientStatsP0DroppedTraces, NO_TAGS);
         reportIfChanged(
-            target.statsd,
-            "client-stats.p0-dropped.traces",
-            target.clientStatsP0DroppedTraces,
-            NO_TAGS);
+            target.statsd, "stats.p0_dropped_spans", target.clientStatsP0DroppedSpans, NO_TAGS);
         reportIfChanged(
-            target.statsd,
-            "client-stats.p0-dropped.spans",
-            target.clientStatsP0DroppedSpans,
-            NO_TAGS);
+            target.statsd, "stats.flushed_payloads", target.clientStatsRequests, NO_TAGS);
+        reportIfChanged(target.statsd, "stats.flush_errors", target.clientStatsErrors, NO_TAGS);
         reportIfChanged(
-            target.statsd, "client-stats.requests", target.clientStatsRequests, NO_TAGS);
-        reportIfChanged(target.statsd, "client-stats.errors", target.clientStatsErrors, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "client-stats.downgrades", target.clientStatsDowngrades, NO_TAGS);
+            target.statsd, "stats.agent_downgrades", target.clientStatsDowngrades, NO_TAGS);
 
       } catch (ArrayIndexOutOfBoundsException e) {
         log.warn(

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -168,7 +168,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     Sink sink = Stub(Sink)
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features,      HealthMetrics.NO_OP,
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features, HealthMetrics.NO_OP,
 
       sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -4,6 +4,7 @@ import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.WellKnownTags
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
+import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
 
@@ -38,6 +39,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       wellKnownTags,
       empty,
       features,
+      HealthMetrics.NO_OP,
       sink,
       10,
       queueSize,
@@ -67,6 +69,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       wellKnownTags,
       [ignoredResourceName].toSet(),
       features,
+      HealthMetrics.NO_OP,
       sink,
       10,
       queueSize,
@@ -100,7 +103,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, 10, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
@@ -129,7 +132,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.spanKindsToComputedStats() >> ["client", "server", "producer", "consumer"]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, 10, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
@@ -165,7 +168,8 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     Sink sink = Stub(Sink)
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features,
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features,      HealthMetrics.NO_OP,
+
       sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
@@ -202,7 +206,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, 10, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS)
     long duration = 100
     List<CoreSpan> trace = [
       new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration, HTTP_OK),
@@ -246,7 +250,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -283,7 +287,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -340,7 +344,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -384,7 +388,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -419,7 +423,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -457,7 +461,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -488,7 +492,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     Sink sink = Stub(Sink)
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     aggregator.start()
 
     when:
@@ -509,7 +513,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> false
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, 10, queueSize, 200, MILLISECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, 200, MILLISECONDS)
     final spans = [
       new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 10, HTTP_OK)
     ]
@@ -541,7 +545,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS)
 
     when:
     def async = CompletableFuture.supplyAsync(new Supplier<Boolean>() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.common.metrics
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.WellKnownTags
+import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
 import org.openjdk.jol.info.GraphLayout
 import spock.lang.Requires
@@ -32,6 +33,7 @@ class FootprintForkedTest extends DDSpecification {
       new WellKnownTags("runtimeid","hostname", "env", "service", "version","language"),
       [].toSet() as Set<String>,
       features,
+      HealthMetrics.NO_OP,
       sink,
       1000,
       1000,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.common.metrics
 
 import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.trace.api.Config
+import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
 import okhttp3.HttpUrl
 
@@ -14,7 +15,7 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     def sco = Mock(SharedCommunicationObjects)
     sco.agentUrl = HttpUrl.parse("http://localhost:8126")
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco)
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco, HealthMetrics.NO_OP,)
     assert aggregator instanceof NoOpMetricsAggregator
   }
 
@@ -25,7 +26,8 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     def sco = Mock(SharedCommunicationObjects)
     sco.agentUrl = HttpUrl.parse("http://localhost:8126")
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco)
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco, HealthMetrics.NO_OP,
+      )
     assert aggregator instanceof ConflatingMetricsAggregator
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
@@ -2,7 +2,11 @@ package datadog.trace.common.metrics
 
 import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.trace.api.Config
+import datadog.trace.api.StatsDClient
+import datadog.trace.core.monitor.HealthMetrics
+import datadog.trace.core.monitor.TracerHealthMetrics
 import datadog.trace.core.test.DDCoreSpecification
+import datadog.trace.util.Strings
 
 import java.util.concurrent.CountDownLatch
 
@@ -11,12 +15,16 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 class MetricsReliabilityTest extends DDCoreSpecification {
 
   static class State {
-    boolean agentMetricsAvailable
+    boolean agentMetricsAvailable = true
+    int statsResponseCode = 200
     boolean receivedStats
     boolean receivedClientComputedHeader
     CountDownLatch latch
-    def reset(agentMetricsAvailable) {
+    String hash
+
+    def reset(agentMetricsAvailable, statsResponseCode = 200) {
       this.agentMetricsAvailable = agentMetricsAvailable
+      this.statsResponseCode = statsResponseCode
       receivedStats = false
       receivedClientComputedHeader = false
       latch = new CountDownLatch(1)
@@ -27,17 +35,18 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     httpServer {
       handlers {
         get("/info") {
-          response.send('{"endpoints":[' + (state.agentMetricsAvailable ? '"/v0.6/stats", ' : '')
-            + '"/v0.4/traces"]}')
+          final def res = '{"endpoints":[' + (state.agentMetricsAvailable ? '"/v0.6/stats", ' : '') + '"/v0.4/traces"], "client_drop_p0s" : true}'
+          state.hash = Strings.sha256(res)
+          response.send(res)
           state.latch.countDown()
         }
         post("/v0.6/stats", {
           state.receivedStats = true
-          response.status(state.agentMetricsAvailable ? 200 : 404).send()
+          response.status(state.statsResponseCode).send()
         })
         put("/v0.4/traces", {
           state.receivedClientComputedHeader = "true" == request.getHeader('Datadog-Client-Computed-Stats')
-          response.status(200).send()
+          response.status(200).addHeader("Datadog-Agent-State", state.hash).send()
         })
       }
     }
@@ -56,8 +65,8 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     def sharedComm = new SharedCommunicationObjects()
     sharedComm.createRemaining(config)
     def featuresDiscovery = sharedComm.featuresDiscovery(config)
-    def tracer = tracerBuilder().sharedCommunicationObjects(sharedComm).config(config).build()
-
+    def healthMetrics = new TracerHealthMetrics(StatsDClient.NO_OP)
+    def tracer = tracerBuilder().sharedCommunicationObjects(sharedComm).healthMetrics(healthMetrics).config(config).build()
     when: "metrics enabled and discovery is performed"
     featuresDiscovery.discover()
 
@@ -73,9 +82,12 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "should have sent statistics and informed the agent that we calculate the stats"
     assert state.receivedClientComputedHeader
     assert state.receivedStats
+    // 1 trace processed. not a p0 drop (first time we see it). No errors
+    assertMetrics(healthMetrics, 1, 0, 1, 0, 0)
+
 
     when: "simulate an agent downgrade"
-    state.reset(false)
+    state.reset(false, 404)
     tracer.startSpan("test", "test").finish()
     tracer.flush()
     tracer.flushMetrics()
@@ -83,8 +95,12 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "a discovery should have done - we do not support anymore stats calculation"
     state.latch.await()
     assert !featuresDiscovery.supportsMetrics()
+    // 2 traces processed. 1 p0 dropped. 2 requests and 1 downgrade no errors
+    assertMetrics(healthMetrics, 2, 1, 2, 0, 1)
+
 
     when: "a span is published"
+    state.reset(false) // we have a call to stats for the downgrade so let's reset the counter
     tracer.startSpan("test", "test").finish()
     tracer.flush()
     tracer.flushMetrics()
@@ -92,6 +108,8 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "should have not sent statistics and informed the agent that we don't calculate the stats anymore"
     assert !state.receivedClientComputedHeader
     assert !state.receivedStats
+    // 2 traces processed. 1 p0 dropped. 2 requests and 1 downgrade no errors
+    assertMetrics(healthMetrics, 2, 1, 2, 0, 1)
 
     when: "we detect that the agent can calculate the stats again"
     state.reset(true)
@@ -109,9 +127,47 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "we should have sent the stats and informed the agent to not calculate the stats on the trace payload"
     assert state.receivedClientComputedHeader
     assert state.receivedStats
+    // 3 traces processed. 2 p0 dropped. 3 requests and 1 downgrade no errors
+    assertMetrics(healthMetrics, 3, 2, 3, 0, 1)
+
+    when: "an error occurred on the agent stats endpoint"
+    state.reset(true, 500)
+    tracer.startSpan("test", "test").finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "the error counter is incremented"
+    assert state.receivedClientComputedHeader
+    assert state.receivedStats
+    // 4 traces processed. 3 p0 dropped. 4 requests and 1 downgrade - 1 error
+    assertMetrics(healthMetrics, 4, 3, 4, 1, 1)
+
+    when: "the next call succeed"
+    state.reset(true)
+    tracer.startSpan("test", "test").setError(true).finish()
+    tracer.flush()
+    tracer.flushMetrics()
+
+    then: "the request counter is incremented"
+    assert state.receivedClientComputedHeader
+    assert state.receivedStats
+    // 5 traces processed. 3 p0 dropped (this one is errored so it's not dropped).
+    // 5 requests and 1 downgrade - 1 error
+    assertMetrics(healthMetrics, 5, 3, 5, 1, 1)
 
     cleanup:
     tracer.close()
     agent.stop()
+  }
+
+  void assertMetrics(HealthMetrics healthMetrics, int traces, int drops, int requests, int errors, int downgrades) {
+    def summary = healthMetrics.summary()
+    assert summary.contains("clientStatsRequests=$requests")
+    assert summary.contains("clientStatsErrors=$errors")
+    assert summary.contains("clientStatsDowngrades=$downgrades")
+    assert summary.contains("clientStatsP0DroppedSpans=$drops")
+    assert summary.contains("clientStatsP0DroppedTraces=$drops")
+    assert summary.contains("clientStatsProcessedSpans=$traces")
+    assert summary.contains("clientStatsProcessedTraces=$traces")
   }
 }


### PR DESCRIPTION
# What Does This Do

Adds the following statsD metrics for CSS:
* `stats.traces_in` -> the number of traces included in the stats calculation
* `stats.spans_in` -> the number of spans included in the stats calculation (same as dd-trace-go)
* `stats.p0_dropped_traces` -> the number of traces that could be dropped if not sampled
* `stats.p0_dropped_spans` -> the number of spans that could be dropped if not sampled
* `stats.flushed_payloads` -> the number of total requests to the agent (`/v0.6/stats`) - same as dd-trace-go
* `stats.flushed_errors` -> the number of errors received when sending the stats  -same as dd-trace-go
* `stats.downgrades`-> the number of downgrades detected (downgrade is detected when the client stats was enabled but the agent suddenly answer with a 404 meaning that the endpoint is no more available)


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
