### PR TITLE
Test `PekkoHttpServerInstrumentationAsyncHttp2Test.test exception` marked as flaky.

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1183,6 +1183,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
   }
 
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/9396", suites = ["PekkoHttpServerInstrumentationAsyncHttp2Test"])
   def "test exception"() {
     setup:
     def method = "GET"


### PR DESCRIPTION
# What Does This Do
Test `PekkoHttpServerInstrumentationAsyncHttp2Test.test exception` marked as flaky.

# Motivation
Green CI.

# Additional Notes
Test failed more than 200 times during last month on GitLab CI.

