### PR TITLE
Properly fall-back on UDS profiling URL

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4741,8 +4741,18 @@ public class Config {
       // when agentless profiling is turned on we send directly to our intake
       return "https://intake.profile." + site + "/api/v2/profile";
     } else {
-      // when profilingUrl and agentless are not set we send to the dd trace agent running locally
-      return getAgentUrl() + "/profiling/v1/input";
+      // When profilingUrl and agentless are not set we send to the dd trace agent running locally
+      // However, there are two gotchas:
+      // - the agentHost, agentPort split will trip on IPv6 addresses because of the colon -> we
+      // need to use the agentUrl
+      // - but the agentUrl can be unix socket and OKHttp doesn't support that so we fall back to
+      // http
+      //
+      // There is some magic behind the scenes where the http url will be converted to UDS if the
+      // target is a unix socket only
+      String baseUrl =
+          agentUrl.startsWith("unix:") ? "http://" + agentHost + ":" + agentPort : agentUrl;
+      return baseUrl + "/profiling/v1/input";
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1665,6 +1665,19 @@ class ConfigTest extends DDSpecification {
     config.getFinalProfilingUrl() == configuredUrl + "/profiling/v1/input"
   }
 
+  def "uds profiling url"() {
+    setup:
+    def configuredUrl = "unix:///path/to/socket"
+    def props = new Properties()
+    props.setProperty(TRACE_AGENT_URL, configuredUrl)
+
+    when:
+    Config config = Config.get(props)
+
+    then:
+    config.getFinalProfilingUrl() == "http://" + config.getAgentHost() + ":" + config.getAgentPort() + "/profiling/v1/input"
+  }
+
   def "fallback to DD_TAGS"() {
     setup:
     environmentVariables.set(DD_TAGS_ENV, "a:1,b:2,c:3")


### PR DESCRIPTION
# What Does This Do
Adds a fallback or UDS profiling URL, similar to https://github.com/DataDog/dd-trace-java/pull/7166

# Motivation
If UDS URL is used profiler will fail when it tries using it because OkHttp does not support UDS URLs
See #9400 

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-12369]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
