### PR TITLE
Replaced abandoned lib `com.github.kstyrc` with actively maintained `com.github.codemonstur` lib.

### DIFF
--- a/dd-java-agent/instrumentation/jedis-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/jedis-1.4/build.gradle
@@ -13,9 +13,12 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'redis.clients', name: 'jedis', version: '1.4.0'
-
-  testImplementation group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
   testImplementation group: 'redis.clients', name: 'jedis', version: '1.4.0'
+
+  testImplementation (group: 'com.github.codemonstur', name: 'embedded-redis', version: '1.4.3') {
+    // excluding logback to avoid conflicts with libs.bundles.test.logging
+    exclude group: 'redis.clients', module: 'jedis'
+  }
 
   // Jedis 3.0 has API changes that prevent instrumentation from applying
   latestDepTestImplementation group: 'redis.clients', name: 'jedis', version: '2.+'

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -17,7 +17,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
   int port = PortUtils.randomOpenPort()
 
   @Shared
-  RedisServer redisServer = RedisServer.builder()
+  RedisServer redisServer = RedisServer.newRedisServer()
   // bind to localhost to avoid firewall popup
   .setting("bind 127.0.0.1")
   // set max memory to avoid problems in CI
@@ -36,7 +36,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
   }
 
   def setupSpec() {
-    println "Using redis: $redisServer.args"
+    println "Using redis: $redisServer.@args"
     redisServer.start()
   }
 
@@ -169,7 +169,6 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
 }
 
 class JedisClientV0Test extends JedisClientTest {
-
   @Override
   int version() {
     return 0
@@ -185,8 +184,8 @@ class JedisClientV0Test extends JedisClientTest {
     return "redis.query"
   }
 }
-class JedisClientV1ForkedTest extends JedisClientTest {
 
+class JedisClientV1ForkedTest extends JedisClientTest {
   @Override
   int version() {
     return 1


### PR DESCRIPTION
# What Does This Do
Replaced abandoned embedded-redis library `com.github.kstyrc` with actively maintained `com.github.codemonstur` alternative.

# Motivation
Clean code. Latest dependencies.

# Additional Notes
This is follow-up for #9225.
I found how to fix test for Jedis `1.4.0` with new version of `embedded-redis`.

