### PR TITLE
Fix using SpanAttribute annotation on multiple parameters

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanDecorator.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanDecorator.java
@@ -128,7 +128,6 @@ public class WithSpanDecorator extends AsyncResultDecorator {
         if (name != null) {
           span.setTag(name, args[parameterIndex]);
         }
-        break;
       }
     }
   }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/test/groovy/SpanAttributeAnnotationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/test/groovy/SpanAttributeAnnotationTest.groovy
@@ -40,5 +40,29 @@ class SpanAttributeAnnotationTest extends AgentTestRunner {
     'list'   | ['value1', 'value2', 'value3']
     typeName = type.substring(0, 1).toUpperCase() + type.substring(1)
   }
+
+  def "test multiple SpanAttribute"() {
+    setup:
+    def methodName = "sayHelloWithMultipleAttributes"
+    TracedMethods."$methodName"("param1", "param2")
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "TracedMethods.$methodName"
+          operationName "TracedMethods.$methodName"
+          parent()
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+            "custom-tag1" "param1"
+            "custom-tag2" "param2"
+          }
+        }
+      }
+    }
+  }
 }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/test/java/annotatedsample/TracedMethods.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/test/java/annotatedsample/TracedMethods.java
@@ -76,6 +76,12 @@ public class TracedMethods {
   }
 
   @WithSpan
+  public static String sayHelloWithMultipleAttributes(
+      @SpanAttribute("custom-tag1") String param1, @SpanAttribute("custom-tag2") String param2) {
+    return "hello!";
+  }
+
+  @WithSpan
   public static void throwException() {
     throw new RuntimeException("Some exception");
   }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/groovy/AddingSpanAttributesAnnotationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/groovy/AddingSpanAttributesAnnotationTest.groovy
@@ -43,6 +43,33 @@ class AddingSpanAttributesAnnotationTest extends AgentTestRunner {
     typeName = type.substring(0, 1).toUpperCase() + type.substring(1)
   }
 
+  def "test AddingSpanAttributes annotated method with multiple annotated parameters"() {
+    setup:
+    def methodName = "sayHelloWithMultipleAttributes"
+    def testSpan = TEST_TRACER.startSpan("test", "operation")
+    def scope = TEST_TRACER.activateManualSpan(testSpan)
+    AnnotatedMethods."$methodName"("param1", "param2")
+    scope.close()
+    testSpan.finish()
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "operation"
+          operationName "operation"
+          parent()
+          errored false
+          tags {
+            defaultTags()
+            "custom-tag1" "param1"
+            "custom-tag2" "param2"
+          }
+        }
+      }
+    }
+  }
+
   def "test AddingSpanAttributes annotated method is skipped if no active span"() {
     setup:
     def testSpan = TEST_TRACER.startSpan("test", "operation")

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/java/annotatedsample/AnnotatedMethods.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.26/src/test/java/annotatedsample/AnnotatedMethods.java
@@ -24,4 +24,10 @@ public class AnnotatedMethods {
   public static String sayHelloWithListAttribute(@SpanAttribute("custom-tag") List<?> param) {
     return "hello!";
   }
+
+  @AddingSpanAttributes
+  public static String sayHelloWithMultipleAttributes(
+      @SpanAttribute("custom-tag1") String param1, @SpanAttribute("custom-tag2") String param2) {
+    return "hello!";
+  }
 }


### PR DESCRIPTION
# What Does This Do
Allow multiple span attributes to be set on the same span using the OpenTelemetry annotation `@SpanAttribute`.

 ```
 @WithSpan
  public static String sayHelloWithMultipleAttributes(
      @SpanAttribute("custom-tag1") String param1, @SpanAttribute("custom-tag2") String param2) {
    return "hello!";
  }
```

**Result before this PR:**
A span with a tag `custom-tag1:param1`

**Result before this PR:**
A span with tags `custom-tag1:param1` and `custom-tag2:param2`

# Motivation
Customer's reaching out to our support team as only the first @SpanAttribute set was included in the span

# Additional Notes
Jira ticket: [APMS-16924]



[APMS-16924]: https://datadoghq.atlassian.net/browse/APMS-16924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ