### PR TITLE
Apply fix for 'Source directory xxx is not a directory.` for all play modules.

### DIFF
--- a/dd-smoke-tests/play-2.4/build.gradle
+++ b/dd-smoke-tests/play-2.4/build.gradle
@@ -8,6 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/dd-smoke-tests/play-common/fix-play-routes.gradle"
 
 def playVer = "2.4.11"
 def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.11")

--- a/dd-smoke-tests/play-2.5/build.gradle
+++ b/dd-smoke-tests/play-2.5/build.gradle
@@ -8,6 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/dd-smoke-tests/play-common/fix-play-routes.gradle"
 
 def playVer = "2.5.19"
 def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.11")

--- a/dd-smoke-tests/play-2.6/build.gradle
+++ b/dd-smoke-tests/play-2.6/build.gradle
@@ -8,6 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/dd-smoke-tests/play-common/fix-play-routes.gradle"
 
 def playVer = "2.6.25"
 def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.12")

--- a/dd-smoke-tests/play-2.7/build.gradle
+++ b/dd-smoke-tests/play-2.7/build.gradle
@@ -8,6 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/dd-smoke-tests/play-common/fix-play-routes.gradle"
 
 def playVer = "2.7.9"
 def scalaVer = System.getProperty("scala.version", /* default = */ "2.13")

--- a/dd-smoke-tests/play-2.8-otel/build.gradle
+++ b/dd-smoke-tests/play-2.8-otel/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/dd-smoke-tests/play-common/fix-play-routes.gradle"
 
 def playVer = "2.8.15"
 def scalaVer = System.getProperty("scala.version", /* default = */ "2.13")


### PR DESCRIPTION
# What Does This Do
Apply fix for 'Source directory xxx is not a directory.` for all play modules.

# Motivation
Green CI.

# Additional Notes
Follow up for #9357. Applied for all `play` modules, as I found same issue for `play-2.4` recently.
Better to apply for all modules to prevent CI failures.
I see NO failures for last 2 weeks for `play-2.8` that was patched in #9357.
