### PR TITLE
Allow manual OCI image promotion

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -954,13 +954,6 @@ publishing-gate:
   needs:
     - job: verify_maven_central_deployment
       optional: true # Required for releases only
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: on_success
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: on_success
-    - when: manual
-      allow_failure: true
 
 configure_system_tests:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -908,8 +908,6 @@ verify_maven_central_deployment:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
-    - when: manual
-      allow_failure: true
   cache: # Cache is used to signal between the override_verify_maven_central and verify_maven_central_deployment jobs
     - key: $CI_PIPELINE_ID-OVERRIDE_SIGNAL
       paths:


### PR DESCRIPTION
# What Does This Do

Allow manual triggering of the GitLab jobs that promote OCI images to staging/prod/prod beta.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
