### PR TITLE
UTF8 caching for v0.4

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -105,6 +105,7 @@ public final class GeneralConfig {
   public static final String JDK_SOCKET_ENABLED = "jdk.socket.enabled";
 
   public static final String OPTIMIZED_MAP_ENABLED = "optimized.map.enabled";
+  public static final String UTF8_CACHE_ENABLED = "utf8.cache.enabled";
   public static final String STACK_TRACE_LENGTH_LIMIT = "stack.trace.length.limit";
 
   public static final String SSI_INJECTION_ENABLED = "injection.enabled";

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/Utf8Benchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/Utf8Benchmark.java
@@ -1,36 +1,26 @@
 package datadog.trace.common.writer.ddagent;
 
+import datadog.utf8.GeneratedTagUtf8Cache;
+import datadog.utf8.GenerationalUtf8Cache;
+import datadog.utf8.SimpleUtf8Cache;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import datadog.trace.api.DDTags;
-import datadog.utf8.GeneratedTagUtf8Cache;
-import datadog.utf8.SimpleUtf8Cache;
-import datadog.utf8.Tags;
-
-import datadog.utf8.GenerationalUtf8Cache;
-import datadog.utf8.ValueUtf8CacheBackup;
-
 /**
- * This benchmark isn't really intended to used to measure throughput,
- * but rather to be used with "-prof gc" to check bytes / op.
- * 
- * Since {@link String#getBytes(java.nio.charset.Charset)} is intrinsified 
- * the caches typically perform worse throughput wise, the benefit of the 
- * caches is to reduce allocation. 
+ * This benchmark isn't really intended to used to measure throughput, but rather to be used with
+ * "-prof gc" to check bytes / op.
+ *
+ * <p>Since {@link String#getBytes(java.nio.charset.Charset)} is intrinsified the caches typically
+ * perform worse throughput wise, the benefit of the caches is to reduce allocation.
  */
 @BenchmarkMode(Mode.Throughput)
 public class Utf8Benchmark {
   static final int NUM_LOOKUPS = 10_000;
-  
+
   static final String[] TAGS = {
     "_dd.asm.keep",
     "ci.provider",
@@ -41,120 +31,121 @@ public class Utf8Benchmark {
     "db.pool",
     "http.forwarder",
     "db.warehouse",
-	"custom"
+    "custom"
   };
-  
+
   static int pos = 0;
   static int standardVal = 0;
-  
+
   static final String nextTag() {
-    if ( pos == TAGS.length - 1 ) {
+    if (pos == TAGS.length - 1) {
       pos = 0;
     } else {
       pos += 1;
     }
     return TAGS[pos];
   }
-  
+
   static final String nextValue(String tag) {
-	if ( tag == "custom" ) {
-	  return nextCustomValue();
-	} else {
-	  return nextStandardValue(tag);
-	}
+    if (tag == "custom") {
+      return nextCustomValue();
+    } else {
+      return nextStandardValue(tag);
+    }
   }
-  
+
   static final String nextCustomValue() {
-	return "custom" + ThreadLocalRandom.current().nextInt();
+    return "custom" + ThreadLocalRandom.current().nextInt();
   }
-  
+
   static final String nextStandardValue(String tag) {
-	return tag + ThreadLocalRandom.current().nextInt(20);
+    return tag + ThreadLocalRandom.current().nextInt(20);
   }
-  
+
   @Benchmark
   public static final String tagUtf8_baseline() {
-	return nextTag();
+    return nextTag();
   }
-  
+
   @Benchmark
   public static final byte[] tagUtf8_nocache() {
-	String tag = nextTag();
-	return tag.getBytes(StandardCharsets.UTF_8);
+    String tag = nextTag();
+    return tag.getBytes(StandardCharsets.UTF_8);
   }
-  
+
   @Benchmark
   public static final byte[] tagUtf8_w_generatedCache() {
-	String tag = nextTag();
-	
-	byte[] cache = GeneratedTagUtf8Cache.lookup(tag);
-	if ( cache != null ) return cache;
-	
-	return tag.getBytes(StandardCharsets.UTF_8);
+    String tag = nextTag();
+
+    byte[] cache = GeneratedTagUtf8Cache.lookup(tag);
+    if (cache != null) return cache;
+
+    return tag.getBytes(StandardCharsets.UTF_8);
   }
-  
+
   static final SimpleUtf8Cache TAG_CACHE = new SimpleUtf8Cache();
-  
+
   @Benchmark
   public static final byte[] tagUtf8_w_cache() {
-	String tag = nextTag();
-	
-	byte[] cache = TAG_CACHE.getUtf8(tag);
-	if ( cache != null ) return cache;
-	
-	return tag.getBytes(StandardCharsets.UTF_8);
+    String tag = nextTag();
+
+    byte[] cache = TAG_CACHE.getUtf8(tag);
+    if (cache != null) return cache;
+
+    return tag.getBytes(StandardCharsets.UTF_8);
   }
 
   @Benchmark
   public static final void valueUtf8_baseline(Blackhole bh) {
-	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+    for (int i = 0; i < NUM_LOOKUPS; ++i) {
       String tag = nextTag();
       String value = nextValue(tag);
-    
+
       bh.consume(tag);
       bh.consume(value);
-	}
+    }
   }
-  
+
   static final GenerationalUtf8Cache VALUE_CACHE = new GenerationalUtf8Cache();
-  
+
   @Benchmark
   public static final void valueUtf8_cache_generational(Blackhole bh) {
-	GenerationalUtf8Cache valueCache = VALUE_CACHE;
-	valueCache.recalibrate();
-	
-	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+    GenerationalUtf8Cache valueCache = VALUE_CACHE;
+    valueCache.recalibrate();
+
+    for (int i = 0; i < NUM_LOOKUPS; ++i) {
       String tag = nextTag();
       String value = nextValue(tag);
-    
+
       byte[] lookup = valueCache.getUtf8(value);
       bh.consume(lookup);
-	}
+    }
   }
-  
+
   static final SimpleUtf8Cache SIMPLE_VALUE_CACHE = new SimpleUtf8Cache();
+
   @Benchmark
   public static final void valueUtf8_cache_simple(Blackhole bh) {
-	SimpleUtf8Cache valueCache = SIMPLE_VALUE_CACHE;
-	valueCache.recalibrate();
-	
-	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+    SimpleUtf8Cache valueCache = SIMPLE_VALUE_CACHE;
+    valueCache.recalibrate();
+
+    for (int i = 0; i < NUM_LOOKUPS; ++i) {
       String tag = nextTag();
       String value = nextValue(tag);
-    
+
       byte[] lookup = valueCache.getUtf8(value);
       bh.consume(lookup);
-	}
+    }
   }
-  
+
   @Benchmark
   public static final void valueUtf8_nocache(Blackhole bh) {
-	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+    for (int i = 0; i < NUM_LOOKUPS; ++i) {
       String tag = nextTag();
       String value = nextValue(tag);
-    
+
       bh.consume(tag);
       bh.consume(value.getBytes(StandardCharsets.UTF_8));
-	}
+    }
   }
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/Utf8Benchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/Utf8Benchmark.java
@@ -1,0 +1,160 @@
+package datadog.trace.common.writer.ddagent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import datadog.trace.api.DDTags;
+import datadog.utf8.GeneratedTagUtf8Cache;
+import datadog.utf8.SimpleUtf8Cache;
+import datadog.utf8.Tags;
+
+import datadog.utf8.GenerationalUtf8Cache;
+import datadog.utf8.ValueUtf8CacheBackup;
+
+/**
+ * This benchmark isn't really intended to used to measure throughput,
+ * but rather to be used with "-prof gc" to check bytes / op.
+ * 
+ * Since {@link String#getBytes(java.nio.charset.Charset)} is intrinsified 
+ * the caches typically perform worse throughput wise, the benefit of the 
+ * caches is to reduce allocation. 
+ */
+@BenchmarkMode(Mode.Throughput)
+public class Utf8Benchmark {
+  static final int NUM_LOOKUPS = 10_000;
+  
+  static final String[] TAGS = {
+    "_dd.asm.keep",
+    "ci.provider",
+    "language",
+    "db.statement",
+    "ci.job.url",
+    "ci.pipeline.url",
+    "db.pool",
+    "http.forwarder",
+    "db.warehouse",
+	"custom"
+  };
+  
+  static int pos = 0;
+  static int standardVal = 0;
+  
+  static final String nextTag() {
+    if ( pos == TAGS.length - 1 ) {
+      pos = 0;
+    } else {
+      pos += 1;
+    }
+    return TAGS[pos];
+  }
+  
+  static final String nextValue(String tag) {
+	if ( tag == "custom" ) {
+	  return nextCustomValue();
+	} else {
+	  return nextStandardValue(tag);
+	}
+  }
+  
+  static final String nextCustomValue() {
+	return "custom" + ThreadLocalRandom.current().nextInt();
+  }
+  
+  static final String nextStandardValue(String tag) {
+	return tag + ThreadLocalRandom.current().nextInt(20);
+  }
+  
+  @Benchmark
+  public static final String tagUtf8_baseline() {
+	return nextTag();
+  }
+  
+  @Benchmark
+  public static final byte[] tagUtf8_nocache() {
+	String tag = nextTag();
+	return tag.getBytes(StandardCharsets.UTF_8);
+  }
+  
+  @Benchmark
+  public static final byte[] tagUtf8_w_generatedCache() {
+	String tag = nextTag();
+	
+	byte[] cache = GeneratedTagUtf8Cache.lookup(tag);
+	if ( cache != null ) return cache;
+	
+	return tag.getBytes(StandardCharsets.UTF_8);
+  }
+  
+  static final SimpleUtf8Cache TAG_CACHE = new SimpleUtf8Cache();
+  
+  @Benchmark
+  public static final byte[] tagUtf8_w_cache() {
+	String tag = nextTag();
+	
+	byte[] cache = TAG_CACHE.getUtf8(tag);
+	if ( cache != null ) return cache;
+	
+	return tag.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Benchmark
+  public static final void valueUtf8_baseline(Blackhole bh) {
+	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+      String tag = nextTag();
+      String value = nextValue(tag);
+    
+      bh.consume(tag);
+      bh.consume(value);
+	}
+  }
+  
+  static final GenerationalUtf8Cache VALUE_CACHE = new GenerationalUtf8Cache();
+  
+  @Benchmark
+  public static final void valueUtf8_cache_generational(Blackhole bh) {
+	GenerationalUtf8Cache valueCache = VALUE_CACHE;
+	valueCache.recalibrate();
+	
+	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+      String tag = nextTag();
+      String value = nextValue(tag);
+    
+      byte[] lookup = valueCache.getUtf8(value);
+      bh.consume(lookup);
+	}
+  }
+  
+  static final SimpleUtf8Cache SIMPLE_VALUE_CACHE = new SimpleUtf8Cache();
+  @Benchmark
+  public static final void valueUtf8_cache_simple(Blackhole bh) {
+	SimpleUtf8Cache valueCache = SIMPLE_VALUE_CACHE;
+	valueCache.recalibrate();
+	
+	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+      String tag = nextTag();
+      String value = nextValue(tag);
+    
+      byte[] lookup = valueCache.getUtf8(value);
+      bh.consume(lookup);
+	}
+  }
+  
+  @Benchmark
+  public static final void valueUtf8_nocache(Blackhole bh) {
+	for ( int i = 0; i < NUM_LOOKUPS; ++i ) {
+      String tag = nextTag();
+      String value = nextValue(tag);
+    
+      bh.consume(tag);
+      bh.consume(value.getBytes(StandardCharsets.UTF_8));
+	}
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/GenerationalUtf8Cache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/GenerationalUtf8Cache.java
@@ -1,0 +1,438 @@
+package datadog.trace.common.writer.ddagent;
+
+import datadog.communication.serialization.EncodingCache;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/** 
+ * 2-level generational cache of UTF8 values - primarily intended to be used for tag values
+ * 
+ * Cache is designed to take advantage of low cardinality tags to avoid 
+ * repeated UTF8 encodings while also minimizing cache overhead and 
+ * churn from high cardinality tags.
+ * 
+ * NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead.
+ * Using the cache has higher CPU overhead than simply calling {@link String#getBytes(java.nio.charset.Charset)}.
+ *  
+ * The cache is thread safe.
+ */
+/* 
+ * Cache works by using a 2-level promotion based scheme.
+ * 
+ * Thread safety is achieved through using CacheEntry objects where the key data 
+ * fields are final.
+ * 
+ * Updating of the cache and bookkeeping are deliberately allowed to be racy to 
+ * minimize CPU overhead and lock contention.
+ *  
+ * The first time a value is requested, the value isn't cached and no CacheEntry 
+ * is created.  Without this refinement, the cost for constructing 
+ * CacheEntry for unique values would negate the benefit of the cache.
+ * 
+ * These first requests are tracked via edenMarkers which indicate if there was 
+ * previously an unsatisfied request to the same initial cache line.
+ * 
+ * If there was a request, then CacheEntry is created and stored into edenEntries.
+ * NOTE: The eden line marking process is imprecise and subject to request 
+ * ordering issues, but given that low cardinality entries are more likely to repeat
+ * next.
+ * 
+ * If a collision occurs in the cache, linear probing is used to check other slots.
+ * New cache entries fill any available slot within the probing window.
+ * 
+ * If a subsequent request, finds a matching item in edenEntries.  The hit count 
+ * of the CacheEntry is bumped.  If the CacheEntry exceeds the current promotion 
+ * threshold, then the CacheEntry is inserted into promotionEntries -- freeing up 
+ * a slot in edenEntries.  If there isn't an available slot in promotionEntries, 
+ * the LRU: least recently used promotionEntry is evicted.
+ * 
+ * If there are no available slots in edenEntries for a newly created CacheEntry...
+ * 
+ * Attempt to early promote the MFU: most frequently used CacheEntry from 
+ * edenEntries to promotedEntries (without eviction).
+ * 
+ * If there's no space in promotedEntries to promote the MFU, then evict the 
+ * LFU: least frequently used entry from edenEntries instead.
+ * 
+ * 
+ * LRU based eviction of the promotedEntries works on tagging with the last hit time.
+ * The access time can be provided directly to ValueUtf8Cache#getUtf8 or can 
+ * be refreshed periodically by calling ValueUtf8Cache#updateAccessTime.
+ * 
+ * If there's a natural transaction boundary around the UTF8 cache, 
+ * calling ValueUtf8Cache#recalibrateThresholds will adjust promotion 
+ * thresholds to provide better cache utilization.
+ */
+public final class GenerationalUtf8Cache implements EncodingCache {
+  private static final int MAX_PROBES = 8;
+  
+  private static final int MIN_PROMOTION_TRESHOLD = 2;
+  private static final int INITIAL_PROMOTION_THRESHOLD = 10;
+  
+  private static final double HIT_DECAY = 0.8D;
+  private static final double PURGE_THRESHOLD = 0.25D;
+  
+  private final CacheEntry[] edenEntries;
+  private final boolean[] edenMarkers;
+  
+  private final CacheEntry[] promotedEntries;
+  
+  private long accessTimeMs;
+  private double promotionThreshold = INITIAL_PROMOTION_THRESHOLD;
+  
+  int edenHits = 0;
+  int promotedHits = 0;
+  int earlyPromotions = 0;
+  int promotions = 0;
+  int edenEvictions = 0;
+  int promotedEvictions = 0;
+  
+  public GenerationalUtf8Cache() {
+	this.accessTimeMs = System.currentTimeMillis();
+	
+	// These sizes must be powers of 2
+	this.edenEntries = new CacheEntry[256];
+	this.edenMarkers = new boolean[256];
+	
+	// The size must be a power of 2
+	this.promotedEntries = new CacheEntry[512];
+  }
+  
+  /**
+   * Updates access time used @link {@link #getUtf8(String, String)} to the provided value
+   */
+  public void updateAccessTime(long accessTimeMs) {
+	this.accessTimeMs = accessTimeMs;
+  }
+  
+  /**
+   * Updates access time to the @link {@link System#currentTimeMillis()}
+   */
+  public void refreshAcessTime() {
+	this.updateAccessTime(System.currentTimeMillis());
+  }
+  
+  public void recalibrate() {
+	this.recalibrate(System.currentTimeMillis());
+  }
+  
+  /**
+   * Recalibrates promotion threshold based on promotion & eviction statistics, 
+   * since last calibration - resets statistics
+   * @param accessTimeMs
+   */
+  public void recalibrate(long accessTimeMs) {
+	this.accessTimeMs = accessTimeMs;
+	
+	CacheEntry[] thisEntries = this.edenEntries;
+	for ( int i = 0; i < thisEntries.length; ++i ) {
+	  CacheEntry entry = thisEntries[i];	  
+	  if ( entry == null ) continue;
+	  
+	  boolean purge = entry.decay();
+	  if ( purge ) this.edenEntries[i] = null;
+	}
+	
+	Arrays.fill(this.edenMarkers, false);
+	
+	int totalPromotions = this.promotions + this.earlyPromotions;
+	if ( totalPromotions == 0 && this.promotionThreshold >= MIN_PROMOTION_TRESHOLD ) {
+	  this.promotionThreshold /= 1.5;
+	} else if ( totalPromotions > this.promotedEvictions / 2 ) {
+	  this.promotionThreshold *= 1.5;
+	}
+	
+	this.edenHits = 0;
+	this.promotedHits = 0;
+	this.earlyPromotions = 0;
+	this.promotions = 0;
+	this.edenEvictions = 0;
+	this.promotedEvictions = 0;
+  }
+  
+  @Override
+  public byte[] encode(CharSequence charSeq) {
+	if ( charSeq instanceof String ) {
+	  String str = (String)charSeq;
+	  return this.getUtf8(str);
+	} else {
+	  return null;
+	}
+  }
+  
+  /**
+   * Returns the UTF-8 encoding of value -- using a cache value if available
+   */
+  public final byte[] getUtf8(String value) {
+    return this.getUtf8(value, this.accessTimeMs);
+  }
+  
+  /**
+   * Returns the UTF-8 encoding of value -- using a cache value if available
+   * If there is cache hit, the specified accessTimeMs is used to update the cache entry
+   */
+  public final byte[] getUtf8(String value, long accessTimeMs) {
+	int valueHash = value.hashCode();
+	
+	CacheEntry[] localEntries = this.edenEntries;
+	long lookupTimeMs = this.accessTimeMs;
+	
+	int matchingLocalIndex = lookupEntry(localEntries, valueHash, value, lookupTimeMs);
+	if ( matchingLocalIndex != -1 ) {
+	  CacheEntry localEntry = localEntries[matchingLocalIndex];
+	  
+	  double hits = localEntry.hit(lookupTimeMs);
+	  if ( hits > this.promotionThreshold ) {
+		// mark promoted first - to avoid racy insertions
+		this.promotions += 1;
+		
+		boolean evicted = lruInsert(this.promotedEntries, localEntry);
+		if ( evicted ) this.promotedEvictions += 1;
+		
+		localEntries[matchingLocalIndex] = null;
+	  }
+	  
+	  this.edenHits += 1;
+	  return localEntry.utf8();
+	}
+	
+	CacheEntry[] promotedEntries = this.promotedEntries;
+	int matchingPromotedIndex = lookupEntry(promotedEntries, valueHash, value, lookupTimeMs);
+	if ( matchingPromotedIndex != -1 ) {
+   	  CacheEntry promotedEntry = promotedEntries[matchingPromotedIndex];
+		  
+	  promotedEntry.hit(lookupTimeMs);
+	  
+	  this.promotedHits += 1;
+	  return promotedEntry.utf8();
+	}
+	
+	boolean wasMarked = reverseMark(this.edenMarkers, valueHash);
+	
+	// If slot isn't marked, this is likely the first request
+	// Don't create an entry yet
+	if ( !wasMarked ) return CacheEntry.utf8(value);
+	
+	CacheEntry newEntry = new CacheEntry(valueHash, value);
+	// First request was swallowed by marking, so double hit
+	newEntry.hit(lookupTimeMs);
+	newEntry.hit(lookupTimeMs);
+	
+	// search for empty slot or failing that the MFU entry
+	int localMfuIndex = findFirstAvailableOrMfuIndex(localEntries, valueHash);
+	CacheEntry localMfuEntry = localEntries[localMfuIndex];
+	
+	// Found an empty slot - fill it
+	if ( localMfuEntry == null ) {
+	  localEntries[localMfuIndex] = newEntry;
+	  return newEntry.utf8();
+	}
+	
+	// See if we can early promote the local MFU entry into the global cache
+	// Early promotion doesn't evict from the global cache
+	int globalAvailableIndex = findAvailable(promotedEntries, localMfuEntry.valueHash());
+	if ( globalAvailableIndex != -1 ) {
+	  promotedEntries[globalAvailableIndex] = localMfuEntry;
+	  this.earlyPromotions += 1;
+	  
+	  localEntries[localMfuIndex] = newEntry;
+	  return CacheEntry.utf8(value);
+	}
+	
+	// No empty slot - or space to promote into the global cache
+	// Insert into local cache while evicting the LFU	
+	boolean evicted = lfuInsert(localEntries, newEntry);
+	if ( evicted ) this.promotedEvictions += 1;
+	
+	return newEntry.utf8();
+  }
+  
+  static final int findAvailable(CacheEntry[] entries, int newValueHash) {
+	int initialBucketIndex = initialBucketIndex(entries, newValueHash);
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry == null || entry.hits() == 0 ) return index;
+	}
+	return -1;
+  }
+  
+  static final int findFirstAvailableOrMfuIndex(CacheEntry[] entries, int newValueHash) {
+	double mfuHits = Double.MIN_VALUE;
+	int mfuIndex = -1;
+	
+	int initialBucketIndex = initialBucketIndex(entries, newValueHash);
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry == null ) return index;
+	  
+	  double hits = entry.hits();
+	  if ( hits > mfuHits ) {
+		mfuHits = hits;
+		mfuIndex = index;
+	  }
+	}
+	return mfuIndex;
+  }
+  
+  static final boolean reverseMark(boolean[] marks, int newValueHash) {
+	int index = initialBucketIndex(marks, newValueHash);
+	boolean wasMarked = marks[index];
+	marks[index] = !wasMarked;
+	return wasMarked;
+  }
+  
+  static final boolean lfuInsert(CacheEntry[] entries, CacheEntry newEntry) {
+    int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
+    
+    // initial scan to see if there's an empty slot or marker entry is already present
+    double lowestHits = Double.MAX_VALUE;
+    int lfuIndex = -1;
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry == null || entry.hits() == 0 ) {
+		entries[index] = newEntry;
+		return false;
+	  } else {
+		double hits = entry.hits();
+		if ( hits < lowestHits ) {
+		  lowestHits = hits;
+		  lfuIndex = index;
+		}
+	  }
+	}
+	
+	// If we get here, then we're evicted the LRU
+	entries[lfuIndex] = newEntry;
+	return true;
+  }
+  
+  static final boolean lruInsert(CacheEntry[] entries, CacheEntry newEntry) {
+    int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
+    
+    // initial scan to see if there's an empty slot or entry is already present
+    long lowestUsedMs = Long.MAX_VALUE;
+    int lruIndex = -1;
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry == null ) {
+		entries[index] = newEntry;
+		return false;
+	  } else if ( entry.matches(newEntry) ) {
+		entries[index] = newEntry;
+		return false;
+	  } else {
+		long lastUsedMs = entry.lastUsedMs();
+		if ( lastUsedMs < lowestUsedMs ) {
+		  lowestUsedMs = lastUsedMs;
+		  lruIndex = index;
+		}
+	  }
+	}
+	
+	entries[lruIndex] = newEntry;
+	return true;
+  }
+  
+  static final int initialBucketIndex(CacheEntry[] entries, int valueHash) {
+    return valueHash & (entries.length - 1);
+  }
+
+  static final int initialBucketIndex(boolean[] marks, int valueHash) {
+    return valueHash & (marks.length - 1);
+  }
+  
+  static final int lookupEntry(
+    CacheEntry[] entries,
+    int valueHash, String value,
+    long lookupTimeMs)
+  {
+	int initialBucketIndex = initialBucketIndex(entries, valueHash);
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry != null && entry.matches(valueHash, value) ) {
+		return index;
+	  }
+	}
+	return -1;
+  }
+  
+  static final int bucketHash(int tagHash, int valueHash) {
+	return tagHash + 31 * valueHash;
+  }
+  
+  static final class CacheEntry {
+	final int valueHash;
+    final String value;
+    final byte[] valueUtf8;
+    
+    boolean promoted = false;
+    long lastUsedMs = 0;
+    double hitCount = 0;
+    
+    public CacheEntry(int valueHash, String value) {
+      this.valueHash = valueHash;
+      this.value = value;
+      this.valueUtf8 = utf8(value);
+    }
+    
+    boolean matches(CacheEntry thatEntry ) {
+      return ( this == thatEntry ) || this.matches(thatEntry.valueHash, thatEntry.value);
+    }
+    
+    boolean matches(int valueHash, String value) {
+      return (this.valueHash == valueHash) && value.equals(this.value);
+    }
+    
+    int valueHash() {
+      return this.valueHash;
+    }
+    
+    double hits() {
+      return this.hitCount;	  
+    }
+    
+    long lastUsedMs() {
+      return this.lastUsedMs;
+    }
+    
+    byte[] utf8() {
+      return this.valueUtf8;
+    }
+    
+    double hit(long lastUsedMs) {
+      this.lastUsedMs = lastUsedMs;
+      this.hitCount += 1;
+      
+      return this.hitCount;
+    }
+    
+    boolean decay() {
+      this.hitCount *= HIT_DECAY;
+      
+      return (this.hitCount < PURGE_THRESHOLD);
+    }
+    
+    static final byte[] utf8(String value) {
+      return value.getBytes(StandardCharsets.UTF_8);
+    }
+    
+    @Override
+    public String toString() {
+      if ( this.value == null ) {
+    	return "marker";
+      } else {
+    	return this.value + " - hits: " + this.hitCount + " used (ms): " + this.lastUsedMs;
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/GenerationalUtf8Cache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/GenerationalUtf8Cache.java
@@ -4,343 +4,338 @@ import datadog.communication.serialization.EncodingCache;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-/** 
+/**
  * 2-level generational cache of UTF8 values - primarily intended to be used for tag values
- * 
- * Cache is designed to take advantage of low cardinality tags to avoid 
- * repeated UTF8 encodings while also minimizing cache overhead and 
- * churn from high cardinality tags.
- * 
- * NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead.
- * Using the cache has higher CPU overhead than simply calling {@link String#getBytes(java.nio.charset.Charset)}.
- *  
- * The cache is thread safe.
+ *
+ * <p>Cache is designed to take advantage of low cardinality tags to avoid repeated UTF8 encodings
+ * while also minimizing cache overhead and churn from high cardinality tags.
+ *
+ * <p>NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead. Using the
+ * cache has higher CPU overhead than simply calling {@link
+ * String#getBytes(java.nio.charset.Charset)}.
+ *
+ * <p>The cache is thread safe.
  */
-/* 
+/*
  * Cache works by using a 2-level promotion based scheme.
- * 
- * Thread safety is achieved through using CacheEntry objects where the key data 
+ *
+ * Thread safety is achieved through using CacheEntry objects where the key data
  * fields are final.
- * 
- * Updating of the cache and bookkeeping are deliberately allowed to be racy to 
+ *
+ * Updating of the cache and bookkeeping are deliberately allowed to be racy to
  * minimize CPU overhead and lock contention.
- *  
- * The first time a value is requested, the value isn't cached and no CacheEntry 
- * is created.  Without this refinement, the cost for constructing 
+ *
+ * The first time a value is requested, the value isn't cached and no CacheEntry
+ * is created.  Without this refinement, the cost for constructing
  * CacheEntry for unique values would negate the benefit of the cache.
- * 
- * These first requests are tracked via edenMarkers which indicate if there was 
+ *
+ * These first requests are tracked via edenMarkers which indicate if there was
  * previously an unsatisfied request to the same initial cache line.
- * 
+ *
  * If there was a request, then CacheEntry is created and stored into edenEntries.
- * NOTE: The eden line marking process is imprecise and subject to request 
+ * NOTE: The eden line marking process is imprecise and subject to request
  * ordering issues, but given that low cardinality entries are more likely to repeat
  * next.
- * 
+ *
  * If a collision occurs in the cache, linear probing is used to check other slots.
  * New cache entries fill any available slot within the probing window.
- * 
- * If a subsequent request, finds a matching item in edenEntries.  The hit count 
- * of the CacheEntry is bumped.  If the CacheEntry exceeds the current promotion 
- * threshold, then the CacheEntry is inserted into promotionEntries -- freeing up 
- * a slot in edenEntries.  If there isn't an available slot in promotionEntries, 
+ *
+ * If a subsequent request, finds a matching item in edenEntries.  The hit count
+ * of the CacheEntry is bumped.  If the CacheEntry exceeds the current promotion
+ * threshold, then the CacheEntry is inserted into promotionEntries -- freeing up
+ * a slot in edenEntries.  If there isn't an available slot in promotionEntries,
  * the LRU: least recently used promotionEntry is evicted.
- * 
+ *
  * If there are no available slots in edenEntries for a newly created CacheEntry...
- * 
- * Attempt to early promote the MFU: most frequently used CacheEntry from 
+ *
+ * Attempt to early promote the MFU: most frequently used CacheEntry from
  * edenEntries to promotedEntries (without eviction).
- * 
- * If there's no space in promotedEntries to promote the MFU, then evict the 
+ *
+ * If there's no space in promotedEntries to promote the MFU, then evict the
  * LFU: least frequently used entry from edenEntries instead.
- * 
- * 
+ *
+ *
  * LRU based eviction of the promotedEntries works on tagging with the last hit time.
- * The access time can be provided directly to ValueUtf8Cache#getUtf8 or can 
+ * The access time can be provided directly to ValueUtf8Cache#getUtf8 or can
  * be refreshed periodically by calling ValueUtf8Cache#updateAccessTime.
- * 
- * If there's a natural transaction boundary around the UTF8 cache, 
- * calling ValueUtf8Cache#recalibrateThresholds will adjust promotion 
+ *
+ * If there's a natural transaction boundary around the UTF8 cache,
+ * calling ValueUtf8Cache#recalibrateThresholds will adjust promotion
  * thresholds to provide better cache utilization.
  */
 public final class GenerationalUtf8Cache implements EncodingCache {
   private static final int MAX_PROBES = 8;
-  
+
   private static final int MIN_PROMOTION_TRESHOLD = 2;
   private static final int INITIAL_PROMOTION_THRESHOLD = 10;
-  
+
   private static final double HIT_DECAY = 0.8D;
   private static final double PURGE_THRESHOLD = 0.25D;
-  
+
   private final CacheEntry[] edenEntries;
   private final boolean[] edenMarkers;
-  
+
   private final CacheEntry[] promotedEntries;
-  
+
   private long accessTimeMs;
   private double promotionThreshold = INITIAL_PROMOTION_THRESHOLD;
-  
+
   int edenHits = 0;
   int promotedHits = 0;
   int earlyPromotions = 0;
   int promotions = 0;
   int edenEvictions = 0;
   int promotedEvictions = 0;
-  
+
   public GenerationalUtf8Cache() {
-	this.accessTimeMs = System.currentTimeMillis();
-	
-	// These sizes must be powers of 2
-	this.edenEntries = new CacheEntry[256];
-	this.edenMarkers = new boolean[256];
-	
-	// The size must be a power of 2
-	this.promotedEntries = new CacheEntry[512];
+    this.accessTimeMs = System.currentTimeMillis();
+
+    // These sizes must be powers of 2
+    this.edenEntries = new CacheEntry[256];
+    this.edenMarkers = new boolean[256];
+
+    // The size must be a power of 2
+    this.promotedEntries = new CacheEntry[512];
   }
-  
-  /**
-   * Updates access time used @link {@link #getUtf8(String, String)} to the provided value
-   */
+
+  /** Updates access time used @link {@link #getUtf8(String, String)} to the provided value */
   public void updateAccessTime(long accessTimeMs) {
-	this.accessTimeMs = accessTimeMs;
+    this.accessTimeMs = accessTimeMs;
   }
-  
-  /**
-   * Updates access time to the @link {@link System#currentTimeMillis()}
-   */
+
+  /** Updates access time to the @link {@link System#currentTimeMillis()} */
   public void refreshAcessTime() {
-	this.updateAccessTime(System.currentTimeMillis());
+    this.updateAccessTime(System.currentTimeMillis());
   }
-  
+
   public void recalibrate() {
-	this.recalibrate(System.currentTimeMillis());
+    this.recalibrate(System.currentTimeMillis());
   }
-  
+
   /**
-   * Recalibrates promotion threshold based on promotion & eviction statistics, 
-   * since last calibration - resets statistics
+   * Recalibrates promotion threshold based on promotion & eviction statistics, since last
+   * calibration - resets statistics
+   *
    * @param accessTimeMs
    */
   public void recalibrate(long accessTimeMs) {
-	this.accessTimeMs = accessTimeMs;
-	
-	CacheEntry[] thisEntries = this.edenEntries;
-	for ( int i = 0; i < thisEntries.length; ++i ) {
-	  CacheEntry entry = thisEntries[i];	  
-	  if ( entry == null ) continue;
-	  
-	  boolean purge = entry.decay();
-	  if ( purge ) this.edenEntries[i] = null;
-	}
-	
-	Arrays.fill(this.edenMarkers, false);
-	
-	int totalPromotions = this.promotions + this.earlyPromotions;
-	if ( totalPromotions == 0 && this.promotionThreshold >= MIN_PROMOTION_TRESHOLD ) {
-	  this.promotionThreshold /= 1.5;
-	} else if ( totalPromotions > this.promotedEvictions / 2 ) {
-	  this.promotionThreshold *= 1.5;
-	}
-	
-	this.edenHits = 0;
-	this.promotedHits = 0;
-	this.earlyPromotions = 0;
-	this.promotions = 0;
-	this.edenEvictions = 0;
-	this.promotedEvictions = 0;
+    this.accessTimeMs = accessTimeMs;
+
+    CacheEntry[] thisEntries = this.edenEntries;
+    for (int i = 0; i < thisEntries.length; ++i) {
+      CacheEntry entry = thisEntries[i];
+      if (entry == null) continue;
+
+      boolean purge = entry.decay();
+      if (purge) this.edenEntries[i] = null;
+    }
+
+    Arrays.fill(this.edenMarkers, false);
+
+    int totalPromotions = this.promotions + this.earlyPromotions;
+    if (totalPromotions == 0 && this.promotionThreshold >= MIN_PROMOTION_TRESHOLD) {
+      this.promotionThreshold /= 1.5;
+    } else if (totalPromotions > this.promotedEvictions / 2) {
+      this.promotionThreshold *= 1.5;
+    }
+
+    this.edenHits = 0;
+    this.promotedHits = 0;
+    this.earlyPromotions = 0;
+    this.promotions = 0;
+    this.edenEvictions = 0;
+    this.promotedEvictions = 0;
   }
-  
+
   @Override
   public byte[] encode(CharSequence charSeq) {
-	if ( charSeq instanceof String ) {
-	  String str = (String)charSeq;
-	  return this.getUtf8(str);
-	} else {
-	  return null;
-	}
+    if (charSeq instanceof String) {
+      String str = (String) charSeq;
+      return this.getUtf8(str);
+    } else {
+      return null;
+    }
   }
-  
-  /**
-   * Returns the UTF-8 encoding of value -- using a cache value if available
-   */
+
+  /** Returns the UTF-8 encoding of value -- using a cache value if available */
   public final byte[] getUtf8(String value) {
     return this.getUtf8(value, this.accessTimeMs);
   }
-  
+
   /**
-   * Returns the UTF-8 encoding of value -- using a cache value if available
-   * If there is cache hit, the specified accessTimeMs is used to update the cache entry
+   * Returns the UTF-8 encoding of value -- using a cache value if available If there is cache hit,
+   * the specified accessTimeMs is used to update the cache entry
    */
   public final byte[] getUtf8(String value, long accessTimeMs) {
-	int valueHash = value.hashCode();
-	
-	CacheEntry[] localEntries = this.edenEntries;
-	long lookupTimeMs = this.accessTimeMs;
-	
-	int matchingLocalIndex = lookupEntry(localEntries, valueHash, value, lookupTimeMs);
-	if ( matchingLocalIndex != -1 ) {
-	  CacheEntry localEntry = localEntries[matchingLocalIndex];
-	  
-	  double hits = localEntry.hit(lookupTimeMs);
-	  if ( hits > this.promotionThreshold ) {
-		// mark promoted first - to avoid racy insertions
-		this.promotions += 1;
-		
-		boolean evicted = lruInsert(this.promotedEntries, localEntry);
-		if ( evicted ) this.promotedEvictions += 1;
-		
-		localEntries[matchingLocalIndex] = null;
-	  }
-	  
-	  this.edenHits += 1;
-	  return localEntry.utf8();
-	}
-	
-	CacheEntry[] promotedEntries = this.promotedEntries;
-	int matchingPromotedIndex = lookupEntry(promotedEntries, valueHash, value, lookupTimeMs);
-	if ( matchingPromotedIndex != -1 ) {
-   	  CacheEntry promotedEntry = promotedEntries[matchingPromotedIndex];
-		  
-	  promotedEntry.hit(lookupTimeMs);
-	  
-	  this.promotedHits += 1;
-	  return promotedEntry.utf8();
-	}
-	
-	boolean wasMarked = reverseMark(this.edenMarkers, valueHash);
-	
-	// If slot isn't marked, this is likely the first request
-	// Don't create an entry yet
-	if ( !wasMarked ) return CacheEntry.utf8(value);
-	
-	CacheEntry newEntry = new CacheEntry(valueHash, value);
-	// First request was swallowed by marking, so double hit
-	newEntry.hit(lookupTimeMs);
-	newEntry.hit(lookupTimeMs);
-	
-	// search for empty slot or failing that the MFU entry
-	int localMfuIndex = findFirstAvailableOrMfuIndex(localEntries, valueHash);
-	CacheEntry localMfuEntry = localEntries[localMfuIndex];
-	
-	// Found an empty slot - fill it
-	if ( localMfuEntry == null ) {
-	  localEntries[localMfuIndex] = newEntry;
-	  return newEntry.utf8();
-	}
-	
-	// See if we can early promote the local MFU entry into the global cache
-	// Early promotion doesn't evict from the global cache
-	int globalAvailableIndex = findAvailable(promotedEntries, localMfuEntry.valueHash());
-	if ( globalAvailableIndex != -1 ) {
-	  promotedEntries[globalAvailableIndex] = localMfuEntry;
-	  this.earlyPromotions += 1;
-	  
-	  localEntries[localMfuIndex] = newEntry;
-	  return CacheEntry.utf8(value);
-	}
-	
-	// No empty slot - or space to promote into the global cache
-	// Insert into local cache while evicting the LFU	
-	boolean evicted = lfuInsert(localEntries, newEntry);
-	if ( evicted ) this.promotedEvictions += 1;
-	
-	return newEntry.utf8();
+    int valueHash = value.hashCode();
+
+    CacheEntry[] localEntries = this.edenEntries;
+    long lookupTimeMs = this.accessTimeMs;
+
+    int matchingLocalIndex = lookupEntry(localEntries, valueHash, value, lookupTimeMs);
+    if (matchingLocalIndex != -1) {
+      CacheEntry localEntry = localEntries[matchingLocalIndex];
+
+      double hits = localEntry.hit(lookupTimeMs);
+      if (hits > this.promotionThreshold) {
+        // mark promoted first - to avoid racy insertions
+        this.promotions += 1;
+
+        boolean evicted = lruInsert(this.promotedEntries, localEntry);
+        if (evicted) this.promotedEvictions += 1;
+
+        localEntries[matchingLocalIndex] = null;
+      }
+
+      this.edenHits += 1;
+      return localEntry.utf8();
+    }
+
+    CacheEntry[] promotedEntries = this.promotedEntries;
+    int matchingPromotedIndex = lookupEntry(promotedEntries, valueHash, value, lookupTimeMs);
+    if (matchingPromotedIndex != -1) {
+      CacheEntry promotedEntry = promotedEntries[matchingPromotedIndex];
+
+      promotedEntry.hit(lookupTimeMs);
+
+      this.promotedHits += 1;
+      return promotedEntry.utf8();
+    }
+
+    boolean wasMarked = reverseMark(this.edenMarkers, valueHash);
+
+    // If slot isn't marked, this is likely the first request
+    // Don't create an entry yet
+    if (!wasMarked) return CacheEntry.utf8(value);
+
+    CacheEntry newEntry = new CacheEntry(valueHash, value);
+    // First request was swallowed by marking, so double hit
+    newEntry.hit(lookupTimeMs);
+    newEntry.hit(lookupTimeMs);
+
+    // search for empty slot or failing that the MFU entry
+    int localMfuIndex = findFirstAvailableOrMfuIndex(localEntries, valueHash);
+    CacheEntry localMfuEntry = localEntries[localMfuIndex];
+
+    // Found an empty slot - fill it
+    if (localMfuEntry == null) {
+      localEntries[localMfuIndex] = newEntry;
+      return newEntry.utf8();
+    }
+
+    // See if we can early promote the local MFU entry into the global cache
+    // Early promotion doesn't evict from the global cache
+    int globalAvailableIndex = findAvailable(promotedEntries, localMfuEntry.valueHash());
+    if (globalAvailableIndex != -1) {
+      promotedEntries[globalAvailableIndex] = localMfuEntry;
+      this.earlyPromotions += 1;
+
+      localEntries[localMfuIndex] = newEntry;
+      return CacheEntry.utf8(value);
+    }
+
+    // No empty slot - or space to promote into the global cache
+    // Insert into local cache while evicting the LFU
+    boolean evicted = lfuInsert(localEntries, newEntry);
+    if (evicted) this.promotedEvictions += 1;
+
+    return newEntry.utf8();
   }
-  
+
   static final int findAvailable(CacheEntry[] entries, int newValueHash) {
-	int initialBucketIndex = initialBucketIndex(entries, newValueHash);
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry == null || entry.hits() == 0 ) return index;
-	}
-	return -1;
+    int initialBucketIndex = initialBucketIndex(entries, newValueHash);
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry == null || entry.hits() == 0) return index;
+    }
+    return -1;
   }
-  
+
   static final int findFirstAvailableOrMfuIndex(CacheEntry[] entries, int newValueHash) {
-	double mfuHits = Double.MIN_VALUE;
-	int mfuIndex = -1;
-	
-	int initialBucketIndex = initialBucketIndex(entries, newValueHash);
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry == null ) return index;
-	  
-	  double hits = entry.hits();
-	  if ( hits > mfuHits ) {
-		mfuHits = hits;
-		mfuIndex = index;
-	  }
-	}
-	return mfuIndex;
+    double mfuHits = Double.MIN_VALUE;
+    int mfuIndex = -1;
+
+    int initialBucketIndex = initialBucketIndex(entries, newValueHash);
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry == null) return index;
+
+      double hits = entry.hits();
+      if (hits > mfuHits) {
+        mfuHits = hits;
+        mfuIndex = index;
+      }
+    }
+    return mfuIndex;
   }
-  
+
   static final boolean reverseMark(boolean[] marks, int newValueHash) {
-	int index = initialBucketIndex(marks, newValueHash);
-	boolean wasMarked = marks[index];
-	marks[index] = !wasMarked;
-	return wasMarked;
+    int index = initialBucketIndex(marks, newValueHash);
+    boolean wasMarked = marks[index];
+    marks[index] = !wasMarked;
+    return wasMarked;
   }
-  
+
   static final boolean lfuInsert(CacheEntry[] entries, CacheEntry newEntry) {
     int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
-    
+
     // initial scan to see if there's an empty slot or marker entry is already present
     double lowestHits = Double.MAX_VALUE;
     int lfuIndex = -1;
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry == null || entry.hits() == 0 ) {
-		entries[index] = newEntry;
-		return false;
-	  } else {
-		double hits = entry.hits();
-		if ( hits < lowestHits ) {
-		  lowestHits = hits;
-		  lfuIndex = index;
-		}
-	  }
-	}
-	
-	// If we get here, then we're evicted the LRU
-	entries[lfuIndex] = newEntry;
-	return true;
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry == null || entry.hits() == 0) {
+        entries[index] = newEntry;
+        return false;
+      } else {
+        double hits = entry.hits();
+        if (hits < lowestHits) {
+          lowestHits = hits;
+          lfuIndex = index;
+        }
+      }
+    }
+
+    // If we get here, then we're evicted the LRU
+    entries[lfuIndex] = newEntry;
+    return true;
   }
-  
+
   static final boolean lruInsert(CacheEntry[] entries, CacheEntry newEntry) {
     int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
-    
+
     // initial scan to see if there's an empty slot or entry is already present
     long lowestUsedMs = Long.MAX_VALUE;
     int lruIndex = -1;
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry == null ) {
-		entries[index] = newEntry;
-		return false;
-	  } else if ( entry.matches(newEntry) ) {
-		entries[index] = newEntry;
-		return false;
-	  } else {
-		long lastUsedMs = entry.lastUsedMs();
-		if ( lastUsedMs < lowestUsedMs ) {
-		  lowestUsedMs = lastUsedMs;
-		  lruIndex = index;
-		}
-	  }
-	}
-	
-	entries[lruIndex] = newEntry;
-	return true;
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry == null) {
+        entries[index] = newEntry;
+        return false;
+      } else if (entry.matches(newEntry)) {
+        entries[index] = newEntry;
+        return false;
+      } else {
+        long lastUsedMs = entry.lastUsedMs();
+        if (lastUsedMs < lowestUsedMs) {
+          lowestUsedMs = lastUsedMs;
+          lruIndex = index;
+        }
+      }
+    }
+
+    entries[lruIndex] = newEntry;
+    return true;
   }
-  
+
   static final int initialBucketIndex(CacheEntry[] entries, int valueHash) {
     return valueHash & (entries.length - 1);
   }
@@ -348,90 +343,87 @@ public final class GenerationalUtf8Cache implements EncodingCache {
   static final int initialBucketIndex(boolean[] marks, int valueHash) {
     return valueHash & (marks.length - 1);
   }
-  
+
   static final int lookupEntry(
-    CacheEntry[] entries,
-    int valueHash, String value,
-    long lookupTimeMs)
-  {
-	int initialBucketIndex = initialBucketIndex(entries, valueHash);
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry != null && entry.matches(valueHash, value) ) {
-		return index;
-	  }
-	}
-	return -1;
+      CacheEntry[] entries, int valueHash, String value, long lookupTimeMs) {
+    int initialBucketIndex = initialBucketIndex(entries, valueHash);
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry != null && entry.matches(valueHash, value)) {
+        return index;
+      }
+    }
+    return -1;
   }
-  
+
   static final int bucketHash(int tagHash, int valueHash) {
-	return tagHash + 31 * valueHash;
+    return tagHash + 31 * valueHash;
   }
-  
+
   static final class CacheEntry {
-	final int valueHash;
+    final int valueHash;
     final String value;
     final byte[] valueUtf8;
-    
+
     boolean promoted = false;
     long lastUsedMs = 0;
     double hitCount = 0;
-    
+
     public CacheEntry(int valueHash, String value) {
       this.valueHash = valueHash;
       this.value = value;
       this.valueUtf8 = utf8(value);
     }
-    
-    boolean matches(CacheEntry thatEntry ) {
-      return ( this == thatEntry ) || this.matches(thatEntry.valueHash, thatEntry.value);
+
+    boolean matches(CacheEntry thatEntry) {
+      return (this == thatEntry) || this.matches(thatEntry.valueHash, thatEntry.value);
     }
-    
+
     boolean matches(int valueHash, String value) {
       return (this.valueHash == valueHash) && value.equals(this.value);
     }
-    
+
     int valueHash() {
       return this.valueHash;
     }
-    
+
     double hits() {
-      return this.hitCount;	  
+      return this.hitCount;
     }
-    
+
     long lastUsedMs() {
       return this.lastUsedMs;
     }
-    
+
     byte[] utf8() {
       return this.valueUtf8;
     }
-    
+
     double hit(long lastUsedMs) {
       this.lastUsedMs = lastUsedMs;
       this.hitCount += 1;
-      
+
       return this.hitCount;
     }
-    
+
     boolean decay() {
       this.hitCount *= HIT_DECAY;
-      
+
       return (this.hitCount < PURGE_THRESHOLD);
     }
-    
+
     static final byte[] utf8(String value) {
       return value.getBytes(StandardCharsets.UTF_8);
     }
-    
+
     @Override
     public String toString() {
-      if ( this.value == null ) {
-    	return "marker";
+      if (this.value == null) {
+        return "marker";
       } else {
-    	return this.value + " - hits: " + this.hitCount + " used (ms): " + this.lastUsedMs;
+        return this.value + " - hits: " + this.hitCount + " used (ms): " + this.lastUsedMs;
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/SimpleUtf8Cache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/SimpleUtf8Cache.java
@@ -1,0 +1,227 @@
+package datadog.trace.common.writer.ddagent;
+
+import datadog.communication.serialization.EncodingCache;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/** 
+ * A simple UTF8 cache - primarily intended for tag names
+ * 
+ * Cache is designed to against resilient against single use tags
+ * 
+ * NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead.
+ * Using the cache has higher CPU overhead than simply calling {@link String#getBytes(java.nio.charset.Charset)}.
+ *  
+ * The cache is thread safe.
+ */
+/* 
+ * Thread safety is achieved through using CacheEntry objects where the key data 
+ * fields are final.
+ * 
+ * Updating of the cache and bookkeeping are deliberately allowed to be racy to 
+ * minimize CPU overhead and lock contention.
+ *  
+ * The first time a value is requested, the value isn't cached and no CacheEntry 
+ * is created.  Without this refinement, the cost for constructing 
+ * CacheEntry for unique values would negate the benefit of the cache.
+ * 
+ * These first requests are tracked via markers which indicate if there was 
+ * previously an unsatisfied request to the same initial cache line.
+ * 
+ * If there was a request, then CacheEntry is created and stored into entries.
+ * NOTE: The cache line marking process is imprecise and subject to request 
+ * ordering issues, but given that low cardinality entries are more likely to repeat
+ * next, imperically this scheme works well.
+ * 
+ * If a collision occurs in the cache, linear probing is used to check other slots.
+ * New cache entries fill any available slot within the probing window.
+ * 
+ * If a subsequent request, finds a matching item in entries.  The hit count 
+ * of the CacheEntry is bumped.
+ * 
+ * If there are no available slots in entries for a newly created CacheEntry,
+ * a LFU: least frequently used eviction policy is used to free up a slot.
+ */
+public final class SimpleUtf8Cache implements EncodingCache {
+  public static final SimpleUtf8Cache INSTANCE = new SimpleUtf8Cache();
+	
+  private static final int MAX_PROBES = 8;
+  
+  private final int SIZE = 256;
+  
+  private final boolean[] markers = new boolean[SIZE];
+  private final CacheEntry[] entries = new CacheEntry[SIZE];
+  
+  private static final double HIT_DECAY = 0.8D;
+  private static final double PURGE_THRESHOLD = 0.25D;
+  
+  protected int hits = 0;
+  protected int evictions = 0;
+  
+  public void recalibrate() {
+	CacheEntry[] thisEntries = this.entries;
+	for ( int i = 0; i < thisEntries.length; ++i ) {
+	  CacheEntry entry = thisEntries[i];
+	  if ( entry == null ) continue;
+	  
+	  boolean purge = entry.decay();
+	  if ( purge ) thisEntries[i] = null;
+	}
+	
+	Arrays.fill(this.markers, false);
+  }
+  
+  @Override
+  public byte[] encode(CharSequence charSeq) {
+	if ( charSeq instanceof String ) {
+	  String str = (String)charSeq;
+	  return this.getUtf8(str);
+	} else {
+	  return null;
+	}
+  }
+  
+  /**
+   * Returns the UTF-8 encoding of value -- using a cache value if available
+   */
+  public final byte[] getUtf8(String value) {
+	CacheEntry[] thisEntries = this.entries;
+
+	int valueHash = value.hashCode();
+	
+	CacheEntry matchingEntry = lookupEntry(thisEntries, valueHash, value);
+	if ( matchingEntry != null ) {
+	  this.hits += 1;
+	  return matchingEntry.utf8();
+	}
+	
+	boolean wasMarked = reverseMark(this.markers, valueHash);
+	if ( !wasMarked ) return CacheEntry.utf8(value);
+	
+	CacheEntry newEntry = new CacheEntry(valueHash, value);
+	newEntry.hit();
+	
+	boolean evicted = lfuInsert(thisEntries, newEntry);
+	if ( evicted ) this.evictions += 1;
+	
+	return newEntry.utf8();
+  }
+  
+  static final CacheEntry lookupEntry(
+    CacheEntry[] entries,
+    int valueHash, String value)
+  {
+	int initialBucketIndex = initialBucketIndex(entries, valueHash);
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry != null && entry.matches(valueHash, value) ) {
+		return entry;
+	  }
+	}
+	return null;
+  }
+  
+  static final boolean lfuInsert(CacheEntry[] entries, CacheEntry newEntry) {
+    int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
+    
+    // initial scan to see if there's an empty slot or marker entry is already present
+    double lowestHits = Double.MAX_VALUE;
+    int lfuIndex = -1;
+	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
+	  if ( index >= entries.length ) index = 0;
+	  
+	  CacheEntry entry = entries[index];
+	  if ( entry == null || entry.hits() == 0 ) {
+		entries[index] = newEntry;
+		return false;
+	  } else {
+		double hits = entry.hits();
+		if ( hits < lowestHits ) {
+		  lowestHits = hits;
+		  lfuIndex = index;
+		}
+	  }
+	}
+	
+	// If we get here, then we're evicting the LRU
+	entries[lfuIndex] = newEntry;
+	return true;
+  }
+  
+  static final int initialBucketIndex(CacheEntry[] entries, int valueHash) {
+    return valueHash & (entries.length - 1);
+  }
+
+  static final int initialBucketIndex(boolean[] marks, int valueHash) {
+    return valueHash & (marks.length - 1);
+  }
+  
+  static final boolean reverseMark(boolean[] marks, int newValueHash) {
+	int index = initialBucketIndex(marks, newValueHash);
+	boolean wasMarked = marks[index];
+	marks[index] = !wasMarked;
+	return wasMarked;
+  }
+		  
+  static final class CacheEntry {
+	final int valueHash;
+    final String value;
+    final byte[] valueUtf8;
+    
+    boolean promoted = false;
+    double hitCount = 0;
+    
+    public CacheEntry(int valueHash, String value) {
+      this.valueHash = valueHash;
+      this.value = value;
+      this.valueUtf8 = utf8(value);
+    }
+    
+    boolean matches(CacheEntry thatEntry ) {
+      return ( this == thatEntry ) || this.matches(thatEntry.valueHash, thatEntry.value);
+    }
+    
+    boolean matches(int valueHash, String value) {
+      return (this.valueHash == valueHash) && value.equals(this.value);
+    }
+    
+    int valueHash() {
+      return this.valueHash;
+    }
+    
+    double hits() {
+      return this.hitCount;	  
+    }
+    
+    byte[] utf8() {
+      return this.valueUtf8;
+    }
+    
+    double hit() {
+      this.hitCount += 1;
+      
+      return this.hitCount;
+    }
+    
+    boolean decay() {
+      this.hitCount *= HIT_DECAY;
+      
+      return (this.hitCount < PURGE_THRESHOLD);
+    }
+    
+    static final byte[] utf8(String value) {
+      return value.getBytes(StandardCharsets.UTF_8);
+    }
+    
+    @Override
+    public String toString() {
+      if ( this.value == null ) {
+    	return "marker";
+      } else {
+    	return this.value + " - hits: " + this.hitCount;
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/SimpleUtf8Cache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/SimpleUtf8Cache.java
@@ -4,152 +4,148 @@ import datadog.communication.serialization.EncodingCache;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-/** 
+/**
  * A simple UTF8 cache - primarily intended for tag names
- * 
- * Cache is designed to against resilient against single use tags
- * 
- * NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead.
- * Using the cache has higher CPU overhead than simply calling {@link String#getBytes(java.nio.charset.Charset)}.
- *  
- * The cache is thread safe.
+ *
+ * <p>Cache is designed to against resilient against single use tags
+ *
+ * <p>NOTE: The aim of this cache is to reduce allocation overhead -- not CPU overhead. Using the
+ * cache has higher CPU overhead than simply calling {@link
+ * String#getBytes(java.nio.charset.Charset)}.
+ *
+ * <p>The cache is thread safe.
  */
-/* 
- * Thread safety is achieved through using CacheEntry objects where the key data 
+/*
+ * Thread safety is achieved through using CacheEntry objects where the key data
  * fields are final.
- * 
- * Updating of the cache and bookkeeping are deliberately allowed to be racy to 
+ *
+ * Updating of the cache and bookkeeping are deliberately allowed to be racy to
  * minimize CPU overhead and lock contention.
- *  
- * The first time a value is requested, the value isn't cached and no CacheEntry 
- * is created.  Without this refinement, the cost for constructing 
+ *
+ * The first time a value is requested, the value isn't cached and no CacheEntry
+ * is created.  Without this refinement, the cost for constructing
  * CacheEntry for unique values would negate the benefit of the cache.
- * 
- * These first requests are tracked via markers which indicate if there was 
+ *
+ * These first requests are tracked via markers which indicate if there was
  * previously an unsatisfied request to the same initial cache line.
- * 
+ *
  * If there was a request, then CacheEntry is created and stored into entries.
- * NOTE: The cache line marking process is imprecise and subject to request 
+ * NOTE: The cache line marking process is imprecise and subject to request
  * ordering issues, but given that low cardinality entries are more likely to repeat
  * next, imperically this scheme works well.
- * 
+ *
  * If a collision occurs in the cache, linear probing is used to check other slots.
  * New cache entries fill any available slot within the probing window.
- * 
- * If a subsequent request, finds a matching item in entries.  The hit count 
+ *
+ * If a subsequent request, finds a matching item in entries.  The hit count
  * of the CacheEntry is bumped.
- * 
+ *
  * If there are no available slots in entries for a newly created CacheEntry,
  * a LFU: least frequently used eviction policy is used to free up a slot.
  */
 public final class SimpleUtf8Cache implements EncodingCache {
   public static final SimpleUtf8Cache INSTANCE = new SimpleUtf8Cache();
-	
+
   private static final int MAX_PROBES = 8;
-  
+
   private final int SIZE = 256;
-  
+
   private final boolean[] markers = new boolean[SIZE];
   private final CacheEntry[] entries = new CacheEntry[SIZE];
-  
+
   private static final double HIT_DECAY = 0.8D;
   private static final double PURGE_THRESHOLD = 0.25D;
-  
+
   protected int hits = 0;
   protected int evictions = 0;
-  
+
   public void recalibrate() {
-	CacheEntry[] thisEntries = this.entries;
-	for ( int i = 0; i < thisEntries.length; ++i ) {
-	  CacheEntry entry = thisEntries[i];
-	  if ( entry == null ) continue;
-	  
-	  boolean purge = entry.decay();
-	  if ( purge ) thisEntries[i] = null;
-	}
-	
-	Arrays.fill(this.markers, false);
+    CacheEntry[] thisEntries = this.entries;
+    for (int i = 0; i < thisEntries.length; ++i) {
+      CacheEntry entry = thisEntries[i];
+      if (entry == null) continue;
+
+      boolean purge = entry.decay();
+      if (purge) thisEntries[i] = null;
+    }
+
+    Arrays.fill(this.markers, false);
   }
-  
+
   @Override
   public byte[] encode(CharSequence charSeq) {
-	if ( charSeq instanceof String ) {
-	  String str = (String)charSeq;
-	  return this.getUtf8(str);
-	} else {
-	  return null;
-	}
+    if (charSeq instanceof String) {
+      String str = (String) charSeq;
+      return this.getUtf8(str);
+    } else {
+      return null;
+    }
   }
-  
-  /**
-   * Returns the UTF-8 encoding of value -- using a cache value if available
-   */
-  public final byte[] getUtf8(String value) {
-	CacheEntry[] thisEntries = this.entries;
 
-	int valueHash = value.hashCode();
-	
-	CacheEntry matchingEntry = lookupEntry(thisEntries, valueHash, value);
-	if ( matchingEntry != null ) {
-	  this.hits += 1;
-	  return matchingEntry.utf8();
-	}
-	
-	boolean wasMarked = reverseMark(this.markers, valueHash);
-	if ( !wasMarked ) return CacheEntry.utf8(value);
-	
-	CacheEntry newEntry = new CacheEntry(valueHash, value);
-	newEntry.hit();
-	
-	boolean evicted = lfuInsert(thisEntries, newEntry);
-	if ( evicted ) this.evictions += 1;
-	
-	return newEntry.utf8();
+  /** Returns the UTF-8 encoding of value -- using a cache value if available */
+  public final byte[] getUtf8(String value) {
+    CacheEntry[] thisEntries = this.entries;
+
+    int valueHash = value.hashCode();
+
+    CacheEntry matchingEntry = lookupEntry(thisEntries, valueHash, value);
+    if (matchingEntry != null) {
+      this.hits += 1;
+      return matchingEntry.utf8();
+    }
+
+    boolean wasMarked = reverseMark(this.markers, valueHash);
+    if (!wasMarked) return CacheEntry.utf8(value);
+
+    CacheEntry newEntry = new CacheEntry(valueHash, value);
+    newEntry.hit();
+
+    boolean evicted = lfuInsert(thisEntries, newEntry);
+    if (evicted) this.evictions += 1;
+
+    return newEntry.utf8();
   }
-  
-  static final CacheEntry lookupEntry(
-    CacheEntry[] entries,
-    int valueHash, String value)
-  {
-	int initialBucketIndex = initialBucketIndex(entries, valueHash);
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry != null && entry.matches(valueHash, value) ) {
-		return entry;
-	  }
-	}
-	return null;
+
+  static final CacheEntry lookupEntry(CacheEntry[] entries, int valueHash, String value) {
+    int initialBucketIndex = initialBucketIndex(entries, valueHash);
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry != null && entry.matches(valueHash, value)) {
+        return entry;
+      }
+    }
+    return null;
   }
-  
+
   static final boolean lfuInsert(CacheEntry[] entries, CacheEntry newEntry) {
     int initialBucketIndex = initialBucketIndex(entries, newEntry.valueHash());
-    
+
     // initial scan to see if there's an empty slot or marker entry is already present
     double lowestHits = Double.MAX_VALUE;
     int lfuIndex = -1;
-	for ( int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index ) {
-	  if ( index >= entries.length ) index = 0;
-	  
-	  CacheEntry entry = entries[index];
-	  if ( entry == null || entry.hits() == 0 ) {
-		entries[index] = newEntry;
-		return false;
-	  } else {
-		double hits = entry.hits();
-		if ( hits < lowestHits ) {
-		  lowestHits = hits;
-		  lfuIndex = index;
-		}
-	  }
-	}
-	
-	// If we get here, then we're evicting the LRU
-	entries[lfuIndex] = newEntry;
-	return true;
+    for (int probe = 0, index = initialBucketIndex; probe < MAX_PROBES; ++probe, ++index) {
+      if (index >= entries.length) index = 0;
+
+      CacheEntry entry = entries[index];
+      if (entry == null || entry.hits() == 0) {
+        entries[index] = newEntry;
+        return false;
+      } else {
+        double hits = entry.hits();
+        if (hits < lowestHits) {
+          lowestHits = hits;
+          lfuIndex = index;
+        }
+      }
+    }
+
+    // If we get here, then we're evicting the LRU
+    entries[lfuIndex] = newEntry;
+    return true;
   }
-  
+
   static final int initialBucketIndex(CacheEntry[] entries, int valueHash) {
     return valueHash & (entries.length - 1);
   }
@@ -157,70 +153,70 @@ public final class SimpleUtf8Cache implements EncodingCache {
   static final int initialBucketIndex(boolean[] marks, int valueHash) {
     return valueHash & (marks.length - 1);
   }
-  
+
   static final boolean reverseMark(boolean[] marks, int newValueHash) {
-	int index = initialBucketIndex(marks, newValueHash);
-	boolean wasMarked = marks[index];
-	marks[index] = !wasMarked;
-	return wasMarked;
+    int index = initialBucketIndex(marks, newValueHash);
+    boolean wasMarked = marks[index];
+    marks[index] = !wasMarked;
+    return wasMarked;
   }
-		  
+
   static final class CacheEntry {
-	final int valueHash;
+    final int valueHash;
     final String value;
     final byte[] valueUtf8;
-    
+
     boolean promoted = false;
     double hitCount = 0;
-    
+
     public CacheEntry(int valueHash, String value) {
       this.valueHash = valueHash;
       this.value = value;
       this.valueUtf8 = utf8(value);
     }
-    
-    boolean matches(CacheEntry thatEntry ) {
-      return ( this == thatEntry ) || this.matches(thatEntry.valueHash, thatEntry.value);
+
+    boolean matches(CacheEntry thatEntry) {
+      return (this == thatEntry) || this.matches(thatEntry.valueHash, thatEntry.value);
     }
-    
+
     boolean matches(int valueHash, String value) {
       return (this.valueHash == valueHash) && value.equals(this.value);
     }
-    
+
     int valueHash() {
       return this.valueHash;
     }
-    
+
     double hits() {
-      return this.hitCount;	  
+      return this.hitCount;
     }
-    
+
     byte[] utf8() {
       return this.valueUtf8;
     }
-    
+
     double hit() {
       this.hitCount += 1;
-      
+
       return this.hitCount;
     }
-    
+
     boolean decay() {
       this.hitCount *= HIT_DECAY;
-      
+
       return (this.hitCount < PURGE_THRESHOLD);
     }
-    
+
     static final byte[] utf8(String value) {
       return value.getBytes(StandardCharsets.UTF_8);
     }
-    
+
     @Override
     public String toString() {
-      if ( this.value == null ) {
-    	return "marker";
+      if (this.value == null) {
+        return "marker";
       } else {
-    	return this.value + " - hits: " + this.hitCount;
+        return this.value + " - hits: " + this.hitCount;
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import okhttp3.RequestBody;
 
 public final class TraceMapperV0_4 implements TraceMapper {
-  static final SimpleUtf8Cache TAG_CACHE = 
-	Config.get().isUtf8CacheEnabled() ? new SimpleUtf8Cache() : null;
-  
+  static final SimpleUtf8Cache TAG_CACHE =
+      Config.get().isUtf8CacheEnabled() ? new SimpleUtf8Cache() : null;
+
   static final GenerationalUtf8Cache VALUE_CACHE =
-	Config.get().isUtf8CacheEnabled() ? new GenerationalUtf8Cache() : null;
-	  
+      Config.get().isUtf8CacheEnabled() ? new GenerationalUtf8Cache() : null;
+
   private final int size;
 
   public TraceMapperV0_4(int size) {
@@ -65,7 +65,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
     public void accept(Metadata metadata) {
       TAG_CACHE.recalibrate();
       VALUE_CACHE.recalibrate();
-      
+
       final boolean writeSamplingPriority = firstSpanInChunk || lastSpanInChunk;
       final UTF8BytesString processTags =
           firstSpanInChunk ? ProcessTags.getTagsForSerialization() : null;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -6,6 +6,7 @@ import datadog.communication.serialization.Codec;
 import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.Writable;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
+import datadog.trace.api.Config;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -23,7 +24,12 @@ import java.util.Map;
 import okhttp3.RequestBody;
 
 public final class TraceMapperV0_4 implements TraceMapper {
-
+  static final SimpleUtf8Cache TAG_CACHE = 
+	Config.get().isUtf8CacheEnabled() ? new SimpleUtf8Cache() : null;
+  
+  static final GenerationalUtf8Cache VALUE_CACHE =
+	Config.get().isUtf8CacheEnabled() ? new GenerationalUtf8Cache() : null;
+	  
   private final int size;
 
   public TraceMapperV0_4(int size) {
@@ -57,6 +63,9 @@ public final class TraceMapperV0_4 implements TraceMapper {
 
     @Override
     public void accept(Metadata metadata) {
+      TAG_CACHE.recalibrate();
+      VALUE_CACHE.recalibrate();
+      
       final boolean writeSamplingPriority = firstSpanInChunk || lastSpanInChunk;
       final UTF8BytesString processTags =
           firstSpanInChunk ? ProcessTags.getTagsForSerialization() : null;
@@ -111,8 +120,8 @@ public final class TraceMapperV0_4 implements TraceMapper {
       writable.writeLong(metadata.getThreadId());
       for (Map.Entry<String, Object> entry : metadata.getTags().entrySet()) {
         if (entry.getValue() instanceof Number) {
-          writable.writeString(entry.getKey(), null);
-          writable.writeObject(entry.getValue(), null);
+          writable.writeString(entry.getKey(), TAG_CACHE);
+          writable.writeObject(entry.getValue(), VALUE_CACHE);
         }
       }
 
@@ -122,8 +131,8 @@ public final class TraceMapperV0_4 implements TraceMapper {
       // since they will be accumulated into maps in the same order downstream,
       // we just need to be sure that the size is the same as the number of elements
       for (Map.Entry<String, String> entry : metadata.getBaggage().entrySet()) {
-        writable.writeString(entry.getKey(), null);
-        writable.writeString(entry.getValue(), null);
+        writable.writeString(entry.getKey(), TAG_CACHE);
+        writable.writeString(entry.getValue(), VALUE_CACHE);
       }
       writable.writeUTF8(THREAD_NAME);
       writable.writeUTF8(metadata.getThreadName());
@@ -133,7 +142,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
       }
       if (null != metadata.getOrigin()) {
         writable.writeUTF8(ORIGIN_KEY);
-        writable.writeString(metadata.getOrigin(), null);
+        writable.writeString(metadata.getOrigin(), VALUE_CACHE);
       }
       if (processTags != null) {
         writable.writeUTF8(PROCESS_TAGS_KEY);
@@ -146,8 +155,8 @@ public final class TraceMapperV0_4 implements TraceMapper {
           // Write map as flat map
           writeFlatMap(key, (Map) value);
         } else if (!(value instanceof Number)) {
-          writable.writeString(entry.getKey(), null);
-          writable.writeObjectString(entry.getValue(), null);
+          writable.writeString(entry.getKey(), TAG_CACHE);
+          writable.writeObjectString(entry.getValue(), VALUE_CACHE);
         }
       }
     }
@@ -189,8 +198,8 @@ public final class TraceMapperV0_4 implements TraceMapper {
         if (newValue instanceof Map) {
           writeFlatMap(newKey, (Map) newValue);
         } else {
-          writable.writeString(newKey, null);
-          writable.writeObjectString(newValue, null);
+          writable.writeString(newKey, TAG_CACHE);
+          writable.writeObjectString(newValue, VALUE_CACHE);
         }
       }
     }
@@ -236,7 +245,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
       try {
         writer.writeObject(value, null);
         writer.flush();
-        writable.writeString(key, null);
+        writable.writeString(key, TAG_CACHE);
         writable.writeBinary(buffer.slice());
       } finally {
         buffer.reset();
@@ -256,13 +265,13 @@ public final class TraceMapperV0_4 implements TraceMapper {
       writable.startMap(metaStruct.isEmpty() ? 12 : 13);
       /* 1  */
       writable.writeUTF8(SERVICE);
-      writable.writeString(span.getServiceName(), null);
+      writable.writeString(span.getServiceName(), VALUE_CACHE);
       /* 2  */
       writable.writeUTF8(NAME);
-      writable.writeObject(span.getOperationName(), null);
+      writable.writeObject(span.getOperationName(), VALUE_CACHE);
       /* 3  */
       writable.writeUTF8(RESOURCE);
-      writable.writeObject(span.getResourceName(), null);
+      writable.writeObject(span.getResourceName(), VALUE_CACHE);
       /* 4  */
       writable.writeUTF8(TRACE_ID);
       writable.writeUnsignedLong(span.getTraceId().toLong());
@@ -280,7 +289,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
       writable.writeLong(PendingTrace.getDurationNano(span));
       /* 9  */
       writable.writeUTF8(TYPE);
-      writable.writeString(span.getType(), null);
+      writable.writeString(span.getType(), VALUE_CACHE);
       /* 10 */
       writable.writeUTF8(ERROR);
       writable.writeInt(span.getError());

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/GenerationalUtf8CacheTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/GenerationalUtf8CacheTest.java
@@ -1,0 +1,168 @@
+package datadog.trace.common.writer.ddagent;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class GenerationalUtf8CacheTest {
+  @ParameterizedTest
+  @ValueSource(strings={"foo", "bar", "baz", "quux"})
+  public void getUtf8(String value) {
+	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+	
+	for ( int i = 0; i < 10; ++i ) {	
+	  byte[] valueUtf8 = cache.getUtf8(value);
+	  assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
+	}
+  }
+  
+  @Test
+  public void caching() {
+	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+	
+	String value = "bar";
+	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+	
+	byte[] first = cache.getUtf8(value);
+	assertArrayEquals(expected, first);
+	
+	// first request isn't cached - to avoid burning slots
+	byte[] second = cache.getUtf8(value);
+	assertArrayEquals(expected, second);
+	assertNotSame(first, second);
+	
+	// after first request, the entry should be cached
+	byte[] third = cache.getUtf8(value);
+	assertArrayEquals(expected, third);
+	assertSame(second, third);
+	
+	assertNotEquals(0, cache.edenHits);
+  }
+  
+  @Test
+  public void promotion() {
+	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+	
+	String value = "bar";
+	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+
+	byte[] first = cache.getUtf8(value);
+	assertArrayEquals(expected, first);
+
+	byte[] second = cache.getUtf8(value);
+	assertArrayEquals(expected, second);
+	assertNotSame(second, first);
+
+	while ( cache.promotions == 0 ) {
+	  byte[] cached = cache.getUtf8(value);
+	  assertArrayEquals(expected, cached);
+	  assertSame(cached, second);
+	}
+	
+	assertNotEquals(0, cache.edenHits);
+	
+	for ( int i = 0; i < 10; ++i ) {
+	  byte[] cached = cache.getUtf8(value);
+	
+	  assertArrayEquals(expected, cached);
+	  assertSame(cached, second);
+	}
+  
+    assertNotEquals(0, cache.promotedHits);
+  }
+  
+  @Test
+  public void fuzz() {
+    Random random = ThreadLocalRandom.current();
+    
+    int edenHits = 0;
+    int promotedHits = 0;
+    
+	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+    for ( int i = 0; i < 1_000; ++i ) {
+      cache.recalibrate();
+      
+      int cycles = 500 + random.nextInt(2_000);
+      for ( int j = 0; j < cycles; ++j ) {
+    	String nextTag = nextTag();
+    	String nextValue = nextValue();
+    	byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
+    	
+    	byte[] nextValueUtf8 = cache.getUtf8(nextValue);
+    	assertArrayEquals(nextExpected, nextValueUtf8);
+      }
+      
+      edenHits += cache.edenHits;
+      promotedHits += cache.promotedHits;
+      
+      printStats(cache);
+    }
+    
+    assertNotEquals(0, edenHits);
+    assertNotEquals(0, promotedHits);
+  }
+  
+  static final String[] TAGS = {
+	"foo",
+	"bar",
+	"baz"
+  };
+  
+  static final String[] BASE_STRINGS = {
+    "Hello",
+    "world",
+    "foo",
+    "bar",
+    "baz",
+    "quux"
+  };
+  
+  static final String nextTag() {
+	ThreadLocalRandom random = ThreadLocalRandom.current();
+	
+	int tagIndex = random.nextInt(TAGS.length + 1);
+	if ( tagIndex >= TAGS.length ) {
+	  return "tag-" + Integer.toString(random.nextInt());
+	} else {
+	  return TAGS[tagIndex];
+	}
+  }
+  
+  static final String nextValue() {
+	ThreadLocalRandom random = ThreadLocalRandom.current();
+	
+	if ( random.nextDouble() < 0.1 ) {
+	  return Integer.toString(random.nextInt());
+	}
+	
+	int baseIndex = random.nextInt(BASE_STRINGS.length);
+	String baseString = BASE_STRINGS[baseIndex];
+	
+	if ( random.nextDouble() < 0.2 ) {
+	  baseString = baseString.toLowerCase();
+	}
+	
+	int valueSuffix = random.nextInt(2 * baseIndex + 1);
+	return baseString + valueSuffix; 
+  }
+  
+  static final void printStats(GenerationalUtf8Cache cache) {
+    System.out.printf(
+	 "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
+	 cache.edenHits,
+	 cache.promotedHits,
+	 cache.promotions,
+	 cache.earlyPromotions,
+	 cache.edenEvictions,
+	 cache.promotedEvictions);
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/GenerationalUtf8CacheTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/GenerationalUtf8CacheTest.java
@@ -8,161 +8,149 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class GenerationalUtf8CacheTest {
   @ParameterizedTest
-  @ValueSource(strings={"foo", "bar", "baz", "quux"})
+  @ValueSource(strings = {"foo", "bar", "baz", "quux"})
   public void getUtf8(String value) {
-	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
-	
-	for ( int i = 0; i < 10; ++i ) {	
-	  byte[] valueUtf8 = cache.getUtf8(value);
-	  assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
-	}
+    GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+
+    for (int i = 0; i < 10; ++i) {
+      byte[] valueUtf8 = cache.getUtf8(value);
+      assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
+    }
   }
-  
+
   @Test
   public void caching() {
-	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
-	
-	String value = "bar";
-	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
-	
-	byte[] first = cache.getUtf8(value);
-	assertArrayEquals(expected, first);
-	
-	// first request isn't cached - to avoid burning slots
-	byte[] second = cache.getUtf8(value);
-	assertArrayEquals(expected, second);
-	assertNotSame(first, second);
-	
-	// after first request, the entry should be cached
-	byte[] third = cache.getUtf8(value);
-	assertArrayEquals(expected, third);
-	assertSame(second, third);
-	
-	assertNotEquals(0, cache.edenHits);
+    GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+
+    String value = "bar";
+    byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+
+    byte[] first = cache.getUtf8(value);
+    assertArrayEquals(expected, first);
+
+    // first request isn't cached - to avoid burning slots
+    byte[] second = cache.getUtf8(value);
+    assertArrayEquals(expected, second);
+    assertNotSame(first, second);
+
+    // after first request, the entry should be cached
+    byte[] third = cache.getUtf8(value);
+    assertArrayEquals(expected, third);
+    assertSame(second, third);
+
+    assertNotEquals(0, cache.edenHits);
   }
-  
+
   @Test
   public void promotion() {
-	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
-	
-	String value = "bar";
-	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+    GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
 
-	byte[] first = cache.getUtf8(value);
-	assertArrayEquals(expected, first);
+    String value = "bar";
+    byte[] expected = value.getBytes(StandardCharsets.UTF_8);
 
-	byte[] second = cache.getUtf8(value);
-	assertArrayEquals(expected, second);
-	assertNotSame(second, first);
+    byte[] first = cache.getUtf8(value);
+    assertArrayEquals(expected, first);
 
-	while ( cache.promotions == 0 ) {
-	  byte[] cached = cache.getUtf8(value);
-	  assertArrayEquals(expected, cached);
-	  assertSame(cached, second);
-	}
-	
-	assertNotEquals(0, cache.edenHits);
-	
-	for ( int i = 0; i < 10; ++i ) {
-	  byte[] cached = cache.getUtf8(value);
-	
-	  assertArrayEquals(expected, cached);
-	  assertSame(cached, second);
-	}
-  
+    byte[] second = cache.getUtf8(value);
+    assertArrayEquals(expected, second);
+    assertNotSame(second, first);
+
+    while (cache.promotions == 0) {
+      byte[] cached = cache.getUtf8(value);
+      assertArrayEquals(expected, cached);
+      assertSame(cached, second);
+    }
+
+    assertNotEquals(0, cache.edenHits);
+
+    for (int i = 0; i < 10; ++i) {
+      byte[] cached = cache.getUtf8(value);
+
+      assertArrayEquals(expected, cached);
+      assertSame(cached, second);
+    }
+
     assertNotEquals(0, cache.promotedHits);
   }
-  
+
   @Test
   public void fuzz() {
     Random random = ThreadLocalRandom.current();
-    
+
     int edenHits = 0;
     int promotedHits = 0;
-    
-	GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
-    for ( int i = 0; i < 1_000; ++i ) {
+
+    GenerationalUtf8Cache cache = new GenerationalUtf8Cache();
+    for (int i = 0; i < 1_000; ++i) {
       cache.recalibrate();
-      
+
       int cycles = 500 + random.nextInt(2_000);
-      for ( int j = 0; j < cycles; ++j ) {
-    	String nextTag = nextTag();
-    	String nextValue = nextValue();
-    	byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
-    	
-    	byte[] nextValueUtf8 = cache.getUtf8(nextValue);
-    	assertArrayEquals(nextExpected, nextValueUtf8);
+      for (int j = 0; j < cycles; ++j) {
+        String nextTag = nextTag();
+        String nextValue = nextValue();
+        byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
+
+        byte[] nextValueUtf8 = cache.getUtf8(nextValue);
+        assertArrayEquals(nextExpected, nextValueUtf8);
       }
-      
+
       edenHits += cache.edenHits;
       promotedHits += cache.promotedHits;
-      
+
       printStats(cache);
     }
-    
+
     assertNotEquals(0, edenHits);
     assertNotEquals(0, promotedHits);
   }
-  
-  static final String[] TAGS = {
-	"foo",
-	"bar",
-	"baz"
-  };
-  
-  static final String[] BASE_STRINGS = {
-    "Hello",
-    "world",
-    "foo",
-    "bar",
-    "baz",
-    "quux"
-  };
-  
+
+  static final String[] TAGS = {"foo", "bar", "baz"};
+
+  static final String[] BASE_STRINGS = {"Hello", "world", "foo", "bar", "baz", "quux"};
+
   static final String nextTag() {
-	ThreadLocalRandom random = ThreadLocalRandom.current();
-	
-	int tagIndex = random.nextInt(TAGS.length + 1);
-	if ( tagIndex >= TAGS.length ) {
-	  return "tag-" + Integer.toString(random.nextInt());
-	} else {
-	  return TAGS[tagIndex];
-	}
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    int tagIndex = random.nextInt(TAGS.length + 1);
+    if (tagIndex >= TAGS.length) {
+      return "tag-" + Integer.toString(random.nextInt());
+    } else {
+      return TAGS[tagIndex];
+    }
   }
-  
+
   static final String nextValue() {
-	ThreadLocalRandom random = ThreadLocalRandom.current();
-	
-	if ( random.nextDouble() < 0.1 ) {
-	  return Integer.toString(random.nextInt());
-	}
-	
-	int baseIndex = random.nextInt(BASE_STRINGS.length);
-	String baseString = BASE_STRINGS[baseIndex];
-	
-	if ( random.nextDouble() < 0.2 ) {
-	  baseString = baseString.toLowerCase();
-	}
-	
-	int valueSuffix = random.nextInt(2 * baseIndex + 1);
-	return baseString + valueSuffix; 
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    if (random.nextDouble() < 0.1) {
+      return Integer.toString(random.nextInt());
+    }
+
+    int baseIndex = random.nextInt(BASE_STRINGS.length);
+    String baseString = BASE_STRINGS[baseIndex];
+
+    if (random.nextDouble() < 0.2) {
+      baseString = baseString.toLowerCase();
+    }
+
+    int valueSuffix = random.nextInt(2 * baseIndex + 1);
+    return baseString + valueSuffix;
   }
-  
+
   static final void printStats(GenerationalUtf8Cache cache) {
     System.out.printf(
-	 "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
-	 cache.edenHits,
-	 cache.promotedHits,
-	 cache.promotions,
-	 cache.earlyPromotions,
-	 cache.edenEvictions,
-	 cache.promotedEvictions);
+        "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
+        cache.edenHits,
+        cache.promotedHits,
+        cache.promotions,
+        cache.earlyPromotions,
+        cache.edenEvictions,
+        cache.promotedEvictions);
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/SimpleUtf8CacheTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/SimpleUtf8CacheTest.java
@@ -1,0 +1,129 @@
+package datadog.trace.common.writer.ddagent;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class SimpleUtf8CacheTest {
+  @ParameterizedTest
+  @ValueSource(strings={"foo", "bar", "baz", "quux"})
+  public void getUtf8(String value) {
+	SimpleUtf8Cache cache = new SimpleUtf8Cache();
+	
+	for ( int i = 0; i < 10; ++i ) {	
+	  byte[] valueUtf8 = cache.getUtf8(value);
+	  assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
+	}
+  }
+  
+  @Test
+  public void caching() {
+	SimpleUtf8Cache cache = new SimpleUtf8Cache();
+	
+	String value = "bar";
+	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+	
+	byte[] first = cache.getUtf8(value);
+	assertArrayEquals(expected, first);
+	
+	// first request isn't cached - to avoid burning slots
+	byte[] second = cache.getUtf8(value);
+	assertArrayEquals(expected, second);
+	assertNotSame(first, second);
+	
+	// after first request, the entry should be cached
+	byte[] third = cache.getUtf8(value);
+	assertArrayEquals(expected, third);
+	assertSame(second, third);
+	
+	assertNotEquals(0, cache.hits);
+  }  
+  
+  @Test
+  public void fuzz() {
+    Random random = ThreadLocalRandom.current();
+    
+    int hits = 0;
+    
+    SimpleUtf8Cache cache = new SimpleUtf8Cache();
+    for ( int i = 0; i < 1_000; ++i ) {
+      cache.recalibrate();
+      
+      int cycles = 500 + random.nextInt(2_000);
+      for ( int j = 0; j < cycles; ++j ) {
+    	String nextTag = nextTag();
+    	String nextValue = nextValue();
+    	byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
+    	
+    	byte[] nextValueUtf8 = cache.getUtf8(nextValue);
+    	assertArrayEquals(nextExpected, nextValueUtf8);
+      }
+      
+      hits += cache.hits;
+      
+      printStats(cache);
+    }
+    
+    assertNotEquals(0, hits);
+  }
+  
+  static final String[] TAGS = {
+	"foo",
+	"bar",
+	"baz"
+  };
+  
+  static final String[] BASE_STRINGS = {
+    "Hello",
+    "world",
+    "foo",
+    "bar",
+    "baz",
+    "quux"
+  };
+  
+  static final String nextTag() {
+	ThreadLocalRandom random = ThreadLocalRandom.current();
+	
+	int tagIndex = random.nextInt(TAGS.length + 1);
+	if ( tagIndex >= TAGS.length ) {
+	  return "tag-" + Integer.toString(random.nextInt());
+	} else {
+	  return TAGS[tagIndex];
+	}
+  }
+  
+  static final String nextValue() {
+	ThreadLocalRandom random = ThreadLocalRandom.current();
+	
+	if ( random.nextDouble() < 0.1 ) {
+	  return Integer.toString(random.nextInt());
+	}
+	
+	int baseIndex = random.nextInt(BASE_STRINGS.length);
+	String baseString = BASE_STRINGS[baseIndex];
+	
+	if ( random.nextDouble() < 0.2 ) {
+	  baseString = baseString.toLowerCase();
+	}
+	
+	int valueSuffix = random.nextInt(2 * baseIndex + 1);
+	return baseString + valueSuffix; 
+  }
+  
+  static final void printStats(SimpleUtf8Cache cache) {
+    System.out.printf(
+	 "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
+	 cache.hits,
+	 cache.evictions);
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/SimpleUtf8CacheTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/ddagent/SimpleUtf8CacheTest.java
@@ -8,122 +8,109 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class SimpleUtf8CacheTest {
   @ParameterizedTest
-  @ValueSource(strings={"foo", "bar", "baz", "quux"})
+  @ValueSource(strings = {"foo", "bar", "baz", "quux"})
   public void getUtf8(String value) {
-	SimpleUtf8Cache cache = new SimpleUtf8Cache();
-	
-	for ( int i = 0; i < 10; ++i ) {	
-	  byte[] valueUtf8 = cache.getUtf8(value);
-	  assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
-	}
+    SimpleUtf8Cache cache = new SimpleUtf8Cache();
+
+    for (int i = 0; i < 10; ++i) {
+      byte[] valueUtf8 = cache.getUtf8(value);
+      assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), valueUtf8);
+    }
   }
-  
+
   @Test
   public void caching() {
-	SimpleUtf8Cache cache = new SimpleUtf8Cache();
-	
-	String value = "bar";
-	byte[] expected = value.getBytes(StandardCharsets.UTF_8);
-	
-	byte[] first = cache.getUtf8(value);
-	assertArrayEquals(expected, first);
-	
-	// first request isn't cached - to avoid burning slots
-	byte[] second = cache.getUtf8(value);
-	assertArrayEquals(expected, second);
-	assertNotSame(first, second);
-	
-	// after first request, the entry should be cached
-	byte[] third = cache.getUtf8(value);
-	assertArrayEquals(expected, third);
-	assertSame(second, third);
-	
-	assertNotEquals(0, cache.hits);
-  }  
-  
+    SimpleUtf8Cache cache = new SimpleUtf8Cache();
+
+    String value = "bar";
+    byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+
+    byte[] first = cache.getUtf8(value);
+    assertArrayEquals(expected, first);
+
+    // first request isn't cached - to avoid burning slots
+    byte[] second = cache.getUtf8(value);
+    assertArrayEquals(expected, second);
+    assertNotSame(first, second);
+
+    // after first request, the entry should be cached
+    byte[] third = cache.getUtf8(value);
+    assertArrayEquals(expected, third);
+    assertSame(second, third);
+
+    assertNotEquals(0, cache.hits);
+  }
+
   @Test
   public void fuzz() {
     Random random = ThreadLocalRandom.current();
-    
+
     int hits = 0;
-    
+
     SimpleUtf8Cache cache = new SimpleUtf8Cache();
-    for ( int i = 0; i < 1_000; ++i ) {
+    for (int i = 0; i < 1_000; ++i) {
       cache.recalibrate();
-      
+
       int cycles = 500 + random.nextInt(2_000);
-      for ( int j = 0; j < cycles; ++j ) {
-    	String nextTag = nextTag();
-    	String nextValue = nextValue();
-    	byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
-    	
-    	byte[] nextValueUtf8 = cache.getUtf8(nextValue);
-    	assertArrayEquals(nextExpected, nextValueUtf8);
+      for (int j = 0; j < cycles; ++j) {
+        String nextTag = nextTag();
+        String nextValue = nextValue();
+        byte[] nextExpected = nextValue.getBytes(StandardCharsets.UTF_8);
+
+        byte[] nextValueUtf8 = cache.getUtf8(nextValue);
+        assertArrayEquals(nextExpected, nextValueUtf8);
       }
-      
+
       hits += cache.hits;
-      
+
       printStats(cache);
     }
-    
+
     assertNotEquals(0, hits);
   }
-  
-  static final String[] TAGS = {
-	"foo",
-	"bar",
-	"baz"
-  };
-  
-  static final String[] BASE_STRINGS = {
-    "Hello",
-    "world",
-    "foo",
-    "bar",
-    "baz",
-    "quux"
-  };
-  
+
+  static final String[] TAGS = {"foo", "bar", "baz"};
+
+  static final String[] BASE_STRINGS = {"Hello", "world", "foo", "bar", "baz", "quux"};
+
   static final String nextTag() {
-	ThreadLocalRandom random = ThreadLocalRandom.current();
-	
-	int tagIndex = random.nextInt(TAGS.length + 1);
-	if ( tagIndex >= TAGS.length ) {
-	  return "tag-" + Integer.toString(random.nextInt());
-	} else {
-	  return TAGS[tagIndex];
-	}
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    int tagIndex = random.nextInt(TAGS.length + 1);
+    if (tagIndex >= TAGS.length) {
+      return "tag-" + Integer.toString(random.nextInt());
+    } else {
+      return TAGS[tagIndex];
+    }
   }
-  
+
   static final String nextValue() {
-	ThreadLocalRandom random = ThreadLocalRandom.current();
-	
-	if ( random.nextDouble() < 0.1 ) {
-	  return Integer.toString(random.nextInt());
-	}
-	
-	int baseIndex = random.nextInt(BASE_STRINGS.length);
-	String baseString = BASE_STRINGS[baseIndex];
-	
-	if ( random.nextDouble() < 0.2 ) {
-	  baseString = baseString.toLowerCase();
-	}
-	
-	int valueSuffix = random.nextInt(2 * baseIndex + 1);
-	return baseString + valueSuffix; 
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    if (random.nextDouble() < 0.1) {
+      return Integer.toString(random.nextInt());
+    }
+
+    int baseIndex = random.nextInt(BASE_STRINGS.length);
+    String baseString = BASE_STRINGS[baseIndex];
+
+    if (random.nextDouble() < 0.2) {
+      baseString = baseString.toLowerCase();
+    }
+
+    int valueSuffix = random.nextInt(2 * baseIndex + 1);
+    return baseString + valueSuffix;
   }
-  
+
   static final void printStats(SimpleUtf8Cache cache) {
     System.out.printf(
-	 "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
-	 cache.hits,
-	 cache.evictions);
+        "eden hits: %5d\tpromotion hits: %5d\tpromotions: %5d\tearly: %5d\tlocal evictions: %5d\tglobal evictions: %5d%n",
+        cache.hits, cache.evictions);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2735,8 +2735,7 @@ public class Config {
 
     this.optimizedMapEnabled =
         configProvider.getBoolean(GeneralConfig.OPTIMIZED_MAP_ENABLED, false);
-    this.utf8CacheEnabled = 
-    	configProvider.getBoolean(GeneralConfig.UTF8_CACHE_ENABLED, true);
+    this.utf8CacheEnabled = configProvider.getBoolean(GeneralConfig.UTF8_CACHE_ENABLED, true);
 
     int defaultStackTraceLengthLimit =
         instrumenterConfig.isCiVisibilityEnabled()
@@ -4422,9 +4421,9 @@ public class Config {
   public boolean isOptimizedMapEnabled() {
     return optimizedMapEnabled;
   }
-  
+
   public boolean isUtf8CacheEnabled() {
-	return utf8CacheEnabled;
+    return utf8CacheEnabled;
   }
 
   public int getStackTraceLengthLimit() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1222,6 +1222,7 @@ public class Config {
   private final boolean jdkSocketEnabled;
 
   private final boolean optimizedMapEnabled;
+  private final boolean utf8CacheEnabled;
   private final int stackTraceLengthLimit;
 
   private final RumInjectorConfig rumInjectorConfig;
@@ -2734,6 +2735,8 @@ public class Config {
 
     this.optimizedMapEnabled =
         configProvider.getBoolean(GeneralConfig.OPTIMIZED_MAP_ENABLED, false);
+    this.utf8CacheEnabled = 
+    	configProvider.getBoolean(GeneralConfig.UTF8_CACHE_ENABLED, true);
 
     int defaultStackTraceLengthLimit =
         instrumenterConfig.isCiVisibilityEnabled()
@@ -4418,6 +4421,10 @@ public class Config {
 
   public boolean isOptimizedMapEnabled() {
     return optimizedMapEnabled;
+  }
+  
+  public boolean isUtf8CacheEnabled() {
+	return utf8CacheEnabled;
   }
 
   public int getStackTraceLengthLimit() {


### PR DESCRIPTION
# What Does This Do

This change adds UTF-8 encoding caching to optimize v0.4 payload construction.

Since String#getBytes is intrinsified these caches actually perform worse throughput wise than an uncached conversion.  However, the caches are useful in reducing allocation from UTF-8 conversions.

For tags, a "simple" cache is used.  The simple cache is a single level cache -- that uses hashing combined with linear probing.  To avoid, cache churn and unnecessary allocation of a CacheEntry, the simple cache uses a first request marking scheme that typically avoids creating a CacheEntry for values that are requested only once.  Eviction from the "simple" cache is done based on LFU policy.

For tag values, a more complicated generational cache is used.  The generational cache combines the delayed CacheEntry logic of the simple cache with a 2nd-level for resilience.

Frequently used entries are "promoted" to the higher level cache.  The 1st level of the generational cache uses a LFU eviction policy.  The 2nd of the generational cache uses a LRU eviction policy.

For the value use cache, the generational policy provided 2x increase in hit rate over the simple cache.

# Motivation

This change reduces the memory allocation overhead caused by UTF-8 encoding.
In systems with limited heap, this change provides up to 10% improvement in throughput reduction by reducing GC cycles.
