### PR TITLE
Set max JVM test version for log4j1

### DIFF
--- a/dd-java-agent/instrumentation/log4j1/build.gradle
+++ b/dd-java-agent/instrumentation/log4j1/build.gradle
@@ -1,3 +1,8 @@
+ext {
+  // Log4j 1.x reached EOL in 2015 and is not compatible with Java 25+: https://endoflife.date/log4j
+  maxJavaVersionForTests = JavaVersion.VERSION_24
+}
+
 muzzle {
   pass {
     group = 'log4j'

--- a/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
+++ b/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
@@ -1,15 +1,10 @@
-import datadog.environment.JavaVirtualMachine
 import datadog.trace.agent.test.AgentTestRunner
 import org.apache.log4j.Category
 import org.apache.log4j.MDC
 import org.apache.log4j.Priority
 import org.apache.log4j.spi.LoggingEvent
-import spock.lang.IgnoreIf
 
 class MdcTest extends AgentTestRunner {
-  @IgnoreIf(reason = "TODO: Fix for Java 25.", value = {
-    JavaVirtualMachine.isJavaVersionAtLeast(25)
-  })
   def "should preserve mdc when logging injection is #injectionEnabled"() {
     setup:
     injectSysConfig("logs.injection", injectionEnabled)


### PR DESCRIPTION
# What Does This Do

Set max JVM test version instead of Ignoring the test

# Motivation

`log4j1` reached EOL in 2015 and is not compatible with Java 25.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-706

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
