### PR TITLE
Update Maven smoke test fixtures with coverage report upload capability

### DIFF
--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_child_service_propagation/events.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_child_service_propagation/events.ftl
@@ -272,6 +272,7 @@
     "error" : 0,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_test_management/events.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_test_management/events.ftl
@@ -274,6 +274,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -339,6 +340,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -406,6 +408,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -473,6 +476,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -540,6 +544,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -609,6 +614,7 @@
     "error" : 1,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",
@@ -721,6 +727,7 @@
     "error" : 0,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
+      "_dd.library_capabilities.coverage_report_upload" : "1",
       "_dd.library_capabilities.early_flake_detection" : "1",
       "_dd.library_capabilities.fail_fast_test_order" : "1",
       "_dd.library_capabilities.impacted_tests" : "1",


### PR DESCRIPTION
# What Does This Do

Updates Maven smoke test fixtures with new coverage report upload capability introduced in https://github.com/DataDog/dd-trace-java/pull/9425

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
