### PR TITLE
chore(ci): enable performance SLO change tracking

### DIFF
--- a/.github/chainguard/self.gitlab.github-access.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.github-access.read.sts.yaml
@@ -4,3 +4,4 @@ subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-java:ref_type:(b
 
 permissions:
   contents: read
+

--- a/.github/chainguard/self.gitlab.github-access.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.github-access.read.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-java:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: read

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -80,6 +80,9 @@ check-slo-breaches:
   interruptible: true
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - if: $POPULATE_CACHE
       when: never
@@ -97,6 +100,8 @@ check-slo-breaches:
       artifacts: true
     - job: benchmarks-dacapo
       artifacts: true
+  before_script:
+    - dd-octo-sts token --scope DataDog/dd-trace-java --policy self.gitlab.github-access.read > check-slo-breaches.github-token
   script:
     # macrobenchmarks are located here, files are already in "converted" format
     - export ARTIFACTS_DIR="$(pwd)/platform/artifacts/" && mkdir -p "${ARTIFACTS_DIR}"
@@ -119,7 +124,10 @@ check-slo-breaches:
           done
       done
     - ls -lah "$ARTIFACTS_DIR"
+    - export GITHUB_TOKEN=$(cat check-slo-breaches.github-token)
     - bp-runner .gitlab/benchmarks/bp-runner.fail-on-breach.yml
+  after_script:
+    - dd-octo-sts revoke -t $(cat check-slo-breaches.github-token)
   artifacts:
     name: "artifacts"
     when: always


### PR DESCRIPTION
# What Does This Do

- Add a `dd-octo-sts` trust policy allowing GitLab CI jobs from main and release branches to read GitHub contents. 
- Update `check-slo-breaches` to use `dd-octo-sts` to fetch a GitHub token and export it to `bp-runner`.

This is necessary for `bp-runner` to track SLO changes using GitHub's API.

# Motivation

https://datadoghq.atlassian.net/browse/APMSP-2198

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMSP-2198](https://datadoghq.atlassian.net/browse/APMSP-2198).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
