### PR TITLE
Change Java 25 to default JVM testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,9 @@ variables:
   GRADLE_VERSION: "8.14.3" # must match gradle-wrapper.properties
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
-  BUILDER_IMAGE_VERSION_PREFIX: "v25.07-" # use either an empty string (e.g. "") for latest images or a version followed by a hyphen (e.g. "v25.05-")
+  BUILDER_IMAGE_VERSION_PREFIX: "v25.09-" # use either an empty string (e.g. "") for latest images or a version followed by a hyphen (e.g. "v25.05-")
   REPO_NOTIFICATION_CHANNEL: "#apm-java-escalations"
-  DEFAULT_TEST_JVMS: /^(8|11|17|21|stable)$/
+  DEFAULT_TEST_JVMS: /^(8|11|17|21|25)$/ # stable is currently not tested, as the latest stable version is LTS v25
   PROFILE_TESTS:
     description: "Enable profiling of tests"
     value: "false"
@@ -61,7 +61,6 @@ workflow:
       - "17"
       - "21"
       - "25"
-      - "stable"
       - "semeru11"
       - "oracle8"
       - "zulu8"
@@ -69,6 +68,7 @@ workflow:
       - "ibm8"
       - "zulu11"
       - "semeru17"
+      # - "stable"
     CI_SPLIT: ["1/1"]
 
 # Gitlab doesn't support "parallel" and "parallel:matrix" at the same time
@@ -636,7 +636,7 @@ test_inst_latest:
     CACHE_TYPE: "latestDep"
   parallel:
     matrix:
-      - testJvm: ["8", "17", "21", "stable"]
+      - testJvm: ["8", "17", "21", "25"] # stable is currently not tested, as the latest stable version is LTS v25
         # Gitlab doesn't support "parallel" and "parallel:matrix" at the same time
         # This emulates "parallel" by including it in the matrix
         CI_SPLIT: [ "1/6", "2/6", "3/6", "4/6", "5/6", "6/6"]
@@ -688,7 +688,7 @@ test_debugger:
   variables:
     GRADLE_TARGET: ":debuggerTest"
     CACHE_TYPE: "base"
-    DEFAULT_TEST_JVMS: /^(8|11|17|21|stable|semeru8)$/
+    DEFAULT_TEST_JVMS: /^(8|11|17|21|25|semeru8)$/ # stable is currently not tested, as the latest stable version is LTS v25
   parallel:
     matrix: *test_matrix
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -154,11 +154,11 @@ def currentJavaHomePath = getJavaHomePath(System.getProperty("java.home"))
 project.afterEvaluate {
   def testJvm = gradle.startParameter.projectProperties["testJvm"]
   def javaTestLauncher = null as Provider<JavaLauncher>
+  // "stable" is calculated as the largest X found in JAVA_X_HOME
   if (testJvm == "stable") {
     def javaVersions = System.getenv()
       .findAll { it.key =~ /^JAVA_[0-9]+_HOME$/ }
       .collect { (it.key =~ /^JAVA_(\d+)_HOME$/)[0][1] as Integer }
-      .findAll { it != 25 }  // Exclude LTS JDK v25 (early access)
 
     if (javaVersions.isEmpty()) {
       throw new GradleException("No valid JAVA_X_HOME environment variables found.")


### PR DESCRIPTION
# What Does This Do

Change Java 25 to be a default JVM for testing. Remove "stable" testing, as the latest stable version is LTS v25.

# Motivation

# Additional Notes

This PR is in prep for Java 25 GA release some time this month. It will not pass until the new image is added to https://github.com/DataDog/dd-trace-java-docker-build. Afterwards, CI will need to be re-triggered.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-83

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
