### PR TITLE
fix(StableConfig): Support keys with no value in YAML

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/stableconfig/StableConfig.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/stableconfig/StableConfig.java
@@ -18,9 +18,11 @@ public final class StableConfig {
   public StableConfig(Object yaml) {
     Map<Object, Object> map = (Map<Object, Object>) yaml;
     this.configId = map.get("config_id") == null ? null : String.valueOf(map.get("config_id"));
-    this.apmConfigurationDefault =
-        unmodifiableMap(
-            (Map<String, Object>) map.getOrDefault("apm_configuration_default", emptyMap()));
+    
+    // getOrDefault returns null if key exists with null value, so we need explicit null check
+    Map<String, Object> apmConfigDefault = (Map<String, Object>) map.getOrDefault("apm_configuration_default", emptyMap());
+    this.apmConfigurationDefault = unmodifiableMap(apmConfigDefault != null ? apmConfigDefault : emptyMap());
+    
     this.apmConfigurationRules = parseRules(map);
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigParserTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigParserTest.groovy
@@ -298,4 +298,46 @@ apm_configuration_rules:
     "{{environment_variables['']}}"      | "Empty environment variable name in template"
     "{{environment_variables['DD_KEY']}" | "Unterminated template in config"
   }
+
+  def "test null and empty values in YAML"() {
+    given:
+    Path filePath = Files.createTempFile("testFile_", ".yaml")
+
+    when:
+    String yaml = """
+config_id: "12345"
+apm_configuration_default:
+apm_configuration_rules:
+"""
+    Files.write(filePath, yaml.getBytes())
+    StableConfigSource.StableConfig cfg = StableConfigParser.parse(filePath.toString())
+
+    then:
+    cfg.getConfigId() == "12345"
+    cfg.getKeys().isEmpty()
+    
+    cleanup:
+    Files.delete(filePath)
+  }
+
+  def "test completely empty values in YAML"() {
+    given:
+    Path filePath = Files.createTempFile("testFile_", ".yaml")
+
+    when:
+    String yaml = """
+config_id: "12345"
+apm_configuration_default: 
+apm_configuration_rules: 
+"""
+    Files.write(filePath, yaml.getBytes())
+    StableConfigSource.StableConfig cfg = StableConfigParser.parse(filePath.toString())
+
+    then:
+    cfg.getConfigId() == "12345"
+    cfg.getKeys().isEmpty()
+    
+    cleanup:
+    Files.delete(filePath)
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.groovy
@@ -71,6 +71,31 @@ class StableConfigSourceTest extends DDSpecification {
     "12345"  | "this is not yaml format!"
   }
 
+  def "test null values in YAML"() {
+    when:
+    Path filePath = Files.createTempFile("testFile_", ".yaml")
+    then:
+    if (filePath == null) {
+      throw new AssertionError("Failed to create: " + filePath)
+    }
+
+    when:
+    // Test the scenario where YAML contains null values for apm_configuration_default and apm_configuration_rules
+    String yaml = """
+config_id: "12345"
+apm_configuration_default:
+apm_configuration_rules:
+"""
+    Files.write(filePath, yaml.getBytes())
+    StableConfigSource stableCfg = new StableConfigSource(filePath.toString(), ConfigOrigin.LOCAL_STABLE_CONFIG)
+
+    then:
+    // Should not throw NullPointerException and should handle null values gracefully
+    stableCfg.getConfigId() == "12345"
+    stableCfg.getKeys().size() == 0
+    Files.delete(filePath)
+  }
+
   def "test file valid format"() {
     given:
     Path filePath = Files.createTempFile("testFile_", ".yaml")


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
