### PR TITLE
Use constant instead of magic values for IsTraceRoot

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -1,15 +1,14 @@
 package datadog.trace.common.metrics;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.WritableFormatter;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public final class SerializingMetricWriter implements MetricWriter {
 
@@ -36,9 +35,12 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] IS_TRACE_ROOT = "IsTraceRoot".getBytes(ISO_8859_1);
   private static final byte[] SPAN_KIND = "SpanKind".getBytes(ISO_8859_1);
   private static final byte[] PEER_TAGS = "PeerTags".getBytes(ISO_8859_1);
-  // Is trace root is a tristate (0 unknown, 1 true, 2 false)
-  public static final int IS_TRACE_ROOT_TRUE = 1;
-  public static final int IS_TRACE_ROOT_FALSE = 2;
+
+  @SuppressWarnings("unused") // Kept for representing all possible states
+  public static final int TRISTATE_UNKNOWN = 0;
+
+  public static final int TRISTATE_TRUE = 1;
+  public static final int TRISTATE_FALSE = 2;
 
   private final WellKnownTags wellKnownTags;
   private final WritableFormatter writer;
@@ -122,7 +124,7 @@ public final class SerializingMetricWriter implements MetricWriter {
     writer.writeBoolean(key.isSynthetics());
 
     writer.writeUTF8(IS_TRACE_ROOT);
-    writer.writeInt(key.isTraceRoot() ? IS_TRACE_ROOT_TRUE : IS_TRACE_ROOT_FALSE);
+    writer.writeInt(key.isTraceRoot() ? TRISTATE_TRUE : TRISTATE_FALSE);
 
     writer.writeUTF8(SPAN_KIND);
     writer.writeUTF8(key.getSpanKind());

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -36,11 +36,9 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] SPAN_KIND = "SpanKind".getBytes(ISO_8859_1);
   private static final byte[] PEER_TAGS = "PeerTags".getBytes(ISO_8859_1);
 
-  @SuppressWarnings("unused") // Kept for representing all possible states
-  public static final int TRISTATE_UNKNOWN = 0;
-
-  public static final int TRISTATE_TRUE = 1;
-  public static final int TRISTATE_FALSE = 2;
+  // Constant declared here for compile-time folding
+  public static final int TRISTATE_TRUE = TriState.TRUE.serialValue;
+  public static final int TRISTATE_FALSE = TriState.FALSE.serialValue;
 
   private final WellKnownTags wellKnownTags;
   private final WritableFormatter writer;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -1,14 +1,15 @@
 package datadog.trace.common.metrics;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-
 import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.WritableFormatter;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+
 import java.util.List;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public final class SerializingMetricWriter implements MetricWriter {
 
@@ -35,6 +36,9 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] IS_TRACE_ROOT = "IsTraceRoot".getBytes(ISO_8859_1);
   private static final byte[] SPAN_KIND = "SpanKind".getBytes(ISO_8859_1);
   private static final byte[] PEER_TAGS = "PeerTags".getBytes(ISO_8859_1);
+  // Is trace root is a tristate (0 unknown, 1 true, 2 false)
+  public static final int IS_TRACE_ROOT_TRUE = 1;
+  public static final int IS_TRACE_ROOT_FALSE = 2;
 
   private final WellKnownTags wellKnownTags;
   private final WritableFormatter writer;
@@ -118,7 +122,7 @@ public final class SerializingMetricWriter implements MetricWriter {
     writer.writeBoolean(key.isSynthetics());
 
     writer.writeUTF8(IS_TRACE_ROOT);
-    writer.writeInt(key.isTraceRoot() ? 1 : 2); // tristate (0 unknown, 1 true, 2 false)
+    writer.writeInt(key.isTraceRoot() ? IS_TRACE_ROOT_TRUE : IS_TRACE_ROOT_FALSE);
 
     writer.writeUTF8(SPAN_KIND);
     writer.writeUTF8(key.getSpanKind());

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/TriState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/TriState.java
@@ -1,0 +1,16 @@
+package datadog.trace.common.metrics;
+
+/**
+ * TriState is used to represent a three-valued logic: true, false, and unknown. The "integer"
+ * values are used for metrics serialization.
+ */
+public enum TriState {
+  UNKNOWN(0),
+  TRUE(1),
+  FALSE(2);
+  public final int serialValue;
+
+  TriState(int serialValue) {
+    this.serialValue = serialValue;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -18,6 +18,9 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 class SerializingMetricWriterTest extends DDSpecification {
 
+  public static final int IS_TRACE_ROOT_TRUE = 1
+  public static final int IS_TRACE_ROOT_FALSE = 2
+
   def "should produce correct message #iterationIndex with process tags enabled #withProcessTags" () {
     setup:
     if (withProcessTags) {
@@ -177,7 +180,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         assert unpacker.unpackBoolean() == key.isSynthetics()
         ++elementCount
         assert unpacker.unpackString() == "IsTraceRoot"
-        assert unpacker.unpackInt() == (key.isTraceRoot() ? 1 : 2)
+        assert unpacker.unpackInt() == (key.isTraceRoot() ? IS_TRACE_ROOT_TRUE : IS_TRACE_ROOT_FALSE)
         ++elementCount
         assert unpacker.unpackString() == "SpanKind"
         assert unpacker.unpackString() == key.getSpanKind() as String

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -17,10 +17,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class SerializingMetricWriterTest extends DDSpecification {
-
-  public static final int TRISTATE_TRUE = 1
-  public static final int TRISTATE_FALSE = 2
-
   def "should produce correct message #iterationIndex with process tags enabled #withProcessTags" () {
     setup:
     if (withProcessTags) {
@@ -180,7 +176,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         assert unpacker.unpackBoolean() == key.isSynthetics()
         ++elementCount
         assert unpacker.unpackString() == "IsTraceRoot"
-        assert unpacker.unpackInt() == (key.isTraceRoot() ? TRISTATE_TRUE : TRISTATE_FALSE)
+        assert unpacker.unpackInt() == (key.isTraceRoot() ? TriState.TRUE.serialValue : TriState.FALSE.serialValue)
         ++elementCount
         assert unpacker.unpackString() == "SpanKind"
         assert unpacker.unpackString() == key.getSpanKind() as String

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -18,8 +18,8 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 class SerializingMetricWriterTest extends DDSpecification {
 
-  public static final int IS_TRACE_ROOT_TRUE = 1
-  public static final int IS_TRACE_ROOT_FALSE = 2
+  public static final int TRISTATE_TRUE = 1
+  public static final int TRISTATE_FALSE = 2
 
   def "should produce correct message #iterationIndex with process tags enabled #withProcessTags" () {
     setup:
@@ -180,7 +180,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         assert unpacker.unpackBoolean() == key.isSynthetics()
         ++elementCount
         assert unpacker.unpackString() == "IsTraceRoot"
-        assert unpacker.unpackInt() == (key.isTraceRoot() ? IS_TRACE_ROOT_TRUE : IS_TRACE_ROOT_FALSE)
+        assert unpacker.unpackInt() == (key.isTraceRoot() ? TRISTATE_TRUE : TRISTATE_FALSE)
         ++elementCount
         assert unpacker.unpackString() == "SpanKind"
         assert unpacker.unpackString() == key.getSpanKind() as String


### PR DESCRIPTION
# What Does This Do

Avoid magic values for IsTraceRoot

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
