### PR TITLE
Temporary fix for mule-4 latest dependencies resolution.

### DIFF
--- a/dd-java-agent/instrumentation/mule-4/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4/build.gradle
@@ -19,7 +19,7 @@ muzzle {
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
-    additionalDependencies +="org.mule.runtime:mule-tracer-customization-impl:$muleVersion"
+    additionalDependencies += "org.mule.runtime:mule-tracer-customization-impl:$muleVersion"
   }
   pass {
     group = 'org.mule.runtime'
@@ -29,14 +29,14 @@ muzzle {
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
-    additionalDependencies +="org.mule.runtime:mule-core:$muleVersion"
+    additionalDependencies += "org.mule.runtime:mule-core:$muleVersion"
   }
 
   fail {
     name = 'before-4.5.0'
     group = 'org.mule.runtime'
     module = 'mule-core'
-    versions =  "[, $muleVersion)"
+    versions = "[, $muleVersion)"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
   }
@@ -263,5 +263,29 @@ spotless {
 idea {
   module {
     jdkName = '11'
+  }
+}
+
+// TODO: Remove once correct version of mule-extensions-xxx will be released.
+dependencies {
+  def reason = 'Temporary hardcode to `1.9.9` because `1.9.10` is failing during latest dependencies resolution on not existing `mule-plugin-mgmt-parent-pom:4.9.8-rc1`'
+
+  constraints {
+    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api') {
+      version { strictly '1.9.9' }
+      because reason
+    }
+    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-mime-types') {
+      version { strictly '1.9.9' }
+      because reason
+    }
+    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api-dsql') {
+      version { strictly '1.9.9' }
+      because reason
+    }
+    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api-persistence') {
+      version { strictly '1.9.9' }
+      because reason
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
Temporary fix for mule-4 latest dependencies resolution.

# Motivation
Fix nightly build on CI and weekly dependencies update

# Additional Notes
Root cause that [mule-extensions-api-parent-1.9.10.pom](https://repository.mulesoft.org/releases/org/mule/runtime/mule-extensions-api-parent/1.9.10/mule-extensions-api-parent-1.9.10.pom) refers to not existing `org.mule:mule-plugin-mgmt-parent-pom:4.9.8-rc1`

Once it will be fixed on mule repository, fix should be rolled back.
