### PR TITLE
Bump flare smoke test duration by 5s to fix rare timeouts causing flakes

### DIFF
--- a/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
+++ b/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
@@ -25,8 +25,9 @@ class TracerFlareSmokeTest extends AbstractSmokeTest {
 
 
   // Time in seconds after which flare is triggered.
-  // We delay the profiler start on Oracle JDK 8, so increase the wait time to at least 20s.
-  private static final int FLARE_TRIGGER_SECONDS = 20
+  // We delay the profiler start on Oracle JDK 8, so increase the wait time to at least 25s. We've seen ≤20 seconds
+  // cause rare test flakes.
+  private static final int FLARE_TRIGGER_SECONDS = 25
   // Number of processes to run in parallel for testing
   private static final int NUMBER_OF_PROCESSES = 2
 


### PR DESCRIPTION
# What Does This Do
20s -> 25s

# Motivation
<img width="1150" height="265" alt="image" src="https://github.com/user-attachments/assets/c415274a-77b7-40cf-9d9e-552c272daa1e" />

Flakes ~1x/4h, would consistently fail when the timeout was 15s

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-12422]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-12422]: https://datadoghq.atlassian.net/browse/PROF-12422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ