### PR TITLE
Added guard for restClient shutdown freeze.

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4ClientTestBase.groovy
@@ -80,7 +80,13 @@ abstract class Lettuce4ClientTestBase extends VersionedNamingTestBase {
 
   def cleanup() {
     connection.close()
-    redisClient.shutdown()
+
+    try {
+      redisClient.shutdown(5, 10, TimeUnit.SECONDS)
+    } catch (Throwable ignored) {
+      // No-op.
+    }
+
     redisServer.stop()
   }
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ClientTestBase.groovy
@@ -81,7 +81,13 @@ abstract class Lettuce5ClientTestBase extends VersionedNamingTestBase {
 
   def cleanup() {
     connection.close()
-    redisClient.shutdown()
+
+    try {
+      redisClient.shutdown(5, 10, TimeUnit.SECONDS)
+    } catch (Throwable ignored) {
+      // No-op.
+    }
+
     redisServer.stop()
   }
 }


### PR DESCRIPTION
# What Does This Do
Adds a **maximum 10-second timeout** for the Redis client shutdown.  
Previously, this test had a high chance of freezing on CI.
After multiple retries, I collected a thread dump from a hung test:
```
"Test worker" #1 [10060] prio=5 os_prio=0 cpu=7203.66ms elapsed=421.50s tid=0x00007fecf0031970 nid=10060 in Object.wait()  [0x00007fecf764c000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait0(java.base@21.0.7/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@21.0.7/Object.java:366)
	at java.lang.Object.wait(java.base@21.0.7/Object.java:339)
	at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:254)
	- locked <0x00000000d816e6f8> (a io.netty.util.concurrent.DefaultPromise)
	at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:32)
	at io.netty.util.concurrent.AbstractFuture.get(AbstractFuture.java:31)
	at com.lambdaworks.redis.AbstractRedisClient.shutdown(AbstractRedisClient.java:277)
	at com.lambdaworks.redis.AbstractRedisClient.shutdown(AbstractRedisClient.java:225)
	at com.lambdaworks.redis.AbstractRedisClient$shutdown.call(Unknown Source)
	at Lettuce4ClientTestBase.cleanup(Lettuce4ClientTestBase.groovy:83)
```

The freeze was traced to line 83:
```
redisClient.shutdown()
```

To prevent indefinite blocking, I refactored it to enforce shutdown with a timeout:
```
    try {
      redisClient.shutdown(5, 10, TimeUnit.SECONDS)
    } catch (Throwable ignored) {
      // No-op.
    }

```

# Motivation
Improve CI stability by preventing test freezes.


