### PR TITLE
Avoid race conditions between contributing and writing to a stat aggregate

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -125,6 +125,7 @@ final class Aggregator implements Runnable {
         MetricKey key = batch.getKey();
         // important that it is still *this* batch pending, must not remove otherwise
         pending.remove(key, batch);
+        // operations concerning the aggregates should be atomic not to potentially loose points.
         aggregates.compute(
             key,
             (k, v) -> {
@@ -150,6 +151,8 @@ final class Aggregator implements Runnable {
           skipped = false;
           writer.startBucket(validKeys.size(), when, reportingIntervalNanos);
           for (MetricKey key : validKeys) {
+            // operations concerning the aggregates should be atomic not to potentially loose
+            // points.
             aggregates.computeIfPresent(
                 key,
                 (k, v) -> {
@@ -181,6 +184,7 @@ final class Aggregator implements Runnable {
   private Set<MetricKey> expungeStaleAggregates() {
     final HashSet<MetricKey> ret = new HashSet<>();
     for (MetricKey metricKey : new HashSet<>(aggregates.keySet())) {
+      // operations concerning the aggregates should be atomic not to potentially loose points.
       aggregates.computeIfPresent(
           metricKey,
           (k, v) -> {


### PR DESCRIPTION
# What Does This Do

In the system tests we noticed that we can have 1 hit missing. This happens under high load.

It appears that the aggregate can be cleared after a batch contributed to it so this contribution is lost.

This PR tries to avoid this scenario using compute of the nonblocking map avoid using explicit reentrant locks around those methods.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
