### PR TITLE
Check for JFP override file in flare when appropriate

### DIFF
--- a/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
+++ b/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
@@ -57,24 +57,28 @@ class TracerFlareSmokeTest extends AbstractSmokeTest {
 
     def command = [javaPath()]
 
-    if (processIndex == 0) {
+    switch (processIndex) {
+      case 0:
       // Process 0: Profiling enabled (default)
-      command.addAll(defaultJavaProperties)
-    } else if (processIndex == 1) {
+        command.addAll(defaultJavaProperties)
+        break
+      case 1:
       // Process 1: Profiling disabled
-      def filteredProperties = defaultJavaProperties.findAll { prop ->
-        !prop.startsWith("-Ddd.profiling.")
-      }
-      command.addAll(filteredProperties)
-      command.add("-Ddd.profiling.enabled=false")
-    } else {
+        def filteredProperties = defaultJavaProperties.findAll { prop ->
+          !prop.startsWith("-Ddd.profiling.")
+        }
+        command.addAll(filteredProperties)
+        command.add("-Ddd.profiling.enabled=false")
+        break
+      case 2:
       // Process 2: Profiling enabled with template override
-      command.addAll(defaultJavaProperties)
+        command.addAll(defaultJavaProperties)
       // Create a temp file with the override content
-      def tempOverrideFile = File.createTempFile("test-override-", ".jfp")
-      tempOverrideFile.deleteOnExit()
-      tempOverrideFile.text = "datadog.ExceptionSample#enabled=false" // Arbitrary event choice
-      command.add("-Ddd.profiling.jfr-template-override-file=" + tempOverrideFile.absolutePath)
+        def tempOverrideFile = File.createTempFile("test-override-", ".jfp")
+        tempOverrideFile.deleteOnExit()
+        tempOverrideFile.text = "datadog.ExceptionSample#enabled=false" // Arbitrary event choice
+        command.add("-Ddd.profiling.jfr-template-override-file=" + tempOverrideFile.absolutePath)
+        break
     }
 
     // Configure flare generation


### PR DESCRIPTION
# What Does This Do
Extends the flare smoke testing to consider whether or not we've provided a JFP template override to the profiler

# Motivation
Better coverage of flare reporting functionality + improving correctness

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-12436]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-12436]: https://datadoghq.atlassian.net/browse/PROF-12436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ