### PR TITLE
Added `ikeycmd` and `ikeyman` utilities from `IBM SDK, Java Technology Edition` to exclusion list.

### DIFF
--- a/metadata/denied-arguments.tsv
+++ b/metadata/denied-arguments.tsv
@@ -46,6 +46,10 @@ datadog_jmxfetch                org.datadog.jmxfetch.App                        
 # Open Liberty
 open_liberty_utility_main       com.ibm.ws.kernel.boot.cmdline.UtilityMain          Skip UtilityMain that expected single jar in classpath
 
+# IBM SDK, Java Technology Edition
+ibm_ikeycmd                     com.ibm.gsk.ikeyman.ikeycmd                         Skip IBM ikeycmd utility
+ibm_ikeyman                     com.ibm.gsk.ikeyman.Ikeyman                         Skip IBM Ikeyman utility
+
 # Elastic Search 7+
 elasticsearch7                  -Des.path.home=*                                    Skip Elastic Search 7+ commands
 

--- a/metadata/requirements.json
+++ b/metadata/requirements.json
@@ -542,6 +542,40 @@
       "envars": null
     },
     {
+      "id": "ibm_ikeycmd",
+      "description": "Skip IBM ikeycmd utility",
+      "os": null,
+      "cmds": [
+        "**/java"
+      ],
+      "args": [
+        {
+          "args": [
+            "com.ibm.gsk.ikeyman.ikeycmd"
+          ],
+          "position": null
+        }
+      ],
+      "envars": null
+    },
+    {
+      "id": "ibm_ikeyman",
+      "description": "Skip IBM Ikeyman utility",
+      "os": null,
+      "cmds": [
+        "**/java"
+      ],
+      "args": [
+        {
+          "args": [
+            "com.ibm.gsk.ikeyman.Ikeyman"
+          ],
+          "position": null
+        }
+      ],
+      "envars": null
+    },
+    {
       "id": "elasticsearch7",
       "description": "Skip Elastic Search 7+ commands",
       "os": null,


### PR DESCRIPTION
# What Does This Do
Added `ikeycmd` and `ikeyman` utilities from `IBM SDK, Java Technology Edition` to exclusion list.

# Motivation
Exclude `UtilityMain` class that is using for running some short-living commands from SSI.

# Additional Notes
There no MacOS `IBM SDK, Java Technology Edition` [distributives available](https://www.ibm.com/support/pages/java-sdk-downloads-version-80).

[LANGPLAT-771]

[LANGPLAT-771]: https://datadoghq.atlassian.net/browse/LANGPLAT-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ