### PR TITLE
Fix tracer OpenLineage instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -1307,14 +1307,17 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
     if (Config.get().isServiceNameSetByUser()
         && !"spark".equals(serviceName)
         && !"hadoop".equals(serviceName)) {
-      log.debug("Service '{}' explicitly set by user, not using the application name", serviceName);
+      log.debug(
+          "Service explicitly set by user, not using the application name. Service name: {}",
+          serviceName);
       return serviceName;
     }
 
     String sparkAppName = conf.get("spark.app.name", null);
     if (sparkAppName != null) {
       log.debug(
-          "Using Spark application name '{}' as the Datadog service for OpenLineage", sparkAppName);
+          "Using Spark application name as the Datadog service for OpenLineage. Spark application name: {}",
+          sparkAppName);
     }
 
     return sparkAppName;

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
@@ -522,11 +522,11 @@ abstract class AbstractSparkListenerTest extends InstrumentationSpecification {
     }
   }
 
-  def "test setupOpenLineage gets service name"(String serviceNameSetByUser, String serviceName, String sparkAppName) {
+  def "test setupOpenLineage gets service name"(boolean serviceNameSetByUser, String serviceName, String sparkAppName) {
     setup:
     SparkConf sparkConf = new SparkConf()
-    injectSysConfig("dd.service.name.set.by.user", serviceNameSetByUser)
-    if (Boolean.parseBoolean(serviceNameSetByUser)) {
+    injectSysConfig("dd.service.name.set.by.user", Boolean.toString(serviceNameSetByUser))
+    if (serviceNameSetByUser) {
       injectSysConfig("dd.service.name", serviceName)
     }
     if (sparkAppName != null) {


### PR DESCRIPTION
# What Does This Do

**Fix service name tagging in OpenLineage events**
Currently, the `ol_service` tag in OpenLineage events is derived from the `sparkServiceName` property, which only becomes available after OpenLineage instrumentation. This delay causes events to miss the service name, making backend correlation difficult.

This PR ensures that OpenLineage events always contain a service name:
 * If the user provides one, it is used directly.
 * If not, `spark.app.name` is used as a fallback.

This serves as a short-term solution. For the long term, the PR also introduces the `_dd.ol_intake.process_tags` tag, which backend systems can later leverage for robust service mapping.

**Fix missing output statistics in OpenLineage events**

OpenLineage output statistics depend on `onTask` events emitted by the Spark listener. The tracer instruments the OpenLineage listener, but currently it does not handle `onTaskEnd` correctly—the method returns without invoking the OpenLineage listener. As a result, `outputStatistics` are absent from OL events.

This PR addresses the issue by ensuring that `onTaskEnd` properly updates task metrics via the OpenLineage listener. The method is lightweight, as it only updates counters for task metrics. This has been tested on a local environment. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
