### PR TITLE
Only restore original scope stack once

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
@@ -2,13 +2,17 @@ package datadog.trace.core.scopemanager;
 
 import datadog.context.Context;
 import datadog.context.ContextKey;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 /** Wraps a {@link ScopeStack} as a {@link Context} so it can be swapped back later. */
 final class ScopeContext implements Context {
-  private final Thread originalThread = Thread.currentThread();
-  private final ScopeStack scopeStack;
+
+  private static final AtomicReferenceFieldUpdater<ScopeContext, ScopeStack> SCOPE_STACK_UPDATER =
+      AtomicReferenceFieldUpdater.newUpdater(ScopeContext.class, ScopeStack.class, "scopeStack");
+
   private final Context context;
+  private volatile ScopeStack scopeStack;
 
   ScopeContext(ScopeStack scopeStack) {
     this(scopeStack, scopeStack.top != null ? scopeStack.top.context : Context.root());
@@ -20,8 +24,8 @@ final class ScopeContext implements Context {
   }
 
   ScopeStack restore() {
-    // take defensive copy of original scope stack when restoring on different thread
-    return originalThread == Thread.currentThread() ? scopeStack : scopeStack.copy();
+    // only restore original scope stack once; if we're asked to restore again use empty stack
+    return SCOPE_STACK_UPDATER.getAndSet(this, scopeStack.empty());
   }
 
   @Nullable

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
@@ -24,12 +24,8 @@ final class ScopeStack {
     this.profilingContextIntegration = profilingContextIntegration;
   }
 
-  ScopeStack copy() {
-    ScopeStack copy = new ScopeStack(profilingContextIntegration);
-    copy.stack.addAll(stack);
-    copy.top = top;
-    copy.overdueRootScope = overdueRootScope;
-    return copy;
+  ScopeStack empty() {
+    return new ScopeStack(profilingContextIntegration);
   }
 
   ContinuableScope active() {


### PR DESCRIPTION
# What Does This Do

Only restore original scope stack once; if we're asked to restore again use empty stack.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
