### PR TITLE
Fix error logged for Bridge methods

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -101,24 +101,33 @@ public class WhereTest {
   @Test
   public void methodMatching() {
     Where where = new Where("String", "substring", "(int,int)", new String[0], null);
-    assertTrue(
+    assertEquals(
+        Where.MethodMatching.MATCH,
         where.isMethodMatching(createMethodNode("substring", "(II)Ljava/lang/String;"), null));
     where = new Where("String", "replaceAll", "(String,String)", new String[0], null);
-    assertTrue(
+    assertEquals(
+        Where.MethodMatching.MATCH,
         where.isMethodMatching(
             createMethodNode(
                 "replaceAll", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"),
             null));
     where = new Where("HashMap", "<init>", "(Map)", new String[0], null);
-    assertTrue(where.isMethodMatching(createMethodNode("<init>", "(Ljava/util/Map;)V"), null));
+    assertEquals(
+        Where.MethodMatching.MATCH,
+        where.isMethodMatching(createMethodNode("<init>", "(Ljava/util/Map;)V"), null));
     where = new Where("ArrayList", "removeIf", "(Predicate)", new String[0], null);
-    assertTrue(
+    assertEquals(
+        Where.MethodMatching.MATCH,
         where.isMethodMatching(
             createMethodNode("removeIf", "(Ljava/util/function/Predicate;)Z"), null));
     where = new Where("String", "concat", "", new String[0], null);
-    assertTrue(where.isMethodMatching(createMethodNode("concat", "String (String)"), null));
+    assertEquals(
+        Where.MethodMatching.MATCH,
+        where.isMethodMatching(createMethodNode("concat", "String (String)"), null));
     where = new Where("String", "concat", " \t", new String[0], null);
-    assertTrue(where.isMethodMatching(createMethodNode("concat", "String (String)"), null));
+    assertEquals(
+        Where.MethodMatching.MATCH,
+        where.isMethodMatching(createMethodNode("concat", "String (String)"), null));
     where =
         new Where(
             "Inner",
@@ -126,18 +135,20 @@ public class WhereTest {
             "(com.datadog.debugger.probe.Outer$Inner)",
             new String[0],
             null);
-    assertTrue(
+    assertEquals(
+        Where.MethodMatching.MATCH,
         where.isMethodMatching(
             createMethodNode("innerMethod", "(Lcom/datadog/debugger/probe/Outer$Inner;)V"), null));
     where = new Where("Inner", "innerMethod", "(Outer$Inner)", new String[0], null);
-    assertTrue(
+    assertEquals(
+        Where.MethodMatching.MATCH,
         where.isMethodMatching(
             createMethodNode("innerMethod", "(Lcom/datadog/debugger/probe/Outer$Inner;)V"), null));
     where = new Where("MyClass", "myMethod", null, new String[] {"42"}, null);
     ClassFileLines classFileLines = mock(ClassFileLines.class);
     MethodNode myMethodNode = createMethodNode("myMethod", "()V");
     when(classFileLines.getMethodsByLine(42)).thenReturn(Arrays.asList(myMethodNode));
-    assertTrue(where.isMethodMatching(myMethodNode, classFileLines));
+    assertEquals(Where.MethodMatching.MATCH, where.isMethodMatching(myMethodNode, classFileLines));
   }
 
   private MethodNode createMethodNode(String name, String desc) {


### PR DESCRIPTION
# What Does This Do
We avoid to instrument Bridge method but we don't want to log error for method not found. So introduce a skip status for method matching to differentiate if we skip instrumentation but still we have found the method

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4428]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4428]: https://datadoghq.atlassian.net/browse/DEBUG-4428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ