### PR TITLE
Add junit-platform-launcher as a test runtime dependency to all modules

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -58,8 +58,6 @@ dependencies {
   testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.1'
   testImplementation group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.9.6'
-
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2") // Required to update dependency lock files
 }
 
 shadowJar {

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -46,8 +46,6 @@ dependencies {
   testImplementation group: 'org.ow2.asm', name: 'asm-util', version: libs.versions.asm.get()
   testImplementation group: "org.junit.jupiter", name: "junit-jupiter-params", version: libs.versions.junit5.get()
   testImplementation project(':dd-java-agent:agent-debugger:debugger-test-scala')
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.7.0")
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: libs.versions.junit5.get()
   testImplementation libs.bundles.mockito
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: libs.versions.okhttp.legacy.get()
   testImplementation group: 'org.springframework.boot', name: 'spring-boot', version: '2.3.5.RELEASE'

--- a/dd-java-agent/agent-llmobs/build.gradle
+++ b/dd-java-agent/agent-llmobs/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(':internal-api')
 
   testImplementation project(':dd-java-agent:testing')
-  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.0'
 }
 
 shadowJar {

--- a/gradle/java_deps.gradle
+++ b/gradle/java_deps.gradle
@@ -4,4 +4,7 @@ dependencies {
   testImplementation libs.bundles.spock
   testImplementation libs.groovy
   testImplementation libs.bundles.test.logging
+
+  // Required to update dependency lock files
+  testRuntimeOnly libs.bundles.junit.platform
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ spock = "2.3-groovy-3.0"
 spock24 = "2.4-M6-groovy-3.0"
 groovy = "3.0.24"
 junit5 = "5.9.2"
+junit-platform = "1.9.2"
 logback = "1.2.13"
 bytebuddy = "1.17.5"
 scala = "2.11.12" # Last version to support Java 7 (2.12+ require Java 8+)
@@ -74,6 +75,7 @@ groovy = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy" }
 groovy-yaml = { module = "org.codehaus.groovy:groovy-yaml", version.ref = "groovy" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 
 mokito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mokito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
@@ -109,6 +111,7 @@ cafe-crypto = ["cafe-crypto-curve25519", "cafe-crypto-ed25519"]
 spock = ["spock-core", "spock-junit4", "objenesis"]
 spock24-spring = ["spock24-core", "spock24-junit4", "spock24-spring"]
 junit5 = ["junit-jupiter", "junit-jupiter-params"]
+junit-platform = ["junit-platform-launcher"]
 mockito = ["mokito-core", "mokito-junit-jupiter", "byte-buddy", "byte-buddy-agent"]
 test-logging = ["logback-classic", "log4j-over-slf4j", "jcl-over-slf4j", "jul-to-slf4j"]
 


### PR DESCRIPTION
# What Does This Do

Adds `junit-platform-launcher` as a test runtime dependency to all modules

# Motivation

- Use the same `junit-platform-launcher` version in every project, and make sure it is compatible with our `junit-jupiter` version 
- Fix `resolveAndLockAll` failures in projects that depend `junit-platform-launcher` (`agent-ci-visibility`, `junit-4.10`)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
