### PR TITLE
Ensure tracer and scheduler are clean after test execution

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -159,7 +159,7 @@ public class SharedCommunicationObjects {
               ret.discover(); // safe to run on same thread
             } else {
               // avoid performing blocking I/O operation on application thread
-              AgentTaskScheduler.getInstance().execute(ret::discoverIfOutdated);
+              AgentTaskScheduler.get().execute(ret::discoverIfOutdated);
             }
           }
           featuresDiscovery = ret;

--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
@@ -87,7 +87,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
         log.debug(
             "Scheduling StatsD connection in {} seconds - {}", remainingDelay, statsDAddress());
       }
-      AgentTaskScheduler.getInstance()
+      AgentTaskScheduler.get()
           .scheduleWithJitter(ConnectTask.INSTANCE, this, remainingDelay, SECONDS);
     } else {
       doConnect();
@@ -168,7 +168,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
               log.debug(
                   "Scheduling StatsD connection in {} seconds - {}", RETRY_DELAY, statsDAddress());
             }
-            AgentTaskScheduler.getInstance()
+            AgentTaskScheduler.get()
                 .scheduleWithJitter(ConnectTask.INSTANCE, this, RETRY_DELAY, SECONDS);
           } else {
             log.debug("Max retries have been reached. Will not attempt again.");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -513,7 +513,7 @@ public class Agent {
 
   private static void registerLogManagerCallback(final ClassLoadCallBack callback) {
     // one minute fail-safe in case the class was unintentionally loaded during premain
-    AgentTaskScheduler.getInstance().schedule(callback, 1, TimeUnit.MINUTES);
+    AgentTaskScheduler.get().schedule(callback, 1, TimeUnit.MINUTES);
     try {
       final Class<?> agentInstallerClass = AGENT_CLASSLOADER.loadClass(AGENT_INSTALLER_CLASS_NAME);
       final Method registerCallbackMethod =
@@ -526,7 +526,7 @@ public class Agent {
 
   private static void registerMBeanServerBuilderCallback(final ClassLoadCallBack callback) {
     // one minute fail-safe in case the class was unintentionally loaded during premain
-    AgentTaskScheduler.getInstance().schedule(callback, 1, TimeUnit.MINUTES);
+    AgentTaskScheduler.get().schedule(callback, 1, TimeUnit.MINUTES);
     try {
       final Class<?> agentInstallerClass = AGENT_CLASSLOADER.loadClass(AGENT_INSTALLER_CLASS_NAME);
       final Method registerCallbackMethod =
@@ -785,7 +785,7 @@ public class Agent {
       if (forceEarlyStart) {
         initializeCrashTrackingDefault();
       } else {
-        AgentTaskScheduler.getInstance().execute(Agent::initializeCrashTrackingDefault);
+        AgentTaskScheduler.get().execute(Agent::initializeCrashTrackingDefault);
       }
     } else {
       // for Java 8 we are relying on JMX to give us the process PID
@@ -796,7 +796,7 @@ public class Agent {
 
   private static void scheduleJmxStart(final int jmxStartDelay) {
     if (jmxStartDelay > 0) {
-      AgentTaskScheduler.getInstance()
+      AgentTaskScheduler.get()
           .scheduleWithJitter(new JmxStartTask(), jmxStartDelay, TimeUnit.SECONDS);
     } else {
       startJmx();
@@ -843,7 +843,7 @@ public class Agent {
           */
           if (getJmxStartDelay() == 0) {
             log.debug("Waiting for profiler initialization");
-            AgentTaskScheduler.getInstance()
+            AgentTaskScheduler.get()
                 .scheduleWithJitter(PROFILER_INIT_AFTER_JMX, 500, TimeUnit.MILLISECONDS);
           } else {
             log.debug("Initializing profiler");

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -83,7 +83,7 @@ public class AgentInstaller {
       }
       int poolCleaningInterval = InstrumenterConfig.get().getResolverResetInterval();
       if (poolCleaningInterval > 0) {
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(
                 SharedTypePools::clear,
                 poolCleaningInterval,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
@@ -29,7 +29,7 @@ public class SourceFileTrackingTransformer implements ClassFileTransformer {
 
   private final ClassesToRetransformFinder finder;
   private final Queue<SourceFileItem> queue = new ConcurrentLinkedQueue<>();
-  private final AgentTaskScheduler scheduler = AgentTaskScheduler.getInstance();
+  private final AgentTaskScheduler scheduler = AgentTaskScheduler.get();
   private final AtomicInteger queueSize = new AtomicInteger(0);
   private AgentTaskScheduler.Scheduled<Runnable> scheduled;
   // this field MUST only be used in flush() calling thread

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -48,7 +48,7 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   private AgentTaskScheduler scheduler;
 
   public DefaultCodeOriginRecorder(Config config, ConfigurationUpdater configurationUpdater) {
-    this(config, configurationUpdater, AgentTaskScheduler.getInstance());
+    this(config, configurationUpdater, AgentTaskScheduler.get());
   }
 
   public DefaultCodeOriginRecorder(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
@@ -94,8 +94,7 @@ public abstract class AbstractExceptionDebugger implements DebuggerContext.Excep
           if (!applyConfigAsync) {
             applyExceptionConfiguration(fingerprint);
           } else {
-            AgentTaskScheduler.getInstance()
-                .execute(() -> applyExceptionConfiguration(fingerprint));
+            AgentTaskScheduler.get().execute(() -> applyExceptionConfiguration(fingerprint));
           }
           break;
         } else {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -36,7 +36,7 @@ public class DebuggerSink {
   private final String tags;
   private final AtomicLong highRateDropped = new AtomicLong();
   private final int uploadFlushInterval;
-  private final AgentTaskScheduler lowRateScheduler = AgentTaskScheduler.getInstance();
+  private final AgentTaskScheduler lowRateScheduler = AgentTaskScheduler.get();
   private volatile AgentTaskScheduler.Scheduled<DebuggerSink> lowRateScheduled;
   private volatile AgentTaskScheduler.Scheduled<DebuggerSink> flushIntervalScheduled;
   private volatile long currentLowRateFlushInterval = LOW_RATE_INITIAL_FLUSH_INTERVAL;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -58,7 +58,7 @@ public class SymDBEnablement implements ProductListener {
       SymDbRemoteConfigRecord symDb = deserializeSymDb(content);
       if (symDb.isUploadSymbols()) {
         // can be long, make it async
-        AgentTaskScheduler.getInstance().execute(this::startSymbolExtraction);
+        AgentTaskScheduler.get().execute(this::startSymbolExtraction);
       } else {
         stopSymbolExtraction();
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
@@ -64,10 +64,10 @@ public class SymbolAggregator {
 
   public void start() {
     flushRemainingScopeScheduled =
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(this::flushRemainingScopes, this, 0, 1, TimeUnit.SECONDS);
     scanJarsScheduled =
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(this::scanQueuedJars, this, 0, 1, TimeUnit.SECONDS);
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -102,7 +102,7 @@ public class IastSystem {
     if (VERBOSITY != Verbosity.OFF) {
       IastMetricCollector.register(new IastMetricCollector());
     }
-    final Reporter reporter = new Reporter(config, AgentTaskScheduler.getInstance());
+    final Reporter reporter = new Reporter(config, AgentTaskScheduler.get());
     final boolean globalContext = config.getIastContextMode() == GLOBAL;
     final IastContext.Provider contextProvider = contextProvider(iast, globalContext);
     if (overheadController == null) {
@@ -111,7 +111,7 @@ public class IastSystem {
               globalContext ? UNLIMITED : config.getIastRequestSampling(),
               config.getIastMaxConcurrentRequests(),
               globalContext,
-              AgentTaskScheduler.getInstance());
+              AgentTaskScheduler.get());
     }
     IastContext.Provider.register(contextProvider);
     final Dependencies dependencies =

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedMap.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedMap.java
@@ -76,11 +76,7 @@ public interface TaintedMap extends Iterable<TaintedObject> {
   static TaintedMap buildWithPurge(final int capacity, int maxAge, TimeUnit maxAgeUnit) {
     final TaintedMapImpl map =
         new TaintedMapImpl(
-            capacity,
-            DEFAULT_MAX_BUCKET_SIZE,
-            maxAge,
-            maxAgeUnit,
-            AgentTaskScheduler.getInstance());
+            capacity, DEFAULT_MAX_BUCKET_SIZE, maxAge, maxAgeUnit, AgentTaskScheduler.get());
     return IastSystem.DEBUG ? new Debug(map) : map;
   }
 
@@ -136,7 +132,7 @@ public interface TaintedMap extends Iterable<TaintedObject> {
      */
     TaintedMapImpl(
         final int capacity, final int maxBucketSize, final int maxAge, final TimeUnit maxAgeUnit) {
-      this(capacity, maxBucketSize, maxAge, maxAgeUnit, AgentTaskScheduler.getInstance());
+      this(capacity, maxBucketSize, maxAge, maxAgeUnit, AgentTaskScheduler.get());
     }
 
     TaintedMapImpl(
@@ -352,7 +348,7 @@ public interface TaintedMap extends Iterable<TaintedObject> {
       delegate.put(entry);
       final long putOps = puts.updateAndGet(current -> current == Long.MAX_VALUE ? 0 : current + 1);
       if (putOps % COMPUTE_STATISTICS_INTERVAL == 0 && LOGGER.isDebugEnabled()) {
-        AgentTaskScheduler.getInstance().execute(this::computeStatistics);
+        AgentTaskScheduler.get().execute(this::computeStatistics);
       }
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMaps.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMaps.java
@@ -14,7 +14,7 @@ public class WeakMaps {
   public static <K, V> WeakMap<K, V> newWeakMap() {
     final WeakConcurrentMap<K, V> map = new WeakConcurrentMap<>(false, true);
     if (!Platform.isNativeImageBuilder()) {
-      AgentTaskScheduler.getInstance()
+      AgentTaskScheduler.get()
           .weakScheduleAtFixedRate(
               MapCleaningTask.INSTANCE,
               map,

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -203,7 +203,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     sink.register(this);
     thread.start();
     cancellation =
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(
                 new ReportTask(),
                 this,

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
@@ -83,7 +83,7 @@ public final class OkHttpSink implements Sink, EventListener {
     } else {
       if (asyncTaskStarted.compareAndSet(false, true)) {
         this.future =
-            AgentTaskScheduler.getInstance()
+            AgentTaskScheduler.get()
                 .scheduleAtFixedRate(new Sender(enqueuedRequests), this, 1, 1, SECONDS);
       }
       sendAsync(messageCount, buffer);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -793,7 +793,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     // Schedule the metrics aggregator to begin reporting after a random delay of 1 to 10 seconds
     // (using milliseconds granularity.) This avoids a fleet of traced applications starting at the
     // same time from sending metrics in sync.
-    AgentTaskScheduler.getInstance()
+    AgentTaskScheduler.get()
         .scheduleWithJitter(MetricsAggregator::start, metricsAggregator, 1, SECONDS);
 
     if (dataStreamsMonitoring == null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -27,7 +27,7 @@ public final class StatusLogger extends JsonAdapter<Config>
     implements AgentTaskScheduler.Task<Config>, JsonAdapter.Factory {
 
   public static void logStatus(Config config) {
-    AgentTaskScheduler.getInstance().schedule(new StatusLogger(), config, 500, MILLISECONDS);
+    AgentTaskScheduler.get().schedule(new StatusLogger(), config, 500, MILLISECONDS);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -128,7 +128,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
   public void start() {
     checkDynamicConfig();
     cancellation =
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(
                 new ReportTask(),
                 this,

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -155,7 +155,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   public void start() {
     if (started.compareAndSet(false, true)) {
       cancellation =
-          AgentTaskScheduler.getInstance()
+          AgentTaskScheduler.get()
               .scheduleAtFixedRate(new Flush(), this, interval, interval, units);
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -430,7 +430,7 @@ public final class ContinuableScopeManager implements ContextManager {
 
     public static void scheduleFor(Map<ScopeStack, ContinuableScope> rootIterationScopes) {
       long period = Math.min(iterationKeepAlive, 10_000);
-      AgentTaskScheduler.getInstance()
+      AgentTaskScheduler.get()
           .scheduleAtFixedRate(
               CLEANER, rootIterationScopes, iterationKeepAlive, period, TimeUnit.MILLISECONDS);
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.core.test
 
-import static datadog.trace.util.AgentThreadFactory.AgentThread.TASK_SCHEDULER
 
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
@@ -36,7 +35,6 @@ abstract class DDCoreSpecification extends DDSpecification {
   }
 
 
-
   protected boolean useNoopStatsDClient() {
     return true
   }
@@ -58,10 +56,14 @@ abstract class DDCoreSpecification extends DDSpecification {
 
   @Override
   void cleanup() {
-    unclosedTracers.each {it.close()}
+    unclosedTracers.each {
+      try {
+        it.close()
+      } catch (Throwable ignored) {
+      }
+    }
     unclosedTracers.clear()
-    AgentTaskScheduler.getInstance().shutdown(10, TimeUnit.SECONDS)
-    AgentTaskScheduler.INSTANCE = new AgentTaskScheduler(TASK_SCHEDULER)
+    AgentTaskScheduler.shutdownAndReset(10, TimeUnit.SECONDS)
   }
 
   protected CoreTracerBuilder tracerBuilder() {

--- a/internal-api/src/main/java/datadog/trace/api/sampling/AdaptiveSampler.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/AdaptiveSampler.java
@@ -173,7 +173,7 @@ public class AdaptiveSampler implements Sampler {
         averageLookback,
         budgetLookback,
         null,
-        AgentTaskScheduler.getInstance(),
+        AgentTaskScheduler.get(),
         startSampler);
   }
 
@@ -199,7 +199,7 @@ public class AdaptiveSampler implements Sampler {
         averageLookback,
         budgetLookback,
         listener,
-        AgentTaskScheduler.getInstance(),
+        AgentTaskScheduler.get(),
         true);
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/AgentTaskScheduler.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentTaskScheduler.java
@@ -27,8 +27,20 @@ public class AgentTaskScheduler implements Executor {
 
   private static final long SHUTDOWN_TIMEOUT = 5; // seconds
 
-  public static AgentTaskScheduler getInstance() {
+  public static AgentTaskScheduler get() {
     return INSTANCE;
+  }
+
+  /**
+   * This method is only for testing. It shuts down the existing executor and swap the instance with
+   * a fresh one.
+   *
+   * @param timeout the amount of time to wait for the shutdown.
+   * @param unit the unit of the time amount.
+   */
+  static void shutdownAndReset(long timeout, TimeUnit unit) {
+    INSTANCE.shutdown(timeout, unit);
+    INSTANCE = new AgentTaskScheduler(TASK_SCHEDULER);
   }
 
   public interface Task<T> {

--- a/internal-api/src/main/java/datadog/trace/util/TempLocationManager.java
+++ b/internal-api/src/main/java/datadog/trace/util/TempLocationManager.java
@@ -298,7 +298,7 @@ public final class TempLocationManager {
     tempDir = baseTempDir.resolve(TEMPDIR_PREFIX + pid);
     if (runStartupCleanup) {
       // do not execute the background cleanup task when running in tests
-      AgentTaskScheduler.getInstance().execute(cleanupTask);
+      AgentTaskScheduler.get().execute(cleanupTask);
     }
 
     createTempDir(tempDir);

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
@@ -31,7 +31,7 @@ public class DependencyService implements Runnable {
 
   public void schedulePeriodicResolution() {
     scheduledTask =
-        AgentTaskScheduler.getInstance()
+        AgentTaskScheduler.get()
             .scheduleAtFixedRate(
                 AgentTaskScheduler.RunnableTask.INSTANCE,
                 this,


### PR DESCRIPTION
# What Does This Do

On `DDCoreSpecification` we spawn tracers. The first issue is that those tracers are not (always) closed and they might leak scheduled (repeated) tasks (like Health reporting, telemetry, metrics calculation) that accumulates in the AgentThreadScheduler queue. 
To mitigate that, this PR decorates the DDCoreTracerBuilder returned on DDCoreSpecification by recording the opened tracers and closing them when the test terminates.

Secondly, we have things that are scheduled with jitter (i.e. metrics calculation) that can be spawn after the test is completed (i.e. the test is quicker than the jitter). Hence they are stale on the scheduler and accumulates. They will hold memory and, in case for instance the agent metrics are enabled, the tests will finish to fail for OOM.

This PR is also removing the final modifier to the AgentTaskScheduler `INSTANCE` (hence only exposing publicly a getter now) in order to be able to shutdown it after each test class and reset with a new one.

Please note that I tried to find alternate solution to avoid removing `final` (i.e. play with Unsafe, etc..) but it resulted in having to deal with Unsafe that is not very portable across jdk and also, static final things might be inlined so I preferred that easier solution.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
