### PR TITLE
Decouple Gradle JDK from JDK8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,6 +256,7 @@ build:
     DEPENDENCY_CACHE_POLICY: pull
   script:
     - if [ $CI_PIPELINE_SOURCE == "schedule" ] ; then ./gradlew resolveAndLockAll --write-locks $GRADLE_ARGS; fi
+    - ./gradlew --version
     - ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar -PskipTests $GRADLE_ARGS
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
@@ -296,6 +297,7 @@ build_tests:
 
   script:
     - *gitlab_base_ref_params
+    - ./gradlew --version
     - ./gradlew clean $GRADLE_TARGET $GRADLE_PARAMS -PskipTests $GRADLE_ARGS
 
 populate_dep_cache:
@@ -362,7 +364,7 @@ spotless:
   stage: tests
   needs: []
   script:
-    - export JAVA_HOME=$JAVA_11_HOME
+    - ./gradlew --version
     - ./gradlew spotlessCheck $GRADLE_ARGS
 
 test_published_artifacts:
@@ -381,6 +383,7 @@ test_published_artifacts:
     - ./gradlew publishToMavenLocal $GRADLE_ARGS
     - cd test-published-dependencies
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - ./gradlew --version
     - ./gradlew check --info $GRADLE_ARGS
   after_script:
     - *cgroup_info
@@ -401,6 +404,7 @@ test_published_artifacts:
     CACHE_TYPE: lib
   script:
     - *gitlab_base_ref_params
+    - ./gradlew --version
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PskipTests -PrunBuildSrcTests -PskipSpotless -PtaskPartitionCount=$NORMALIZED_NODE_TOTAL -PtaskPartition=$NORMALIZED_NODE_INDEX $GRADLE_ARGS
   after_script:
     - *cgroup_info
@@ -461,6 +465,7 @@ muzzle:
     CACHE_TYPE: inst
   script:
     - export SKIP_BUILDSCAN="true"
+    - ./gradlew --version
     - ./gradlew :runMuzzle -PtaskPartitionCount=$NORMALIZED_NODE_TOTAL -PtaskPartition=$NORMALIZED_NODE_INDEX $GRADLE_ARGS
   after_script:
     - *cgroup_info
@@ -482,6 +487,7 @@ muzzle-dep-report:
     CACHE_TYPE: inst
   script:
     - export SKIP_BUILDSCAN="true"
+    - ./gradlew --version
     - ./gradlew generateMuzzleReport muzzleInstrumentationReport $GRADLE_ARGS
   after_script:
     - *cgroup_info
@@ -541,6 +547,7 @@ muzzle-dep-report:
       fi
     - *prepare_test_env
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEM -Xmx$GRADLE_MEM $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=1024M -Ddatadog.forkedMinHeapSize=128M"
+    - ./gradlew --version
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PtestJvm=$testJvm -PtaskPartitionCount=$NORMALIZED_NODE_TOTAL -PtaskPartition=$NORMALIZED_NODE_INDEX $GRADLE_ARGS --continue || $CONTINUE_ON_FAILURE
   after_script:
     - *restore_pretest_env

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
@@ -59,7 +59,10 @@ class AssertBuilder<C extends CallSiteAssert> {
       return [null, null]
     }
     final isEnabled = type.getMethodsByName('isEnabled').first()
-    final returnStatement = isEnabled.body.get().statements.first.get().asReturnStmt()
+    // JavaParser's NodeList has method getFirst() returning an Optional, however with Java 21's
+    // SequencedCollection, Groovy picks the getFirst() that returns the object itself.
+    // Using `first()` rather than `first` picks the groovy method instead, fixing the situation.
+    final returnStatement = isEnabled.body.get().statements.first().asReturnStmt()
     final enabledMethodCall = returnStatement.expression.get().asMethodCallExpr()
     final enabled = resolveMethod(enabledMethodCall)
     final enabledArgs = enabledMethodCall.getArguments().collect { it.asStringLiteralExpr().asString() }.toSet()

--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -152,17 +152,16 @@ abstract class InstrumentTask extends DefaultTask {
   }
 
   private workQueue() {
-    if (this.javaVersion) {
-      def javaLauncher = this.javaToolchainService.launcherFor { spec ->
-        spec.languageVersion.set(JavaLanguageVersion.of(this.javaVersion))
-      }.get()
-      return this.workerExecutor.processIsolation { spec ->
-        spec.forkOptions { fork ->
-          fork.executable = javaLauncher.executablePath
-        }
+    if (!this.javaVersion) {
+      this.javaVersion = "8"
+    }
+    def javaLauncher = this.javaToolchainService.launcherFor { spec ->
+      spec.languageVersion.set(JavaLanguageVersion.of(this.javaVersion))
+    }.get()
+    return this.workerExecutor.processIsolation { spec ->
+      spec.forkOptions { fork ->
+        fork.executable = javaLauncher.executablePath
       }
-    } else {
-      return this.workerExecutor.noIsolation()
     }
   }
 }

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -10,8 +10,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
 tasks.named("compileJava", JavaCompile).configure {
-  // need access to sun.* packages
-  setJavaVersion(it, 8, true)
+  configureCompiler(it, 8, JavaVersion.VERSION_1_8, "Need access to sun.* packages")
 }
 
 // FIXME: Improve test coverage.
@@ -40,9 +39,7 @@ sourceSets {
 }
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 dependencies {

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -4,13 +4,13 @@ plugins {
   id 'me.champeau.jmh'
 }
 
-ext {
-  // need access to sun.* packages
-  skipSettingCompilerRelease = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
+
+tasks.named("compileJava", JavaCompile).configure {
+  // need access to sun.* packages
+  setJavaVersion(it, 8)
+}
 
 // FIXME: Improve test coverage.
 minimumBranchCoverage = 0.0

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -1,3 +1,5 @@
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+
 // The shadowJar of this project will be injected into the JVM's bootstrap classloader
 plugins {
   id 'com.gradleup.shadow'
@@ -9,7 +11,7 @@ apply plugin: "idea"
 
 tasks.named("compileJava", JavaCompile).configure {
   // need access to sun.* packages
-  setJavaVersion(it, 8)
+  setJavaVersion(it, 8, true)
 }
 
 // FIXME: Improve test coverage.
@@ -37,8 +39,8 @@ sourceSets {
   }
 }
 
-compileMain_java11Java.configure {
-  setJavaVersion(it, 11)
+tasks.named("compileMain_java11Java", JavaCompile) {
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
@@ -52,7 +54,7 @@ tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-tasks.named("forbiddenApisMain_java11") {
+tasks.named("forbiddenApisMain_java11", CheckForbiddenApis) {
   failOnMissingClasses = false
 }
 
@@ -63,14 +65,12 @@ idea {
 }
 
 jmh {
-  jmhVersion = libs.versions.jmh.get()
+  jmhVersion = libs.versions.jmh
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-project.afterEvaluate {
-  tasks.withType(Test).configureEach {
-    if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
-      jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED'] // for HostNameResolverForkedTest
-    }
+tasks.withType(Test).configureEach {
+  if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
+    jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED'] // for HostNameResolverForkedTest
   }
 }

--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -67,7 +67,10 @@ jmh {
 }
 
 tasks.withType(Test).configureEach {
-  if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
-    jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED'] // for HostNameResolverForkedTest
-  }
+  configureJvmArgs(
+    it,
+    JavaVersion.VERSION_16,
+    ['--add-opens', 'java.base/java.net=ALL-UNNAMED'] // for HostNameResolverForkedTest
+    )
+
 }

--- a/dd-java-agent/agent-builder/build.gradle
+++ b/dd-java-agent/agent-builder/build.gradle
@@ -20,7 +20,7 @@ sourceSets {
 }
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/dd-java-agent/agent-builder/build.gradle
+++ b/dd-java-agent/agent-builder/build.gradle
@@ -20,9 +20,7 @@ sourceSets {
 }
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 dependencies {

--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -66,3 +66,13 @@ tasks.named("shadowJar", ShadowJar) {
 tasks.named("jar", Jar) {
   archiveClassifier = 'unbundled'
 }
+
+tasks.named("compileTestGroovy") {
+  configureCompiler(
+    it,
+    8,
+    JavaVersion.VERSION_1_8,
+    "Groovy generates synthetic accessors methods from superclass, we don't want that for `MisbehavingClassLoader`," +
+    " otherwise anonymous class has one `loadClass` accessor's signature has `java.lang.Module`"
+    )
+}

--- a/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
@@ -7,3 +7,11 @@ apply from: "$rootDir/gradle/java.gradle"
 dependencies {
   implementation group: 'org.scala-lang', name: 'scala-compiler', version: '2.13.3'
 }
+
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}

--- a/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-test-scala/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -11,17 +11,8 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/version.gradle"
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.withType(AbstractCompile).configureEach {
-  // ensure no APIs beyond JDK8 are used
-  options.release = 8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8, "Ensure no APIs beyond JDK8 are used")
 }
 
 // First version with Mac M1 support

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
@@ -4,8 +4,6 @@ ext {
   // By default tests with be compiled for `minJavaVersionForTests` version,
   // but in this case we would like to avoid this since we would like to run with ZULU8
   skipSettingTestJavaVersion = true
-  // need access to jdk.jfr package
-  skipSettingCompilerRelease = true
   excludeJdk = ['SEMERU11', 'SEMERU17']
 }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
@@ -38,8 +38,8 @@ dependencies {
  * We force IDEA to treat this as Java11 project with 'idea' plugin below.
  */
 [JavaCompile, GroovyCompile].each {
-  tasks.withType(it).configureEach {
-    setJavaVersion(it, 11)
+  tasks.withType(it, AbstractCompile).configureEach {
+    setJavaVersion(it, 11, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     // Disable '-processing' because some annotations are not claimed.

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
@@ -37,16 +37,12 @@ dependencies {
  * We specify source/target as Java8 to get code that is loadable on Java8 - JFR defs are Java8 compatible.
  * We force IDEA to treat this as Java11 project with 'idea' plugin below.
  */
-[JavaCompile, GroovyCompile].each {
-  tasks.withType(it, AbstractCompile).configureEach {
-    setJavaVersion(it, 11, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-    // Disable '-processing' because some annotations are not claimed.
-    // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
-    // Disable '-path' because we do not have some of the paths seem to be missing.
-    options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
-  }
+tasks.withType(AbstractCompile).configureEach {
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
+  // Disable '-processing' because some annotations are not claimed.
+  // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
+  // Disable '-path' because we do not have some of the paths seem to be missing.
+  options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
 }
 
 tasks.named("forbiddenApisMain") {

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -1,3 +1,5 @@
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+
 // Set properties before any plugins get loaded
 ext {
   // the tests need Java 11 because the JFR writer got compiled with a version
@@ -28,9 +30,8 @@ excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
 
 
 // Shared JFR implementation. The earliest Java version JFR is working on is Java 8
-
 tasks.named("compileTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   // tests should be compiled in Java 8 compatible way
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
@@ -40,7 +41,7 @@ tasks.named("compileTestJava", JavaCompile) {
   options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
 }
 
-tasks.named("forbiddenApisMain") {
+tasks.named("forbiddenApisMain", CheckForbiddenApis) {
   failOnMissingClasses = false
 }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -31,10 +31,8 @@ excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
 
 // Shared JFR implementation. The earliest Java version JFR is working on is Java 8
 tasks.named("compileTestJava", JavaCompile) {
-  setJavaVersion(it, 11, true)
   // tests should be compiled in Java 8 compatible way
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
   // Disable '-processing' because some annotations are not claimed.
   // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
   // Disable '-path' because we do not have some of the paths seem to be missing.

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -4,9 +4,6 @@ ext {
   // of ByteBuffer.position(int) which is binary incompatible with Java 8 ¯\_(ツ)_/¯
   minJavaVersionForTests = JavaVersion.VERSION_11
 
-  // need access to jdk.jfr package
-  skipSettingCompilerRelease = true
-
   excludeJdk = ['SEMERU11', 'SEMERU17']
 }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
@@ -56,9 +56,11 @@ idea {
 }
 
 tasks.withType(Test).configureEach {
-  if (javaLauncher.get().metadata.languageVersion.asInt() >= 9) {
-    jvmArgs += [
+  configureJvmArgs(
+    it,
+    JavaVersion.VERSION_1_9,
+    [
       '--add-opens',
       'jdk.jfr/jdk.jfr.internal=ALL-UNNAMED'] // JPMSJFRAccess needs access to jdk.jfr.internal package
-  }
+    )
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
@@ -1,3 +1,5 @@
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
@@ -13,8 +15,12 @@ sourceSets {
   }
 }
 
-compileMain_java11Java.configure {
-  setJavaVersion(it, 11)
+tasks.named("compileJava", JavaCompile) {
+  setJavaVersion(it, 11, true)
+}
+
+tasks.named("compileMain_java11Java", JavaCompile) {
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_9
   targetCompatibility = JavaVersion.VERSION_1_9
 }
@@ -37,12 +43,12 @@ excludedClassesCoverage += [
   'com.datadog.profiling.controller.jfr.SimpleJFRAccess*'
 ]
 
-jar {
+tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-forbiddenApisMain {
-  failOnMissingClasses = false
+tasks.named("forbiddenApisMain", CheckForbiddenApis) {
+  it.failOnMissingClasses = false
 }
 
 idea {
@@ -51,12 +57,10 @@ idea {
   }
 }
 
-project.afterEvaluate {
-  tasks.withType(Test).configureEach {
-    if (javaLauncher.get().metadata.languageVersion.asInt() >= 9) {
-      jvmArgs += [
-        '--add-opens',
-        'jdk.jfr/jdk.jfr.internal=ALL-UNNAMED'] // JPMSJFRAccess needs access to jdk.jfr.internal package
-    }
+tasks.withType(Test).configureEach {
+  if (javaLauncher.get().metadata.languageVersion.asInt() >= 9) {
+    jvmArgs += [
+      '--add-opens',
+      'jdk.jfr/jdk.jfr.internal=ALL-UNNAMED'] // JPMSJFRAccess needs access to jdk.jfr.internal package
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
@@ -1,9 +1,6 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
-
-  // need access to jdk.jfr package
-  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
@@ -16,13 +16,11 @@ sourceSets {
 }
 
 tasks.named("compileJava", JavaCompile) {
-  setJavaVersion(it, 11, true)
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8, "Need access to jdk.jfr.internal.*")
 }
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_9
-  targetCompatibility = JavaVersion.VERSION_1_9
+  configureCompiler(it, 11, JavaVersion.VERSION_1_9)
 }
 
 dependencies {

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
@@ -7,8 +7,6 @@ ext {
   // By default tests with be compiled for `minJavaVersionForTests` version,
   // but in this case we would like to avoid this since we would like to run with ZULU8
   skipSettingTestJavaVersion = true
-  // need access to jdk.jfr package
-  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -39,6 +37,10 @@ dependencies {
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it).configureEach {
     setJavaVersion(it, 11)
+    if (it instanceof JavaCompile) {
+      // need access to jdk.jfr package
+      options.release = null
+    }
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     // Disable '-processing' because some annotations are not claimed.

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
@@ -36,13 +36,7 @@ dependencies {
  */
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it).configureEach {
-    setJavaVersion(it, 11)
-    if (it instanceof JavaCompile) {
-      // need access to jdk.jfr package
-      options.release = null
-    }
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 11, JavaVersion.VERSION_1_8, "Need access to jdk.jfr package")
     // Disable '-processing' because some annotations are not claimed.
     // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
     // Disable '-path' because we do not have some of the paths seem to be missing.

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/build.gradle
@@ -5,8 +5,6 @@ ext {
   // By default tests with be compiled for `minJavaVersionForTests` version,
   // but in this case we would like to avoid this since we would like to run with ORACLE8
   skipSettingTestJavaVersion = true
-  // need access to jdk.jfr package
-  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -47,7 +47,7 @@ configurations.configureEach {
 
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it).configureEach {
-    setJavaVersion(it, 11)
+    setJavaVersion(it, 11, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     // Disable '-processing' because some annotations are not claimed.

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -47,9 +47,7 @@ configurations.configureEach {
 
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it).configureEach {
-    setJavaVersion(it, 11, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 11, JavaVersion.VERSION_1_8)
     // Disable '-processing' because some annotations are not claimed.
     // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
     // Disable '-path' because we do not have some of the paths seem to be missing.

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -87,14 +87,17 @@ tasks.named("forbiddenApisTest_java11") {
 
 tasks.named("compileTestJava") { dependsOn('generateTestClassNameTries') }
 tasks.named("compileTest_java11Java") {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 tasks.named("compileTest_java21Java") {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-  setJavaVersion(it, 21)
+  configureCompiler(
+    it,
+    21,
+    JavaVersion.VERSION_1_8,
+    "This source set is specifically designed to make `javac` from a JDK post 18/19, generates " +
+    "bytecode that emit `invokeinterface` for `java.lang.Object` methods on an interface type. " +
+    "See https://bugs.openjdk.org/browse/JDK-8272715."
+    )
 }
 
 tasks.named("jmh") {

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -85,7 +85,9 @@ tasks.named("forbiddenApisTest_java11") {
   failOnMissingClasses = false
 }
 
-tasks.named("compileTestJava") { dependsOn('generateTestClassNameTries') }
+tasks.named("compileTestJava") {
+  dependsOn('generateTestClassNameTries')
+}
 tasks.named("compileTest_java11Java") {
   configureCompiler(it, 11, JavaVersion.VERSION_11)
 }

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -88,6 +88,14 @@ tasks.named("forbiddenApisTest_java11") {
 tasks.named("compileTestJava") {
   dependsOn('generateTestClassNameTries')
 }
+tasks.named("compileTestGroovy") {
+  configureCompiler(it,
+    8,
+    JavaVersion.VERSION_1_8,
+    "Groovy generates synthetic accessors methods from superclass, we don't want that for `URLClassLoader`," +
+    " otherwise anonymous class has one `loadClass` accessor's signature has `java.lang.Module`"
+    )
+}
 tasks.named("compileTest_java11Java") {
   configureCompiler(it, 11, JavaVersion.VERSION_11)
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
@@ -303,7 +303,11 @@ class ObjectIntrospectionSpecification extends DDSpecification {
   void 'conversion of an element throws'() {
     setup:
     def cs = new CharSequence() {
-      @Delegate String s = ''
+      // When run on JDK8 this prevents `NoClassDefFoundError` of `java.lang.constant.Constable`.
+      // Since JDK12 types like Integer, String implement Constable, and groovy capture this
+      // in the enclosing class, which fails on JDK8 when it is loaded,
+      // see https://github.com/groovy/groovy-eclipse/issues/1436
+      @Delegate(interfaces = false) String s = ''
 
       @Override
       String toString() {

--- a/dd-java-agent/benchmark-integration/play-perftest/build.gradle
+++ b/dd-java-agent/benchmark-integration/play-perftest/build.gradle
@@ -1,3 +1,5 @@
+import com.github.spotbugs.snom.SpotBugsTask
+
 plugins {
   id 'org.gradle.playframework'
 }
@@ -12,6 +14,14 @@ play {
     javaVersion = JavaVersion.VERSION_1_8
   }
   injectedRoutesGenerator = true
+}
+
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
 }
 
 dependencies {

--- a/dd-java-agent/benchmark-integration/play-perftest/build.gradle
+++ b/dd-java-agent/benchmark-integration/play-perftest/build.gradle
@@ -18,7 +18,7 @@ play {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -25,14 +25,12 @@ sourceSets {
   }
 }
 
-def compileMain_java6Java = tasks.named("compileMain_java6Java") {
-  setJavaVersion(it, 8, true)
-  sourceCompatibility = JavaVersion.VERSION_1_6
-  targetCompatibility = JavaVersion.VERSION_1_6
+def java6CompileTask = tasks.named("compileMain_java6Java") {
+  configureCompiler(it, 8, JavaVersion.VERSION_1_6)
 }
 
 tasks.named("compileJava") {
-  dependsOn compileMain_java6Java
+  dependsOn(java6CompileTask)
 }
 
 dependencies {

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -25,13 +25,15 @@ sourceSets {
   }
 }
 
-compileMain_java6Java.configure {
-  setJavaVersion(it, 8)
+def compileMain_java6Java = tasks.named("compileMain_java6Java") {
+  setJavaVersion(it, 8, true)
   sourceCompatibility = JavaVersion.VERSION_1_6
   targetCompatibility = JavaVersion.VERSION_1_6
 }
 
-tasks.compileJava.dependsOn compileMain_java6Java
+tasks.named("compileJava") {
+  dependsOn compileMain_java6Java
+}
 
 dependencies {
   main_java6CompileOnly 'de.thetaphi:forbiddenapis:3.8'

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
@@ -39,28 +39,22 @@ repositories {
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-["compileTestScala", "compileLatestDepTestScala"].each { name ->
-  tasks.named(name, ScalaCompile) {
-    setJavaVersion(it, 11)
+["compileMain_java11Java", "compileTestScala", "compileLatestDepTestScala"].each {
+  tasks.named(it, AbstractCompile) {
+    setJavaVersion(it, 11, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  setJavaVersion(it, 11)
   dependsOn compileTestScala
   classpath += files(compileTestScala.destinationDirectory)
 }
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  setJavaVersion(it, 11)
   dependsOn compileLatestDepTestScala
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }
@@ -91,6 +85,8 @@ dependencies {
   latestDepTestImplementation group: 'org.scala-lang.modules', name: 'scala-java8-compat_2.13', version: '1.0.+'
 }
 
-configurations.getByName("latestDepTestRuntimeClasspath").resolutionStrategy {
-  it.force libs.slf4j
+configurations.named("latestDepTestRuntimeClasspath") {
+  it.resolutionStrategy {
+    it.force libs.slf4j
+  }
 }

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
@@ -41,20 +41,18 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 ["compileMain_java11Java", "compileTestScala", "compileLatestDepTestScala"].each {
   tasks.named(it, AbstractCompile) {
-    setJavaVersion(it, 11, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 11, JavaVersion.VERSION_1_8)
   }
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11)
   dependsOn compileTestScala
   classpath += files(compileTestScala.destinationDirectory)
 }
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11)
   dependsOn compileLatestDepTestScala
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }

--- a/dd-java-agent/instrumentation/axis2-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/axis2-1.3/build.gradle
@@ -23,15 +23,15 @@ configurations.configureEach {
   }
 }
 
-["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
+["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
+  tasks.named(it, GroovyCompile) {
     javaLauncher = getJavaLauncherFor(11)
   }
 }
 
-["compileLatestDepForkedTestJava", "compileLatestDepTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 11)
+["compileLatestDepForkedTestJava", "compileLatestDepTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    configureCompiler(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/cxf-2.1/build.gradle
+++ b/dd-java-agent/instrumentation/cxf-2.1/build.gradle
@@ -24,15 +24,11 @@ addTestSuite('latestDepTest')
 addTestSuiteForDir('cxf3LatestDepTest', 'test')
 
 tasks.named("compileCxf3LatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
 }
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {

--- a/dd-java-agent/instrumentation/exception-profiling/build.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 // Must use Java 11 to build JFR enabled code - there is no JFR in OpenJDK 8 (revisit once JFR in Java 8 is available)
 ["compileMain_java11Java", "compileTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 11)
+    setJavaVersion(it, 11, true)
     it.sourceCompatibility = JavaVersion.VERSION_1_8
     it.targetCompatibility = JavaVersion.VERSION_1_8
     it.options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'])

--- a/dd-java-agent/instrumentation/exception-profiling/build.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/build.gradle
@@ -21,9 +21,7 @@ dependencies {
 // Must use Java 11 to build JFR enabled code - there is no JFR in OpenJDK 8 (revisit once JFR in Java 8 is available)
 ["compileMain_java11Java", "compileTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 11, true)
-    it.sourceCompatibility = JavaVersion.VERSION_1_8
-    it.targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 11, JavaVersion.VERSION_1_8, "Must use Java 11 to build JFR enabled code - there is no JFR in OpenJDK 8 (revisit once JFR in Java 8 is available)")
     it.options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'])
   }
 }

--- a/dd-java-agent/instrumentation/graal/native-image/build.gradle
+++ b/dd-java-agent/instrumentation/graal/native-image/build.gradle
@@ -13,11 +13,9 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
-["compileMain_java11Java", "compileTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 11, true)
-    it.sourceCompatibility = JavaVersion.VERSION_11
-    it.targetCompatibility = JavaVersion.VERSION_11
+["compileMain_java11Java", "compileTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    configureCompiler(it, 11, JavaVersion.VERSION_11, "Needs access to module jdk.internal.vm.ci")
     it.options.compilerArgs.addAll([
       '-Xlint:all,-processing,-options,-path',
       '--add-modules',

--- a/dd-java-agent/instrumentation/graal/native-image/build.gradle
+++ b/dd-java-agent/instrumentation/graal/native-image/build.gradle
@@ -15,9 +15,9 @@ apply plugin: "idea"
 
 ["compileMain_java11Java", "compileTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
+    setJavaVersion(it, 11, true)
     it.sourceCompatibility = JavaVersion.VERSION_11
     it.targetCompatibility = JavaVersion.VERSION_11
-    setJavaVersion(it, 11)
     it.options.compilerArgs.addAll([
       '-Xlint:all,-processing,-options,-path',
       '--add-modules',
@@ -34,7 +34,7 @@ dependencies {
   main_java11CompileOnly group: 'org.graalvm.nativeimage', name: 'svm', version: '20.0.0'
 }
 
-forbiddenApisMain_java11 {
+tasks.named("forbiddenApisMain_java11") {
   failOnMissingClasses = false
 }
 

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/build.gradle
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/build.gradle
@@ -51,19 +51,19 @@ dependencies {
   graphql20LatestDepTestImplementation group: 'com.graphql-java', name: 'graphql-java', version: '20.+'
   graphql21LatestDepTestImplementation group: 'com.graphql-java', name: 'graphql-java', version: '21.+'
   latestDepTestImplementation group: 'com.graphql-java', name: 'graphql-java', version: '22.+'
+}
 
-  [
-    compileLatestDepTestJava,
-    compileLatestDepTestGroovy,
-    compileLatestDepForkedTestJava,
-    compileLatestDepForkedTestGroovy,
-    compileGraphql21LatestDepTestJava,
-    compileGraphql21LatestDepTestGroovy,
-    compileGraphql21LatestDepForkedTestJava,
-    compileGraphql21LatestDepForkedTestGroovy
-  ].each {
-    it.configure {
-      setJavaVersion(it, 11)
-    }
+[
+  "compileLatestDepTestJava",
+  "compileLatestDepTestGroovy",
+  "compileLatestDepForkedTestJava",
+  "compileLatestDepForkedTestGroovy",
+  "compileGraphql21LatestDepTestJava",
+  "compileGraphql21LatestDepTestGroovy",
+  "compileGraphql21LatestDepForkedTestJava",
+  "compileGraphql21LatestDepForkedTestGroovy"
+].each {
+  tasks.named(it) {
+    configureCompiler(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
@@ -13,7 +13,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepJava11Test', 'latestDepTest', 'test')
 
 tasks.named("compileLatestDepJava11TestJava", JavaCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11)
 }
 tasks.named("compileLatestDepJava11TestGroovy", GroovyCompile) {
   javaLauncher = getJavaLauncherFor(11)

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
@@ -6,12 +6,16 @@ muzzle {
 
 apply from: "${rootDir}/gradle/java.gradle"
 
+compileJava {
+  javaCompiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(8)
+  }
+}
+
 addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
-
-
   testImplementation libs.guava
   testImplementation group: 'io.netty', name: 'netty-all', version: '4.1.9.Final'
   testImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '7.0.0'

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
@@ -6,8 +6,8 @@ muzzle {
 
 apply from: "${rootDir}/gradle/java.gradle"
 
-compileJava {
-  setJavaVersion(it, 8)
+tasks.named("compileJava") {
+  configureCompiler(it, 8)
 }
 
 addTestSuiteForDir('latestDepTest', 'test')

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/build.gradle
@@ -7,9 +7,7 @@ muzzle {
 apply from: "${rootDir}/gradle/java.gradle"
 
 compileJava {
-  javaCompiler = javaToolchains.compilerFor {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
+  setJavaVersion(it, 8)
 }
 
 addTestSuiteForDir('latestDepTest', 'test')

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
@@ -26,19 +26,27 @@ idea {
  * Declare previewTest, a test suite that requires the Javac/Java --enable-preview feature flag
  */
 addTestSuite('previewTest')
+
+// Set all compile tasks to use JDK21 but let instrumentation code targets 1.8 compatibility
+tasks.withType(AbstractCompile).configureEach {
+  setJavaVersion(it, 21, true)
+}
+tasks.named("compileJava") {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 // Configure groovy test file compilation
-compilePreviewTestGroovy.configure {
-  javaLauncher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(21)
-  }
+tasks.named("compilePreviewTestGroovy") {
   options.compilerArgs.add("--enable-preview")
 }
 // Configure Java test files compilation
-compilePreviewTestJava.configure {
+tasks.named("compilePreviewTestJava") {
+  setJavaVersion(it, 21, true)
   options.compilerArgs.add("--enable-preview")
 }
 // Configure tests execution
-previewTest.configure {
+tasks.named("previewTest") {
   jvmArgs = ['--enable-preview']
 }
 // Require the preview test suite to run as part of module check
@@ -48,13 +56,4 @@ tasks.named("check") {
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
-}
-
-// Set all compile tasks to use JDK21 but let instrumentation code targets 1.8 compatibility
-project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 21)
-}
-compileJava.configure {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
@@ -29,20 +29,15 @@ addTestSuite('previewTest')
 
 // Set all compile tasks to use JDK21 but let instrumentation code targets 1.8 compatibility
 tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 21, true)
-}
-tasks.named("compileJava") {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 21, JavaVersion.VERSION_1_8)
 }
 
 // Configure groovy test file compilation
-tasks.named("compilePreviewTestGroovy") {
+tasks.named("compilePreviewTestGroovy", GroovyCompile) {
   options.compilerArgs.add("--enable-preview")
 }
 // Configure Java test files compilation
-tasks.named("compilePreviewTestJava") {
-  setJavaVersion(it, 21, true)
+tasks.named("compilePreviewTestJava", JavaCompile) {
   options.compilerArgs.add("--enable-preview")
 }
 // Configure tests execution

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-11.0/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   if (it.name != 'compileCsiJava') {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-11.0/build.gradle
@@ -32,12 +32,11 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 11, true)
-  if (it.name != 'compileCsiJava') {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-    if (it instanceof JavaCompile) {
-      it.options.release.set(11)
-    }
+  switch (it.name) {
+    case 'compileCsiJava':
+      configureCompiler(it, 11, JavaVersion.VERSION_1_8)
+      break
+    default:
+      configureCompiler(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-15.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-15.0/build.gradle
@@ -32,12 +32,11 @@ dependencies {
 }
 
 tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17, true)
-  if (it.name != 'compileCsiJava') {
-    sourceCompatibility = JavaVersion.VERSION_15
-    targetCompatibility = JavaVersion.VERSION_15
-    if (it instanceof JavaCompile) {
-      it.options.release.set(15)
-    }
+  switch (it.name) {
+    case 'compileCsiJava':
+      configureCompiler(it, 17, JavaVersion.VERSION_1_8)
+      break
+    default:
+      configureCompiler(it, 17, JavaVersion.VERSION_15)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-15.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-15.0/build.gradle
@@ -31,8 +31,8 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
-project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17)
+tasks.withType(AbstractCompile).configureEach {
+  setJavaVersion(it, 17, true)
   if (it.name != 'compileCsiJava') {
     sourceCompatibility = JavaVersion.VERSION_15
     targetCompatibility = JavaVersion.VERSION_15

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-17.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-17.0/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17)
+  setJavaVersion(it, 17, true)
   if (it.name != 'compileCsiJava') {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-17.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-17.0/build.gradle
@@ -32,12 +32,11 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17, true)
-  if (it.name != 'compileCsiJava') {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-    if (it instanceof JavaCompile) {
-      it.options.release.set(17)
-    }
+  switch (it.name) {
+    case 'compileCsiJava':
+      configureCompiler(it, 17, JavaVersion.VERSION_1_8)
+      break
+    default:
+      configureCompiler(it, 17)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-9.0/build.gradle
@@ -32,12 +32,11 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 11, true)
-  if (it.name != 'compileCsiJava') {
-    sourceCompatibility = JavaVersion.VERSION_1_9
-    targetCompatibility = JavaVersion.VERSION_1_9
-    if (it instanceof JavaCompile) {
-      it.options.release.set(9)
-    }
+  switch (it.name) {
+    case 'compileCsiJava':
+      configureCompiler(it, 11, JavaVersion.VERSION_1_8)
+      break
+    default:
+      configureCompiler(it, 11, JavaVersion.VERSION_1_9)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-9.0/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   if (it.name != 'compileCsiJava') {
     sourceCompatibility = JavaVersion.VERSION_1_9
     targetCompatibility = JavaVersion.VERSION_1_9

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
@@ -13,12 +13,10 @@ apply plugin: "idea"
 
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  it.sourceCompatibility = JavaVersion.VERSION_11
-  it.targetCompatibility = JavaVersion.VERSION_11
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy") {
   javaLauncher = getJavaLauncherFor(11)
 }
 

--- a/dd-java-agent/instrumentation/java/java-nio-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-nio-1.8/build.gradle
@@ -14,9 +14,7 @@ apply plugin: "idea"
 // Must use Java 11 to build JFR enabled code - there is no JFR in OpenJDK 8 (revisit once JFR in Java 8 is available)
 ["compileMain_java11Java", "compileTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    it.sourceCompatibility = JavaVersion.VERSION_11
-    it.targetCompatibility = JavaVersion.VERSION_11
-    setJavaVersion(it, 11)
+    configureCompiler(it, 11, JavaVersion.VERSION_11, "Must use Java 11 to build JFR enabled code - there is no JFR in OpenJDK 8 (revisit once JFR in Java 8 is available)")
     it.options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'])
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -87,6 +87,15 @@ tasks.named("latestDepJava11Test") {
   javaLauncher = getJavaLauncherFor(11)
 }
 
+tasks.withType(GroovyCompile).configureEach {
+  configureCompiler(
+    it,
+    8,
+    JavaVersion.VERSION_1_8,
+    "Connection has new methods with new types introduced in Java 9 that are not available on Java 8."
+    )
+}
+
 tasks.withType(Test).configureEach {
   usesService(testcontainersLimit)
 }

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
@@ -22,7 +22,7 @@ tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
@@ -20,6 +20,14 @@ tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:jdbc')
   testImplementation group: 'org.scalikejdbc', name: 'scalikejdbc_2.13', version: '3.5.0'

--- a/dd-java-agent/instrumentation/jersey/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/build.gradle
@@ -23,9 +23,7 @@ compileJersey3JettyTestGroovy {
   javaLauncher = getJavaLauncherFor(11)
 }
 compileTestJava.configure {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
 jersey3JettyTest {

--- a/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
@@ -28,7 +28,7 @@ addTestSuiteForDir('jetty11Test', 'test')
 addTestSuiteForDir('jetty10LatestDepTest', 'test')
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  configureCompiler(it, 11, JavaVersion.VERSION_11)
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
@@ -26,11 +26,11 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteForDir('jetty11Test', 'test')
 addTestSuiteForDir('jetty10LatestDepTest', 'test')
+
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  it.sourceCompatibility = JavaVersion.VERSION_1_8
-  it.targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
+
 dependencies {
   main_java11CompileOnly group: 'org.eclipse.jetty', name: 'jetty-client', version: '10.0.0'
   main_java11Implementation(project(':dd-java-agent:instrumentation:jetty:jetty-client:jetty-client-common')) {

--- a/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-10.0/build.gradle
@@ -26,10 +26,10 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteForDir('jetty11Test', 'test')
 addTestSuiteForDir('jetty10LatestDepTest', 'test')
-compileMain_java11Java.configure {
+tasks.named("compileMain_java11Java", JavaCompile) {
+  setJavaVersion(it, 11, true)
   it.sourceCompatibility = JavaVersion.VERSION_1_8
   it.targetCompatibility = JavaVersion.VERSION_1_8
-  setJavaVersion(it, 11)
 }
 dependencies {
   main_java11CompileOnly group: 'org.eclipse.jetty', name: 'jetty-client', version: '10.0.0'

--- a/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-12.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-client/jetty-client-12.0/build.gradle
@@ -15,15 +15,15 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-compileMain_java17Java.configure {
-  setJavaVersion(it, 17)
+tasks.named("compileMain_java17Java") {
+  configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
 
-configurations.matching({ it.name.startsWith('test') || it.name.startsWith('latestDepTest') }).each({
+configurations.matching { it.name.startsWith('test') || it.name.startsWith('latestDepTest') }.configureEach {
   it.resolutionStrategy {
     force group: 'org.slf4j', name: 'slf4j-api', version: libs.versions.slf4j.get()
   }
-})
+}
 
 dependencies {
   main_java17CompileOnly group: 'org.eclipse.jetty', name: 'jetty-client', version: '12.0.0'

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/build.gradle
@@ -17,15 +17,10 @@ apply plugin: "idea"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteForDir('latestDepForkedTest', 'test')
 
-tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-tasks.withType(GroovyCompile) {
+tasks.withType(GroovyCompile).configureEach {
   javaLauncher = getJavaLauncherFor(11)
 }
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   javaLauncher = getJavaLauncherFor(11)
 }
 

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/build.gradle
@@ -17,6 +17,10 @@ apply plugin: "idea"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteForDir('latestDepForkedTest', 'test')
 
+tasks.named("compileMain_java11Java") {
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
+}
+
 tasks.withType(GroovyCompile).configureEach {
   javaLauncher = getJavaLauncherFor(11)
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
@@ -35,9 +35,7 @@ addTestSuiteExtendingForDir('ee10LatestDepForkedTest', 'ee10LatestDepTest', 'tes
 
 ["compileMain_java17Java", "compileTestJava"].each {
   tasks.named(it, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 ["ee8LatestDepTest", "ee9LatestDepTest", "ee10LatestDepTest"].each {

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
@@ -33,16 +33,15 @@ addTestSuiteExtendingForDir('ee10ForkedTest', 'ee10Test', 'test/ee10')
 addTestSuiteExtendingForDir('ee10LatestDepTest', 'latestDepTest', 'test/ee10')
 addTestSuiteExtendingForDir('ee10LatestDepForkedTest', 'ee10LatestDepTest', 'test/ee10')
 
-["compileMain_java17Java", "compileTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+["compileMain_java17Java", "compileTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 }
-
-["ee8LatestDepTest", "ee9LatestDepTest", "ee10LatestDepTest"].each { name ->
-  tasks.named(name, Test) {
+["ee8LatestDepTest", "ee9LatestDepTest", "ee10LatestDepTest"].each {
+  tasks.named(it, Test) {
     it.jvmArgs += ['-Dtest.dd.latestDepTest=true']
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
@@ -106,7 +106,7 @@ instrument {
 }
 
 tasks.named("compileMain_jetty10Java", JavaCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 addTestSuiteForDir('jetty92ForkedTest', 'test')
@@ -118,7 +118,7 @@ tasks.named("latestDepForkedTest") {
   javaLauncher = getJavaLauncherFor(11)
 }
 tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/junit/junit-4.10/munit-junit-4/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-4.10/munit-junit-4/build.gradle
@@ -31,11 +31,21 @@ dependencies {
   latestDepTestImplementation group: 'org.scalameta', name: 'munit_2.13', version: '+'
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy") {
   dependsOn compileTestScala
   classpath += files(sourceSets.test.scala.destinationDirectory)
 }
-compileLatestDepTestGroovy {
+
+tasks.named("compileLatestDepTestGroovy") {
   dependsOn compileLatestDepTestScala
   classpath += files(sourceSets.latestDepTest.scala.destinationDirectory)
 }
+
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+

--- a/dd-java-agent/instrumentation/junit/junit-4.10/munit-junit-4/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-4.10/munit-junit-4/build.gradle
@@ -43,7 +43,7 @@ tasks.named("compileLatestDepTestGroovy") {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/junit/junit-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/build.gradle
@@ -55,16 +55,14 @@ dependencies {
   latestDepTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '+'
 }
 
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching { it.name.startsWith('test') }.configureEach {
   it.resolutionStrategy {
     force group: 'org.junit.platform', name: 'junit-platform-launcher', version: libs.versions.junit.platform.get()
     force group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: libs.versions.junit5.get()
     force group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: libs.versions.junit5.get()
   }
-})
+}
 
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
 }

--- a/dd-java-agent/instrumentation/junit/junit-5.3/junit-5.8/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/junit-5.8/build.gradle
@@ -49,17 +49,15 @@ dependencies {
   latestDepTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '+'
 }
 
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching { it.name.startsWith('test') }.configureEach {
   it.resolutionStrategy {
     force group: 'org.junit.platform', name: 'junit-platform-launcher', version: libs.versions.junit.platform.get()
     force group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: libs.versions.junit5.get()
     force group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: libs.versions.junit5.get()
   }
-})
+}
 
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
 }
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
@@ -16,24 +16,22 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
-["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 }
 
-tasks.withType(JavaCompile).each {
-  it.configure {
-    setJavaVersion(it, 17)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
+tasks.withType(JavaCompile).configureEach {
+  setJavaVersion(it, 17, true)
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType(GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(17)
+tasks.withType(GroovyCompile).configureEach {
+  setJavaVersion(it, 17, true)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
@@ -18,20 +18,16 @@ addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 ["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
   tasks.named(it, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 
 tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 17, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
 }
 
 tasks.withType(GroovyCompile).configureEach {
-  setJavaVersion(it, 17, true)
+  configureCompiler(it, 17)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/karate/build.gradle
+++ b/dd-java-agent/instrumentation/karate/build.gradle
@@ -82,7 +82,5 @@ sourceSets {
 }
 
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }

--- a/dd-java-agent/instrumentation/liberty-20/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-20/build.gradle
@@ -4,7 +4,6 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 def openlibertyHomeDir = project.layout.buildDirectory.dir("openliberty")
-
 String testWebAppDir = 'wlp/usr/servers/defaultServer/dropins/war/testapp'
 
 sourceSets {
@@ -63,6 +62,14 @@ configurations.named("testRuntimeOnly") {
 }
 configurations.named("webappRuntimeClasspath") {
   exclude group: 'ch.qos.logback', module: 'logback-classic'
+}
+
+tasks.named('compileJava', JavaCompile) {
+  // Other wise might fails with
+  //   import com.ibm.ws.classloading.internal.ThreadContextClassLoader;
+  //                    ^
+  //     Invalid CEN header (invalid extra data field size for tag: 0xbfef size: 445)
+  setJavaVersion(it, 8)
 }
 
 // unzips the dependencies from the 'zipped' configuration so 'compileOnly' can reference it

--- a/dd-java-agent/instrumentation/liberty-20/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-20/build.gradle
@@ -65,11 +65,11 @@ configurations.named("webappRuntimeClasspath") {
 }
 
 tasks.named('compileJava', JavaCompile) {
-  // Other wise might fails with
-  //   import com.ibm.ws.classloading.internal.ThreadContextClassLoader;
-  //                    ^
-  //     Invalid CEN header (invalid extra data field size for tag: 0xbfef size: 445)
-  setJavaVersion(it, 8)
+  // If using higher toolchain for compilation the following failure happens :
+  // > import com.ibm.ws.classloading.internal.ThreadContextClassLoader;
+  // >                  ^
+  // >   Invalid CEN header (invalid extra data field size for tag: 0xbfef size: 445)
+  configureCompiler(it, 8)
 }
 
 // unzips the dependencies from the 'zipped' configuration so 'compileOnly' can reference it

--- a/dd-java-agent/instrumentation/liberty-23/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-23/build.gradle
@@ -7,8 +7,8 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 def openlibertyHomeDir = project.layout.buildDirectory.dir("openliberty")
-
 String testWebAppDir = 'wlp/usr/servers/defaultServer/dropins/war/testapp'
+
 sourceSets {
   register("webapp") {
     java {
@@ -69,6 +69,18 @@ configurations.named("testRuntimeOnly") {
 }
 configurations.named("webappRuntimeClasspath") {
   exclude group: 'ch.qos.logback', module: 'logback-classic'
+}
+
+tasks.named("compileJava") {
+  configureCompiler(
+    it,
+    8,
+    JavaVersion.VERSION_1_8,
+    "Since JDK 18/19 (https://bugs.openjdk.org/browse/JDK-8272715) javac compiler use `INVOKEINTERFACE` bytecode to " +
+    "call Object's class like `getClass` on \"com/ibm/wsspi/http/HttpRequest\", rather than, `INVOKEVIRTUAL` byte " +
+    "code to call `getClass` on \"java/lang/Object\", this code perfectly legal according to JLS 9.2, " +
+    "however this fails in Muzzle checks."
+    )
 }
 
 // unzips the dependencies from the 'zipped' configuration so 'compileOnly' can reference it

--- a/dd-java-agent/instrumentation/liberty-23/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-23/build.gradle
@@ -71,18 +71,6 @@ configurations.named("webappRuntimeClasspath") {
   exclude group: 'ch.qos.logback', module: 'logback-classic'
 }
 
-tasks.named("compileJava") {
-  configureCompiler(
-    it,
-    8,
-    JavaVersion.VERSION_1_8,
-    "Since JDK 18/19 (https://bugs.openjdk.org/browse/JDK-8272715) javac compiler use `INVOKEINTERFACE` bytecode to " +
-    "call Object's class like `getClass` on \"com/ibm/wsspi/http/HttpRequest\", rather than, `INVOKEVIRTUAL` byte " +
-    "code to call `getClass` on \"java/lang/Object\", this code perfectly legal according to JLS 9.2, " +
-    "however this fails in Muzzle checks."
-    )
-}
-
 // unzips the dependencies from the 'zipped' configuration so 'compileOnly' can reference it
 abstract class UnpackOpenLiberty extends Copy {
   @Input

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
@@ -14,17 +14,17 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 }
 
-["compileTestGroovy", "compileLatestDepTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+["compileTestGroovy", "compileLatestDepTestGroovy"].each {
+  tasks.named(it, AbstractCompile) {
+    setJavaVersion(it, 17, true)
   }
 }
 

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
@@ -16,15 +16,13 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 ["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
   tasks.named(it, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 
 ["compileTestGroovy", "compileLatestDepTestGroovy"].each {
-  tasks.named(it, AbstractCompile) {
-    setJavaVersion(it, 17, true)
+  tasks.named(it, GroovyCompile) {
+    configureCompiler(it, 17)
   }
 }
 

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -101,9 +101,7 @@ sourceSets {
 }
 
 tasks.named("compileMain_java11Java") {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 tasks.named("jar", Jar) {
@@ -124,11 +122,11 @@ tasks.named("compileMule46ForkedTestGroovy", GroovyCompile) {
 
 tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
   dependsOn 'mvnPackage', 'extractLatestMuleServices'
-  setJavaVersion(it, 17)
+  configureCompiler(it, 17)
 }
 
 tasks.named("compileLatestDepForkedTestJava", JavaCompile) {
-  setJavaVersion(it, 17)
+  configureCompiler(it, 17)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -100,17 +100,17 @@ sourceSets {
   }
 }
 
-compileMain_java11Java.configure {
-  setJavaVersion(it, 11)
+tasks.named("compileMain_java11Java") {
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-jar {
+tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-forbiddenApisMain_java11 {
+tasks.named("forbiddenApisMain_java11") {
   failOnMissingClasses = false
 }
 

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -224,6 +224,7 @@ tasks.register('extractLatestMuleServices', Sync) {
 // build the mule application via maven
 tasks.register('mvnPackage', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   commandLine "$rootDir/mvnw", "-Ddatadog.builddir=$buildDir", "-Ddatadog.name=mule-test-application", "-Ddatadog.version=$version", 'package'
   outputs.dir("$buildDir/target")
   inputs.dir("$appDir/src")

--- a/dd-java-agent/instrumentation/play/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.6/build.gradle
@@ -127,9 +127,7 @@ configurations.matching({ it.name.startsWith('latestDepTest') }).each({
   }
 })
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  it.sourceCompatibility = JavaVersion.VERSION_11
-  it.targetCompatibility = JavaVersion.VERSION_11
+  configureCompiler(it, 11)
 }
 compileLatestDepTestScala {
   javaLauncher = getJavaLauncherFor(11)

--- a/dd-java-agent/instrumentation/play/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.6/build.gradle
@@ -127,9 +127,9 @@ configurations.matching({ it.name.startsWith('latestDepTest') }).each({
   }
 })
 tasks.named("compileLatestDepTestJava", JavaCompile) {
+  setJavaVersion(it, 11)
   it.sourceCompatibility = JavaVersion.VERSION_11
   it.targetCompatibility = JavaVersion.VERSION_11
-  setJavaVersion(it, 11)
 }
 compileLatestDepTestScala {
   javaLauncher = getJavaLauncherFor(11)

--- a/dd-java-agent/instrumentation/quartz-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/quartz-2.0/build.gradle
@@ -33,12 +33,12 @@ dependencies {
 }
 
 [
-  compileLatestDepTestGroovy,
-  compileLatestDepTestJava,
-  compileVersion40TestGroovy,
-  compileVersion40TestJava
+  "compileLatestDepTestGroovy",
+  "compileLatestDepTestJava",
+  "compileVersion40TestGroovy",
+  "compileVersion40TestJava"
 ].each {
-  it.configure {
+  tasks.named(it, AbstractCompile) {
     setJavaVersion(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/quartz-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/quartz-2.0/build.gradle
@@ -39,6 +39,6 @@ dependencies {
   "compileVersion40TestJava"
 ].each {
   tasks.named(it, AbstractCompile) {
-    setJavaVersion(it, 11)
+    configureCompiler(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/build.gradle
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/build.gradle
@@ -28,12 +28,20 @@ dependencies {
 
 project.afterEvaluate {
   tasks.withType(Test).configureEach {
-    if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
-      jvmArgs += ['--add-opens', 'java.base/java.math=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.text=ALL-UNNAMED']
-    }
+    configureJvmArgs(
+      it,
+      JavaVersion.VERSION_16,
+      [
+        '--add-opens',
+        'java.base/java.math=ALL-UNNAMED',
+        '--add-opens',
+        'java.base/java.util.concurrent=ALL-UNNAMED',
+        '--add-opens',
+        'java.base/java.net=ALL-UNNAMED',
+        '--add-opens',
+        'java.base/java.text=ALL-UNNAMED'
+      ]
+      )
     usesService(testcontainersLimit)
   }
 }

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
@@ -31,14 +31,20 @@ dependencies {
   testImplementation(project(':dd-java-agent:instrumentation:redisson:redisson-2.3.0'))
 }
 
-project.afterEvaluate {
-  tasks.withType(Test).configureEach {
-    if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
-      jvmArgs += ['--add-opens', 'java.base/java.math=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.net=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.text=ALL-UNNAMED']
-    }
-    usesService(testcontainersLimit)
-  }
+tasks.withType(Test).configureEach {
+  configureJvmArgs(
+    it,
+    JavaVersion.VERSION_16,
+    [
+      '--add-opens',
+      'java.base/java.math=ALL-UNNAMED',
+      '--add-opens',
+      'java.base/java.util.concurrent=ALL-UNNAMED',
+      '--add-opens',
+      'java.base/java.net=ALL-UNNAMED',
+      '--add-opens',
+      'java.base/java.text=ALL-UNNAMED'
+    ]
+    )
+  usesService(testcontainersLimit)
 }

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/build.gradle
@@ -21,13 +21,13 @@ idea {
   }
 }
 
-// Set all compile tasks to use JDK17 but let instrumentation code target 1.8 compatibility
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17)
-}
-compileJava.configure {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(
+    it,
+    17,
+    JavaVersion.VERSION_1_8,
+    "Set all compile tasks to use JDK17 but let instrumentation code target 1.8 compatibility"
+    )
 }
 
 addTestSuiteForDir('latestDepTest', 'test')

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/build.gradle
@@ -23,11 +23,12 @@ idea {
 
 // Set all compile tasks to use JDK17 but let instrumentation code target 1.8 compatibility
 project.tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17)
-}
-compileJava.configure {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(
+    it,
+    17,
+    JavaVersion.VERSION_1_8,
+    "Set all compile tasks to use JDK17 but let instrumentation code target 1.8 compatibility"
+    )
 }
 
 addTestSuiteForDir('latestDepTest', 'test')

--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -1,6 +1,4 @@
 ext {
-  // need access to sun.rmi package
-  skipSettingCompilerRelease = true
   // TODO Java 17: The necessary packages are not opened on Java 17
   maxJavaVersionForTests = JavaVersion.VERSION_15
 }
@@ -12,6 +10,11 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+
+tasks.withType(JavaCompile).configureEach {
+  // need access to sun.rmi package
+  setJavaVersion(it, 8)
+}
 
 def rmic = tasks.register('rmic', Exec) {
   dependsOn testClasses

--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -12,8 +12,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 tasks.withType(JavaCompile).configureEach {
-  // need access to sun.rmi package
-  setJavaVersion(it, 8)
+  configureCompiler(it, 8, JavaVersion.VERSION_1_8, "Need access to sun.rmi package")
 }
 
 def rmic = tasks.register('rmic', Exec) {

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
@@ -60,6 +60,15 @@ tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
   dependsOn "compileLatestDepForkedTestScala"
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
+
 dependencies {
   // first version that works with the tests on JDK11 (without dependency problems):
   compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.10.7'

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
@@ -62,7 +62,7 @@ tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
@@ -59,7 +59,7 @@ tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
@@ -57,6 +57,14 @@ tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 dependencies {
   compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.13.0'
   implementation project(':dd-java-agent:instrumentation:scala-promise')

--- a/dd-java-agent/instrumentation/scala/build.gradle
+++ b/dd-java-agent/instrumentation/scala/build.gradle
@@ -27,16 +27,32 @@ final testTasks = scalaVersions.collect { scalaLibrary ->
   def (major, minor) = version.split('_').collect(Integer.&valueOf)
   final javaConcatenation = major > 2 || minor > 11 // after 2.11 scala uses java.lang.StringBuilder to perform concatenation
 
-  final implementationConfiguration = configurations.create("${version}Implementation") {
+  final customSourceSet = sourceSets.create("${version}") {
+    scala {
+      srcDirs = ['src/test/scala']
+    }
+  }
+
+  final implementationConfiguration = configurations.named(customSourceSet.implementationConfigurationName) {
     canBeConsumed = false
     canBeResolved = false
     canBeDeclared = true
   }
-  final classPathConfiguration = configurations.create("${version}CompileClasspath") {
+
+  final classPathConfiguration = configurations.named(customSourceSet.compileClasspathConfigurationName) {
     canBeConsumed = false
     canBeResolved = true
     canBeDeclared = false
-    extendsFrom(implementationConfiguration)
+    extendsFrom(implementationConfiguration.get())
+    customSourceSet.compileClasspath += it
+  }
+
+  tasks.named(customSourceSet.getCompileTaskName("scala"), ScalaCompile) {
+    // Despite the compatibility matrix, scala compiler doesn't properly
+    // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+    // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+    // * https://github.com/gradle/gradle/issues/19456
+    configureCompiler(it, 8)
   }
 
   dependencies { handler ->
@@ -47,19 +63,12 @@ final testTasks = scalaVersions.collect { scalaLibrary ->
     }
   }
 
-  final customSourceSet = sourceSets.create("${version}") {
-    scala {
-      srcDirs = ['src/test/scala']
-      compileClasspath += classPathConfiguration
-    }
-  }
-
   return tasks.register("test$version", Test) {
     classpath = classpath
       .filter { !it.toString().contains('scala-library') }   // exclude default scala-library
       .minus(files(sourceSets.test.scala.classesDirectory))  // exclude default /build/classes/scala/test folder
       .plus(customSourceSet.output.classesDirs)              // add /build/classes/scala/${version} folder
-      .plus(classPathConfiguration)                          // add new scala-library configuration
+      .plus(classPathConfiguration.get())                    // add new scala-library configuration
     systemProperty('uses.java.concat', javaConcatenation)
     dependsOn(tasks.named("compile${version.capitalize()}Scala"))
     group = 'verification'

--- a/dd-java-agent/instrumentation/scala/build.gradle
+++ b/dd-java-agent/instrumentation/scala/build.gradle
@@ -49,7 +49,7 @@ final testTasks = scalaVersions.collect { scalaLibrary ->
 
   tasks.named(customSourceSet.getCompileTaskName("scala"), ScalaCompile) {
     // Despite the compatibility matrix, scala compiler doesn't properly
-    // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+    // get the right compiler flags with JDK11 toolchain. Using 8 works.
     // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
     // * https://github.com/gradle/gradle/issues/19456
     configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/scalatest/build.gradle
+++ b/dd-java-agent/instrumentation/scalatest/build.gradle
@@ -35,7 +35,7 @@ tasks.named("compileLatestDepTestGroovy") {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/scalatest/build.gradle
+++ b/dd-java-agent/instrumentation/scalatest/build.gradle
@@ -23,14 +23,22 @@ dependencies {
   latestDepTestImplementation group: 'org.scalatest', name: 'scalatest_2.12', version: '+'
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy") {
   dependsOn compileTestScala
   classpath += files(sourceSets.test.scala.destinationDirectory)
 }
 
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy") {
   dependsOn compileLatestDepTestScala
   classpath += files(sourceSets.latestDepTest.scala.destinationDirectory)
+}
+
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
 }
 
 configurations.configureEach {

--- a/dd-java-agent/instrumentation/selenium/build.gradle
+++ b/dd-java-agent/instrumentation/selenium/build.gradle
@@ -43,7 +43,5 @@ configurations.matching({ it.name.startsWith('test') || it.name.startsWith('late
 })
 
 tasks.named("compileLatestDepTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }

--- a/dd-java-agent/instrumentation/spring/spring-cloud-zuul-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-cloud-zuul-2.0/build.gradle
@@ -12,6 +12,18 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+tasks.named("compileJava", JavaCompile) {
+  // TODO
+  // public class HeaderUtils {
+  //        ^
+  //   ZipException opening "aspectjweaver-1.8.13.jar": Invalid CEN header (invalid zip64 extra data field size)
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
+  doFirst {
+    println it.javaCompiler.get().executablePath
+
+  }
+}
+
 dependencies {
   compileOnly group: 'org.springframework.cloud', name: 'spring-cloud-netflix-zuul', version: '2.0.0.RELEASE'
   compileOnly group: 'com.netflix.zuul', name: 'zuul-core', version: '1.3.1' // "optional" dependency of ^^

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
@@ -29,7 +29,7 @@ addTestSuiteForDir('latestSpring5Test', 'test')
 
 ["compileSpring6TestJava", "compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
@@ -29,9 +29,7 @@ addTestSuiteForDir('latestSpring5Test', 'test')
 
 ["compileSpring6TestJava", "compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-security/spring-security-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-security/spring-security-6.0/build.gradle
@@ -8,7 +8,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 final springBootVersion = '3.0.0'
 
 tasks.withType(AbstractCompile).configureEach {
-  setJavaVersion(it, 17)
+  configureCompiler(it, 17)
 }
 
 tasks.withType(GroovyCompile).configureEach {

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
@@ -11,15 +11,13 @@ addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepBootTest', 'latestDepTest', 'bootTest')
 
-tasks.withType(JavaCompile).each {
-  it.configure {
-    setJavaVersion(it, 17)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
+tasks.withType(JavaCompile).configureEach {
+  setJavaVersion(it, 17, true)
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType(GroovyCompile).each {
+tasks.withType(GroovyCompile).configureEach {
   it.javaLauncher = getJavaLauncherFor(17)
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
@@ -12,9 +12,7 @@ addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepBootTest', 'latestDepTest', 'bootTest')
 
 tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 17, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 17, JavaVersion.VERSION_1_8)
 }
 
 tasks.withType(GroovyCompile).configureEach {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
@@ -16,16 +16,16 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir("latestDepTest", "test")
 
-["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 }
 
-tasks.withType(GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(17)
+tasks.withType(GroovyCompile).configureEach {
+  setJavaVersion(it, 17)
   groovyOptions.setParameters(true)
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
@@ -18,14 +18,12 @@ addTestSuiteForDir("latestDepTest", "test")
 
 ["compileMain_java17Java", "compileTestJava", "compileLatestDepTestJava"].each {
   tasks.named(it, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 
 tasks.withType(GroovyCompile).configureEach {
-  setJavaVersion(it, 17)
+  configureCompiler(it, 17)
   groovyOptions.setParameters(true)
 }
 

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
@@ -146,13 +146,13 @@ dependencies {
   latestDepTestRuntimeOnly(project(':dd-java-agent:instrumentation:tomcat:tomcat-9.0'))
 }
 
-project.afterEvaluate {
-  tasks.withType(Test).configureEach {
-    if (javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
-      // to avoid java.lang.IllegalAccessException: class org.apache.tomcat.util.compat.JreCompat cannot access a member of class java.io.FileSystem (in module java.base) with modifiers "static final"
-      jvmArgs += ['--add-opens', 'java.base/java.io=ALL-UNNAMED']
-    }
-  }
+tasks.withType(Test).configureEach {
+  // to avoid java.lang.IllegalAccessException: class org.apache.tomcat.util.compat.JreCompat cannot access a member of class java.io.FileSystem (in module java.base) with modifiers "static final"
+  configureJvmArgs(
+    it,
+    JavaVersion.VERSION_16,
+    ['--add-opens', 'java.base/java.io=ALL-UNNAMED']
+    )
 }
 
 // Exclude all the dependencies from test for latestDepTest since the names are completely different.

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
@@ -60,11 +60,11 @@ dependencies {
 
 ["compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 11)
+    configureCompiler(it, 11)
   }
 }
 ["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
   tasks.named(it, GroovyCompile) {
-    it.javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
@@ -63,9 +63,8 @@ dependencies {
     setJavaVersion(it, 11)
   }
 }
-
-["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
+  tasks.named(it, GroovyCompile) {
+    it.javaLauncher = getJavaLauncherFor(11)
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/build.gradle
@@ -22,12 +22,6 @@ configurations {
   testArtifacts
 }
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}
-
 // Create test artifacts so vertx-rx can reuse the server test instrumentation and base class
 artifacts {
   testArtifacts testJar
@@ -57,4 +51,8 @@ dependencies {
 
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '+'
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '+'
+}
+
+tasks.named("compileJava", JavaCompile) {
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
@@ -18,13 +18,11 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuite("latestDepTest")
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 ["compileTestGroovy", "compileLatestDepTestGroovy"].each {
   tasks.named(it, GroovyCompile) {
-    setJavaVersion(it, 11)
+    configureCompiler(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
@@ -18,14 +18,13 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuite("latestDepTest")
 
 tasks.named("compileMain_java11Java", JavaCompile) {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-["compileTestGroovy", "compileLatestDepTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+["compileTestGroovy", "compileLatestDepTestGroovy"].each {
+  tasks.named(it, GroovyCompile) {
+    setJavaVersion(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -118,25 +118,21 @@ tasks.named("latestDepTest") {
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  setJavaVersion(it, 11)
+  configureCompiler(it, 11)
 }
 
 ["compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each {
   tasks.named(it, GroovyCompile) {
-    setJavaVersion(it, 17)}
+    configureCompiler(it, 17)}
 }
 
 tasks.named("compileTestJava", JavaCompile) {
-  setJavaVersion(it, 11, true)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 ["compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each {
   tasks.named(it, JavaCompile) {
-    setJavaVersion(it, 17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 

--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
-
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_11
   latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_17
@@ -120,24 +118,23 @@ tasks.named("latestDepTest") {
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  setJavaVersion(it, 11)
 }
 
-["compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
-  }
+["compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each {
+  tasks.named(it, GroovyCompile) {
+    setJavaVersion(it, 17)}
 }
 
 tasks.named("compileTestJava", JavaCompile) {
-  setJavaVersion(it, 11)
+  setJavaVersion(it, 11, true)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-["compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    setJavaVersion(it, 17)
+["compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each {
+  tasks.named(it, JavaCompile) {
+    setJavaVersion(it, 17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }

--- a/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
@@ -37,7 +37,7 @@ tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
@@ -35,6 +35,14 @@ tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 dependencies {
   compileOnly group: 'dev.zio', name: "zio_$scalaVersion", version: zioVersion
 

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -4,12 +4,12 @@ plugins {
   id 'com.gradleup.shadow'
 }
 
-ext {
-  // need access to sun.misc package
-  skipSettingCompilerRelease = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
+
+tasks.withType(JavaCompile).configureEach {
+  // need access to sun.misc package
+  setJavaVersion(it, 8)
+}
 
 minimumBranchCoverage = 0.5
 minimumInstructionCoverage = 0.5

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 tasks.withType(JavaCompile).configureEach {
   // need access to sun.misc package
-  setJavaVersion(it, 8)
+  setJavaVersion(it, 8, true)
 }
 
 minimumBranchCoverage = 0.5

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -7,8 +7,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 tasks.withType(JavaCompile).configureEach {
-  // need access to sun.misc package
-  setJavaVersion(it, 8, true)
+  configureCompiler(it, 8, JavaVersion.VERSION_1_8, "Need access to sun.misc package")
 }
 
 minimumBranchCoverage = 0.5

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -21,7 +21,7 @@ shadowJar {
 
 // Use Java 11 to build application
 tasks.withType(JavaCompile).configureEach {
-  configureCompiler(delegate, 11)
+  configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
 dependencies {

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -20,8 +20,8 @@ shadowJar {
 }
 
 // Use Java 11 to build application
-tasks.withType(JavaCompile) {
-  setJavaVersion(delegate, 11)
+tasks.withType(JavaCompile).configureEach {
+  configureCompiler(delegate, 11)
 }
 
 dependencies {
@@ -38,9 +38,9 @@ tasks.withType(Test).configureEach {
   jvmArgs "-Ddatadog.smoketest.appsec.springboot-graphql.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
-task testRuntimeActivation(type: Test) {
+tasks.register('testRuntimeActivation', Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
-    "-Ddatadog.smoketest.appsec.springboot-graphql.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+      "-Ddatadog.smoketest.appsec.springboot-graphql.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 tasks.named('check') {

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -40,7 +40,7 @@ tasks.withType(Test).configureEach {
 
 tasks.register('testRuntimeActivation', Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
-      "-Ddatadog.smoketest.appsec.springboot-graphql.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+    "-Ddatadog.smoketest.appsec.springboot-graphql.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 tasks.named('check') {

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -19,8 +19,8 @@ tasks.named("forbiddenApisMain") {
 }
 
 // Use Java 17 to build application
-tasks.withType(JavaCompile) {
-  setJavaVersion(delegate, 17)
+tasks.withType(JavaCompile).configureEach {
+  configureCompiler(delegate, 17)
 }
 
 dependencies {
@@ -44,9 +44,9 @@ tasks.withType(Test).configureEach {
   jvmArgs "-Ddatadog.smoketest.appsec.springbootsecurity.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
-task testRuntimeActivation(type: Test) {
+tasks.register('testRuntimeActivation', Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
-    "-Ddatadog.smoketest.appsec.springbootsecurity.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+      "-Ddatadog.smoketest.appsec.springbootsecurity.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 tasks.named('check') {

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -46,7 +46,7 @@ tasks.withType(Test).configureEach {
 
 tasks.register('testRuntimeActivation', Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
-      "-Ddatadog.smoketest.appsec.springbootsecurity.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+    "-Ddatadog.smoketest.appsec.springbootsecurity.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 tasks.named('check') {

--- a/dd-smoke-tests/build.gradle
+++ b/dd-smoke-tests/build.gradle
@@ -9,6 +9,15 @@ dependencies {
   api project(':utils:test-agent-utils:decoder')
 }
 
+tasks.withType(GroovyCompile).configureEach {
+  configureCompiler(
+    it,
+    8,
+    JavaVersion.VERSION_1_8,
+    "CharBuffer#flip() signature needs to be ()Ljava.nio.Buffer (to run on JDK8)."
+    )
+}
+
 // Disable forbiddenApis for all smoke-test modules
 allprojects {
   tasks.matching { it.name.startsWith('forbiddenApis') }.configureEach {

--- a/dd-smoke-tests/concurrent/java-21/build.gradle
+++ b/dd-smoke-tests/concurrent/java-21/build.gradle
@@ -19,9 +19,7 @@ java {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 21)
-  sourceCompatibility = JavaVersion.VERSION_21
-  targetCompatibility = JavaVersion.VERSION_21
+  configureCompiler(it, 21, JavaVersion.VERSION_21)
 }
 
 // Disable plugin tasks that do not support Java 21:

--- a/dd-smoke-tests/concurrent/java-25/build.gradle
+++ b/dd-smoke-tests/concurrent/java-25/build.gradle
@@ -18,18 +18,19 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'JDK 25 Concurrent Integration Tests'
 
-tasks.named('compileJava') {
+javaToolchains {
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(25)
+    }
+  }
+}
+
+tasks.named('compileJava', JavaCompile) {
   setJavaVersion(it, 25)
   sourceCompatibility = JavaVersion.VERSION_25
   targetCompatibility = JavaVersion.VERSION_25
   options.compilerArgs.add("--enable-preview")
-  javaToolchains {
-    java {
-      toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-      }
-    }
-  }
 }
 
 tasks.named('compileTestGroovy') {

--- a/dd-smoke-tests/concurrent/java-25/build.gradle
+++ b/dd-smoke-tests/concurrent/java-25/build.gradle
@@ -27,16 +27,12 @@ javaToolchains {
 }
 
 tasks.named('compileJava', JavaCompile) {
-  setJavaVersion(it, 25)
-  sourceCompatibility = JavaVersion.VERSION_25
-  targetCompatibility = JavaVersion.VERSION_25
+  configureCompiler(it, 25, JavaVersion.VERSION_25)
   options.compilerArgs.add("--enable-preview")
 }
 
 tasks.named('compileTestGroovy') {
-  setJavaVersion(it, 8)
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  configureCompiler(it, 8, JavaVersion.VERSION_1_8)
 }
 
 // Disable plugin tasks that do not support Java 25:

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -43,7 +43,7 @@ tasks.withType(Test).configureEach {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -1,4 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id 'com.gradleup.shadow'
@@ -37,4 +39,16 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+}
+
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }

--- a/dd-smoke-tests/iast-util/iast-util-11/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-11/build.gradle
@@ -22,9 +22,7 @@ dependencies {
 }
 
 tasks.named("compileJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
 tasks.named("forbiddenApisMain") {

--- a/dd-smoke-tests/iast-util/iast-util-17/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-17/build.gradle
@@ -22,9 +22,7 @@ dependencies {
 }
 
 tasks.named("compileJava", JavaCompile) {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+  configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
 
 tasks.named("forbiddenApisMain") {

--- a/dd-smoke-tests/java9-modules/build.gradle
+++ b/dd-smoke-tests/java9-modules/build.gradle
@@ -10,11 +10,8 @@ tasks.named("jar", Jar) {
   }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 tasks.withType(JavaCompile).configureEach { JavaCompile jc ->
-  setJavaVersion(jc, 11)
+  configureCompiler(jc, 11, JavaVersion.VERSION_1_9, "Need Java module support")
   // read up classpath lazily to avoid early locking of gradle settings
   jc.options.compilerArgumentProviders.add(new CommandLineArgumentProvider() {
       @Override
@@ -28,7 +25,7 @@ tasks.withType(Test).configureEach {
   dependsOn "jar"
 }
 
-tasks.withType(Test).forEach {
+tasks.withType(Test).configureEach {
   it.doFirst {
     JavaInstallationMetadata metadata = it.getJavaLauncher().get().metadata
     // We can safely assume that the general configuration has disabled this test if

--- a/dd-smoke-tests/kafka-3/application/src/main/java/datadog/smoketest/kafka/iast/IastController.java
+++ b/dd-smoke-tests/kafka-3/application/src/main/java/datadog/smoketest/kafka/iast/IastController.java
@@ -34,13 +34,13 @@ public class IastController {
 
   public IastController(
       @Qualifier("iastStringTemplate")
-      final ReplyingKafkaTemplate<String, String, String> stringTemplate,
+          final ReplyingKafkaTemplate<String, String, String> stringTemplate,
       @Qualifier("iastByteArrayTemplate")
-      final ReplyingKafkaTemplate<byte[], byte[], String> byteArrayTemplate,
+          final ReplyingKafkaTemplate<byte[], byte[], String> byteArrayTemplate,
       @Qualifier("iastByteBufferTemplate")
-      final ReplyingKafkaTemplate<ByteBuffer, ByteBuffer, String> byteBufferTemplate,
+          final ReplyingKafkaTemplate<ByteBuffer, ByteBuffer, String> byteBufferTemplate,
       @Qualifier("iastJsonTemplate")
-      final ReplyingKafkaTemplate<IastMessage, IastMessage, String> jsonTemplate) {
+          final ReplyingKafkaTemplate<IastMessage, IastMessage, String> jsonTemplate) {
     this.stringTemplate = stringTemplate;
     this.byteArrayTemplate = byteArrayTemplate;
     this.byteBufferTemplate = byteBufferTemplate;

--- a/dd-smoke-tests/play-2.4/build.gradle
+++ b/dd-smoke-tests/play-2.4/build.gradle
@@ -79,6 +79,14 @@ tasks.named("compileTestGroovy", GroovyCompile) {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.4/build.gradle
+++ b/dd-smoke-tests/play-2.4/build.gradle
@@ -81,7 +81,7 @@ tasks.named("compileTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.5/build.gradle
+++ b/dd-smoke-tests/play-2.5/build.gradle
@@ -81,6 +81,14 @@ tasks.named("compileTestGroovy", GroovyCompile) {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.5/build.gradle
+++ b/dd-smoke-tests/play-2.5/build.gradle
@@ -83,7 +83,7 @@ tasks.named("compileTestGroovy", GroovyCompile) {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.6/build.gradle
+++ b/dd-smoke-tests/play-2.6/build.gradle
@@ -83,7 +83,7 @@ tasks.named('compileTestGroovy') {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.6/build.gradle
+++ b/dd-smoke-tests/play-2.6/build.gradle
@@ -81,6 +81,14 @@ tasks.named('compileTestGroovy') {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.7/build.gradle
+++ b/dd-smoke-tests/play-2.7/build.gradle
@@ -83,7 +83,7 @@ tasks.named('compileTestGroovy') {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.7/build.gradle
+++ b/dd-smoke-tests/play-2.7/build.gradle
@@ -81,6 +81,14 @@ tasks.named('compileTestGroovy') {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.8-otel/build.gradle
+++ b/dd-smoke-tests/play-2.8-otel/build.gradle
@@ -79,7 +79,7 @@ tasks.named('compileTestGroovy') {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.8-otel/build.gradle
+++ b/dd-smoke-tests/play-2.8-otel/build.gradle
@@ -77,6 +77,14 @@ tasks.named('compileTestGroovy') {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.8-split-routes/build.gradle
+++ b/dd-smoke-tests/play-2.8-split-routes/build.gradle
@@ -79,7 +79,7 @@ tasks.named('compileTestGroovy') {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.8-split-routes/build.gradle
+++ b/dd-smoke-tests/play-2.8-split-routes/build.gradle
@@ -77,6 +77,14 @@ tasks.named('compileTestGroovy') {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/play-2.8/build.gradle
+++ b/dd-smoke-tests/play-2.8/build.gradle
@@ -82,7 +82,7 @@ tasks.named('compileTestGroovy') {
 
 tasks.withType(ScalaCompile).configureEach {
   // Despite the compatibility matrix, scala compiler doesn't properly
-  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // get the right compiler flags with JDK11 toolchain. Using 8 works.
   // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   // * https://github.com/gradle/gradle/issues/19456
   configureCompiler(it, 8)

--- a/dd-smoke-tests/play-2.8/build.gradle
+++ b/dd-smoke-tests/play-2.8/build.gradle
@@ -80,6 +80,14 @@ tasks.named('compileTestGroovy') {
   }
 }
 
+tasks.withType(ScalaCompile).configureEach {
+  // Despite the compatibility matrix, scala compiler doesn't properly
+  // ger the right compiler flags with JDK11 toolchain. Using 8 works.
+  // * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  // * https://github.com/gradle/gradle/issues/19456
+  configureCompiler(it, 8)
+}
+
 tasks.withType(AbstractCopyTask).each {
   // Don't know why the play plugin tries to copy the logback.xml file twice, but only accept it once
   it.configure {

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -17,6 +17,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('quarkusBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "${rootDir}/${gradlewCommand}", "build", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/rum/tomcat-10/build.gradle
+++ b/dd-smoke-tests/rum/tomcat-10/build.gradle
@@ -29,9 +29,7 @@ java {
   }
 }
 tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-smoke-tests/rum/tomcat-11/build.gradle
+++ b/dd-smoke-tests/rum/tomcat-11/build.gradle
@@ -30,9 +30,7 @@ java {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+  configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
@@ -14,6 +14,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('webfluxBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -24,9 +24,7 @@ dependencies {
 }
 
 tasks.named("compileJava", JavaCompile) {
-  setJavaVersion(it, 11)
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
 tasks.named("forbiddenApisMain") {

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -24,9 +24,7 @@ dependencies {
 }
 
 tasks.named("compileJava", JavaCompile) {
-  setJavaVersion(it, 17)
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+  configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
 
 tasks.named("forbiddenApisMain") {

--- a/dd-smoke-tests/springboot-jpa/build.gradle
+++ b/dd-smoke-tests/springboot-jpa/build.gradle
@@ -29,3 +29,7 @@ tasks.withType(Test).configureEach {
   dependsOn "bootWar"
   jvmArgs "-Ddatadog.smoketest.springboot.bootWar.path=${tasks.bootWar.archiveFile.get()}"
 }
+
+tasks.withType(GroovyCompile).configureEach {
+  configureCompiler(it, 8)
+}

--- a/dd-smoke-tests/springboot-openliberty-20/build.gradle
+++ b/dd-smoke-tests/springboot-openliberty-20/build.gradle
@@ -15,6 +15,7 @@ def mvnwCommand = isWindows ? 'mvnw.cmd' : 'mvnw'
 // compile the Open liberty spring boot server
 tasks.register('mvnStage', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   commandLine "$rootDir/${mvnwCommand}", 'package', "-Dtarget.dir=${buildDir}/application/target"
   inputs.dir "$appDir/src"
   inputs.file "$appDir/pom.xml"

--- a/dd-smoke-tests/springboot-openliberty-23/build.gradle
+++ b/dd-smoke-tests/springboot-openliberty-23/build.gradle
@@ -14,6 +14,7 @@ def mvnwCommand = isWindows ? 'mvnw.cmd' : 'mvnw'
 // compile the Open liberty spring boot server
 tasks.register('mvnStage', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   commandLine "$rootDir/${mvnwCommand}", 'package', "-Dtarget.dir=${buildDir}/application/target"
   inputs.dir "$appDir/src"
   inputs.file "$appDir/pom.xml"

--- a/dd-smoke-tests/vertx-3.4/build.gradle
+++ b/dd-smoke-tests/vertx-3.4/build.gradle
@@ -18,6 +18,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
+++ b/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
@@ -15,6 +15,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/vertx-3.9/build.gradle
+++ b/dd-smoke-tests/vertx-3.9/build.gradle
@@ -16,6 +16,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/vertx-4.2/build.gradle
+++ b/dd-smoke-tests/vertx-4.2/build.gradle
@@ -17,6 +17,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -47,6 +47,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 // define the task that builds the quarkus project
 tasks.register('earBuild', Exec) {
   workingDir "$appDir"
+  environment.JAVA_HOME = System.getenv("JAVA_8_HOME")
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
   commandLine "$rootDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,8 @@ org.gradle.caching=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
 org.gradle.java.installations.auto-detect=false
 org.gradle.java.installations.auto-download=false
-# 8 and 11 is needed to build
+# 8, 11, 17, 21 and 25 are needed to build
 org.gradle.java.installations.fromEnv=JAVA_8_HOME,JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_25_HOME
+
+# Toggle on to get more details during IJ sync
+#org.gradle.logging.level=info

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -384,6 +384,9 @@ ext.configureCompiler = (AbstractCompile it, int toolchainVersion, JavaVersion c
         it.sourceCompatibility = compatibilityVersion
         it.targetCompatibility = compatibilityVersion
       }
+      if (unsetReleaseFlagReason != null) {
+        logger.info("Using specific toolchain because: {}", unsetReleaseFlagReason)
+      }
     } else if (it instanceof ScalaCompile) {
       ScalaCompile sc = (ScalaCompile) it
       sc.javaLauncher = launcher

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -6,6 +6,15 @@ import java.nio.file.Paths
 
 apply plugin: 'java-library'
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(8)
+  }
+}
+
 apply from: "$rootDir/gradle/codenarc.gradle"
 apply from: "$rootDir/gradle/forbiddenapis.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
@@ -35,15 +44,6 @@ def applyCodeCoverage = !(
 
 if (applyCodeCoverage) {
   apply from: "$rootDir/gradle/jacoco.gradle"
-}
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
 }
 
 // when building with Java 9+, lazily set compiler --release flag to match target

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -40,6 +40,12 @@ if (applyCodeCoverage) {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(8)
+  }
+}
+
 // when building with Java 9+, lazily set compiler --release flag to match target
 def skipSettingCompilerRelease = project.findProperty('skipSettingCompilerRelease')
 if (!skipSettingCompilerRelease && JavaVersion.current().isJava9Compatible()) {

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -6,9 +6,6 @@ import java.nio.file.Paths
 
 apply plugin: 'java-library'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 apply from: "$rootDir/gradle/codenarc.gradle"
 apply from: "$rootDir/gradle/forbiddenapis.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
@@ -40,18 +37,27 @@ if (applyCodeCoverage) {
   apply from: "$rootDir/gradle/jacoco.gradle"
 }
 
-if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
-  def version = JavaVersion.toVersion(project.getProperty('minJavaVersionForTests'))
-  def name = "java$version.majorVersion"
-  sourceSets {
-    "main_$name" {
-      java.srcDirs = ["${project.projectDir}/src/main/$name"]
-    }
+java {
+  // Our minimum target
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+
+  // See https://docs.gradle.org/current/userguide/upgrading_version_5.html, Automatic target JVM version
+  disableAutoTargetJvm()
+  withJavadocJar()
+  withSourcesJar()
+}
+
+if (project.hasProperty('minJavaVersionForTests') && project.findProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
+  def version = JavaVersion.toVersion(project.findProperty('minJavaVersionForTests'))
+  def name = "java${version.majorVersion}"
+  def mainForJavaVersionSourceSet = sourceSets.create("main_$name") {
+    java.srcDirs = ["${project.projectDir}/src/main/$name"]
   }
 
-  tasks.named("compileMain_${name}Java", JavaCompile).configure {
-    sourceCompatibility = version
-    targetCompatibility = version
+  // Task name is registered when source set was created
+  tasks.named(mainForJavaVersionSourceSet.compileJavaTaskName, JavaCompile) {
+    configureCompiler(it, version.majorVersion.toInteger().intValue(), version)
   }
 
   // "socket-utils" is only set to compileOnly because the implementation dependency incorrectly adds Java17 classes to all jar prefixes.
@@ -82,13 +88,6 @@ if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJav
   }
 }
 
-java {
-  // See https://docs.gradle.org/current/userguide/upgrading_version_5.html, Automatic target JVM version
-  disableAutoTargetJvm()
-  withJavadocJar()
-  withSourcesJar()
-}
-
 tasks.named("jar", Jar) {
   /**
    Make Jar build fail on duplicate files
@@ -101,7 +100,7 @@ tasks.named("jar", Jar) {
    confusing failures.
    Instead we should 'fail early' and avoid building such Jars.
    */
-  duplicatesStrategy = 'fail'
+  duplicatesStrategy = DuplicatesStrategy.FAIL
 
   manifest {
     attributes(
@@ -301,30 +300,50 @@ tasks.withType(JavaCompile).configureEach {
   }
 }
 
-// Enforce the use of a toolchain compiler
-ext.setJavaVersion = (AbstractCompile it, int requiredJdkToolchainVersion, boolean unsetReleaseFlag = false) -> {
+/**
+ * Customize the compiler config.
+ * Adapts depending on the compile task type (java, groovy, scala covered).
+ * For java changes the compiler from the toolchain, and adapts its configuration.
+ *
+ * For Groovy and Scala compile tasks only sets the launcher.
+ */
+ext.configureCompiler = (AbstractCompile it, int toolchainVersion, JavaVersion compatibilityVersion = null, String unsetReleaseFlagReason = null) -> {
   Provider<JavaCompiler> compiler = javaToolchains.compilerFor {
-    languageVersion = JavaLanguageVersion.of(requiredJdkToolchainVersion)
+    languageVersion = JavaLanguageVersion.of(toolchainVersion)
   }
   Provider<JavaLauncher> launcher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(requiredJdkToolchainVersion)
+    languageVersion = JavaLanguageVersion.of(toolchainVersion)
   }
   try {
     if (it instanceof JavaCompile) {
       JavaCompile jc = (JavaCompile) it
       jc.javaCompiler = compiler
-      if (unsetReleaseFlag || requiredJdkToolchainVersion == 8) {
+      if (compatibilityVersion != null) {
+        jc.targetCompatibility = compatibilityVersion
+        jc.sourceCompatibility = compatibilityVersion
+      }
+      def isReleaseFlagIncompatibleWithTarget = compatibilityVersion != null
+      && !compatibilityVersion.isCompatibleWith(JavaVersion.toVersion(toolchainVersion))
+      if (unsetReleaseFlagReason != null || isReleaseFlagIncompatibleWithTarget || toolchainVersion == 8) {
+        logger.debug("Not using --release for {}", jc.path)
         // Don't set the release flag, as code need unpublished symbols,
         // those are not accessible when using `--release N`
         // e.g. with sun.misc.SharedSecrets, or jdk.jfr.internal.JVM
         jc.options.release = null
-      } else if (JavaVersion.toVersion(requiredJdkToolchainVersion).isJava9Compatible()) {
-        jc.options.release = requiredJdkToolchainVersion
+        if (unsetReleaseFlagReason != null) {
+          logger.info("Not using '--release' because: {}", unsetReleaseFlagReason)
+        }
+      } else if (JavaVersion.toVersion(toolchainVersion).isJava9Compatible()) {
+        jc.options.release = toolchainVersion
         jc.options.compilerArgs.add('-Xlint:-options')
       }
     } else if (it instanceof GroovyCompile) {
       GroovyCompile gc = (GroovyCompile) it
       gc.javaLauncher = launcher
+      if (compatibilityVersion != null) {
+        it.sourceCompatibility = compatibilityVersion
+        it.targetCompatibility = compatibilityVersion
+      }
     } else if (it instanceof ScalaCompile) {
       ScalaCompile sc = (ScalaCompile) it
       sc.javaLauncher = launcher
@@ -332,7 +351,7 @@ ext.setJavaVersion = (AbstractCompile it, int requiredJdkToolchainVersion, boole
       throw new GradleException("Unsupported compile type: ${it.getClass()}")
     }
   } catch (NoSuchElementException ignored) {
-    throw new GradleException("Unable to find compiler for Java $requiredJdkToolchainVersion. Have you set JAVA_${requiredJdkToolchainVersion}_HOME?")
+    throw new GradleException("Unable to find compiler for Java $toolchainVersion. Have you set JAVA_${toolchainVersion}_HOME?")
   }
 } as Closure<Void>
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -181,6 +181,10 @@ ext.configureJvmArgs = (Test testTask, JavaVersion applyFromVersion, List<String
 def configureTestJvm(Project project, boolean applyCodeCoverage) {
   def currentJavaHomePath = getJavaHomePath(System.getProperty("java.home"))
   def normalizedTestJvm = project.providers.gradleProperty("testJvm").map { testJvm ->
+    if (testJvm.isBlank()) {
+      throw new GradleException("testJvm property is blank")
+    }
+
     // "stable" is calculated as the largest X found in JAVA_X_HOME
     if (testJvm == "stable") {
       def javaVersions = providers.environmentVariablesPrefixedBy("JAVA_").map { javaHomes ->

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -76,7 +76,7 @@ if (project.hasProperty('minJavaVersionForTests') && project.findProperty('minJa
 
   // In some cases we would like to avoid setting java version to `minJavaVersionForTests`.
   // For example we would like to be able to run profiling tests with ZULU8, but we cannot run it with other JDK8 implementations at the moment
-  def skipSettingTestJavaVersion = project.hasProperty('skipSettingTestJavaVersion') && project.getProperty('skipSettingTestJavaVersion')
+  def skipSettingTestJavaVersion = project.hasProperty('skipSettingTestJavaVersion') && project.findProperty('skipSettingTestJavaVersion')
   if (!skipSettingTestJavaVersion) {
     tasks.withType(JavaCompile).configureEach {
       if (it.name.toLowerCase().contains("test")) {
@@ -413,21 +413,21 @@ def isJavaVersionAllowedForProperty(JavaVersion version, String propertyPrefix =
   def maxProp = propertyPrefix.isEmpty() ? 'maxJavaVersionForTests' : "${propertyPrefix}MaxJavaVersionForTests"
   def definedMin = project.hasProperty(minProp)
   def definedMax = project.hasProperty(maxProp)
-  if (definedMin && project.getProperty(minProp).compareTo(version) > 0) {
+  if (definedMin && project.findProperty(minProp).compareTo(version) > 0) {
     logger.info("isJavaVersionAllowedForProperty is false b/o minProp=${minProp} is defined and greater than version=${version}")
     return false
   }
   //default to the general min if defined and specific one is was not defined
-  if (!propertyPrefix.isEmpty() && !definedMin && project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests').compareTo(version) > 0) {
-    logger.info("isJavaVersionAllowedForProperty is false b/o minJavaVersionForTests=${project.getProperty('minJavaVersionForTests')} is defined and greater than version=${version}")
+  if (!propertyPrefix.isEmpty() && !definedMin && project.hasProperty('minJavaVersionForTests') && project.findProperty('minJavaVersionForTests').compareTo(version) > 0) {
+    logger.info("isJavaVersionAllowedForProperty is false b/o minJavaVersionForTests=${project.findProperty('minJavaVersionForTests')} is defined and greater than version=${version}")
     return false
   }
-  if (definedMax && project.getProperty(maxProp).compareTo(version) < 0) {
-    logger.info("isJavaVersionAllowedForProperty is false b/o maxProp=${project.getProperty(maxProp)} is defined and lower than version=${version}")
+  if (definedMax && project.findProperty(maxProp).compareTo(version) < 0) {
+    logger.info("isJavaVersionAllowedForProperty is false b/o maxProp=${project.findProperty(maxProp)} is defined and lower than version=${version}")
     return false
   }
-  if (!propertyPrefix.isEmpty() && !definedMax && project.hasProperty('maxJavaVersionForTests') && project.getProperty('maxJavaVersionForTests').compareTo(version) < 0) {
-    logger.info("isJavaVersionAllowedForProperty is false b/o maxJavaVersionForTests=${project.getProperty('maxJavaVersionForTests')} is defined and lower than version=${version}")
+  if (!propertyPrefix.isEmpty() && !definedMax && project.hasProperty('maxJavaVersionForTests') && project.findProperty('maxJavaVersionForTests').compareTo(version) < 0) {
+    logger.info("isJavaVersionAllowedForProperty is false b/o maxJavaVersionForTests=${project.findProperty('maxJavaVersionForTests')} is defined and lower than version=${version}")
     return false
   }
   return true
@@ -443,11 +443,11 @@ def isJavaLanguageVersionAllowed(JavaLanguageVersion languageVersion, String tes
 }
 
 def isJdkForced(String javaName) {
-  return (project.hasProperty('forceJdk') && project.getProperty('forceJdk').any { it.equalsIgnoreCase(javaName) })
+  return (project.hasProperty('forceJdk') && project.findProperty('forceJdk').any { it.equalsIgnoreCase(javaName) })
 }
 
 def isJdkExcluded(String javaName) {
-  return (project.hasProperty('excludeJdk') && project.getProperty('excludeJdk').any { it.equalsIgnoreCase(javaName) })
+  return (project.hasProperty('excludeJdk') && project.findProperty('excludeJdk').any { it.equalsIgnoreCase(javaName) })
 }
 
 def getJavaHomePath(String path) {

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -1,8 +1,7 @@
-import org.gradle.api.internal.provider.PropertyFactory
-import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
-
 import java.nio.file.Files
 import java.nio.file.Paths
+import org.gradle.api.internal.provider.PropertyFactory
+import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
 
 apply plugin: 'java-library'
 
@@ -139,87 +138,126 @@ tasks.named("javadoc", Javadoc) {
   }
 }
 
-def currentJavaHomePath = getJavaHomePath(System.getProperty("java.home"))
+class ProvideJvmArgsOnJvmLauncherVersion implements CommandLineArgumentProvider {
+  @Internal
+  Test test
+  @Input
+  JavaVersion applyFromVersion
+  @Input
+  List<String> jvmArgsToApply
+  @Input
+  Provider<Boolean> additionalCondition
 
-project.afterEvaluate {
-  def testJvm = gradle.startParameter.projectProperties["testJvm"]
-  def javaTestLauncher = null as Provider<JavaLauncher>
+  ProvideJvmArgsOnJvmLauncherVersion(Test test, JavaVersion applyFromVersion, List<String> jvmArgsToApply, Provider<Boolean> additionalCondition) {
+    this.test = test
+    this.applyFromVersion = applyFromVersion
+    this.jvmArgsToApply = jvmArgsToApply
+    this.additionalCondition = additionalCondition
+  }
 
-  // "stable" is calculated as the largest X found in JAVA_X_HOME
-  if (testJvm == "stable") {
-    def javaVersions = providers.environmentVariablesPrefixedBy("JAVA_").map { javaHomes ->
-      javaHomes
+  @Override
+  Iterable<String> asArguments() {
+    def launcherVersion = test.javaLauncher.map { JavaVersion.toVersion(it.metadata.languageVersion.asInt()) }
+    .orElse(JavaVersion.current())
+    .get()
+
+    if (launcherVersion.isCompatibleWith(applyFromVersion) && additionalCondition.getOrElse(true)) {
+      jvmArgsToApply
+    } else {
+      []
+    }
+  }
+}
+ext.configureJvmArgs = (Test testTask, JavaVersion applyFromVersion, List<String> jvmArgsToApply, Provider<Boolean> additionalCondition = null) -> {
+  testTask.jvmArgumentProviders.add(new ProvideJvmArgsOnJvmLauncherVersion(
+  testTask,
+  applyFromVersion,
+  jvmArgsToApply,
+  additionalCondition ?: testTask.project.providers.provider { true }
+  ))
+}
+
+
+def configureTestJvm(Project project, boolean applyCodeCoverage) {
+  def currentJavaHomePath = getJavaHomePath(System.getProperty("java.home"))
+  def normalizedTestJvm = project.providers.gradleProperty("testJvm").map { testJvm ->
+    // "stable" is calculated as the largest X found in JAVA_X_HOME
+    if (testJvm == "stable") {
+      def javaVersions = providers.environmentVariablesPrefixedBy("JAVA_").map { javaHomes ->
+        javaHomes
         .findAll { it.key =~ /^JAVA_[0-9]+_HOME$/ }
         .collect { (it.key =~ /^JAVA_(\d+)_HOME$/)[0][1] as Integer }
-    }.get()
+      }.get()
 
-    if (javaVersions.isEmpty()) {
-      throw new GradleException("No valid JAVA_X_HOME environment variables found.")
-    }
+      if (javaVersions.isEmpty()) {
+        throw new GradleException("No valid JAVA_X_HOME environment variables found.")
+      }
 
-    testJvm = javaVersions.max().toString()
-  }
-
-  if (testJvm) {
-    def testJvmHomePath
-    if (Files.exists(Paths.get(testJvm))) {
-      testJvmHomePath = getJavaHomePath(testJvm)
+      javaVersions.max().toString()
     } else {
-      def matcher = testJvm =~ /([a-zA-Z]*)([0-9]+)/
+      testJvm
+    }
+  }.map { logger.info("normalized testJvm: " + it); it }
+
+  def testJvmHomePath = normalizedTestJvm.map {
+    if (Files.exists(Paths.get(it))) {
+      getJavaHomePath(it)
+    } else {
+      def matcher = it =~ /([a-zA-Z]*)([0-9]+)/
       if (!matcher.matches()) {
-        throw new GradleException("Unable to find launcher for Java '$testJvm'. It needs to match '([a-zA-Z]*)([0-9]+)'.")
+        throw new GradleException("Unable to find launcher for Java '$it'. It needs to match '([a-zA-Z]*)([0-9]+)'.")
       }
       def testJvmLanguageVersion = matcher.group(2) as Integer
-      def testJvmEnv = "JAVA_${testJvm}_HOME"
+      def testJvmEnv = "JAVA_${it}_HOME"
       def testJvmHome = providers.environmentVariable(testJvmEnv).orNull
       if (!testJvmHome) {
-        throw new GradleException("Unable to find launcher for Java '$testJvm'. Have you set '$testJvmEnv'?")
+        throw new GradleException("Unable to find launcher for Java '$it'. Have you set '$testJvmEnv'?")
       }
-      testJvmHomePath = getJavaHomePath(testJvmHome)
-    }
-    // Only change test JVM if it's not the one we are running the gradle build with
-    if (currentJavaHomePath != testJvmHomePath) {
-      def jvmSpec = new SpecificInstallationToolchainSpec(project.services.get(PropertyFactory), file(testJvmHomePath))
-      // The provider always says that a value is present so we need to wrap it for proper error messages
-      Provider<JavaLauncher> launcher = providers.provider {
-        try {
-          return javaToolchains.launcherFor(jvmSpec).get()
-        } catch (NoSuchElementException ignored) {
-          throw new GradleException("Unable to find launcher for Java $testJvm. Does '$testJvmHome' point to a JDK?")
-        }
-      }
-      javaTestLauncher = launcher
-    }
-  }
 
-  tasks.withType(Test).configureEach {
-    def allowReflectiveAccessToJdk = true
-    if (project.hasProperty('allowReflectiveAccessToJdk')) {
-      allowReflectiveAccessToJdk = project.getProperty('allowReflectiveAccessToJdk')
+      getJavaHomePath(testJvmHome)
     }
-    if (javaTestLauncher) {
-      def metadata = javaTestLauncher.get().metadata
-      def allowedOrForced = !isJdkExcluded(testJvm) &&
-        (isJavaLanguageVersionAllowed(metadata.languageVersion, it.name) || isJdkForced(testJvm))
+  }.map { logger.info("testJvm home path: " + it); it }
+
+  def javaTestLauncher = testJvmHomePath.zip(normalizedTestJvm) { testJvmHome, testJvm ->
+    // Only change test JVM if it's not the one we are running the gradle build with
+    if (currentJavaHomePath == testJvmHome) {
+      null
+    } else {
+      def jvmSpec = new SpecificInstallationToolchainSpec(project.services.get(PropertyFactory), file(testJvmHome))
+      // The provider always says that a value is present so we need to wrap it for proper error messages
+
+      javaToolchains.launcherFor(jvmSpec).orElse(providers.provider {
+        throw new GradleException("Unable to find launcher for Java $testJvm. Does '$testJvmHome' point to a JDK?")
+      })
+    }
+  }.flatMap { it }.map { logger.info("testJvm launcher: " + it.executablePath); it }
+
+  // Apply the launcher
+  tasks.withType(Test).configureEach { Test testTask ->
+    if (javaTestLauncher.isPresent()) {
       javaLauncher = javaTestLauncher
-      onlyIf { allowedOrForced }
+      onlyIf("Allowed or forced JDK") {
+        !isJdkExcluded(normalizedTestJvm.get()) &&
+        (isJavaLanguageVersionAllowed(javaTestLauncher.get().metadata.languageVersion, it.name) || isJdkForced(normalizedTestJvm.get()))
+      }
+
+      // Disable jacoco for additional 'testJvm' tests to speed things up a bit
       if (applyCodeCoverage) {
         jacoco {
-          // Disable jacoco for additional JVM tests to speed things up a bit
           enabled = false
         }
       }
-      if (metadata.languageVersion.asInt() >= 16 && allowReflectiveAccessToJdk) {
-        // temporary workaround when using Java16+: some tests require reflective access to java.lang/java.util
-        jvmArgs += ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED']
-      }
     } else {
-      def name = it.name
-      onlyIf { isJavaVersionAllowed(JavaVersion.current(), name) }
-      if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) && allowReflectiveAccessToJdk) {
-        jvmArgs += ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED']
-      }
+      onlyIf("is current Daemon JVM  allowed") { isJavaVersionAllowed(JavaVersion.current(), testTask.name) }
     }
+
+    // temporary workaround when using Java16+: some tests require reflective access to java.lang/java.util
+    configureJvmArgs(
+    testTask,
+    JavaVersion.VERSION_16,
+    ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED'],
+    project.providers.provider { project.properties['allowReflectiveAccessToJdk'] as Boolean }.orElse(true)
+    )
 
     if (configurations.hasProperty("latestDepTestRuntimeClasspath")) {
       doFirst {
@@ -229,29 +267,31 @@ project.afterEvaluate {
       }
     }
   }
+}
+configureTestJvm(project, applyCodeCoverage)
 
-  [JavaCompile, ScalaCompile, GroovyCompile].each { type ->
-    tasks.withType(type).configureEach {
-      if (options.fork) {
-        options.forkOptions.with {
-          memoryMaximumSize = "256M"
-        }
+
+[JavaCompile, ScalaCompile, GroovyCompile].each { type ->
+  tasks.withType(type).configureEach {
+    if (options.fork) {
+      options.forkOptions.with {
+        memoryMaximumSize = "256M"
       }
     }
   }
+}
 
-  if (project.plugins.hasPlugin('kotlin')) {
-    ['compileKotlin', 'compileTestKotlin'].each { type ->
-      tasks.named(type) {
-        kotlinDaemonJvmArguments = ["-Xmx256m", "-XX:+UseParallelGC"]
-      }
+if (project.plugins.hasPlugin('kotlin')) {
+  ['compileKotlin', 'compileTestKotlin'].each { type ->
+    tasks.named(type) {
+      kotlinDaemonJvmArguments = ["-Xmx256m", "-XX:+UseParallelGC"]
     }
   }
+}
 
-  tasks.withType(JavaExec).configureEach {
-    if (!it.maxHeapSize) {
-      it.maxHeapSize = '256M'
-    }
+tasks.withType(JavaExec).configureEach {
+  if (!it.maxHeapSize) {
+    it.maxHeapSize = '256M'
   }
 }
 
@@ -295,7 +335,7 @@ tasks.withType(JavaCompile).configureEach {
     def releaseFlagValue = options.release.getOrNull()
     if (releaseFlagValue != null && !JavaVersion.toVersion(targetCompatibility).isCompatibleWith(JavaVersion.toVersion(releaseFlagValue))) {
       logger.warn('⚠️ The release flag and targetCompatibility have different values **release will win**, targetCompatibility: ' + targetCompatibility.toString() + ', release: ' + releaseFlagValue + '\n' +
-        '  compiler: ' + javaCompiler.get().executablePath.asFile)
+      '  compiler: ' + javaCompiler.get().executablePath.asFile)
     }
   }
 }

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -9,12 +9,6 @@ apply plugin: 'java-library'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
-}
-
 apply from: "$rootDir/gradle/codenarc.gradle"
 apply from: "$rootDir/gradle/forbiddenapis.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
@@ -285,19 +279,48 @@ if (project.hasProperty("removeJarVersionNumbers") && removeJarVersionNumbers) {
   }
 }
 
-ext.setJavaVersion = (it, javaVersionInteger) -> {
+// Configure the compile task with release if possible
+// other wise use the java 8 compiler
+tasks.withType(JavaCompile).configureEach {
+  def targetVersion = JavaVersion.toVersion(targetCompatibility).majorVersion as Integer
+  if (JavaVersion.current().isJava9Compatible()) {
+    it.options.release = targetVersion
+    // Disable '-options' because we are compiling for java8 from the daemon JDK deliberately
+    it.options.compilerArgs.add('-Xlint:-options')
+  } else {
+    it.javaCompiler = javaToolchains.compilerFor {
+      languageVersion = JavaLanguageVersion.of(targetVersion)
+    }
+  }
+  doFirst("audit-compiler-setting") {
+    def releaseFlagValue = options.release.getOrNull()
+    if (releaseFlagValue != null && !JavaVersion.toVersion(targetCompatibility).isCompatibleWith(JavaVersion.toVersion(releaseFlagValue))) {
+      logger.warn('⚠️ The release flag and targetCompatibility have different values **release will win**, targetCompatibility: ' + targetCompatibility.toString() + ', release: ' + releaseFlagValue + '\n' +
+        '  compiler: ' + javaCompiler.get().executablePath.asFile)
+    }
+  }
+}
+
+// Enforce the use of a toolchain compiler
+ext.setJavaVersion = (AbstractCompile it, int requiredJdkToolchainVersion, boolean unsetReleaseFlag = false) -> {
   Provider<JavaCompiler> compiler = javaToolchains.compilerFor {
-    languageVersion = JavaLanguageVersion.of(javaVersionInteger)
+    languageVersion = JavaLanguageVersion.of(requiredJdkToolchainVersion)
   }
   Provider<JavaLauncher> launcher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(javaVersionInteger)
+    languageVersion = JavaLanguageVersion.of(requiredJdkToolchainVersion)
   }
   try {
     if (it instanceof JavaCompile) {
       JavaCompile jc = (JavaCompile) it
       jc.javaCompiler = compiler
-      if (javaVersionInteger == 8) {
+      if (unsetReleaseFlag || requiredJdkToolchainVersion == 8) {
+        // Don't set the release flag, as code need unpublished symbols,
+        // those are not accessible when using `--release N`
+        // e.g. with sun.misc.SharedSecrets, or jdk.jfr.internal.JVM
         jc.options.release = null
+      } else if (JavaVersion.toVersion(requiredJdkToolchainVersion).isJava9Compatible()) {
+        jc.options.release = requiredJdkToolchainVersion
+        jc.options.compilerArgs.add('-Xlint:-options')
       }
     } else if (it instanceof GroovyCompile) {
       GroovyCompile gc = (GroovyCompile) it
@@ -309,7 +332,7 @@ ext.setJavaVersion = (it, javaVersionInteger) -> {
       throw new GradleException("Unsupported compile type: ${it.getClass()}")
     }
   } catch (NoSuchElementException ignored) {
-    throw new GradleException("Unable to find compiler for Java $javaVersionInteger. Have you set JAVA_${javaVersionInteger}_HOME?")
+    throw new GradleException("Unable to find compiler for Java $requiredJdkToolchainVersion. Have you set JAVA_${requiredJdkToolchainVersion}_HOME?")
   }
 } as Closure<Void>
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -46,14 +46,6 @@ if (applyCodeCoverage) {
   apply from: "$rootDir/gradle/jacoco.gradle"
 }
 
-// when building with Java 9+, lazily set compiler --release flag to match target
-def skipSettingCompilerRelease = project.findProperty('skipSettingCompilerRelease')
-if (!skipSettingCompilerRelease && JavaVersion.current().isJava9Compatible()) {
-  compileJava.options.release = project.provider {
-    JavaVersion.toVersion(targetCompatibility).majorVersion as Integer
-  }
-}
-
 if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
   def version = JavaVersion.toVersion(project.getProperty('minJavaVersionForTests'))
   def name = "java$version.majorVersion"

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -16,11 +16,11 @@ java {
 
 tasks.withType<JavaCompile>().configureEach {
   // need access to sun.misc.SharedSecrets
-  setJavaVersion(8)
+  setJavaVersion(8, true)
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int) {
-  (project.extra["setJavaVersion"] as Closure<*>).call(this, javaVersionInteger)
+fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
+  (project.extra["setJavaVersion"] as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
 }
 
 val minimumBranchCoverage by extra(0.7)

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -15,12 +15,11 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  // need access to sun.misc.SharedSecrets
-  setJavaVersion(8, true)
+  configureCompiler(8, JavaVersion.VERSION_1_8, "Need access to sun.misc.SharedSecrets")
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
-  (project.extra["setJavaVersion"] as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
+fun AbstractCompile.configureCompiler(javaVersionInteger: Int, compatibilityVersion: JavaVersion? = null, unsetReleaseFlagReason: String? = null) {
+  (project.extra["configureCompiler"] as Closure<*>).call(this, javaVersionInteger, compatibilityVersion, unsetReleaseFlagReason)
 }
 
 val minimumBranchCoverage by extra(0.7)

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
   id("me.champeau.jmh")
 }
 
-val skipSettingCompilerRelease by extra(true) // need access to sun.misc.SharedSecrets
-
 apply(from = "$rootDir/gradle/java.gradle")
 apply(from = "$rootDir/gradle/tries.gradle")
 
@@ -16,13 +14,8 @@ java {
   }
 }
 
-tasks.compileJava {
-  javaCompiler = javaToolchains.compilerFor {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
-}
-
-tasks.compileTestJava {
+tasks.withType<JavaCompile>().configureEach {
+  // need access to sun.misc.SharedSecrets
   setJavaVersion(8)
 }
 

--- a/internal-api/internal-api-9/build.gradle.kts
+++ b/internal-api/internal-api-9/build.gradle.kts
@@ -18,17 +18,17 @@ java {
   }
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach() {
   javadocTool = javaToolchains.javadocToolFor(java.toolchain)
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int) {
-  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger)
+fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
+  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
 }
 
 listOf(JavaCompile::class.java, GroovyCompile::class.java).forEach { compileTaskType ->
-  tasks.withType(compileTaskType) {
-    setJavaVersion(11)
+  tasks.withType(compileTaskType).configureEach {
+    setJavaVersion(11, true)
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
   }
@@ -55,7 +55,7 @@ idea {
 }
 
 jmh {
-  jmhVersion = libs.versions.jmh.get()
+  jmhVersion = libs.versions.jmh
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
   jvm = providers.environmentVariable("JAVA_11_HOME").map { Paths.get(it, "bin", "java").toString() }
 }

--- a/internal-api/internal-api-9/build.gradle.kts
+++ b/internal-api/internal-api-9/build.gradle.kts
@@ -22,15 +22,13 @@ tasks.withType<Javadoc>().configureEach() {
   javadocTool = javaToolchains.javadocToolFor(java.toolchain)
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
-  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
+fun AbstractCompile.configureCompiler(javaVersionInteger: Int, compatibilityVersion: JavaVersion? = null, unsetReleaseFlagReason: String? = null) {
+  (project.extra["configureCompiler"] as Closure<*>).call(this, javaVersionInteger, compatibilityVersion, unsetReleaseFlagReason)
 }
 
 listOf(JavaCompile::class.java, GroovyCompile::class.java).forEach { compileTaskType ->
   tasks.withType(compileTaskType).configureEach {
-    setJavaVersion(11, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    configureCompiler(11, JavaVersion.VERSION_1_8)
   }
 }
 

--- a/utils/socket-utils/build.gradle.kts
+++ b/utils/socket-utils/build.gradle.kts
@@ -22,15 +22,13 @@ tasks.named<CheckForbiddenApis>("forbiddenApisMain_java17") {
   failOnMissingClasses = false
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
-  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
+fun AbstractCompile.configureCompiler(javaVersionInteger: Int, compatibilityVersion: JavaVersion? = null, unsetReleaseFlagReason: String? = null) {
+  (project.extra["configureCompiler"] as Closure<*>).call(this, javaVersionInteger, compatibilityVersion, unsetReleaseFlagReason)
 }
 
 listOf("compileMain_java17Java", "compileTestJava").forEach {
   tasks.named<JavaCompile>(it) {
-    setJavaVersion(17, true)
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    configureCompiler(17, JavaVersion.VERSION_1_8)
   }
 }
 

--- a/utils/socket-utils/build.gradle.kts
+++ b/utils/socket-utils/build.gradle.kts
@@ -22,13 +22,13 @@ tasks.named<CheckForbiddenApis>("forbiddenApisMain_java17") {
   failOnMissingClasses = false
 }
 
-fun AbstractCompile.setJavaVersion(javaVersionInteger: Int) {
-  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger)
+fun AbstractCompile.setJavaVersion(javaVersionInteger: Int, unsetReleaseFlag: Boolean) {
+  (project.extra.get("setJavaVersion") as Closure<*>).call(this, javaVersionInteger, unsetReleaseFlag)
 }
 
 listOf("compileMain_java17Java", "compileTestJava").forEach {
   tasks.named<JavaCompile>(it) {
-    setJavaVersion(17)
+    setJavaVersion(17, true)
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
   }


### PR DESCRIPTION
# What Does This Do

🙌 This allows to compile, test and produce a correct jar when the JDK running Gradle is not 1.8. I.e. it's possible to run Gradle with JDK 21.

Another win by decoupling the Gradle JDK, the build better encodes the expected bytecode target of the produced jars.

⚠️ However, some other tasks cannot run on later JDK, the reason is that the plugins that registered these tasks are too old to run on latest JDK ; **spotless**, **spotbugs** are an example of such plugins. This should be addressed in later PR, and it will likely require to run Gradle on JDK 11 minimum.


This work resumes what was started in #8883, and maybe before that. Instead of applying the toolchain for every compile tasks, it relies on the ability of the JVM running the _Gradle Daemon_ to compile Java 1.8 (note that Java 25 can still compile to Java 1.8, and Gradle 8.14.3 carn on JDK 24 at most).

In order to achieve this, work had to be done on the default compiler configuration, and customized compiler configuration which was done via `setJavaVersion`

> [!IMPORTANT]
> `setJavaVersion` was renamed to `configureCompiler`, and now takes multiple arguments the last two are optional:
> 1. the compile task itself
> 2. the explicit required toolchain, e.g. when using JDK 17
> 3. the targeted bytecode, otherwise the compiler use the toolchain's default target
> 4. the reason why _required toolchain_ and _target bytecode_ are different.

E.g. in IntelliJ using JDK 24 works for compiling, and running tests

_Settings | Build, Execution, Deployment | Build Tools | Gradle_
<img width="1094" height="828" alt="image" src="https://github.com/user-attachments/assets/4c113035-9ca6-4bde-8ea9-9bde0442aad4" />


# Motivation

This preliminary work should unlocks other tasks:

* Bumping plugins and other dependencies of the build, this can improve build efficiency, reduce security risks of using older unmaintained major versions.
* Better support for JDK 25


# Additional Notes

The produced jars, found on the GH releases page, have been checked against a tool I crafted. Other tools didn't work or didn't perform what was needed.

> [!NOTE]
> 
> 🔗 https://github.com/bric3/jardiff
> 
> Shortcomings: 
> * not released anywhere, one has to build it - a possible idea would be to integrate this in a gradle plugin to make the diff easier to read.
> * needs JDK 25

Ran the following command on this branch (folder `dd-trace-java`), and on `master` (folder `dd-trace-java-copy-1`)

```shell
$ ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar
```

_Assuming that `jardiff` runs `java -jar jardiff/build/shadowed-app/jardiff-0.1.0-SNAPSHOT.jar` using java 25. Also the following snippet use `delta` render the diff, but it's not strictly necessary._

The following diffs have been performed:

* `dd-java-agent`

   ```shell
   jardiff ../dd-trace-java{-copy-1,}/dd-java-agent/build/libs/dd-java-agent-1.54.0-SNAPSHOT.jar -c classdata --class-text-producer=class-file-version --exclude "**/*.yaml,**/*.MF,**/*.version,*.version" | delta --syntax-theme=GitHub --light 
   ```
   
   <img width="2540" height="355" alt="image" src="https://github.com/user-attachments/assets/7c166e09-c2b1-485e-bc2d-9df6a0e82328" />

   
   <details><summary>byte code differences, appear to be only order of some fields</summary>
   
   Remove the `--class-text-producer=class-file-version`

   <img width="1375" height="1623" alt="image" src="https://github.com/user-attachments/assets/1d04a730-4876-4904-a440-b531b26693ad" />
   </details>


* `dd-trace-api`

   ```shell
   jardiff ../dd-trace-java{-copy-1,}/dd-trace-api/build/libs/dd-trace-api-1.54.0-SNAPSHOT.jar -c classdata --exclude "**/*.yaml,**/*.MF,**/*.version,*.version" | delta --syntax-theme=GitHub --light
   ```

* `dd-trace-ot`

   ```shell
   jardiff ../dd-trace-java{-copy-1,}/dd-trace-ot/build/libs/dd-trace-ot-1.54.0-SNAPSHOT.jar -c classdata --exclude "**/*.yaml,**/*.MF,**/*.version,*.version" | delta --syntax-theme=GitHub --light
   ```


> [!NOTE]
> While running compiling and generating the code using a more recent JDK. I noticed the following change in bytecode for some methods, this is legal and will run correctly on JDK 8.
> <img width="1794" height="1076" alt="image" src="https://github.com/user-attachments/assets/d1f028b7-daf2-4eb2-98ec-c3534346b618" />
> <img width="2520" height="628" alt="image" src="https://github.com/user-attachments/assets/cc8884e9-81f0-4878-8594-81c699be2f69" />
>
> Thanks to @mcculls for digging into the reasons, and updating muzzle in #9649
> >
> > AFAICT the behaviour changed in Java 18/19 when the JDK team were digging more into the interaction between interfaces and their implicit superclass `java.lang.Object` - for a long time `javac` had always generated `invokevirtual` calls to `Object` method refs, which while it worked is not quite correct if you read the JLS spec closely.
> > This was originally noticed back in https://bugs.openjdk.org/browse/JDK-4974954 when comparing `javac`'s output to that from `jikes`, which is another Java compiler (one that sticks really closely to the letter of the spec).
> > Nothing much happened until Java 18/19 when [JDK-8272715](https://bugs.openjdk.org/browse/JDK-8272715) and [JDK-8282080](https://bugs.openjdk.org/browse/JDK-8282080) led to a wholesale refactoring of that part of the code.
> > The key change is described in [JDK-8272715](https://bugs.openjdk.org/browse/JDK-8272715):
> > * invocations of `java.lang.Object` methods on interfaces in the classfile will use `invokeinterface` referring to the interface, which is consistent with JLS 9.2. This will be done regardless of whether the interface declares the method explicitly or not.
> >
> > TL;DR is that both forms will work in Java 8, i.e. they'll resolve to the same method in the end, but the `invokeinterface` call is more consistent with the JLS spec.



# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
