### PR TITLE
Encode contributing.md style guide to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,17 +7,54 @@ end_of_line=lf
 insert_final_newline=true
 indent_style=space
 indent_size=2
-
-[*.json]
-indent_style=space
-indent_size=2
+ij_continuation_indent_size=4
 
 [*.java]
-indent_style=space
-indent_size=2
-continuation_indent_size=4
+ij_java_class_count_to_use_import_on_demand = 99
+ij_java_insert_inner_class_imports = false
+ij_java_imports_layout = |,$*,|,*,|
+ij_java_layout_on_demand_import_from_same_package_first = true
+ij_java_layout_static_imports_separately = true
+ij_java_names_count_to_use_import_on_demand = 99
+ij_java_packages_to_use_import_on_demand = java.awt.*,javax.swing.*
+
+
+ij_java_block_comment_add_space = false
+ij_java_block_comment_at_first_column = false
+ij_java_line_comment_add_space = true
+ij_java_line_comment_add_space_on_reformat = false
+ij_java_line_comment_at_first_column = false
+
+
+[*.groovy]
+ij_groovy_class_count_to_use_import_on_demand = 99
+ij_groovy_imports_layout = $*,|,*,|
+ij_groovy_names_count_to_use_import_on_demand = 99
+ij_groovy_packages_to_use_import_on_demand = java.awt.*,javax.swing.*
+
+ij_groovy_block_comment_add_space = false
+ij_groovy_block_comment_at_first_column = false
+ij_groovy_line_comment_add_space = true
+ij_groovy_line_comment_add_space_on_reformat = false
+ij_groovy_line_comment_at_first_column = false
+
+[{*.kt,*.kts}]
+ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
+
+ij_kotlin_name_count_to_use_star_import = 99
+ij_kotlin_name_count_to_use_star_import_for_members = 99
+ij_kotlin_packages_to_use_import_on_demand = kotlinx.android.synthetic.**,io.ktor.**
+
+ij_kotlin_block_comment_add_space = false
+ij_kotlin_block_comment_at_first_column = false
+ij_kotlin_line_comment_add_space = true
+ij_kotlin_line_comment_add_space_on_reformat = false
+ij_kotlin_line_comment_at_first_column = false
+
 
 [{*.yml,*.yaml}]
-indent_style=space
-indent_size=2
+ij_yaml_line_comment_add_space = true
+ij_yaml_line_comment_add_space_on_reformat = false
+ij_yaml_line_comment_at_first_column = false
 


### PR DESCRIPTION
# What Does This Do

The [contributing guide](CONTRIBUTING.md) describes a few rules to set on each new checkout or after a `git clean -fdx`. Writing those rules in the `.editorconfig` should make the IDE aware of them by default without having to configure anything.

Those are IJ specific (leveraging [IJ `.editorconfig` integration](https://www.jetbrains.com/help/idea/editorconfig.html)), as I don't think other IDE / text editors support these.

# Motivation

Ease of setup. No need to setup formater this on other worktrees.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
