### PR TITLE
Set correct subdomain when sending intake requests via EVP proxy

### DIFF
--- a/communication/src/main/java/datadog/communication/BackendApiFactory.java
+++ b/communication/src/main/java/datadog/communication/BackendApiFactory.java
@@ -49,8 +49,14 @@ public class BackendApiFactory {
       String traceId = config.getIdGenerationStrategy().generateTraceId().toString();
       String evpProxyEndpoint = featuresDiscovery.getEvpProxyEndpoint();
       HttpUrl evpProxyUrl = sharedCommunicationObjects.agentUrl.resolve(evpProxyEndpoint);
+      String subdomain = intake.getUrlPrefix();
       return new EvpProxyApi(
-          traceId, evpProxyUrl, retryPolicyFactory, sharedCommunicationObjects.okHttpClient, true);
+          traceId,
+          evpProxyUrl,
+          subdomain,
+          retryPolicyFactory,
+          sharedCommunicationObjects.okHttpClient,
+          true);
     }
 
     log.warn(

--- a/communication/src/main/java/datadog/communication/EvpProxyApi.java
+++ b/communication/src/main/java/datadog/communication/EvpProxyApi.java
@@ -25,23 +25,25 @@ public class EvpProxyApi implements BackendApi {
   private static final String X_DATADOG_PARENT_ID_HEADER = "x-datadog-parent-id";
   private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
   private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
-  private static final String API_SUBDOMAIN = "api";
   private static final String GZIP_ENCODING = "gzip";
 
   private final String traceId;
   private final HttpRetryPolicy.Factory retryPolicyFactory;
   private final HttpUrl evpProxyUrl;
+  private final String subdomain;
   private final OkHttpClient httpClient;
   private final boolean responseCompression;
 
   public EvpProxyApi(
       String traceId,
       HttpUrl evpProxyUrl,
+      String subdomain,
       HttpRetryPolicy.Factory retryPolicyFactory,
       OkHttpClient httpClient,
       boolean responseCompression) {
     this.traceId = traceId;
     this.evpProxyUrl = evpProxyUrl.resolve(String.format("api/%s/", API_VERSION));
+    this.subdomain = subdomain;
     this.retryPolicyFactory = retryPolicyFactory;
     this.httpClient = httpClient;
     this.responseCompression = responseCompression;
@@ -60,7 +62,7 @@ public class EvpProxyApi implements BackendApi {
     Request.Builder requestBuilder =
         new Request.Builder()
             .url(url)
-            .addHeader(X_DATADOG_EVP_SUBDOMAIN_HEADER, API_SUBDOMAIN)
+            .addHeader(X_DATADOG_EVP_SUBDOMAIN_HEADER, subdomain)
             .addHeader(X_DATADOG_TRACE_ID_HEADER, traceId)
             .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId);
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -273,7 +273,7 @@ class ConfigurationApiImplTest extends Specification {
     HttpUrl proxyUrl = HttpUrl.get(address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
     OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
-    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client, responseCompression)
+    return new EvpProxyApi(traceId, proxyUrl, "api", retryPolicyFactory, client, responseCompression)
   }
 
   private BackendApi givenIntakeApi(URI address, boolean responseCompression) {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
@@ -121,7 +121,7 @@ class GitDataApiTest extends Specification {
     HttpUrl proxyUrl = HttpUrl.get(intakeServer.address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
     OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
-    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client, true)
+    return new EvpProxyApi(traceId, proxyUrl, "api", retryPolicyFactory, client, true)
   }
 
   private Path givenPackFile() {


### PR DESCRIPTION
# What Does This Do

Sets correct `X-Datadog-EVP-Subdomain` when sending requests through EVP proxy.

# Motivation

Previously the subdomain was hardcoded to `api`, which didn't work when sending requests to intake.
Code coverage report uploading was affected.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
