### PR TITLE
add type to requests sent to intake

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
@@ -54,6 +54,7 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
     private final DebuggerIntakeRequestData debugger;
     private final String ddsource = "dd_debugger";
     private final String message;
+    private final String type = "snapshot";
 
     private final String ddtags;
 
@@ -145,6 +146,10 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
 
     public String getProcessTags() {
       return processTags;
+    }
+
+    public String getType() {
+      return type;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -25,6 +25,8 @@ public class ProbeStatus {
   @Json(name = "ddsource")
   private final String ddSource = "dd_debugger";
 
+  private final String type = "diagnostic";
+
   private final String service;
   private final String message;
   private final long timestamp;
@@ -49,6 +51,10 @@ public class ProbeStatus {
 
   public String getDdSource() {
     return ddSource;
+  }
+
+  public String getType() {
+    return type;
   }
 
   public String getService() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -36,7 +36,8 @@ public class SymbolSink {
       "{%n"
           + "\"ddsource\": \"dd_debugger\",%n"
           + "\"service\": \"%s\",%n"
-          + "\"runtimeId\": \"%s\"%n"
+          + "\"runtimeId\": \"%s\",%n"
+          + "\"type\": \"symdb\"%n"
           + "}";
   static final int MAX_SYMDB_UPLOAD_SIZE = 50 * 1024 * 1024;
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -325,6 +325,7 @@ class ProbeStatusSinkTest {
         MoshiHelper.createMoshiProbeStatus().adapter(ProbeStatus.class);
     ProbeStatus probeStatus = adapter.fromJson(buffer);
     assertEquals("dd_debugger", probeStatus.getDdSource());
+    assertEquals("diagnostic", probeStatus.getType());
     assertEquals(SERVICE_NAME, probeStatus.getService());
     assertEquals("Error installing probe " + PROBE_ID + ".", probeStatus.getMessage());
     assertEquals(PROBE_ID, probeStatus.getDiagnostics().getProbeId());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -35,6 +35,7 @@ class SymbolSinkTest {
     String strEventContent = new String(eventContent.getContent());
     assertTrue(strEventContent.contains("\"ddsource\": \"dd_debugger\""));
     assertTrue(strEventContent.contains("\"service\": \"service1\""));
+    assertTrue(strEventContent.contains("\"type\": \"symdb\""));
     BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
     assertEquals("file", symbolContent.getPartName());
     assertEquals("file.json", symbolContent.getFileName());

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
@@ -53,6 +53,10 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
     execute(appUrl, TRACED_METHOD_NAME, "oops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);
+    registerIntakeRequestListener(
+        intakeRequest -> {
+          assertEquals("snapshot", intakeRequest.getType());
+        });
     processRequests(
         () -> {
           if (snapshotIdTags.isEmpty()) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -68,6 +68,10 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
     setCurrentConfiguration(createConfig(probe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
     AtomicBoolean snapshotReceived = new AtomicBoolean();
+    registerIntakeRequestListener(
+        intakeRequest -> {
+          assertEquals("snapshot", intakeRequest.getType());
+        });
     registerSnapshotListener(
         snapshot -> {
           assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());


### PR DESCRIPTION
# What Does This Do
help to discriminate type of content when processing by intake

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
