### PR TITLE
Add Selenium and Cucumber modules to list of test instrumentations to avoid running sample tests

### DIFF
--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -4,6 +4,7 @@ import java.time.temporal.ChronoUnit
 def isTestingInstrumentation(Project project) {
   return [
     "junit-4.10",
+    "cucumber",
     "cucumber-junit-4",
     "junit-4.13",
     "munit-junit-4",


### PR DESCRIPTION
# What Does This Do

Adds Selenium module to the list of test instrumentations.

# Motivation

Test instrumentations contain sample tests (that are not actual tests for the tracer, but rather fixtures that we use to verify that instrumentation works correctly).
These instrumentation modules need to be added to a special list: for the modules present additional configuration is done that excludes sample tests from being run.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
