### PR TITLE
Refactor JUnit4 `@Rule` to JUnit5 `@TempDir`.

### DIFF
--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/BaseIoCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/BaseIoCallSiteTest.groovy
@@ -1,13 +1,16 @@
 package datadog.trace.instrumentation.java.io
 
 import datadog.trace.agent.test.InstrumentationSpecification
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 abstract class BaseIoCallSiteTest extends InstrumentationSpecification {
-
-  @Rule
-  TemporaryFolder temporaryFolder = new TemporaryFolder(parentFolder())
+  @Shared
+  @TempDir
+  Path temporaryFolder
 
   @Override
   protected void configurePreAgent() {
@@ -15,28 +18,12 @@ abstract class BaseIoCallSiteTest extends InstrumentationSpecification {
   }
 
   protected File newFile(final String name) {
-    return temporaryFolder.newFile(name)
+    Path p = temporaryFolder.resolve(name)
+    Files.createDirectories(p.getParent())
+    return Files.createFile(p).toFile()
   }
 
-  protected File getRootFolder() {
+  protected Path getRootFolder() {
     return temporaryFolder.getRoot()
-  }
-
-  /**
-   * We cannot use @TempDir from spock due to dependencies, this method tries to write to the build folder to prevent
-   * permissions with /tmp
-   */
-  private static File parentFolder() {
-    def folder = new File(BaseIoCallSiteTest.getResource('.').toURI())
-    while (folder.name != 'build') {
-      folder = folder.parentFile
-    }
-    folder = new File(folder, 'tmp')
-    if (!folder.exists()) {
-      if (!folder.mkdirs()) {
-        throw new RuntimeException('Cannot create folder ' + folder)
-      }
-    }
-    return folder
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
@@ -11,7 +11,7 @@ class FileInputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     PathTraversalModule iastModule = Mock(PathTraversalModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_iast.txt').toString()
 
     when:
     TestFileInputStreamSuite.newFileInputStream(path)
@@ -24,7 +24,7 @@ class FileInputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     final helper = Mock(FileLoadedRaspHelper)
     FileLoadedRaspHelper.INSTANCE = helper
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_rasp.txt').toString()
 
     when:
     TestFileInputStreamSuite.newFileInputStream(path)

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
@@ -13,7 +13,7 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     PathTraversalModule iastModule = Mock(PathTraversalModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_iast_1.txt').toString()
 
     when:
     TestFileOutputStreamSuite.newFileOutputStream(path)
@@ -26,7 +26,7 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     PathTraversalModule iastModule = Mock(PathTraversalModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_iast_2.txt').toString()
 
     when:
     TestFileOutputStreamSuite.newFileOutputStream(path, false)
@@ -39,7 +39,7 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     final helper = Mock(FileLoadedRaspHelper)
     FileLoadedRaspHelper.INSTANCE = helper
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_rasp_1.txt').toString()
 
     when:
     TestFileOutputStreamSuite.newFileOutputStream(path)
@@ -52,7 +52,7 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     final helper = Mock(FileLoadedRaspHelper)
     FileLoadedRaspHelper.INSTANCE = helper
-    final path = newFile('test.txt').toString()
+    final path = newFile('test_rasp_2.txt').toString()
 
     when:
     TestFileOutputStreamSuite.newFileOutputStream(path, false)

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
@@ -11,10 +11,10 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     PathTraversalModule iastModule = Mock(PathTraversalModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final path = 'test.txt'
+    final path = 'test_iast.txt'
 
     when:
-    TestPathSuite.resolve(getRootFolder().toPath(), path)
+    TestPathSuite.resolve(getRootFolder(), path)
 
     then:
     1 * iastModule.onPathTraversal(path)
@@ -24,8 +24,8 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     PathTraversalModule iastModule = Mock(PathTraversalModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final sibling = newFile('test1.txt').toPath()
-    final path = 'test2.txt'
+    final sibling = newFile('test_iast_1.txt').toPath()
+    final path = 'test_iast_2.txt'
 
     when:
     TestPathSuite.resolveSibling(sibling, path)
@@ -38,10 +38,10 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     final helper = Mock(FileLoadedRaspHelper)
     FileLoadedRaspHelper.INSTANCE = helper
-    final path = 'test.txt'
+    final path = 'test_rasp.txt'
 
     when:
-    TestPathSuite.resolve(getRootFolder().toPath(), path)
+    TestPathSuite.resolve(getRootFolder(), path)
 
     then:
     1 * helper.beforeFileLoaded(path)
@@ -51,8 +51,8 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
     setup:
     final helper = Mock(FileLoadedRaspHelper)
     FileLoadedRaspHelper.INSTANCE = helper
-    final sibling = newFile('test1.txt').toPath()
-    final path = 'test2.txt'
+    final sibling = newFile('test_rasp_1.txt').toPath()
+    final path = 'test_rasp_2.txt'
 
     when:
     TestPathSuite.resolveSibling(sibling, path)

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/datadog/trace/instrumentation/maven3/AbstractMavenTest.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/datadog/trace/instrumentation/maven3/AbstractMavenTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -12,16 +13,15 @@ import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.eventspy.EventSpy;
 import org.apache.maven.execution.ExecutionEvent;
 import org.codehaus.plexus.PlexusContainer;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class AbstractMavenTest {
-
-  @ClassRule public static TemporaryFolder WORKING_DIRECTORY = new TemporaryFolder();
+  @TempDir static Path WORKING_DIRECTORY;
 
   protected AbstractMavenTest() {
     System.setProperty(
-        "maven.multiModuleProjectDirectory", WORKING_DIRECTORY.getRoot().getAbsolutePath());
+        "maven.multiModuleProjectDirectory",
+        WORKING_DIRECTORY.getRoot().toAbsolutePath().toString());
   }
 
   protected void executeMaven(
@@ -58,7 +58,8 @@ public abstract class AbstractMavenTest {
     arguments[2] = goal;
     System.arraycopy(additionalArgs, 0, arguments, 3, additionalArgs.length);
 
-    mavenCli.doMain(arguments, WORKING_DIRECTORY.getRoot().getAbsolutePath(), stdOut, stderr);
+    mavenCli.doMain(
+        arguments, WORKING_DIRECTORY.getRoot().toAbsolutePath().toString(), stdOut, stderr);
 
     Exception error = spy.handlerError.get();
     if (error != null) {

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
@@ -257,7 +257,7 @@ public class MavenUtilsTest extends AbstractMavenTest {
     Map<String, String> replacements =
         Collections.singletonMap("my_jdk_home_path", toolchainJdkHome.getAbsolutePath());
 
-    File toolchainsFile = new File(WORKING_DIRECTORY.getRoot(), "toolchains.xml");
+    File toolchainsFile = WORKING_DIRECTORY.getRoot().resolve("toolchains.xml").toFile();
     try (FileWriter toolchainsFileWriter = new FileWriter(toolchainsFile)) {
       Template coveragesTemplate = FREEMARKER.getTemplate("sampleToolchains.ftl");
       coveragesTemplate.process(replacements, toolchainsFileWriter);


### PR DESCRIPTION
# What Does This Do
Refactors tests to replace JUnit4 `@Rule` usage with JUnit5’s `@TempDir`.

# Motivation
Improves code clarity and consistency by aligning with JUnit5 APIs. This removes legacy JUnit4 dependencies and moves the test suite fully onto JUnit5.

# Additional Notes
This PR is a follow-up for  #9445.
