### PR TITLE
Fixing pekko test: revert previous change and fix test server

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -174,15 +174,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
   }
 
-  /**
-   * Hook method to allow subclasses to wait for request processing to complete.
-   * This is particularly useful for asynchronous HTTP server implementations
-   * where spans may still not be closed after the HTTP response is sent.
-   */
-  protected void waitForRequestToComplete() {
-    // Default implementation does nothing - override in subclasses as needed
-  }
-
   // used in blocking tests to check if the handler was skipped
   volatile boolean handlerRan
 
@@ -1203,8 +1194,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
-
-    waitForRequestToComplete()
 
     expect:
     response.code() == EXCEPTION.status

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
@@ -40,21 +40,6 @@ abstract class PekkoHttpServerInstrumentationTest extends HttpServerTest<PekkoHt
     true
   }
 
-  @Override
-  protected void waitForRequestToComplete() {
-    // Pekko HTTP is asynchronous, and spans may not be completed
-    // immediately after the HTTP response is sent. Wait for the trace
-    // to be written to avoid race conditions in trace assertions.
-    try {
-      // Wait up to 1 sec for the trace to be written
-      TEST_WRITER.waitForTracesMax(1, 1)
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt()
-      // If interrupted, proceed anyway - test may still pass
-    }
-  }
-
-
   //@Ignore("https://github.com/DataDog/dd-trace-java/pull/5213")
   @Override
   boolean testBadUrl() {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/scala/PekkoHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/scala/PekkoHttpTestWebServer.scala
@@ -136,7 +136,11 @@ object PekkoHttpTestWebServer {
   private val exceptionHandler = ExceptionHandler {
     case e: Exception =>
       val span = activeSpan()
-      TraceUtils.handleException(span, e)
+      if (span != null) {
+        // The exception handler is bypassing the normal instrumentation flow, so we need to handle things here
+        TraceUtils.handleException(span, e)
+        span.finish()
+      }
       complete(
         HttpResponse(status = EXCEPTION.getStatus, entity = e.getMessage)
       )


### PR DESCRIPTION
# What Does This Do

- revert #9493 
- close span in the exception handling code in the test server

# Motivation

honestly this is a bit beyond my comprehension, and AI helped me find this, but it seems there is a race condition in which handler gets to treat the exception, if it's the instrumentation handler things work fin, but if it's the test server handler, then the span is not finished. At least that's how I understand it.

# Additional Notes

Pekko's instrumentation was submitted by an external contributor 2 years ago.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
