### PR TITLE
Add session level metrics for Failed Test Replay

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -284,6 +284,11 @@ public class TestImpl implements DDTest {
       }
     }
 
+    boolean debugInfoCaptured = span.getTag(Tags.ERROR_DEBUG_INFO_CAPTURED) != null;
+    if (debugInfoCaptured) {
+      executionResults.setHasFailedTestReplayTests();
+    }
+
     AgentTracer.closeActive();
 
     onSpanFinish.accept(span);
@@ -310,9 +315,7 @@ public class TestImpl implements DDTest {
         span.getTag(Tags.TEST_IS_RETRY) != null ? IsRetry.TRUE : null,
         span.getTag(Tags.TEST_HAS_FAILED_ALL_RETRIES) != null ? HasFailedAllRetries.TRUE : null,
         retryReason instanceof TagValue ? (TagValue) retryReason : null,
-        span.getTag(Tags.ERROR_DEBUG_INFO_CAPTURED) != null
-            ? FailedTestReplayEnabled.TestMetric.TRUE
-            : null,
+        debugInfoCaptured ? FailedTestReplayEnabled.TestMetric.TRUE : null,
         span.getTag(Tags.TEST_IS_RUM_ACTIVE) != null ? IsRum.TRUE : null,
         CIConstants.SELENIUM_BROWSER_DRIVER.equals(span.getTag(Tags.TEST_BROWSER_DRIVER))
             ? BrowserDriver.SELENIUM

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
@@ -290,6 +290,10 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
       setTag(Tags.TEST_TEST_MANAGEMENT_ENABLED, true);
     }
 
+    if (result.hasFailedTestReplayTests()) {
+      setTag(DDTags.TEST_HAS_FAILED_TEST_REPLAY, true);
+    }
+
     testsSkipped.add(result.getTestsSkippedTotal());
 
     tagsPropagator.mergeTestFrameworks(result.getTestFrameworks());

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -9,12 +9,9 @@ import datadog.trace.api.civisibility.domain.BuildModuleLayout;
 import datadog.trace.api.civisibility.domain.BuildSessionSettings;
 import datadog.trace.api.civisibility.domain.JavaAgent;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
-import datadog.trace.api.civisibility.telemetry.TagValue;
-import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
 import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.civisibility.Constants;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.config.ExecutionSettings;
 import datadog.trace.civisibility.config.ExecutionSettingsFactory;
@@ -196,20 +193,13 @@ public class BuildSystemSessionImpl<T extends CoverageProcessor> extends Abstrac
         TagMergeSpec.of(Tags.TEST_ITR_TESTS_SKIPPING_TYPE),
         TagMergeSpec.of(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, Long::sum),
         TagMergeSpec.of(DDTags.CI_ITR_TESTS_SKIPPED, Boolean::logicalOr),
-        TagMergeSpec.of(Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr));
+        TagMergeSpec.of(Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr),
+        TagMergeSpec.of(DDTags.TEST_HAS_FAILED_TEST_REPLAY, Boolean::logicalOr));
   }
 
   @Override
   public BuildSessionSettings getSettings() {
     return settings;
-  }
-
-  @Override
-  protected Collection<TagValue> additionalTelemetryTags() {
-    if (Constants.EFD_ABORT_REASON_FAULTY.equals(span.getTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON))) {
-      return Collections.singleton(EarlyFlakeDetectionAbortReason.FAULTY);
-    }
-    return Collections.emptySet();
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
@@ -166,6 +166,7 @@ public class ProxyTestModule implements TestFrameworkModule {
           earlyFlakeDetectionEnabled && executionStrategy.isEFDLimitReached();
       TestManagementSettings testManagementSettings = executionSettings.getTestManagementSettings();
       boolean testManagementEnabled = testManagementSettings.isEnabled();
+      boolean hasFailedTestReplayTests = executionResults.hasFailedTestReplayTests();
       long testsSkippedTotal = executionResults.getTestsSkippedByItr();
 
       signalClient.send(
@@ -177,6 +178,7 @@ public class ProxyTestModule implements TestFrameworkModule {
               earlyFlakeDetectionEnabled,
               earlyFlakeDetectionFaulty,
               testManagementEnabled,
+              hasFailedTestReplayTests,
               testsSkippedTotal,
               new TreeSet<>(testFrameworks)));
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -153,6 +153,10 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       setTag(Tags.TEST_TEST_MANAGEMENT_ENABLED, true);
     }
 
+    if (executionResults.hasFailedTestReplayTests()) {
+      setTag(DDTags.TEST_HAS_FAILED_TEST_REPLAY, true);
+    }
+
     super.end(endTime);
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -7,12 +7,9 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.civisibility.config.LibraryCapability;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
-import datadog.trace.api.civisibility.telemetry.TagValue;
-import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
 import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.civisibility.Constants;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestSession;
@@ -22,7 +19,6 @@ import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionStrategy;
 import java.util.Collection;
-import java.util.Collections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -97,15 +93,8 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         TagMergeSpec.of(Tags.TEST_EARLY_FLAKE_ENABLED),
         TagMergeSpec.of(Tags.TEST_EARLY_FLAKE_ABORT_REASON),
         TagMergeSpec.of(DDTags.CI_ITR_TESTS_SKIPPED),
-        TagMergeSpec.of(Tags.TEST_TEST_MANAGEMENT_ENABLED));
-  }
-
-  @Override
-  protected Collection<TagValue> additionalTelemetryTags() {
-    if (Constants.EFD_ABORT_REASON_FAULTY.equals(span.getTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON))) {
-      return Collections.singleton(EarlyFlakeDetectionAbortReason.FAULTY);
-    }
-    return Collections.emptySet();
+        TagMergeSpec.of(Tags.TEST_TEST_MANAGEMENT_ENABLED),
+        TagMergeSpec.of(DDTags.TEST_HAS_FAILED_TEST_REPLAY));
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -13,12 +13,14 @@ public class ModuleExecutionResult extends ModuleSignal {
   private static final int EARLY_FLAKE_DETECTION_ENABLED_FLAG = 4;
   private static final int EARLY_FLAKE_DETECTION_FAULTY_FLAG = 8;
   private static final int TEST_MANAGEMENT_ENABLED_FLAG = 16;
+  private static final int HAS_FAILED_TEST_REPLAY_TESTS_FLAG = 32;
 
   private final boolean coverageEnabled;
   private final boolean testSkippingEnabled;
   private final boolean earlyFlakeDetectionEnabled;
   private final boolean earlyFlakeDetectionFaulty;
   private final boolean testManagementEnabled;
+  private final boolean hasFailedTestReplayTests;
   private final long testsSkippedTotal;
   private final Collection<TestFramework> testFrameworks;
 
@@ -30,6 +32,7 @@ public class ModuleExecutionResult extends ModuleSignal {
       boolean earlyFlakeDetectionEnabled,
       boolean earlyFlakeDetectionFaulty,
       boolean testManagementEnabled,
+      boolean hasFailedTestReplayTests,
       long testsSkippedTotal,
       Collection<TestFramework> testFrameworks) {
     super(sessionId, moduleId);
@@ -38,6 +41,7 @@ public class ModuleExecutionResult extends ModuleSignal {
     this.earlyFlakeDetectionEnabled = earlyFlakeDetectionEnabled;
     this.earlyFlakeDetectionFaulty = earlyFlakeDetectionFaulty;
     this.testManagementEnabled = testManagementEnabled;
+    this.hasFailedTestReplayTests = hasFailedTestReplayTests;
     this.testsSkippedTotal = testsSkippedTotal;
     this.testFrameworks = testFrameworks;
   }
@@ -62,6 +66,10 @@ public class ModuleExecutionResult extends ModuleSignal {
     return testManagementEnabled;
   }
 
+  public boolean hasFailedTestReplayTests() {
+    return hasFailedTestReplayTests;
+  }
+
   public long getTestsSkippedTotal() {
     return testsSkippedTotal;
   }
@@ -84,6 +92,7 @@ public class ModuleExecutionResult extends ModuleSignal {
         && moduleId == that.moduleId
         && coverageEnabled == that.coverageEnabled
         && testSkippingEnabled == that.testSkippingEnabled
+        && hasFailedTestReplayTests == that.hasFailedTestReplayTests
         && testsSkippedTotal == that.testsSkippedTotal
         && Objects.equals(testFrameworks, that.testFrameworks);
   }
@@ -95,6 +104,7 @@ public class ModuleExecutionResult extends ModuleSignal {
         moduleId,
         coverageEnabled,
         testSkippingEnabled,
+        hasFailedTestReplayTests,
         testsSkippedTotal,
         testFrameworks);
   }
@@ -108,6 +118,8 @@ public class ModuleExecutionResult extends ModuleSignal {
         + moduleId
         + ", coverageEnabled="
         + coverageEnabled
+        + ", hasFailedTestReplayTests="
+        + hasFailedTestReplayTests
         + ", testSkippingEnabled="
         + testSkippingEnabled
         + ", itrTestsSkipped="
@@ -142,6 +154,9 @@ public class ModuleExecutionResult extends ModuleSignal {
     if (testManagementEnabled) {
       flags |= TEST_MANAGEMENT_ENABLED_FLAG;
     }
+    if (hasFailedTestReplayTests) {
+      flags |= HAS_FAILED_TEST_REPLAY_TESTS_FLAG;
+    }
     s.write(flags);
 
     s.write(testsSkippedTotal);
@@ -160,6 +175,7 @@ public class ModuleExecutionResult extends ModuleSignal {
     boolean earlyFlakeDetectionEnabled = (flags & EARLY_FLAKE_DETECTION_ENABLED_FLAG) != 0;
     boolean earlyFlakeDetectionFaulty = (flags & EARLY_FLAKE_DETECTION_FAULTY_FLAG) != 0;
     boolean testManagementEnabled = (flags & TEST_MANAGEMENT_ENABLED_FLAG) != 0;
+    boolean hasFailedTestReplayTests = (flags & HAS_FAILED_TEST_REPLAY_TESTS_FLAG) != 0;
 
     long testsSkippedTotal = Serializer.readLong(buffer);
     Collection<TestFramework> testFrameworks =
@@ -173,6 +189,7 @@ public class ModuleExecutionResult extends ModuleSignal {
         earlyFlakeDetectionEnabled,
         earlyFlakeDetectionFaulty,
         testManagementEnabled,
+        hasFailedTestReplayTests,
         testsSkippedTotal,
         testFrameworks);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionResults.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionResults.java
@@ -1,10 +1,12 @@
 package datadog.trace.civisibility.test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 
 public class ExecutionResults {
 
   private final LongAdder testsSkippedByItr = new LongAdder();
+  private final AtomicBoolean hasFailedTestReplayTests = new AtomicBoolean();
 
   public void incrementTestsSkippedByItr() {
     testsSkippedByItr.increment();
@@ -12,5 +14,13 @@ public class ExecutionResults {
 
   public long getTestsSkippedByItr() {
     return testsSkippedByItr.sum();
+  }
+
+  public void setHasFailedTestReplayTests() {
+    this.hasFailedTestReplayTests.set(true);
+  }
+
+  public boolean hasFailedTestReplayTests() {
+    return hasFailedTestReplayTests.get();
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -16,11 +16,11 @@ class ModuleExecutionResultTest extends Specification {
 
     where:
     signal << [
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, false, false, false, false, 0, Collections.emptyList()),
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, true, false, true, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2"))),
-      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, true, true, false, false, 2, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework("junit", "5.9.2"))),
-      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, false, false, false, true, true, 3, Arrays.asList(new TestFramework("junit", null), new TestFramework("junit", "5.9.2"))),
-      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, true, true, true, true, true, Integer.MAX_VALUE, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework(null, "5.9.2")))
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, false, false, false, false, false, 0, Collections.emptyList()),
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, true, false, true, true, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2"))),
+      new ModuleExecutionResult(DDTraceId.from(12345), 67890, false, true, true, false, false, true, 2, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework("junit", "5.9.2"))),
+      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, false, false, false, true, true, false, 3, Arrays.asList(new TestFramework("junit", null), new TestFramework("junit", "5.9.2"))),
+      new ModuleExecutionResult(DD128bTraceId.from(12345, 67890), 67890, true, true, true, true, true, true, Integer.MAX_VALUE, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework(null, "5.9.2")))
     ]
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -12,7 +12,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -41,8 +41,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
-    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, true, true, false, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, true, true, false, false, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -70,8 +70,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, true, false, true, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
-    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, false, true, false, true, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalA = new ModuleExecutionResult(DDTraceId.from(123), 456, true, false, true, false, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signalB = new ModuleExecutionResult(DDTraceId.from(234), 567, false, true, false, true, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -118,7 +118,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2"))))
+      client.send(new ModuleExecutionResult(DDTraceId.from(123), 456, false, false, false, false, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2"))))
     }
 
     then:
@@ -130,7 +130,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
+    def signal = new ModuleExecutionResult(DDTraceId.from(123), 456, true, true, false, false, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")))
     def server = new SignalServer()
 
     def errorResponse = new ErrorResponse("An error occurred while processing the signal")

--- a/dd-smoke-tests/junit-console/src/test/resources/test_junit_console_failed_test_replay/events.ftl
+++ b/dd-smoke-tests/junit-console/src/test/resources/test_junit_console_failed_test_replay/events.ftl
@@ -325,6 +325,7 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_6},
+      "_dd.test.has_failed_test_replay" : "true",
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -371,6 +372,7 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_7},
+      "_dd.test.has_failed_test_replay" : "true",
       "_dd.test.is_user_provided_service" : "true",
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
       "component" : "junit5",

--- a/dd-smoke-tests/maven/src/test/resources/test_failed_maven_failed_test_replay/events.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_failed_maven_failed_test_replay/events.ftl
@@ -4,6 +4,7 @@
     "error" : 1,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.test.has_failed_test_replay" : "true",
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -54,6 +55,7 @@
     "error" : 1,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "_dd.test.has_failed_test_replay" : "true",
       "_dd.test.is_user_provided_service" : "true",
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
       "component" : "maven",

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -78,6 +78,7 @@ public class DDTags {
   public static final String CI_ENV_VARS = "_dd.ci.env_vars";
   public static final String CI_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped";
   public static final String TEST_IS_USER_PROVIDED_SERVICE = "_dd.test.is_user_provided_service";
+  public static final String TEST_HAS_FAILED_TEST_REPLAY = "_dd.test.has_failed_test_replay";
   public static final String MEASURED = "_dd.measured";
   public static final String PID_TAG = "process_id";
   public static final String SCHEMA_VERSION_TAG_KEY = "_dd.trace_span_attribute_schema";


### PR DESCRIPTION
# What Does This Do
- Sets the `has_failed_test_replay` field in `event_finished` metrics when the session contained at least one test with Failed Test Replay debug info captured. 

# Motivation

- Follow-up PR to #9214 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
