### PR TITLE
Exclude non Temurin JDK for structured concurrency smoke tests

### DIFF
--- a/dd-smoke-tests/concurrent/java-25/build.gradle
+++ b/dd-smoke-tests/concurrent/java-25/build.gradle
@@ -10,6 +10,8 @@ ext {
   // Relying on forked JVM 25 is hardcoded in the test suites (see createProcessBuilder()).
   minJavaVersionForTests = JavaVersion.VERSION_1_8
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
+  // Only runs on Temurin build as it spawns a Temurin 25 for test process.
+  excludeJdk = ['IBM8', 'SEMERU8']
 }
 
 apply from: "$rootDir/gradle/java.gradle"


### PR DESCRIPTION
# What Does This Do

This PR excludes non Temurin JDK from smoke test jobs as the hardcoded forked JVM spawn to run the test application is a Temurin based and won't start with [non standard JVM args](https://github.com/DataDog/dd-trace-java/blob/d858d534450accb13fdd442cff6d31b833a7d942/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy#L195).

# Motivation

Smoke test CI jobs for IBM / Semuru are failing.

# Additional Notes

Thanks @AlexeyKuznetsov-DD for the highlight!

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
