### PR TITLE
Roll back the pinned version of mule-4, since the issue has already been fixed in the external repository

### DIFF
--- a/dd-java-agent/instrumentation/mule-4/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4/build.gradle
@@ -265,27 +265,3 @@ idea {
     jdkName = '11'
   }
 }
-
-// TODO: Remove once correct version of mule-extensions-xxx will be released.
-dependencies {
-  def reason = 'Temporary hardcode to `1.9.9` because `1.9.10` is failing during latest dependencies resolution on not existing `mule-plugin-mgmt-parent-pom:4.9.8-rc1`'
-
-  constraints {
-    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api') {
-      version { strictly '1.9.9' }
-      because reason
-    }
-    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-mime-types') {
-      version { strictly '1.9.9' }
-      because reason
-    }
-    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api-dsql') {
-      version { strictly '1.9.9' }
-      because reason
-    }
-    add('latestDepForkedTestImplementation', 'org.mule.runtime:mule-extensions-api-persistence') {
-      version { strictly '1.9.9' }
-      because reason
-    }
-  }
-}


### PR DESCRIPTION
# What Does This Do
Roll back the pinned version of mule-4, since the issue has already been fixed in the external repository

# Motivation
Clean code.

# Additional Notes
Cleanup #9466 changes.
