### PR TITLE
Reuse SpanBuilder within a Thread

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -977,9 +977,28 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public CoreSpanBuilder buildSpan(
       final String instrumentationName, final CharSequence operationName) {
-    CoreSpanBuilder tlSpanBuilder = this.tlSpanBuilder.get();
-    tlSpanBuilder.reset(instrumentationName, operationName);
-    return tlSpanBuilder;
+	// retrieve the thread's typical SpanBuilder and check if it is currently in use
+	CoreSpanBuilder tlSpanBuilder = this.tlSpanBuilder.get();
+	boolean wasReset = tlSpanBuilder.reset(instrumentationName, operationName);
+    if ( wasReset ) return tlSpanBuilder;
+    
+    // TODO: counter for how often the fallback is used?
+    CoreSpanBuilder newSpanBuilder = new CoreSpanBuilder(this);
+    newSpanBuilder.reset(instrumentationName, operationName);
+    
+    // DQH - Debated how best to handle the case of someone requesting a CoreSpanBuilder 
+    // and then not using it.  Without an ability to replace the cached CoreSpanBuilder, 
+    // that case could result in permanently burning the cache for a given thread.
+    
+    // That could be solved with additional logic during CoreSpanBuilder#build 
+    // that checks to see if the cached CoreSpanBuilder is in use and then replaces it 
+    // with the freed CoreSpanBuilder, but that would put extra logic in the common path.
+    
+    // Instead of making the release process more complicating, I'm chosing to just 
+    // override here when we know we're already in an uncommon path.
+    this.tlSpanBuilder.set(newSpanBuilder);
+    
+    return newSpanBuilder;
   }
 
   @Override
@@ -1409,10 +1428,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
     return Collections.unmodifiableMap(inverted);
   }
-
+  
   /** Spans are built using this builder */
-  public static class CoreSpanBuilder implements AgentTracer.SpanBuilder {
+  /*
+   * To reduce overhead, CoreSpanBuilders are reused.
+   * For simplicity, CoreSpanBuilder isn't thread safe, so CoreSpanBuilders can only be reused within one thread.
+   */
+  public static final class CoreSpanBuilder implements AgentTracer.SpanBuilder {
     private final CoreTracer tracer;
+    
+    private boolean inUse = false;
 
     private String instrumentationName;
     private CharSequence operationName;
@@ -1436,7 +1461,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       this.tracer = tracer;
     }
 
-    void reset(String instrumentationName, CharSequence operationName) {
+    boolean reset(String instrumentationName, CharSequence operationName) {
+      if ( this.inUse ) return false;
+      this.inUse = true;
+      
       this.instrumentationName = instrumentationName;
       this.operationName = operationName;
 
@@ -1448,11 +1476,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       this.errorFlag = false;
       this.spanType = null;
       this.ignoreScope = false;
-      this.builderCiVisibilityContextData = null;
+      this.builderRequestContextDataAppSec = null;
       this.builderRequestContextDataIast = null;
       this.builderCiVisibilityContextData = null;
       this.links = null;
       this.spanId = 0L;
+      
+      return true;
     }
 
     @Override
@@ -1469,6 +1499,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           span.setEndpointTracker(tracker);
         }
       }
+      
+      this.inUse = false;
       return span;
     }
 


### PR DESCRIPTION
# What Does This Do
This changes reuses a SpanBuilder within a thread.

# Motivation
SpanBuilders are one of the major causes of allocation within the client library, but typically only SpanBuilder is needed at a time in a thread.  By reseting and reusing the SpanBuilder, tracing allocation can be reduced significantly.

By reducing allocation, the garbage collector needs to run less frequently improving the maximum sustainable throughput of the host application.

In local tests with Spring Petclinic, this reduces the throughput penalty with tiny heaps (<80m) significantly from -39% to -19%.  On larger heaps, the gain is smaller, since garbage collector has less of an impact on the application.
