### PR TITLE
Correct the mixup in compression algorithms on Oracle JDK 8

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressingRequestBody.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressingRequestBody.java
@@ -85,9 +85,9 @@ final class CompressingRequestBody extends RequestBody {
 
   // https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md#general-structure-of-lz4-frame-format
   private static final int[] LZ4_MAGIC = new int[] {0x04, 0x22, 0x4D, 0x18};
-  private static final int ZIP_MAGIC[] = new int[] {80, 75, 3, 4};
-  private static final int GZ_MAGIC[] = new int[] {31, 139};
-  private static final int ZSTD_MAGIC[] = new int[] {0x28, 0xB5, 0x2F, 0xFD};
+  private static final int[] ZIP_MAGIC = new int[] {80, 75, 3, 4};
+  private static final int[] GZ_MAGIC = new int[] {31, 139};
+  private static final int[] ZSTD_MAGIC = new int[] {0x28, 0xB5, 0x2F, 0xFD};
 
   private final InputStreamSupplier inputStreamSupplier;
   private final OutputStreamMappingFunction outputStreamMapper;
@@ -364,15 +364,15 @@ final class CompressingRequestBody extends RequestBody {
         {
           return out -> out;
         }
-      case ZSTD:
-        {
-          return CompressingRequestBody::toZstdStream;
-        }
-      case ON:
       case LZ4:
-      default:
         {
           return CompressingRequestBody::toLz4Stream;
+        }
+      case ON:
+      case ZSTD:
+      default:
+        {
+          return CompressingRequestBody::toZstdStream;
         }
     }
   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressionType.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressionType.java
@@ -35,7 +35,7 @@ enum CompressionType {
       case "zstd":
         return ZSTD;
       default:
-        log.warn("Unrecognizable compression type: {}. Defaulting to 'lz4'.", type);
+        log.warn("Unrecognizable compression type: {}. Defaulting to '{}'.", type, ZSTD);
         return ON;
     }
   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/CompressingRequestBodyTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/CompressingRequestBodyTest.java
@@ -170,7 +170,6 @@ class CompressingRequestBodyTest {
           break;
         }
       case LZ4:
-      case ON:
         {
           assertTrue(CompressingRequestBody.isLz4(compressedStream));
           byte[] uncompressed = IOUtils.toByteArray(new LZ4FrameInputStream(compressedStream));
@@ -188,6 +187,7 @@ class CompressingRequestBodyTest {
           assertEquals(compressed.length, instance.getWrittenBytes());
           break;
         }
+      case ON:
       case ZSTD:
         {
           assertTrue(CompressingRequestBody.isZstd(compressedStream));

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -373,11 +373,11 @@ public class ProfileUploaderTest {
     byte[] uploadedBytes = rawJfr.get();
     if (compression.equals("gzip")) {
       uploadedBytes = unGzip(uploadedBytes);
-    } else if (compression.equals("zstd")) {
-      uploadedBytes = unZstd(uploadedBytes);
-    } else if (compression.equals("on")
-        || compression.equals("lz4")
+    } else if (compression.equals("zstd")
+        || compression.equals("on")
         || compression.equals("invalid")) {
+      uploadedBytes = unZstd(uploadedBytes);
+    } else if (compression.equals("lz4")) {
       uploadedBytes = unLz4(uploadedBytes);
     }
     assertArrayEquals(expectedBytes, uploadedBytes);


### PR DESCRIPTION
# What Does This Do
This provides the fix for the profiler smoke-tests when running on Oracle JDK 8

# Motivation
Oracle JDK 8 JFR is storing the recordings compressed by GZip - our library detects that and avoids re-compression.
But this will cause issues when we try to decompress the gzip stream using zstd in the smoke tests.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
