### PR TITLE
Update `jackson-databind` library.

### DIFF
--- a/dd-java-agent/agent-ci-visibility/civisibility-test-fixtures/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/civisibility-test-fixtures/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   api group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.1'
   api group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
   api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0'
-  api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.0'
+  api libs.jackson.databind
   api group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.9.6'
   api group: 'org.xmlunit', name: 'xmlunit-core', version: '2.10.3'
 }

--- a/dd-java-agent/agent-crashtracking/build.gradle
+++ b/dd-java-agent/agent-crashtracking/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   testImplementation libs.bundles.junit5
   testImplementation libs.bundles.mockito
+  testImplementation libs.jackson.databind
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: libs.versions.okhttp.legacy.get()
-  testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10'
 }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/build.gradle
@@ -33,11 +33,11 @@ dependencies {
   implementation libs.lz4
   implementation libs.aircompressor
 
-  testImplementation libs.bundles.junit5
   testImplementation project(':dd-java-agent:agent-profiling:profiling-testing')
+  testImplementation project(':utils:test-utils')
+  testImplementation libs.bundles.junit5
   testImplementation libs.bundles.mockito
+  testImplementation libs.jackson.databind
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: libs.versions.okhttp.legacy.get()
-
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
 }
 

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
   testImplementation group: 'com.flipkart.zjsonpatch', name: 'zjsonpatch', version: '0.4.11'
   testImplementation libs.logback.classic
-  testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.0'
+  testImplementation libs.jackson.databind
 }
 
 shadowJar {

--- a/dd-java-agent/instrumentation/finatra-2.9/build.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/build.gradle
@@ -27,14 +27,12 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:netty:netty-4.1')
 
   testImplementation group: 'com.twitter', name: 'finatra-http_2.11', version: '19.12.0'
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
   // Required for older versions of finatra on JDKs >= 11
   testImplementation group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
 
   latestPre207TestImplementation group: 'com.twitter', name: 'finatra-http_2.11', version: '[,20.7.0)'
 
   latestDepTestImplementation group: 'com.twitter', name: 'finatra-http_2.11', version: '+'
-  latestDepTestImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0'
 }
 
 tasks.named("compileLatestDepTestGroovy").configure {

--- a/dd-java-agent/instrumentation/jose-jwt/build.gradle
+++ b/dd-java-agent/instrumentation/jose-jwt/build.gradle
@@ -12,5 +12,4 @@ addTestSuiteForDir('latestDepTest', 'test')
 dependencies {
   testImplementation group: 'com.auth0', name: 'java-jwt', version: '4.0.0-beta.0'
   testImplementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.24.4'
-  testImplementation group: 'com.fasterxml.jackson.core', name:'jackson-databind', version:'2.13.2.2'
 }

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/build.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
   testImplementation group: 'io.cucumber', name: 'cucumber-java', version: '5.4.0'
   testImplementation group: 'io.cucumber', name: 'cucumber-junit', version: '5.4.0'
-  testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.1'
+  testImplementation libs.jackson.databind
 
   latestDepTestImplementation group: 'io.cucumber', name: 'cucumber-java', version: '+'
   latestDepTestImplementation group: 'io.cucumber', name: 'cucumber-junit', version: '+'

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/build.gradle
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
   testImplementation group: 'io.cucumber', name: 'cucumber-junit-platform-engine', version: '5.4.0'
   testImplementation group: 'io.cucumber', name: 'cucumber-java', version: '5.4.0'
-  testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.1'
+  testImplementation libs.jackson.databind
 
   latestDepTestImplementation group: 'io.cucumber', name: 'cucumber-java', version: '+'
   latestDepTestImplementation group: 'io.cucumber', name: 'cucumber-junit-platform-engine', version: '+'

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:java-io')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.8')
-  testImplementation libs.jackson.databind
+  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.4')
 
   // Include latest version of kafka itself along with latest version of client libs.
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.+'
@@ -63,7 +63,7 @@ dependencies {
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:java-io')
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.12')
-  iastLatestDepTest3Implementation libs.jackson.databind
+  iastLatestDepTest3Implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.4')
   iastLatestDepTest3Implementation project(':dd-java-agent:agent-iast:iast-test-fixtures')
 
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:java-io')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.8')
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
+  testImplementation libs.jackson.databind
 
   // Include latest version of kafka itself along with latest version of client libs.
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.+'
@@ -71,7 +71,7 @@ dependencies {
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:java-io')
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   iastLatestDepTest3RuntimeOnly project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.12')
-  iastLatestDepTest3Implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3')
+  iastLatestDepTest3Implementation libs.jackson.databind
   iastLatestDepTest3Implementation project(':dd-java-agent:agent-iast:iast-test-fixtures')
 
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:java-io')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.8')
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
+  testImplementation libs.jackson.databind
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
   testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   testImplementation libs.bundles.mockito
   testImplementation libs.bundles.jmc
   testImplementation libs.aircompressor
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
+  testImplementation libs.jackson.databind
 }
 
 tasks.withType(Test).configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ asm = "9.8"
 cafe_crypto = "0.1.0"
 lz4 = "1.7.1"
 jmh = "1.37"
+jackson = "2.20.0"
 
 [libraries]
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
@@ -99,6 +100,8 @@ coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version
 
 jmc-common = { module = "org.openjdk.jmc:common", version.ref = "jmc" }
 jmc-flightrecorder = { module = "org.openjdk.jmc:flightrecorder", version.ref = "jmc" }
+
+jackson-databind = {module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson"}
 
 [bundles]
 asm = ["asm", "asmcommons"]


### PR DESCRIPTION
# What Does This Do
Upgrades the `jackson-databind` dependency to the latest stable release, with a few exceptions where compatibility issues required holding back specific submodules.

# Motivation
Keeping dependencies up-to-date ensures we benefit from the latest bug fixes, performance improvements, and security patches. This upgrade also reduces the risk of falling too far behind upstream, making future updates smoother.

# Additional Notes
- Certain submodules remain pinned due to known incompatibilities.
- No functional changes to our codebase are expected as part of this upgrade.
- Tests have been run to validate compatibility with the updated library.