### PR TITLE
Disable byte-buddy's Nexus mechanism

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -55,6 +55,7 @@ public class AgentInstaller {
 
   static {
     addByteBuddyRawSetting();
+    disableByteBuddyNexus();
     // register weak map supplier as early as possible
     WeakMaps.registerAsSupplier();
     circularityErrorWorkaround();
@@ -333,6 +334,11 @@ public class AgentInstaller {
         SystemProperties.set(TypeDefinition.RAW_TYPES_PROPERTY, savedPropertyValue);
       }
     }
+  }
+
+  private static void disableByteBuddyNexus() {
+    // disable byte-buddy's Nexus mechanism (we don't need it, and it triggers use of Unsafe)
+    SystemProperties.set("net.bytebuddy.nexus.disabled", "true");
   }
 
   private static AgentBuilder.RedefinitionStrategy.Listener redefinitionStrategyListener(


### PR DESCRIPTION
# What Does This Do

Disable byte-buddy's Nexus mechanism by setting the system property defined in https://javadoc.io/doc/net.bytebuddy/byte-buddy-dep/latest/constant-values.html#net.bytebuddy.dynamic.Nexus.PROPERTY

# Motivation

We don't need byte-buddy's Nexus mechanism, and it triggers use of Unsafe.

The simple constructor for `AgentBuilder.Default` calls the more complex `AgentBuilder` constructor with `new InitializationStrategy.SelfInjection.Split()` as the default initialization strategy. We override this setting later on when we call `disableClassFormatChanges()`, but this doesn't stop the eager construction of  `InitializationStrategy.SelfInjection.Split`, even though it is not actually used.

The `Split` constructor creates a `NexusAccessor` which uses `Unsafe` via reflection to inject the Nexus mechanism (a way of adding [dynamic type initializers](https://javadoc.io/static/net.bytebuddy/byte-buddy-dep/1.17.6/net/bytebuddy/implementation/LoadedTypeInitializer.html))

Setting the `net.bytebuddy.nexus.disabled` system property to `true` skips injection of the Nexus mechanism, and avoids a startup warning about use of `Unsafe` on Java 24+