### PR TITLE
Prevent using v1/input endpoint for snapshots

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -271,13 +271,11 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
         newState.debuggerLogEndpoint = DEBUGGER_ENDPOINT_V1;
       }
       // both debugger v2 and diagnostics endpoints are forwarding events to the DEBUGGER intake
-      // because older agents support diagnostics, we fall back to it before falling back to v1
+      // because older agents support diagnostics from DD agent 7.49
       if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V2)) {
         newState.debuggerSnapshotEndpoint = DEBUGGER_ENDPOINT_V2;
       } else if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
         newState.debuggerSnapshotEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
-      } else if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V1)) {
-        newState.debuggerSnapshotEndpoint = DEBUGGER_ENDPOINT_V1;
       }
       if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
         newState.debuggerDiagnosticsEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -440,8 +440,8 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_TELEMETRY_PROXY_RESPONSE) }
     features.supportsTelemetryProxy()
     features.supportsDebugger()
-    features.getDebuggerSnapshotEndpoint() == "debugger/v1/input"
-    !features.supportsDebuggerDiagnostics()
+    features.getDebuggerSnapshotEndpoint() == "debugger/v1/diagnostics"
+    features.supportsDebuggerDiagnostics()
     0 * _
   }
 

--- a/communication/src/test/resources/agent-features/agent-info-with-telemetry-proxy.json
+++ b/communication/src/test/resources/agent-features/agent-info-with-telemetry-proxy.json
@@ -15,6 +15,7 @@
     "/evp_proxy/v1/",
     "/evp_proxy/v2/",
     "/debugger/v1/input",
+    "/debugger/v1/diagnostics",
     "/v0.7/config"
   ],
   "feature_flags": [

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -341,9 +341,11 @@ public class DebuggerAgent {
   private static String getSnapshotEndpoint(
       Config config, DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery) {
     if (ddAgentFeaturesDiscovery.supportsDebugger()) {
-      return ddAgentFeaturesDiscovery
-          .buildUrl(ddAgentFeaturesDiscovery.getDebuggerSnapshotEndpoint())
-          .toString();
+      String debuggerSnapshotEndpoint = ddAgentFeaturesDiscovery.getDebuggerSnapshotEndpoint();
+      if (debuggerSnapshotEndpoint == null) {
+        throw new IllegalArgumentException("Cannot find snapshot endpoint on datadog agent");
+      }
+      return ddAgentFeaturesDiscovery.buildUrl(debuggerSnapshotEndpoint).toString();
     }
     return config.getFinalDebuggerSnapshotUrl();
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -385,7 +385,7 @@ public class CapturingTestBase {
     setFieldInConfig(config, "dynamicInstrumentationClassFileDumpEnabled", true);
     setFieldInConfig(config, "dynamicInstrumentationVerifyByteCode", false);
     setFieldInConfig(config, "debuggerCodeOriginMaxUserFrames", 20);
-
+    setFieldInConfig(config, "dynamicInstrumentationSnapshotUrl", "http://localhost:8080");
     return config;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
@@ -101,7 +101,7 @@ public class DebuggerAgentTest {
     setFieldInConfig(Config.get(), "dynamicInstrumentationMaxPayloadSize", 4096L);
     setFieldInContainerInfo(ContainerInfo.get(), "containerId", "");
     String infoContent =
-        "{\"endpoints\": [\"v0.4/traces\", \"debugger/v1/input\", \"v0.7/config\"] }";
+        "{\"endpoints\": [\"v0.4/traces\", \"debugger/v1/input\", \"debugger/v1/diagnostics\", \"v0.7/config\"] }";
     datadogAgentServer.enqueue(new MockResponse().setResponseCode(200).setBody(infoContent));
     datadogAgentServer.enqueue(new MockResponse().setResponseCode(200).setBody(infoContent));
     try (BufferedReader reader =

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -80,6 +80,7 @@ import static datadog.communication.http.OkHttpUtils.buildHttpClient
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT
+import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_SNAPSHOT_URL
 import static datadog.trace.api.config.DebuggerConfig.DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious
@@ -308,6 +309,7 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
   def codeOriginSetup() {
     injectSysConfig(CODE_ORIGIN_FOR_SPANS_ENABLED, "true", true)
     injectSysConfig(DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE, "false", true)
+    injectSysConfig(DYNAMIC_INSTRUMENTATION_SNAPSHOT_URL, "http://localhost:1234/debugger/v1/input", true)
     rebuildConfig()
 
     def configuration = Configuration.builder()

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4176,7 +4176,7 @@ public class Config {
     } else if (isCiVisibilityAgentlessEnabled()) {
       return Intake.LOGS.getAgentlessUrl(this) + "logs";
     } else {
-      return getFinalDebuggerBaseUrl() + "/debugger/v1/input";
+      throw new IllegalArgumentException("Cannot find snapshot endpoint on datadog agent");
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -267,6 +267,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(DYNAMIC_INSTRUMENTATION_VERIFY_BYTECODE, "true")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_INSTRUMENT_THE_WORLD, "method")
     prop.setProperty(DYNAMIC_INSTRUMENTATION_EXCLUDE_FILES, "exclude file")
+    prop.setProperty(DYNAMIC_INSTRUMENTATION_SNAPSHOT_URL, "http://somehost:123/debugger/v1/input")
     prop.setProperty(EXCEPTION_REPLAY_ENABLED, "true")
     prop.setProperty(TRACE_X_DATADOG_TAGS_MAX_LENGTH, "128")
     prop.setProperty(JDK_SOCKET_ENABLED, "false")
@@ -2785,7 +2786,6 @@ class ConfigTest extends DDSpecification {
     Config config = Config.get(prop)
 
     then:
-    config.finalDebuggerSnapshotUrl == "http://localhost:8126/debugger/v1/input"
     config.finalDebuggerSymDBUrl == "http://localhost:8126/symdb/v1/input"
   }
 


### PR DESCRIPTION
# What Does This Do
snapshots should always send to DEBUGGER track through v2/input or v1/diagnostics endpoints. v1/input is unredacted.
v1/diagnostics endpoint was introduced since DD agent 7.49

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4522]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4522]: https://datadoghq.atlassian.net/browse/DEBUG-4522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ