### PR TITLE
Fixed git command hangs in case if no remote exists.

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/git/impacted/no_remote/git/config
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/git/impacted/no_remote/git/config
@@ -5,6 +5,7 @@
 	logallrefupdates = true
 	ignorecase = true
 	precomposeunicode = true
+	sshCommand = ssh -o ConnectTimeout=2
 [remote "origin"]
 	url = git@git.com:datadog/non_existing_repo.git
 	fetch = +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
# What Does This Do
Fixes a hanging test: `test get base branch sha: no remote clone`.
The test was failing with: `Timeout while waiting for git ls-remote -.-heads origin main`.

# Motivation
Green CI

# Additional Notes
After enabling debug logs for git, I discovered the issue came from ssh being used by default. Since ssh has no built-in timeout, the process could hang indefinitely.

For the record, there are two possible approaches:
1. Set an SSH timeout: `sshCommand = ssh -o ConnectTimeout=2`.
2. Use an HTTPS URL to bypass SSH entirely: `url = https://some-host/datadog/non_existing_repo.git`

This PR applies option (1), using a timeout.