### PR TITLE
Fix gradle update pipeline

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -48,7 +48,7 @@ jobs:
           GH_ADD_ARGS=""
           COUNT=0
           BRANCH_HEAD=$(git rev-parse HEAD)
-          for lockfile in $(git status --porcelain=v1 | awk '{ print $NF }'); do
+          for lockfile in $(git status --porcelain=v1 -- ':(glob)**/gradle.lockfile' | awk '{ print $NF }'); do
             echo "Found lockfile: $lockfile"
             GH_ADD_ARGS="$GH_ADD_ARGS --add $lockfile"
             COUNT=$((COUNT+1))


### PR DESCRIPTION
# What Does This Do

Fix the pipeline Update Gradle Dependencies

# Motivation

In #7362, the simple `git add "**/gradle.lockfile"` has been replaced by a slightly more complex script that handles signed commit. Though some files or folders that are not `gradle.lockfile` files are included in the commit, causing some [errors](https://github.com/DataDog/dd-trace-java/actions/runs/17888755085/job/50866397699#step:8:66)

# Additional Notes

~Test run : https://github.com/DataDog/dd-trace-java/actions/runs/17917057938~ No test run, octo-sts allow it only on `master` 😢 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
