### PR TITLE
Reference to scheduled action should be inside task to avoid race condition.

### DIFF
--- a/gradle/dump_hanging_test.gradle
+++ b/gradle/dump_hanging_test.gradle
@@ -68,16 +68,16 @@ tasks.withType(Test).configureEach { testTask ->
     }, delayMinutes, TimeUnit.MINUTES)
 
     // Store handles for cancellation in doLast.
-    ext.dumpFuture = future
-    ext.dumpScheduler = scheduler
+    testTask.ext.dumpFuture = future
+    testTask.ext.dumpScheduler = scheduler
   }
 
   doLast {
     // Cancel if the task finished before the scheduled dump.
     try {
-      ext.dumpFuture?.cancel(false)
+      testTask.ext.dumpFuture?.cancel(false)
     } finally {
-      ext.dumpScheduler?.shutdownNow()
+      testTask.ext.dumpScheduler?.shutdownNow()
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Reference to scheduled action should be inside task (not project) to avoid race condition.

# Motivation
Green CI.

# Additional Notes
This is a follow-up on #9414.
