### PR TITLE
Rewrite test-suites in kotlin

### DIFF
--- a/gradle/test-suites.gradle.kts
+++ b/gradle/test-suites.gradle.kts
@@ -1,0 +1,79 @@
+import org.gradle.api.plugins.jvm.JvmTestSuite
+
+fun Project.addTestSuiteExtendingForDir(testSuiteName: String, parentSuiteName: String, dirName: String) {
+  testing {
+    suites {
+      create(testSuiteName, JvmTestSuite::class) {
+        sources {
+          java {
+            srcDirs("src/$dirName/java")
+          }
+          resources {
+            srcDirs("src/$dirName/resources")
+          }
+          if (project.plugins.hasPlugin("groovy")) {
+            groovy {
+              srcDirs("src/$dirName/groovy")
+            }
+          }
+          if (project.plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
+            kotlin {
+              srcDirs("src/$dirName/kotlin")
+            }
+          }
+          if (project.plugins.hasPlugin("scala")) {
+            scala {
+              srcDirs("src/$dirName/scala")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  configurations {
+    val extendConf = { suffix: String ->
+      val config = named("${testSuiteName}${suffix}")
+      val parentConfig = named("${parentSuiteName}${suffix}")
+      if (parentConfig.isPresent) {
+        config.configure {
+          extendsFrom(parentConfig.get())
+        }
+      }
+
+      if (testSuiteName.matches(Regex(".*ForkedTest$"))) {
+        val nonForkedBaseConfName = testSuiteName.replaceFirst("Forked", "")
+        val nonForkedConfig = maybeCreate("${nonForkedBaseConfName}${suffix}")
+        config.configure {
+          extendsFrom(nonForkedConfig)
+        }
+      }
+    }
+
+    extendConf("CompileOnly")
+    extendConf("Implementation")
+    extendConf("RuntimeOnly")
+    extendConf("AnnotationProcessor")
+  }
+
+  tasks.register("${testSuiteName}Jar", Jar::class) {
+    dependsOn(tasks.named("${testSuiteName}Classes"))
+    from(sourceSets.named(testSuiteName).get().output)
+    archiveClassifier.set(testSuiteName)
+  }
+
+  // The project dependency definition cannot sit inside previous blocks. As of Gradle 8.8, configurations cannot be mutated after they have been used as part of the dependency graph.
+  // See: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutate_configuration_after_locking
+  // And related issue: https://github.com/gradle/gradle/issues/28867
+  dependencies {
+    add("${testSuiteName}Implementation", project(project.path))
+  }
+}
+
+fun Project.addTestSuiteForDir(testSuiteName: String, dirName: String) {
+  addTestSuiteExtendingForDir(testSuiteName, "test", dirName)
+}
+
+fun Project.addTestSuite(testSuiteName: String) {
+  addTestSuiteForDir(testSuiteName, testSuiteName)
+}


### PR DESCRIPTION
# What Does This Do

This PR creates a new file `test-suites.gradle.kts`, written in Kotlin. However, this Kotlin file cannot be easily used yet because it needs to replace the original `test-suites.gradle` file. BUT, this file is called from the broader Groovy https://github.com/DataDog/dd-trace-java/blob/master/gradle/java_no_deps.gradle#L15 file, where the `apply from:` mechanism only works for other Groovy files. Thus, we would need to convert all of these transitively dependent build files to Kotlin first, which is a massive undertaking...

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
