### PR TITLE
Exclude config-utils from shadowed sub-projects

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -184,6 +184,7 @@ def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
     exclude(project(':components:context'))
+    exclude(project(':utils:config-utils'))
     exclude(project(':utils:time-utils'))
     exclude(dependency('org.slf4j::'))
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,7 @@ final class CachedData {
       exclude(project(':remote-config:remote-config-api'))
       exclude(project(':remote-config:remote-config-core'))
       exclude(project(':telemetry'))
+      exclude(project(':utils:config-utils'))
       exclude(project(':utils:container-utils'))
       exclude(project(':utils:socket-utils'))
       exclude(project(':utils:time-utils'))


### PR DESCRIPTION
# Motivation

This avoids duplicate jar entries from ending up in the agent jar since the refactoring in https://github.com/DataDog/dd-trace-java/pull/9426

Before:
```
     4434  09-23-2025 14:08   iast/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   metrics/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   trace/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   cws-tls/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   logs-intake/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   appsec/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   profiling/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   debugger/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   inst/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   ci-visibility/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:08   llm-obs/datadog/trace/api/ConfigCollector.classdata
     4434  09-23-2025 14:07   datadog/trace/api/ConfigCollector.class
```

After:
```
     4434  09-23-2025 14:42   datadog/trace/api/ConfigCollector.class
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
