### PR TITLE
Avoid to extract symbols for static final fields

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -82,8 +82,13 @@ public class SymbolExtractor {
   private static List<Symbol> extractFields(ClassNode classNode) {
     List<Symbol> fields = new ArrayList<>();
     for (FieldNode fieldNode : classNode.fields) {
-      SymbolType symbolType =
-          ASMHelper.isStaticField(fieldNode) ? SymbolType.STATIC_FIELD : SymbolType.FIELD;
+      boolean isStatic = ASMHelper.isStaticField(fieldNode);
+      boolean isFinal = ASMHelper.isFinalField(fieldNode);
+      if (isFinal && isStatic) {
+        // skip final static fields, considered as constant and not captured by context probes
+        continue;
+      }
+      SymbolType symbolType = isStatic ? SymbolType.STATIC_FIELD : SymbolType.FIELD;
       LanguageSpecifics fieldSpecifics =
           new LanguageSpecifics.Builder()
               .addModifiers(extractFieldModifiers(fieldNode.access))

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -837,23 +837,8 @@ class SymbolExtractionTransformerTest {
         Enum.class.getTypeName(),
         null,
         null);
-    assertEquals(4, myEnumClassScope.getSymbols().size());
-    Symbol oneField = myEnumClassScope.getSymbols().get(0);
-    assertLangSpecifics(
-        oneField.getLanguageSpecifics(),
-        asList("public", "static", "final", "enum"),
-        null,
-        null,
-        null,
-        null);
-    Symbol valuesField = myEnumClassScope.getSymbols().get(3);
-    assertLangSpecifics(
-        valuesField.getLanguageSpecifics(),
-        asList("private", "static", "final", "synthetic"),
-        null,
-        null,
-        null,
-        null);
+    // enum constants are static final fields and therefore not extracted
+    assertEquals(0, myEnumClassScope.getSymbols().size());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
static final fields are not used in completion anyway and not captured by CapturedContext probes. So those symbols are useless.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4488]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4488]: https://datadoghq.atlassian.net/browse/DEBUG-4488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ