### PR TITLE
Fix symbol extraction for interface static method

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -237,8 +237,10 @@ public class SymbolExtractor {
               "Invalid access modifiers method[" + methodNode.name + methodNode.desc + "]: " + bit);
       }
     }
-    // if class is an interface && method as code this is a default method
-    if ((classNode.access & Opcodes.ACC_INTERFACE) > 0 && methodNode.instructions.size() > 0) {
+    // if class is an interface && method has code && non-static this is a default method
+    if ((classNode.access & Opcodes.ACC_INTERFACE) > 0
+        && methodNode.instructions.size() > 0
+        && (methodNode.access & Opcodes.ACC_STATIC) == 0) {
       results.add("default");
     }
     return results;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -829,6 +829,14 @@ class SymbolExtractionTransformerTest {
         null,
         null,
         Void.TYPE.getTypeName());
+    Scope m4MethodScope = i1ClassScope.getScopes().get(1);
+    assertLangSpecifics(
+        m4MethodScope.getLanguageSpecifics(),
+        asList("public", "static"),
+        null,
+        null,
+        null,
+        String.class.getTypeName());
     Scope myEnumClassScope = symbolSinkMock.jarScopes.get(3).getScopes().get(0);
     assertLangSpecifics(
         myEnumClassScope.getLanguageSpecifics(),

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction14.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction14.java
@@ -23,6 +23,9 @@ public abstract class SymbolExtraction14 extends Object implements I1, I2{
 
 interface I1 {
   default void m3(){}
+  static String m4(String arg){
+    return arg;
+  }
 }
 
 interface I2 {


### PR DESCRIPTION
# What Does This Do
not all methods with code  in interface are default, only the non-static ones

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4271]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4271]: https://datadoghq.atlassian.net/browse/DEBUG-4271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ