### PR TITLE
Remove extra jersey smoke test module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -165,7 +165,6 @@ include(
   ":dd-smoke-tests:gradle",
   ":dd-smoke-tests:grpc-1.5",
   ":dd-smoke-tests:java9-modules",
-  ":dd-smoke-tests:jersey",
   ":dd-smoke-tests:jersey-2",
   ":dd-smoke-tests:jersey-3",
   ":dd-smoke-tests:jboss-modules",


### PR DESCRIPTION
# What Does This Do

Remove extra `:dd-smoke-tests:jersey` module in settings file

# Motivation

Address warning: `
Configuring project ':dd-smoke-tests:jersey' without an existing directory is deprecated. The configured projectDirectory '.../dd-trace-java/dd-smoke-tests/jersey' does not exist, can't be written to or is not a directory. This behavior has been deprecated.`

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
