### PR TITLE
Port remote API response to Java 8+

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -3,6 +3,8 @@ package datadog.trace.common.writer;
 import datadog.trace.relocate.api.IOLogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalInt;
 import org.slf4j.Logger;
 
 public abstract class RemoteApi {
@@ -141,21 +143,19 @@ public abstract class RemoteApi {
       this.response = response;
     }
 
-    public final boolean success() {
+    public boolean success() {
       return success;
     }
 
-    // TODO: DQH - In Java 8, switch to OptionalInteger
-    public final Integer status() {
-      return status;
+    public OptionalInt status() {
+      return status == null ? OptionalInt.empty() : OptionalInt.of(status);
     }
 
-    // TODO: DQH - In Java 8, switch to Optional<Throwable>?
-    public final Throwable exception() {
-      return exception;
+    public Optional<Throwable> exception() {
+      return Optional.ofNullable(exception);
     }
 
-    public final String response() {
+    public String response() {
       return response;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -308,14 +308,14 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     // TODO: missing queue.spans (# of spans being sent)
     flushedBytes.add(sizeInBytes);
 
-    if (response.exception() != null) {
+    if (response.exception().isPresent()) {
       // covers communication errors -- both not receiving a response or
       // receiving malformed response (even when otherwise successful)
       apiErrors.increment();
     }
 
-    Integer status = response.status();
-    if (status != null) {
+    int status = response.status().orElse(0);
+    if (status != 0) {
       if (200 == status) {
         apiResponsesOK.increment();
       } else {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -68,7 +68,8 @@ class DDAgentApiTest extends DDCoreSpecification {
     expect:
     def response = client.sendSerializedTraces(payload)
     response.success()
-    response.status() == 200
+    response.status().present
+    response.status().asInt == 200
     agent.getLastRequest().path == "/" + agentVersion
 
     cleanup:
@@ -96,7 +97,8 @@ class DDAgentApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     !clientResponse.success()
-    clientResponse.status() == 404
+    clientResponse.status().present
+    clientResponse.status().asInt == 404
     agent.getLastRequest().path == "/v0.3/traces"
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -335,7 +335,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onPublish(minimalTrace, _)
     1 * healthMetrics.onSerialize(_)
     1 * healthMetrics.onFlush(false)
-    1 * healthMetrics.onSend(1, _, { response -> response.success() && response.status() == 200 })
+    1 * healthMetrics.onSend(1, _, { response -> response.success() && response.status().present && response.status().asInt == 200 })
 
     when:
     writer.close()
@@ -394,7 +394,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onPublish(minimalTrace, _)
     1 * healthMetrics.onSerialize(_)
     1 * healthMetrics.onFlush(false)
-    1 * healthMetrics.onFailedSend(1, _, { response -> !response.success() && response.status() == 500 })
+    1 * healthMetrics.onFailedSend(1, _, { response -> !response.success() && response.status().present && response.status().asInt == 500 })
 
     when:
     writer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -297,7 +297,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onPublish(minimalTrace, _)
     1 * healthMetrics.onSerialize(_)
     1 * healthMetrics.onFlush(false)
-    1 * healthMetrics.onSend(1, _, { response -> response.success() && response.status() == 200 })
+    1 * healthMetrics.onSend(1, _, { response -> response.success() && response.status().present && response.status().asInt == 200 })
 
     when:
     writer.close()
@@ -355,7 +355,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onPublish(minimalTrace, _)
     1 * healthMetrics.onSerialize(_)
     1 * healthMetrics.onFlush(false)
-    1 * healthMetrics.onFailedSend(1, _, { response -> !response.success() && response.status() == 500 })
+    1 * healthMetrics.onFailedSend(1, _, { response -> !response.success() && response.status().present && response.status().asInt == 500 })
 
     when:
     writer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -60,7 +60,8 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     clientResponse.success()
-    clientResponse.status() == 200
+    clientResponse.status().present
+    clientResponse.status().asInt == 200
     agentEvpProxy.getLastRequest().path == path
     agentEvpProxy.getLastRequest().getHeader(DDEvpProxyApi.DD_EVP_SUBDOMAIN_HEADER) == intakeSubdomain
 
@@ -95,7 +96,8 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     clientResponse.success()
-    clientResponse.status() == 200
+    clientResponse.status().present
+    clientResponse.status().asInt == 200
     agentEvpProxy.getLastRequest().path == path
     agentEvpProxy.getLastRequest().getHeader(DDEvpProxyApi.DD_EVP_SUBDOMAIN_HEADER) == intakeSubdomain
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -58,7 +58,8 @@ class DDIntakeApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     clientResponse.success()
-    clientResponse.status() == 200
+    clientResponse.status().present
+    clientResponse.status().asInt == 200
     intake.getLastRequest().path == path
 
     cleanup:
@@ -92,7 +93,8 @@ class DDIntakeApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     clientResponse.success()
-    clientResponse.status() == 200
+    clientResponse.status().present
+    clientResponse.status().asInt == 200
     intake.getLastRequest().path == path
 
     cleanup:
@@ -126,7 +128,8 @@ class DDIntakeApiTest extends DDCoreSpecification {
     expect:
     def clientResponse = client.sendSerializedTraces(payload)
     clientResponse.success()
-    clientResponse.status() == 200
+    clientResponse.status().present
+    clientResponse.status().asInt == 200
     intake.getLastRequest().path == path
 
     cleanup:
@@ -152,7 +155,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, traces)
 
     expect:
-    client.sendSerializedTraces(payload).status()
+    client.sendSerializedTraces(payload).status().present
     intake.lastRequest.contentType == "application/msgpack"
     convertMap(intake.lastRequest.body) == expectedRequestBody
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -172,7 +172,7 @@ class HealthMetricsTest extends Specification {
 
   def "test onSend #iterationIndex"() {
     setup:
-    def latch = new CountDownLatch(3 + (response.exception() ? 1 : 0) + (response.status() ? 1 : 0))
+    def latch = new CountDownLatch(3 + (response.exception().present ? 1 : 0) + (response.status().present ? 1 : 0))
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
     healthMetrics.start()
 
@@ -184,11 +184,11 @@ class HealthMetricsTest extends Specification {
     1 * statsD.count('api.requests.total', 1)
     1 * statsD.count('flush.traces.total', traceCount)
     1 * statsD.count('flush.bytes.total', sendSize)
-    if (response.exception()) {
+    if (response.exception().present) {
       1 * statsD.count('api.errors.total', 1)
     }
-    if (response.status()) {
-      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status()}"])
+    if (response.status().present) {
+      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status().asInt}"])
     }
     0 * _
 
@@ -209,7 +209,7 @@ class HealthMetricsTest extends Specification {
 
   def "test onFailedSend #iterationIndex"() {
     setup:
-    def latch = new CountDownLatch(3 + (response.exception() ? 1 : 0) + (response.status() ? 1 : 0))
+    def latch = new CountDownLatch(3 + (response.exception().present ? 1 : 0) + (response.status().present ? 1 : 0))
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
     healthMetrics.start()
 
@@ -221,11 +221,11 @@ class HealthMetricsTest extends Specification {
     1 * statsD.count('api.requests.total', 1)
     1 * statsD.count('flush.traces.total', traceCount)
     1 * statsD.count('flush.bytes.total', sendSize)
-    if (response.exception()) {
+    if (response.exception().present) {
       1 * statsD.count('api.errors.total', 1)
     }
-    if (response.status()) {
-      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status()}"])
+    if (response.status().present) {
+      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status().asInt}"])
     }
     0 * _
 

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -97,8 +97,9 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
     expect:
     RemoteApi.Response response = api.sendSerializedTraces(prepareRequest(traces, mapper))
     assert !response.response().isEmpty()
-    assert null == response.exception()
-    assert 200 == response.status()
+    assert !response.exception().present
+    assert response.status().present
+    assert 200 == response.status().asInt
     assert response.success()
     assert discovery.getTraceEndpoint() == "${version}/traces"
     assert endpoint.get() == "${Config.get().getAgentUrl()}/${version}/traces"
@@ -120,8 +121,9 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
     expect:
     RemoteApi.Response response = api.sendSerializedTraces(prepareRequest([[span]], mapper))
     assert !response.response().isEmpty()
-    assert null == response.exception()
-    assert 200 == response.status()
+    assert !response.exception().present
+    assert response.status().present
+    assert 200 == response.status().asInt
     assert response.success()
     assert discovery.getTraceEndpoint() == "${version}/traces"
     assert endpoint.get() == "${Config.get().getAgentUrl()}/${version}/traces"
@@ -137,8 +139,9 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
     expect:
     RemoteApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest(traces, mapper))
     assert !response.response().isEmpty()
-    assert null == response.exception()
-    assert 200 == response.status()
+    assert !response.exception().present
+    assert response.status().present
+    assert 200 == response.status().asInt
     assert response.success()
     assert udsDiscovery.getTraceEndpoint() == "${version}/traces"
     assert endpoint.get() == "http://${SOMEHOST}:${SOMEPORT}/${version}/traces"
@@ -158,8 +161,9 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
     expect:
     RemoteApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest([[span]], mapper))
     assert !response.response().isEmpty()
-    assert null == response.exception()
-    assert 200 == response.status()
+    assert !response.exception().present
+    assert response.status().present
+    assert 200 == response.status().asInt
     assert response.success()
     assert udsDiscovery.getTraceEndpoint() == "${version}/traces"
     assert endpoint.get() == "http://${SOMEHOST}:${SOMEPORT}/${version}/traces"


### PR DESCRIPTION
# What Does This Do

This PR fixes a leftover after Java 8+ migration.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
