### PR TITLE
Fix Gradle Dependencies with `Javadoc` task

### DIFF
--- a/utils/config-utils/build.gradle.kts
+++ b/utils/config-utils/build.gradle.kts
@@ -13,3 +13,7 @@ dependencies {
 
   testImplementation(project(":utils:test-utils"))
 }
+
+tasks.named("javadoc") {
+  dependsOn("generateSupportedConfigurations")
+}


### PR DESCRIPTION
# What Does This Do
Fixes the following issue in build:
```
A problem was found with the configuration of task ':utils:config-utils:javadoc' (type 'Javadoc').`
Reason: Task ':utils:config-utils:javadoc' uses this output of task ':utils:config-utils:generateSupportedConfigurations' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
