### PR TITLE
Convert configurations syntax to use lazy API

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 

--- a/dd-java-agent/instrumentation/axis2-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/axis2-1.3/build.gradle
@@ -14,7 +14,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteForDir('latestDepForkedTest', 'test')
-configurations.all {
+configurations.configureEach {
   // the version used by axis2 isn't available in a public repository - we don't need it, so exclude it
   exclude group: 'org.apache.woden', module: 'woden'
   // shut up about broken xml-api pom relocation

--- a/dd-java-agent/instrumentation/javax-xml/build.gradle
+++ b/dd-java-agent/instrumentation/javax-xml/build.gradle
@@ -14,7 +14,7 @@ repositories {
   }
 }
 
-configurations.all {
+configurations.configureEach {
   // shut up about broken xml-api pom relocation
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -71,7 +71,7 @@ configurations {
   latestMuleServices
 }
 
-configurations.all {
+configurations.configureEach {
   exclude group: 'pull-parser', module: 'pull-parser'
 
   resolutionStrategy {

--- a/dd-java-agent/instrumentation/owasp-esapi-2/build.gradle
+++ b/dd-java-agent/instrumentation/owasp-esapi-2/build.gradle
@@ -7,7 +7,7 @@ muzzle {
   }
 }
 
-configurations.all {
+configurations.configureEach {
   // shut up about broken xml-api pom relocation
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'

--- a/dd-java-agent/instrumentation/resteasy-appsec/build.gradle
+++ b/dd-java-agent/instrumentation/resteasy-appsec/build.gradle
@@ -22,7 +22,7 @@ addTestSuite('jettyAsyncTest')
 //check.dependsOn nettyTest, jettyAsyncTest
 // CI invocations are only for test/latestDepTest
 test.finalizedBy nettyTest, jettyAsyncTest
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.deactivateDependencyLocking()
 }
 dependencies {

--- a/dd-java-agent/instrumentation/spark/build.gradle
+++ b/dd-java-agent/instrumentation/spark/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.deactivateDependencyLocking()
 }
 dependencies {

--- a/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
@@ -13,7 +13,7 @@ muzzle {
     assertInverse = true
   }
 }
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.deactivateDependencyLocking()
 }
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -33,7 +33,7 @@ ext {
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
   maxJavaVersionForTests = JavaVersion.VERSION_11
 }
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.deactivateDependencyLocking()
 }
 dependencies {

--- a/dd-java-agent/instrumentation/sslsocket/build.gradle
+++ b/dd-java-agent/instrumentation/sslsocket/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 // IBM8 is having troubles with TLS set up by jetty 9.4.
 // As a temporary workaround we used a lower jetty version for ssl socket tests
-configurations.all {
+configurations.configureEach {
   resolutionStrategy {
     force group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.2.30.v20200428'
   }

--- a/dd-java-agent/instrumentation/synapse-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/synapse-3.0/build.gradle
@@ -9,7 +9,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
-configurations.all {
+configurations.configureEach {
   // the version used by Synapse isn't available in a public repository - we don't need it, so exclude it
   exclude group: 'org.snmp4j', module: 'snmp4j'
   exclude group: 'org.snmp4j', module: 'snmp4j-agent'

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
@@ -65,7 +65,7 @@ addTestSuiteExtendingForDir('latest10ForkedTest', 'latest10Test', 'latestDepTest
 
 def tomcatVersion = '5.5.12' // earliest 5.5.x available in maven central (with all needed dependencies).
 
-configurations.all {
+configurations.configureEach {
   // shut up about broken xml-api pom relocation
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'

--- a/dd-java-agent/instrumentation/tomcat/tomcat-appsec/tomcat-appsec-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-appsec/tomcat-appsec-5.5/build.gradle
@@ -55,7 +55,7 @@ dependencies {
   implementation project(':dd-java-agent:instrumentation:tomcat:tomcat-common')
 }
 
-configurations.all {
+configurations.configureEach {
   // shut up about broken xml-api pom relocation
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'

--- a/dd-java-agent/instrumentation/tomcat/tomcat-common/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-common/build.gradle
@@ -1,6 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-configurations.all {
+configurations.configureEach {
   // shut up about broken xml-api pom relocation
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-10/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   latestDepTestImplementation group: 'org.eclipse.jetty.websocket', name: 'websocket-javax-server', version: '10.+'
 
   testRuntimeOnly project(":dd-java-agent:instrumentation:websocket:javax-websocket-1.0")
-  configurations.all {
+  configurations.configureEach {
     it.resolutionStrategy {
       force libs.slf4j
     }

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-11/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-11/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   testRuntimeOnly project(":dd-java-agent:instrumentation:websocket:jetty-websocket:jetty-websocket-10")
   testRuntimeOnly project(":dd-java-agent:instrumentation:websocket:jakarta-websocket-2.0")
 
-  configurations.all {
+  configurations.configureEach {
     it.resolutionStrategy {
       force libs.slf4j
     }

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-12/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-12/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   testRuntimeOnly project(":dd-java-agent:instrumentation:websocket:javax-websocket-1.0")
   testRuntimeOnly project(":dd-java-agent:instrumentation:websocket:jakarta-websocket-2.0")
 
-  configurations.all {
+  configurations.configureEach {
     it.resolutionStrategy {
       force libs.slf4j
     }

--- a/dd-trace-ot/build.gradle.kts
+++ b/dd-trace-ot/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
 }
 
 // gradle can't downgrade the opentracing dependencies with `strictly`
-configurations.matching { it.name.startsWith("ot31") }.all {
+configurations.matching { it.name.startsWith("ot31") }.configureEach {
   resolutionStrategy {
     force("io.opentracing:opentracing-api:0.31.0")
     force("io.opentracing:opentracing-util:0.31.0")


### PR DESCRIPTION
# What Does This Do

Convert `configurations.all` (eager API) to `configurations.configureEach` (lazy API)

# Motivation

Build improvements

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
