### PR TITLE
Remove extra `.configure` method

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/CallSiteInstrumentationPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/CallSiteInstrumentationPlugin.kt
@@ -98,7 +98,7 @@ abstract class CallSiteInstrumentationPlugin : Plugin<Project>{
       extendsFrom(project.configurations.named(mainSourceSet.compileClasspathConfigurationName).get())
     }
 
-    project.tasks.named(csiSourceSet.getCompileTaskName("java"), AbstractCompile::class.java).configure {
+    project.tasks.named(csiSourceSet.getCompileTaskName("java"), AbstractCompile::class.java) {
       sourceCompatibility = JavaVersion.VERSION_1_8.toString()
       targetCompatibility = JavaVersion.VERSION_1_8.toString()
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -32,7 +32,7 @@ excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
 
 // Shared JFR implementation. The earliest Java version JFR is working on is Java 8
 
-tasks.named("compileTestJava").configure {
+tasks.named("compileTestJava") {
   setJavaVersion(it, 11)
   // tests should be compiled in Java 8 compatible way
   sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/benchmark/build.gradle
+++ b/dd-java-agent/benchmark/build.gradle
@@ -38,7 +38,7 @@ jmh {
   jmhVersion = libs.versions.jmh.get()
 }
 
-tasks.named('jmh').configure {
+tasks.named('jmh') {
   dependsOn ':dd-java-agent:shadowJar'
 }
 

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -147,7 +147,7 @@ def includeShadowJar(TaskProvider<ShadowJar> shadowJarTask, String jarname) {
     }
   }
 
-  project.tasks.named("processResources").configure {
+  project.tasks.named("processResources") {
     dependsOn shadowJarTask
   }
   shadowJarTask.configure generalShadowJarConfig
@@ -344,7 +344,7 @@ tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 }
 
-tasks.register('checkAgentJarSize').configure {
+tasks.register('checkAgentJarSize') {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
@@ -354,6 +354,6 @@ tasks.register('checkAgentJarSize').configure {
   dependsOn "shadowJar"
 }
 
-tasks.named('check').configure {
+tasks.named('check') {
   dependsOn 'checkAgentJarSize'
 }

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
@@ -18,7 +18,7 @@ apply from: "$rootDir/gradle/test-with-scala.gradle"
 addTestSuite('akka23Test')
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileAkka23TestGroovy").configure {
+tasks.named("compileAkka23TestGroovy") {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)
 }
 
@@ -41,7 +41,7 @@ sourceSets {
     }
   }
 }
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
@@ -68,6 +68,6 @@ configurations.matching({ it.name.startsWith('akka23') }).each({
 
 
 // Run 2.3 tests along with the rest of unit tests
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "akka23Test"
 }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/build.gradle
@@ -103,10 +103,10 @@ dependencies {
   latestDepTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '+'
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "test_before_1_11_106"
 }
 
-tasks.named("forkedTest").configure {
+tasks.named("forkedTest") {
   dependsOn "test_before_1_11_106ForkedTest"
 }

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -128,7 +128,7 @@ if (project.gradle.startParameter.taskNames.any { it.endsWith("generateMuzzleRep
 }
 
 
-tasks.named('shadowJar').configure {
+tasks.named('shadowJar') {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   dependencies {
     // the tracer is now in a separate shadow jar

--- a/dd-java-agent/instrumentation/enable-wallclock-profiling/build.gradle
+++ b/dd-java-agent/instrumentation/enable-wallclock-profiling/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   latestDepTestImplementation group: 'io.netty', name: 'netty-transport', version: '+'
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latestDep4Test"
 }
 

--- a/dd-java-agent/instrumentation/finatra-2.9/build.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/build.gradle
@@ -35,16 +35,16 @@ dependencies {
   latestDepTestImplementation group: 'com.twitter', name: 'finatra-http_2.11', version: '+'
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath = classpath.plus(files(compileLatestDepTestScala.destinationDirectory))
   dependsOn "compileLatestDepTestScala"
 }
 
-tasks.named("compileLatestPre207TestGroovy").configure {
+tasks.named("compileLatestPre207TestGroovy") {
   classpath = classpath.plus(files(compileLatestPre207TestScala.destinationDirectory))
   dependsOn "compileLatestPre207TestScala"
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   finalizedBy latestPre207Test
 }

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
@@ -12,13 +12,13 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepJava11Test', 'latestDepTest', 'test')
 
-tasks.named("compileLatestDepJava11TestJava").configure {
+tasks.named("compileLatestDepJava11TestJava") {
   setJavaVersion(it, 11)
 }
-tasks.named("compileLatestDepJava11TestGroovy").configure {
+tasks.named("compileLatestDepJava11TestGroovy") {
   javaLauncher = getJavaLauncherFor(11)
 }
-tasks.named("latestDepJava11Test").configure {
+tasks.named("latestDepJava11Test") {
   javaLauncher = getJavaLauncherFor(11)
 }
 

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/build.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/build.gradle
@@ -42,7 +42,7 @@ previewTest.configure {
   jvmArgs = ['--enable-preview']
 }
 // Require the preview test suite to run as part of module check
-tasks.named("check").configure {
+tasks.named("check") {
   dependsOn "previewTest"
 }
 

--- a/dd-java-agent/instrumentation/java-http-client/build.gradle
+++ b/dd-java-agent/instrumentation/java-http-client/build.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
 
-tasks.named("compileMain_java11Java").configure {
+tasks.named("compileMain_java11Java") {
   it.sourceCompatibility = JavaVersion.VERSION_11
   it.targetCompatibility = JavaVersion.VERSION_11
   setJavaVersion(it, 11)

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   latestDepTestImplementation group: 'org.jboss.resteasy', name: 'resteasy-jaxrs', version: '+'
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "resteasy31Test"
   dependsOn "nestedTest"
 }

--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -77,12 +77,12 @@ dependencies {
   latestDepJava11TestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '+'
 }
 
-tasks.named("check").configure {
+tasks.named("check") {
   dependsOn "oldH2Test"
   dependsOn "oldPostgresTest"
 }
 
-tasks.named("latestDepJava11Test").configure {
+tasks.named("latestDepJava11Test") {
   javaLauncher = getJavaLauncherFor(11)
 }
 

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
@@ -10,12 +10,12 @@ apply plugin: 'scala'
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn "compileTestScala"
   classpath += files(compileTestScala.destinationDirectory)
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
@@ -105,7 +105,7 @@ instrument {
   ]
 }
 
-tasks['compileMain_jetty10Java'].configure {
+tasks.named("compileMain_jetty10Java") {
   setJavaVersion(it, 11)
 }
 
@@ -114,10 +114,10 @@ addTestSuiteForDir('jetty94ForkedTest', 'test')
 addTestSuiteForDir('latestDepJetty9ForkedTest', 'test')
 addTestSuiteForDir('latestDepForkedTest', 'test')
 
-tasks.named("latestDepForkedTest").configure {
+tasks.named("latestDepForkedTest") {
   javaLauncher = getJavaLauncherFor(11)
 }
-tasks.named("compileLatestDepForkedTestGroovy").configure {
+tasks.named("compileLatestDepForkedTestGroovy") {
   setJavaVersion(it, 11)
 }
 

--- a/dd-java-agent/instrumentation/junit-4.10/build.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/build.gradle
@@ -12,7 +12,7 @@ muzzle {
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(compileLatestDepTestKotlin.destinationDirectory)
 }
 

--- a/dd-java-agent/instrumentation/junit-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/junit-5.3/build.gradle
@@ -58,7 +58,7 @@ configurations.matching({ it.name.startsWith('test') }).each({
   }
 })
 
-tasks.named("compileLatestDepTestJava").configure {
+tasks.named("compileLatestDepTestJava") {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/build.gradle
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/build.gradle
@@ -57,7 +57,7 @@ configurations.matching({ it.name.startsWith('test') }).each({
   }
 })
 
-tasks.named("compileLatestDepTestJava").configure {
+tasks.named("compileLatestDepTestJava") {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/instrumentation/karate/build.gradle
+++ b/dd-java-agent/instrumentation/karate/build.gradle
@@ -81,7 +81,7 @@ sourceSets {
   }
 }
 
-tasks.named("compileLatestDepTestJava").configure {
+tasks.named("compileLatestDepTestJava") {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
@@ -26,15 +26,15 @@ apply from: "$rootDir/gradle/test-with-kotlin.gradle"
 
 addTestSuite('latestDepTest')
 
-tasks.named("compileTestFixturesGroovy").configure {
+tasks.named("compileTestFixturesGroovy") {
   classpath += files(compileTestFixturesKotlin.destinationDirectory)
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(compileTestKotlin.destinationDirectory)
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(compileLatestDepTestKotlin.destinationDirectory)
 }
 

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -114,20 +114,20 @@ forbiddenApisMain_java11 {
   failOnMissingClasses = false
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'mvnPackage', 'extractMuleServices'
 }
 
-tasks.named("compileMule46ForkedTestGroovy").configure {
+tasks.named("compileMule46ForkedTestGroovy") {
   dependsOn 'mvnPackage', 'extractMule46Services'
 }
 
-tasks.named("compileLatestDepForkedTestGroovy").configure {
+tasks.named("compileLatestDepForkedTestGroovy") {
   dependsOn 'mvnPackage', 'extractLatestMuleServices'
   setJavaVersion(it, 17)
 }
 
-tasks.named("compileLatestDepForkedTestJava").configure {
+tasks.named("compileLatestDepForkedTestJava") {
   setJavaVersion(it, 17)
 }
 

--- a/dd-java-agent/instrumentation/netty/netty-buffer-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/netty/netty-buffer-4.0/build.gradle
@@ -21,6 +21,6 @@ dependencies {
   latestDepTestImplementation group: 'io.netty', name: 'netty-buffer', version: '+'
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latestDep4Test"
 }

--- a/dd-java-agent/instrumentation/netty/netty-concurrent-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/netty/netty-concurrent-4.0/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   latestDepTestImplementation group: 'io.netty', name: 'netty-common', version: '+'
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latestDep4Test"
 }
 

--- a/dd-java-agent/instrumentation/netty/netty-promise-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/netty/netty-promise-4.0/build.gradle
@@ -21,6 +21,6 @@ dependencies {
   latestDepTestImplementation group: 'io.netty', name: 'netty-common', version: '+'
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latestDep4Test"
 }

--- a/dd-java-agent/instrumentation/pekko-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/pekko-concurrent/build.gradle
@@ -23,7 +23,7 @@ apply from: "$rootDir/gradle/test-with-scala.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/build.gradle
@@ -108,12 +108,12 @@ latestDepIastTest {
   }
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "baseTest"
   dependsOn "iastTest"
 }
 
-tasks.named('latestDepTest').configure {
+tasks.named('latestDepTest') {
   dependsOn "latestDepIastTest"
 }
 

--- a/dd-java-agent/instrumentation/play/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.6/build.gradle
@@ -126,7 +126,7 @@ configurations.matching({ it.name.startsWith('latestDepTest') }).each({
     force group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.5'
   }
 })
-tasks.named("compileLatestDepTestJava").configure {
+tasks.named("compileLatestDepTestJava") {
   it.sourceCompatibility = JavaVersion.VERSION_11
   it.targetCompatibility = JavaVersion.VERSION_11
   setJavaVersion(it, 11)

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
@@ -40,6 +40,6 @@ tasks.withType(Test).configureEach {
   usesService(testcontainersLimit)
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   finalizedBy latestReactorTest
 }

--- a/dd-java-agent/instrumentation/restlet-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/restlet-2.2/build.gradle
@@ -23,7 +23,7 @@ repositories {
 addTestSuiteForDir('baseForkedTest', 'baseTest')
 addTestSuite('latestDepTest')
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "baseForkedTest"
 }
 

--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -30,6 +30,6 @@ def rmic = tasks.register('rmic', Exec) {
     )
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn rmic
 }

--- a/dd-java-agent/instrumentation/scala-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/scala-concurrent/build.gradle
@@ -19,16 +19,16 @@ addTestSuite('latestDepTest')
 addTestSuiteForDir('latest12Test', 'latestDepTest')
 addTestSuiteForDir('latest11Test', 'test')
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
-tasks.named("compileLatest12TestGroovy").configure {
+tasks.named("compileLatest12TestGroovy") {
   classpath += files(sourceSets.latest12Test.scala.classesDirectory)
 }
-tasks.named("compileLatest11TestGroovy").configure {
+tasks.named("compileLatest11TestGroovy") {
   classpath += files(sourceSets.latest11Test.scala.classesDirectory)
 }
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
@@ -45,7 +45,7 @@ dependencies {
   latestDepTestImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latest11Test"
   dependsOn "latest12Test"
 }

--- a/dd-java-agent/instrumentation/scala-promise/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/build.gradle
@@ -13,7 +13,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala'
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
 

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
@@ -45,17 +45,17 @@ sourceSets {
   latestDepForkedTest.scala.srcDir project(':dd-java-agent:instrumentation:scala-promise').sourceSets.test.scala
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(sourceSets.test.scala.classesDirectory)
   dependsOn "compileTestScala"
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
   dependsOn "compileLatestDepTestScala"
 }
 
-tasks.named("compileLatestDepForkedTestGroovy").configure {
+tasks.named("compileLatestDepForkedTestGroovy") {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
   dependsOn "compileLatestDepForkedTestScala"
 }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
@@ -45,15 +45,15 @@ sourceSets {
   latestDepForkedTest.scala.srcDir project(':dd-java-agent:instrumentation:scala-promise').sourceSets.test.scala
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
-tasks.named("compileLatestDepForkedTestGroovy").configure {
+tasks.named("compileLatestDepForkedTestGroovy") {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
 }
 

--- a/dd-java-agent/instrumentation/scala/build.gradle
+++ b/dd-java-agent/instrumentation/scala/build.gradle
@@ -66,7 +66,7 @@ final testTasks = scalaVersions.collect { scalaLibrary ->
   }
 }
 
-tasks.named('test', Test).configure {
+tasks.named('test', Test) {
   systemProperty('uses.java.concat', false) // version 2.10.7 does not use java concatenation
   finalizedBy(testTasks)
 }

--- a/dd-java-agent/instrumentation/selenium/build.gradle
+++ b/dd-java-agent/instrumentation/selenium/build.gradle
@@ -42,7 +42,7 @@ configurations.matching({ it.name.startsWith('test') || it.name.startsWith('late
   }
 })
 
-tasks.named("compileLatestDepTestJava").configure {
+tasks.named("compileLatestDepTestJava") {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/instrumentation/slick/build.gradle
+++ b/dd-java-agent/instrumentation/slick/build.gradle
@@ -10,12 +10,12 @@ apply plugin: 'scala'
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn "compileTestScala"
   classpath += files(compileTestScala.destinationDirectory)
 }
 
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '+'
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "test_spark24"
   dependsOn "test_spark32"
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -57,6 +57,6 @@ dependencies {
   latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '3.+'
 }
 
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn "test_spark32"
 }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   latestIastTestImplementation project(':dd-java-agent:instrumentation:jackson-core:jackson-core-2.12')
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn "latestBoot20Test"
   dependsOn "latestBoot24Test"
   dependsOn "latestBoot2LatestTest"

--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -67,7 +67,6 @@ dependencies {
   latestDepTestRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-5')
 }
 
-
 def extractWildfly(config, zipFileNamePrefix, sync) {
   delete(fileTree(buildDir).include("wildfly-*/standalone/deployments/**"))
 
@@ -84,7 +83,6 @@ def extractWildfly(config, zipFileNamePrefix, sync) {
     throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
   }
 }
-
 
 tasks.register("extractWildfly", Copy) {
   dependsOn configurations.wildflyTest
@@ -107,21 +105,22 @@ tasks.register("extractLatestWildfly", Copy) {
   onlyIf { !project.rootProject.hasProperty("skipTests") }
 }
 
-
-tasks.named("test").configure {
+tasks.named("test") {
   dependsOn 'extractWildfly'
 }
 
-tasks.named("forkedTest").configure {
+tasks.named("forkedTest") {
   dependsOn 'extractWildfly'
 }
-tasks.named("latestDepForkedTest").configure {
+
+tasks.named("latestDepForkedTest") {
   dependsOn 'extractLatestWildfly'
 }
 
-tasks.named("latestDepTest").configure {
+tasks.named("latestDepTest") {
   dependsOn 'extractLatestWildfly'
 }
+
 compileTestGroovy.configure {
   javaLauncher = getJavaLauncherFor(11)
 }
@@ -131,6 +130,7 @@ compileTestGroovy.configure {
     javaLauncher = getJavaLauncherFor(17)
   }
 }
+
 compileTestJava.configure {
   it.configure {
     setJavaVersion(it, 11)
@@ -154,6 +154,7 @@ processTestResources {
       )
   }
 }
+
 [processLatestDepTestResources, processLatestDepForkedTestResources].each {
   it.filesMatching('**/WEB-INF/web.xml') {
     expand(

--- a/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
@@ -29,7 +29,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
-tasks.named("compileLatestDepTestGroovy").configure {
+tasks.named("compileLatestDepTestGroovy") {
   dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDirectory)
 }

--- a/dd-smoke-tests/armeria-grpc/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/build.gradle
@@ -79,7 +79,7 @@ armeriaBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'armeriaBuild'
   outputs.upToDateWhen {
     !armeriaBuild.didWork

--- a/dd-smoke-tests/concurrent/java-21/build.gradle
+++ b/dd-smoke-tests/concurrent/java-21/build.gradle
@@ -31,7 +31,7 @@ forbiddenApisMain {
   failOnMissingClasses = false
 }
 ['spotlessApply', 'spotlessCheck', 'spotlessJava', 'spotbugsMain'].each {
-  tasks.named(it).configure { enabled = false }
+  tasks.named(it) { enabled = false }
 }
 
 application {

--- a/dd-smoke-tests/concurrent/java-25/build.gradle
+++ b/dd-smoke-tests/concurrent/java-25/build.gradle
@@ -18,7 +18,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'JDK 25 Concurrent Integration Tests'
 
-tasks.named('compileJava').configure {
+tasks.named('compileJava') {
   setJavaVersion(it, 25)
   sourceCompatibility = JavaVersion.VERSION_25
   targetCompatibility = JavaVersion.VERSION_25
@@ -32,7 +32,7 @@ tasks.named('compileJava').configure {
   }
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   setJavaVersion(it, 8)
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
@@ -46,7 +46,7 @@ forbiddenApisMain {
   failOnMissingClasses = false
 }
 ['spotlessApply', 'spotlessCheck', 'spotlessJava', 'spotbugsMain'].each {
-  tasks.named(it).configure { enabled = false }
+  tasks.named(it) { enabled = false }
 }
 
 application {

--- a/dd-smoke-tests/iast-util/iast-util-11/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-11/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   testFixturesImplementation testFixtures(project(":dd-smoke-tests:iast-util"))
 }
 
-tasks.named("compileJava", JavaCompile).configure {
+tasks.named("compileJava", JavaCompile) {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11

--- a/dd-smoke-tests/iast-util/iast-util-17/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-17/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   testFixturesImplementation testFixtures(project(":dd-smoke-tests:iast-util"))
 }
 
-tasks.named("compileJava", JavaCompile).configure {
+tasks.named("compileJava", JavaCompile) {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/dd-smoke-tests/kafka-3/build.gradle
+++ b/dd-smoke-tests/kafka-3/build.gradle
@@ -41,7 +41,7 @@ tasks.register('bootJar', Exec) {
   group('build')
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'bootJar'
   outputs.upToDateWhen {
     !bootJar.didWork

--- a/dd-smoke-tests/log-injection/build.gradle
+++ b/dd-smoke-tests/log-injection/build.gradle
@@ -56,7 +56,7 @@ sourceSets {
 }
 
 
-tasks.named('processLoggingResources').configure {
+tasks.named('processLoggingResources') {
   // Don't know why this tries to copy the logback.xml file twice, but only accept it once
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
@@ -128,7 +128,7 @@ dependencies {
 
 def generateTestingJar(String interfaceName, String backend, List<Configuration> configurationsList) {
   def name = interfaceName + "Interface" + backend + "Backend"
-  tasks.register(name, ShadowJar).configure {
+  tasks.register(name, ShadowJar) {
     from sourceSets.main.output
     from sourceSets.logging.output
 

--- a/dd-smoke-tests/play-2.4/build.gradle
+++ b/dd-smoke-tests/play-2.4/build.gradle
@@ -72,7 +72,7 @@ configurations.testImplementation {
   exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.5/build.gradle
+++ b/dd-smoke-tests/play-2.5/build.gradle
@@ -74,7 +74,7 @@ configurations.testImplementation {
   exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.6/build.gradle
+++ b/dd-smoke-tests/play-2.6/build.gradle
@@ -74,7 +74,7 @@ configurations.testImplementation {
   exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.7/build.gradle
+++ b/dd-smoke-tests/play-2.7/build.gradle
@@ -74,7 +74,7 @@ configurations.testImplementation {
   exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.8-otel/build.gradle
+++ b/dd-smoke-tests/play-2.8-otel/build.gradle
@@ -70,7 +70,7 @@ configurations.testImplementation {
   exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.8-split-routes/build.gradle
+++ b/dd-smoke-tests/play-2.8-split-routes/build.gradle
@@ -70,7 +70,7 @@ configurations.testImplementation {
   exclude group: 'com.typesafe.play', module: "play-test_$scalaVer"
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/play-2.8/build.gradle
+++ b/dd-smoke-tests/play-2.8/build.gradle
@@ -73,7 +73,7 @@ configurations.testImplementation {
   exclude group: 'com.typesafe.play', module: "play-test_$scalaVer"
 }
 
-tasks.named('compileTestGroovy').configure {
+tasks.named('compileTestGroovy') {
   dependsOn 'stageMainDist'
   outputs.upToDateWhen {
     !stageMainDist.didWork

--- a/dd-smoke-tests/quarkus-native/build.gradle
+++ b/dd-smoke-tests/quarkus-native/build.gradle
@@ -60,7 +60,7 @@ if (version >= 17) {
     dependsOn project(':dd-java-agent').tasks.named('shadowJar') // Use dev agent
   }
 
-  tasks.named('compileTestGroovy').configure {
+  tasks.named('compileTestGroovy') {
     dependsOn 'quarkusNativeBuild'
     outputs.upToDateWhen {
       !quarkusNativeBuild.didWork

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -38,7 +38,7 @@ quarkusBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'quarkusBuild'
   outputs.upToDateWhen {
     !quarkusBuild.didWork

--- a/dd-smoke-tests/rum/wildfly-15/build.gradle
+++ b/dd-smoke-tests/rum/wildfly-15/build.gradle
@@ -67,7 +67,7 @@ earBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn tasks.earBuild
   outputs.upToDateWhen {
     !earBuild.didWork

--- a/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
@@ -35,7 +35,7 @@ webfluxBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'webfluxBuild'
   outputs.upToDateWhen {
     !webfluxBuild.didWork

--- a/dd-smoke-tests/spring-boot-3.0-native/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/build.gradle
@@ -64,7 +64,7 @@ if (version >= 17) {
     dependsOn project(':dd-java-agent').tasks.named('shadowJar') // Use dev agent
   }
 
-  tasks.named('compileTestGroovy').configure {
+  tasks.named('compileTestGroovy') {
     dependsOn 'springNativeBuild'
     outputs.upToDateWhen {
       !springNativeBuild.didWork

--- a/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
@@ -39,7 +39,7 @@ webfluxBuild30 {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'webfluxBuild30'
   outputs.upToDateWhen {
     !webfluxBuild30.didWork

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
@@ -39,7 +39,7 @@ compileTestGroovy {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'webmvcBuild30'
   outputs.upToDateWhen {
     !webmvcBuild30.didWork

--- a/dd-smoke-tests/spring-boot-3.3-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.3-webmvc/build.gradle
@@ -39,7 +39,7 @@ compileTestGroovy {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'webmvcBuild3'
   outputs.upToDateWhen {
     !webmvcBuild3.didWork

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(':dd-smoke-tests:iast-util:iast-util-11')
 }
 
-tasks.named("compileJava", JavaCompile).configure {
+tasks.named("compileJava", JavaCompile) {
   setJavaVersion(it, 11)
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(':dd-smoke-tests:iast-util:iast-util-17')
 }
 
-tasks.named("compileJava", JavaCompile).configure {
+tasks.named("compileJava", JavaCompile) {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/dd-smoke-tests/springboot-openliberty-20/build.gradle
+++ b/dd-smoke-tests/springboot-openliberty-20/build.gradle
@@ -21,7 +21,7 @@ tasks.register('mvnStage', Exec) {
   outputs.file jarPath
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'mvnStage'
   outputs.upToDateWhen {
     !mvnStage.didWork

--- a/dd-smoke-tests/springboot-openliberty-23/build.gradle
+++ b/dd-smoke-tests/springboot-openliberty-23/build.gradle
@@ -21,7 +21,7 @@ tasks.register('mvnStage', Exec) {
   outputs.file jarPath
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'mvnStage'
   outputs.upToDateWhen {
     !mvnStage.didWork

--- a/dd-smoke-tests/vertx-3.4/build.gradle
+++ b/dd-smoke-tests/vertx-3.4/build.gradle
@@ -38,7 +38,7 @@ vertxBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'vertxBuild'
   outputs.upToDateWhen {
     !vertxBuild.didWork

--- a/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
+++ b/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
@@ -35,7 +35,7 @@ vertxBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'vertxBuild'
   outputs.upToDateWhen {
     !vertxBuild.didWork

--- a/dd-smoke-tests/vertx-3.9/build.gradle
+++ b/dd-smoke-tests/vertx-3.9/build.gradle
@@ -36,7 +36,7 @@ vertxBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'vertxBuild'
   outputs.upToDateWhen {
     !vertxBuild.didWork

--- a/dd-smoke-tests/vertx-4.2/build.gradle
+++ b/dd-smoke-tests/vertx-4.2/build.gradle
@@ -37,7 +37,7 @@ vertxBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn 'vertxBuild'
   outputs.upToDateWhen {
     !vertxBuild.didWork

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -67,7 +67,7 @@ earBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   dependsOn tasks.earBuild
   outputs.upToDateWhen {
     !earBuild.didWork

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -19,7 +19,7 @@ tasks.register('forkedTestJacocoData') {
   }
 }
 
-tasks.named('jacocoTestReport').configure {
+tasks.named('jacocoTestReport') {
   dependsOn('test', 'forkedTestJacocoData')
   reports {
     xml.required = true
@@ -77,10 +77,10 @@ afterEvaluate {
     onlyIf { !project.rootProject.hasProperty('skipTests') }
   }
 
-  tasks.named('jacocoTestCoverageVerification').configure {
+  tasks.named('jacocoTestCoverageVerification') {
     dependsOn('jacocoTestReport')
   }
-  tasks.named('check').configure {
+  tasks.named('check') {
     dependsOn('jacocoTestCoverageVerification')
   }
 }

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -21,7 +21,7 @@ ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainers
 
 // Task for tests that want to run forked in their own separate JVM
 if (tasks.matching({ it.name == 'forkedTest' }).empty) {
-  tasks.register('forkedTest', Test).configure {
+  tasks.register('forkedTest', Test) {
     useJUnitPlatform()
   }
 }
@@ -252,7 +252,7 @@ project.afterEvaluate {
 
   if (project.plugins.hasPlugin('kotlin')) {
     ['compileKotlin', 'compileTestKotlin'].each { type ->
-      tasks.named(type).configure {
+      tasks.named(type) {
         kotlinDaemonJvmArguments = ["-Xmx256m", "-XX:+UseParallelGC"]
       }
     }

--- a/gradle/test-with-kotlin.gradle
+++ b/gradle/test-with-kotlin.gradle
@@ -2,7 +2,7 @@
 apply plugin: 'kotlin'
 apply from: "$rootDir/gradle/spotless/spotless-kotlin.gradle"
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   //Note: look like it should be `classpath += files(sourceSets.test.kotlin.classesDirectory)`
   //instead, but kotlin plugin doesn't support it (yet?)
   classpath += files(compileTestKotlin.destinationDirectory)

--- a/gradle/test-with-scala.gradle
+++ b/gradle/test-with-scala.gradle
@@ -7,6 +7,6 @@ dependencies {
   testImplementation libs.scala
 }
 
-tasks.named("compileTestGroovy").configure {
+tasks.named("compileTestGroovy") {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }

--- a/test-published-dependencies/ot-is-shaded/build.gradle
+++ b/test-published-dependencies/ot-is-shaded/build.gradle
@@ -115,7 +115,7 @@ tasks.register('checkJarSize') {
   }
 }
 
-tasks.named('check').configure {
+tasks.named('check') {
   dependsOn 'checkJarContents'
   dependsOn 'checkJarSize'
 }

--- a/utils/socket-utils/build.gradle.kts
+++ b/utils/socket-utils/build.gradle.kts
@@ -27,7 +27,7 @@ fun AbstractCompile.setJavaVersion(javaVersionInteger: Int) {
 }
 
 listOf("compileMain_java17Java", "compileTestJava").forEach {
-  tasks.named<JavaCompile>(it).configure {
+  tasks.named<JavaCompile>(it) {
     setJavaVersion(17)
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()


### PR DESCRIPTION
# What Does This Do

`named {}` and `register {}` Gradle methods already invoke `.configure {}`, so removing the extra `.configure` doesn't change existing behavior or laziness.

# Motivation

Clean up build

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
