### PR TITLE
Ensure no unexpected labels are introduced

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 # Contributor Checklist
 
 - Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
-- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
+- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
 - Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
   Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
 - Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,7 +34,7 @@ _Trigger:_ When creating or updating a pull request.
 
 _Action:_ Check the pull request did not introduce unexpected label.
 
-_Recovery:_ Update the pull requets or add a comment to trigger the action again.
+_Recovery:_ Update the pull request or add a comment to trigger the action again.
 
 ### draft-release-notes-on-tag [🔗](draft-release-notes-on-tag.yaml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,14 @@ _Action:_ Check the pull request complies with [the contribution guidelines](htt
 
 _Recovery:_ Manually verify the guideline compliance.
 
+### check-pull-request-labels [🔗](check-pull-request-labels.yaml)
+
+_Trigger:_ When creating or updating a pull request.
+
+_Action:_ Check the pull request did not introduce unexpected label.
+
+_Recovery:_ Update the pull requets or add a comment to trigger the action again.
+
 ### draft-release-notes-on-tag [🔗](draft-release-notes-on-tag.yaml)
 
 _Trigger:_ When creating a tag, or manually (providing a tag)

--- a/.github/workflows/check-pull-request-labels.yaml
+++ b/.github/workflows/check-pull-request-labels.yaml
@@ -1,0 +1,82 @@
+name: Validate PR Label Format
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_pr_labels:
+    name: Check pull request labels
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Skip draft pull requests
+            if (context.payload.pull_request.draft) {
+              return
+            }
+            // Define valid label categories
+            const validCategories = [
+              'type:',
+              'comp:',
+              'inst:',
+              'tag:',
+              'performance:',  // To refactor to 'ci: ' in the future
+              'run-tests:'     // Unused since GitLab migration
+            ]
+            // Look for invalid labels
+            const invalidLabels = context.payload.pull_request.labels
+              .map(label => label.name)
+              .filter(label => validCategories.every(prefix => !label.startsWith(prefix)))
+            const hasInvalidLabels = invalidLabels.length > 0
+            // Get existing comments to check for blocking comment
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            const commentMarker = '<!-- dd-trace-java-check-pr-labels-workflow -->'
+            const blockingComment = comments.data.find(comment => comment.body.includes(commentMarker))
+            // Create or update blocking comment if there are invalid labels
+            if (hasInvalidLabels) {
+              const commentBody = '**PR Blocked - Invalid Label**\n\n' +
+                `The pull request introduced unexpected labels:\n\n` +
+                invalidLabels.map(label => `* \`${label}\``).join('\n') + '\n\n' +
+                '**This PR is blocked until:**\n' +
+                '1. The invalid labels are deleted, and\n' +
+                '2. A maintainer deletes this comment to unblock the PR\n\n' +
+                '**Note:** Simply removing labels from the pull request is not enough - a maintainer must remove the label and delete this comment to remove the block.\n\n' +
+                commentMarker
+
+              if (blockingComment) {
+                // Update existing blocking comment
+                await github.rest.issues.updateComment({
+                  comment_id: blockingComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                })
+              } else {
+                // Create new blocking comment
+                await github.rest.issues.createComment({
+                  issue_number: context.payload.pull_request.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                })
+              }
+              blockingComment = true
+            }
+            if (blockingComment) {
+              // Block the PR by failing the workflow
+              core.setFailed(`PR blocked: Invalid labels detected: (${invalidLabels.join(', ')}). A maintainer must delete the blocking comment after fixing the labels to allow merging.`)
+            }


### PR DESCRIPTION
# What Does This Do

This PR ensures that pull requests don't introduce unexpected labels. 

# Motivation

This should reduce the manual housekeeping effort.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
