### PR TITLE
Update CODEOWNERS (rename apm-sdk-api to apm-sdk-capabilities)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,20 +12,20 @@
 /.gitlab/                              @DataDog/apm-release-platform
 /.gitlab-ci.yml                        @DataDog/apm-release-platform
 
-# @DataDog/apm-sdk-api-java
-/dd-java-agent/agent-otel                                       @DataDog/apm-sdk-api-java
-/dd-smoke-tests/sample-trace                                    @DataDog/apm-sdk-api-java
-/dd-trace-core/src/main/java/datadog/trace/core/baggage         @DataDog/apm-sdk-api-java
-/dd-trace-core/src/test/groovy/datadog/trace/core/baggage       @DataDog/apm-sdk-api-java
-/dd-trace-core/src/main/java/datadog/trace/core/propagation     @DataDog/apm-sdk-api-java
-/dd-trace-core/src/test/groovy/datadog/trace/core/propagation   @DataDog/apm-sdk-api-java
-/dd-trace-core/src/main/java/datadog/trace/core/scopemanager    @DataDog/apm-sdk-api-java
-/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager  @DataDog/apm-sdk-api-java
-/dd-trace-ot/                                                   @DataDog/apm-sdk-api-java
-/internal-api/src/main/java/datadog/trace/bootstrap             @DataDog/apm-sdk-api-java
-/internal-api/src/test/groovy/datadog/trace/bootstrap           @DataDog/apm-sdk-api-java
-/internal-api/src/main/java/datadog/trace/api/sampling          @DataDog/apm-sdk-api-java
-/internal-api/src/test/groovy/datadog/trace/api/sampling        @DataDog/apm-sdk-api-java
+# @DataDog/apm-sdk-capabilities-java
+/dd-java-agent/agent-otel                                       @DataDog/apm-sdk-capabilities-java
+/dd-smoke-tests/sample-trace                                    @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/main/java/datadog/trace/core/baggage         @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/test/groovy/datadog/trace/core/baggage       @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/main/java/datadog/trace/core/propagation     @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/test/groovy/datadog/trace/core/propagation   @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/main/java/datadog/trace/core/scopemanager    @DataDog/apm-sdk-capabilities-java
+/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager  @DataDog/apm-sdk-capabilities-java
+/dd-trace-ot/                                                   @DataDog/apm-sdk-capabilities-java
+/internal-api/src/main/java/datadog/trace/bootstrap             @DataDog/apm-sdk-capabilities-java
+/internal-api/src/test/groovy/datadog/trace/bootstrap           @DataDog/apm-sdk-capabilities-java
+/internal-api/src/main/java/datadog/trace/api/sampling          @DataDog/apm-sdk-capabilities-java
+/internal-api/src/test/groovy/datadog/trace/api/sampling        @DataDog/apm-sdk-capabilities-java
 
 # @DataDog/apm-serverless
 /dd-trace-core/src/main/java/datadog/trace/lambda/              @DataDog/apm-serverless


### PR DESCRIPTION
# What Does This Do

# Motivation
Team name changed from API to Capabilities a while ago - this change is required to reflect this in Github teams

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
