### PR TITLE
Update smoke test tasks to use lazy API

### DIFF
--- a/dd-smoke-tests/appsec/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.appsec.springboot.SpringbootApplication')
   }

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -8,13 +8,13 @@ description = 'SpringBoot Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.appsec.springbootsecurity.SpringbootApplication')
   }
 }
 
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }
 

--- a/dd-smoke-tests/appsec/springboot/build.gradle
+++ b/dd-smoke-tests/appsec/springboot/build.gradle
@@ -7,7 +7,7 @@ description = 'SpringBoot Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.appsec.springboot.SpringbootApplication')
   }

--- a/dd-smoke-tests/cli/build.gradle
+++ b/dd-smoke-tests/cli/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 description = 'Command Line Application Smoke Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.cli.CliApplication')
   }

--- a/dd-smoke-tests/concurrent/java-21/build.gradle
+++ b/dd-smoke-tests/concurrent/java-21/build.gradle
@@ -17,6 +17,7 @@ java {
     languageVersion = JavaLanguageVersion.of(21)
   }
 }
+
 tasks.withType(JavaCompile).configureEach {
   setJavaVersion(it, 21)
   sourceCompatibility = JavaVersion.VERSION_21
@@ -27,9 +28,10 @@ tasks.withType(JavaCompile).configureEach {
 // * forbiddenApis is missing classes
 // * spotless as the google-java-format version does not support Java 21 and can't be changed once applied
 // * spotbugs failed to read class using newer bytecode versions
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }
+
 ['spotlessApply', 'spotlessCheck', 'spotlessJava', 'spotbugsMain'].each {
   tasks.named(it) { enabled = false }
 }

--- a/dd-smoke-tests/concurrent/java-25/build.gradle
+++ b/dd-smoke-tests/concurrent/java-25/build.gradle
@@ -42,9 +42,10 @@ tasks.named('compileTestGroovy') {
 // * forbiddenApis is missing classes
 // * spotless as the google-java-format version does not support Java 25 and can't be changed once applied
 // * spotbugs failed to read class using newer bytecode versions
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }
+
 ['spotlessApply', 'spotlessCheck', 'spotlessJava', 'spotbugsMain'].each {
   tasks.named(it) { enabled = false }
 }

--- a/dd-smoke-tests/crashtracking/build.gradle
+++ b/dd-smoke-tests/crashtracking/build.gradle
@@ -10,7 +10,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Crashtracking Integration Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.crashtracking.CrashtrackingTestApplication')
   }

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -5,13 +7,13 @@ plugins {
 description = 'Check classes loaded by custom system class-loader are transformed'
 apply from: "$rootDir/gradle/java.gradle"
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'sample.app.App')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/spring-boot-plugin.gradle"
 description = 'Kafka Smoke Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.datastreams.kafkaschemaregistry.KafkaProducerWithSchemaRegistry')
   }

--- a/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/latest-jdk-app/build.gradle
@@ -1,10 +1,12 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     id 'application'
     id 'com.gradleup.shadow'
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
     // Define the main class for the application.
     mainClass = 'App'
 }

--- a/dd-smoke-tests/field-injection/build.gradle
+++ b/dd-smoke-tests/field-injection/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -5,13 +7,13 @@ plugins {
 description = 'Check fields get injected where expected'
 apply from: "$rootDir/gradle/java.gradle"
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.fieldinjection.FieldInjectionApp')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   testImplementation project(':dd-java-agent:agent-ci-visibility:civisibility-test-fixtures')
 }
 
-test {
+tasks.named("test", Test) {
   testLogging {
     events "passed", "skipped", "failed", "standardOut", "standardError"
   }

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
   id 'java'
@@ -11,13 +13,13 @@ description = 'IAST propagation Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/iast-util/iast-util-11/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-11/build.gradle
@@ -27,6 +27,6 @@ tasks.named("compileJava", JavaCompile) {
   targetCompatibility = JavaVersion.VERSION_11
 }
 
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }

--- a/dd-smoke-tests/iast-util/iast-util-17/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-17/build.gradle
@@ -27,6 +27,6 @@ tasks.named("compileJava", JavaCompile) {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }

--- a/dd-smoke-tests/java9-modules/build.gradle
+++ b/dd-smoke-tests/java9-modules/build.gradle
@@ -4,7 +4,7 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.moduleapp.ModuleApplication')
   }

--- a/dd-smoke-tests/jersey-2/build.gradle
+++ b/dd-smoke-tests/jersey-2/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 description = 'Jersey 2 Smoke Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes "Main-Class": "com.restserver.Main"
   }

--- a/dd-smoke-tests/jersey-3/build.gradle
+++ b/dd-smoke-tests/jersey-3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 description = 'Jersey 3 Smoke Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes "Main-Class": "smoketest.MainApp"
   }

--- a/dd-smoke-tests/lib-injection/build.gradle
+++ b/dd-smoke-tests/lib-injection/build.gradle
@@ -10,7 +10,7 @@ application {
   mainClass = 'datadog.smoketest.Application'
 }
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes(
       'Premain-Class': 'datadog.smoketest.Agent',

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -16,7 +16,7 @@ dependencies {
   testImplementation project(':dd-java-agent:agent-ci-visibility:civisibility-test-fixtures')
 }
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.maven.MavenRunner')
   }

--- a/dd-smoke-tests/osgi/build.gradle
+++ b/dd-smoke-tests/osgi/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   testImplementation project(':dd-smoke-tests')
 }
 
-jar {
+tasks.named("jar", Jar) {
   include 'datadog/smoketest/osgi/app/**'
 }
 

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -10,7 +12,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Profiling Integration Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.profiling.ProfilingTestApplication')
   }
@@ -43,7 +45,7 @@ tasks.withType(Test).configureEach {
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   include {
     return it.directory || it.path.endsWith('.jar') ||
       it.path.startsWith('io/opentracing') ||

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -34,7 +34,8 @@ tasks.register('quarkusBuild', Exec) {
 }
 
 evaluationDependsOn ':dd-trace-api'
-quarkusBuild {
+
+tasks.named("quarkusBuild") {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -35,7 +35,7 @@ tasks.register('quarkusBuild', Exec) {
 
 evaluationDependsOn ':dd-trace-api'
 
-tasks.named("quarkusBuild") {
+tasks.named("quarkusBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/ratpack-1.5/build.gradle
+++ b/dd-smoke-tests/ratpack-1.5/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.ratpack.RatpackApp')
   }

--- a/dd-smoke-tests/resteasy/build.gradle
+++ b/dd-smoke-tests/resteasy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 description = 'RestEasy Smoke Test.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes "Main-Class": "smoketest.resteasy.Main"
   }

--- a/dd-smoke-tests/rum/tomcat-10/build.gradle
+++ b/dd-smoke-tests/rum/tomcat-10/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   testImplementation project(':dd-smoke-tests:rum')
 }
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'com.example.Main')
   }

--- a/dd-smoke-tests/rum/tomcat-11/build.gradle
+++ b/dd-smoke-tests/rum/tomcat-11/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   testImplementation project(':dd-smoke-tests:rum')
 }
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'com.example.Main')
   }
@@ -28,6 +28,7 @@ java {
     languageVersion = JavaLanguageVersion.of(17)
   }
 }
+
 tasks.withType(JavaCompile).configureEach {
   setJavaVersion(it, 17)
   sourceCompatibility = JavaVersion.VERSION_17

--- a/dd-smoke-tests/rum/tomcat-9/build.gradle
+++ b/dd-smoke-tests/rum/tomcat-9/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   testImplementation project(':dd-smoke-tests:rum')
 }
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'com.example.Main')
   }

--- a/dd-smoke-tests/rum/wildfly-15/build.gradle
+++ b/dd-smoke-tests/rum/wildfly-15/build.gradle
@@ -63,7 +63,7 @@ tasks.register('earBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-tasks.named("earBuild") {
+tasks.named("earBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/rum/wildfly-15/build.gradle
+++ b/dd-smoke-tests/rum/wildfly-15/build.gradle
@@ -63,7 +63,7 @@ tasks.register('earBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-earBuild {
+tasks.named("earBuild") {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'com.gradleup.shadow'
 }
 
-
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -10,13 +10,13 @@ description = 'Spring Boot 2.3 Jetty Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
   mergeServiceFiles()
   append 'META-INF/spring.handlers'

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -7,13 +9,13 @@ description = 'Spring Boot 2.4 Webflux Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -7,13 +9,13 @@ description = 'Spring Boot 2.5 Webflux Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 plugins {
@@ -9,13 +10,13 @@ description = 'Spring Boot 2.6 Webflux Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
   mergeServiceFiles()
   append 'META-INF/spring.handlers'

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -11,13 +11,13 @@ description = 'Spring Boot 2.6 Webmvc Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
   mergeServiceFiles()
   append 'META-INF/spring.handlers'

--- a/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Spring Boot 2.7 Webflux Smoke Tests.'
@@ -31,7 +30,7 @@ tasks.register('webfluxBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-webfluxBuild {
+tasks.named("webfluxBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
@@ -35,7 +35,7 @@ tasks.register('webfluxBuild30', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-webfluxBuild30 {
+tasks.named("webfluxBuild30", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
@@ -35,11 +35,8 @@ tasks.register('webmvcBuild30', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy", GroovyCompile) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
-}
-
-tasks.named("compileTestGroovy") {
   dependsOn 'webmvcBuild30'
   outputs.upToDateWhen {
     !webmvcBuild30.didWork

--- a/dd-smoke-tests/spring-boot-3.3-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.3-webmvc/build.gradle
@@ -35,11 +35,8 @@ tasks.register('webmvcBuild3', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy", GroovyCompile) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
-}
-
-tasks.named("compileTestGroovy") {
   dependsOn 'webmvcBuild3'
   outputs.upToDateWhen {
     !webmvcBuild3.didWork

--- a/dd-smoke-tests/spring-boot-rabbit/build.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -7,13 +9,13 @@ description = 'SpringBoot RabbitMQ Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/spring-security/build.gradle
+++ b/dd-smoke-tests/spring-security/build.gradle
@@ -11,7 +11,7 @@ description = 'Spring Security Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'com.example.jwt.SecurityJwtDemoApplication')
   }
@@ -35,7 +35,7 @@ tasks.withType(Test).configureEach {
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.jar.archiveFile.get()}"
 }
 
-processResources {
+tasks.named("processResources", ProcessResources) {
   doFirst {
     def resourcesDir = sourceSets.main.output.resourcesDir
     resourcesDir.mkdirs()

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
   id 'com.google.protobuf' version '0.8.18'
@@ -31,13 +33,13 @@ protobuf {
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootGrpcApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -29,7 +29,7 @@ tasks.named("compileJava", JavaCompile) {
   targetCompatibility = JavaVersion.VERSION_11
 }
 
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }
 

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -29,7 +29,7 @@ tasks.named("compileJava", JavaCompile) {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
-forbiddenApisMain {
+tasks.named("forbiddenApisMain") {
   failOnMissingClasses = false
 }
 

--- a/dd-smoke-tests/springboot-mongo/build.gradle
+++ b/dd-smoke-tests/springboot-mongo/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'com.gradleup.shadow'
 }
@@ -7,13 +9,13 @@ description = 'SpringBoot Spring-Data-Mongo Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }
 }
 
-shadowJar {
+tasks.named("shadowJar", ShadowJar) {
   configurations = [project.configurations.runtimeClasspath]
 }
 

--- a/dd-smoke-tests/springboot-openliberty-23/build.gradle
+++ b/dd-smoke-tests/springboot-openliberty-23/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "$rootDir/gradle/java.gradle"
 description = 'SpringBoot Open Liberty Smoke Tests'
 

--- a/dd-smoke-tests/springboot/build.gradle
+++ b/dd-smoke-tests/springboot/build.gradle
@@ -12,7 +12,7 @@ description = 'SpringBoot Smoke Tests.'
 
 // The standard spring-boot plugin doesn't play nice with our project
 // so we'll build a fat jar instead
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.springboot.SpringbootApplication')
   }

--- a/dd-smoke-tests/tracer-flare/build.gradle
+++ b/dd-smoke-tests/tracer-flare/build.gradle
@@ -1,7 +1,7 @@
 apply from: "$rootDir/gradle/java.gradle"
 description = 'Tracer Flare Smoke Tests.'
 
-jar {
+tasks.named("jar", Jar) {
   manifest {
     attributes('Main-Class': 'datadog.smoketest.flare.SimpleApp')
   }

--- a/dd-smoke-tests/vertx-3.4/build.gradle
+++ b/dd-smoke-tests/vertx-3.4/build.gradle
@@ -34,7 +34,7 @@ tasks.register('vertxBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-vertxBuild {
+tasks.named("vertxBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
+++ b/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
@@ -31,7 +31,7 @@ tasks.register('vertxBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-vertxBuild {
+tasks.named("vertxBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/vertx-3.9/build.gradle
+++ b/dd-smoke-tests/vertx-3.9/build.gradle
@@ -32,7 +32,7 @@ tasks.register('vertxBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-vertxBuild {
+tasks.named("vertxBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/vertx-4.2/build.gradle
+++ b/dd-smoke-tests/vertx-4.2/build.gradle
@@ -33,7 +33,7 @@ tasks.register('vertxBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-vertxBuild {
+tasks.named("vertxBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -63,7 +63,7 @@ tasks.register('earBuild', Exec) {
   .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
-earBuild {
+tasks.named("earBuild", Exec) {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 


### PR DESCRIPTION
# What Does This Do

Update smoke test gradle file tasks to use lazy API formatting

# Motivation

Build improvements

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
