### PR TITLE
wildfly-9.0 configuration was eager and misplaced

### DIFF
--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
+
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_11
   latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_17
@@ -53,53 +55,49 @@ dependencies {
   latestDepTestImplementation group: 'org.wildfly.core', name: 'wildfly-server', version: '+'
   wildflyLatestDepTest "org.wildfly:wildfly-dist:+@zip"
 
-  configurations.wildflyLatestDepTest.resolve()
-  def latestWildflyVersion = configurations.wildflyLatestDepTest.resolvedConfiguration.getResolvedArtifacts().find {
-    it.name == "wildfly-dist"
-  }.moduleVersion.id.version
-
-  latestDepForkedTest {
-    configure {
-      jvmArgs += ["-Dtest.jboss.home=$buildDir/wildfly-${latestWildflyVersion}"]
-    }
-  }
-
   latestDepTestRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-5')
 }
 
-def extractWildfly(config, zipFileNamePrefix, sync) {
-  delete(fileTree(buildDir).include("wildfly-*/standalone/deployments/**"))
+def extractWildfly(NamedDomainObjectProvider<Configuration> config, String zipFileNamePrefix, Copy sync) {
+  def zipPath = config.map { Configuration c ->
+    c.filter { File file ->
+      file.name.startsWith(zipFileNamePrefix)
+    }.singleFile
+  }.orElse(providers.provider { throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix) })
 
-  def zipPath = config.find {
-    it.name.startsWith(zipFileNamePrefix)
+  sync.from(zipTree(zipPath)) {
+    // Strip the first path segment
+    eachFile { FileCopyDetails f ->
+      def segments = f.relativePath.segments
+      if (segments.length > 1) {
+        f.relativePath = new RelativePath(!f.directory, segments[1..-1] as String[])
+      } else {
+        f.exclude()
+      }
+    }
   }
-  if (zipPath != null) {
-    def zipFile = file(zipPath)
-    def outputDir = file("${buildDir}")
-
-    sync.from zipTree(zipFile)
-    sync.into outputDir
-  } else {
-    throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
+  sync.into(layout.buildDirectory.dir("tmp/wildfly-dist-${config.name}"))
+  sync.doFirst {
+    delete(sync.destinationDir)
   }
 }
 
-tasks.register("extractWildfly", Copy) {
+def extractWildflyTask = tasks.register("extractWildfly", Copy) {
   dependsOn configurations.wildflyTest
   mustRunAfter tasks.compileTestGroovy
-  extractWildfly(configurations.wildflyTest, "wildfly-dist", it)
+  extractWildfly(configurations.named("wildflyTest"), "wildfly-dist", it)
 
   // When tests are disabled this would still be run, so disable this manually
   onlyIf { !project.rootProject.hasProperty("skipTests") }
 }
 
-tasks.register("extractLatestWildfly", Copy) {
+def extractLatestWildfly = tasks.register("extractLatestWildfly", Copy) {
   mustRunAfter tasks.compileLatestDepTestGroovy
   mustRunAfter tasks.compileLatestDepForkedTestGroovy
   mustRunAfter tasks.compileLatestDepTestJava
   mustRunAfter tasks.compileLatestDepForkedTestJava
   mustRunAfter tasks.compileJava
-  extractWildfly(configurations.wildflyLatestDepTest, "wildfly", it)
+  extractWildfly(configurations.named("wildflyLatestDepTest"), "wildfly", it)
 
   // When tests are disabled this would still be run, so disable this manually
   onlyIf { !project.rootProject.hasProperty("skipTests") }
@@ -163,10 +161,31 @@ processTestResources {
   }
 }
 
-forkedTest {
-  configure {
-    jvmArgs += ["-Dtest.jboss.home=$buildDir/wildfly-21.0.0.Final"]
+abstract class DistributionLocationProvider implements CommandLineArgumentProvider {
+  @InputDirectory
+  @PathSensitive(PathSensitivity.RELATIVE)
+  abstract Property<File> getDistribution()
+
+  @Override
+  Iterable<String> asArguments() {
+    ["-Dtest.jboss.home=${distribution.get()}"]
   }
+}
+
+tasks.named("forkedTest", Test) {
+  jvmArgumentProviders.add(
+    objects.newInstance(DistributionLocationProvider).tap {
+      distribution = extractWildflyTask.map { it.destinationDir }
+    }
+    )
+}
+
+tasks.named("latestDepForkedTest", Test) {
+  jvmArgumentProviders.add(
+    objects.newInstance(DistributionLocationProvider).tap {
+      distribution = extractLatestWildfly.map { it.destinationDir }
+    }
+    )
 }
 
 


### PR DESCRIPTION
# What Does This Do

Task declaration was misplaced in the dependencies block. And the `forkedTest` and `latestDepForkedTest` tasks had an awkward setup depending on the resolved version. Moreover, the extract tasks where using the `buildDir` as destination which overlapped with every other tasks input in this project. 

Now the tasks are properly wired and extracted in proper subfolders.  

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
