### PR TITLE
Introducing NativeLoader

### DIFF
--- a/components/nativeloader/build.gradle.kts
+++ b/components/nativeloader/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  `java-library`
+}
+
+apply(from = "$rootDir/gradle/java.gradle")
+
+dependencies {
+  implementation(project(":components:environment"))
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/ClassLoaderResourcePathLocator.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/ClassLoaderResourcePathLocator.java
@@ -1,0 +1,39 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+import java.util.Objects;
+
+public final class ClassLoaderResourcePathLocator implements PathLocator {
+  private final ClassLoader classLoader;
+  private final String baseResource;
+  
+  public ClassLoaderResourcePathLocator(
+    final ClassLoader classLoader,
+    final String baseResource)
+  {
+    this.classLoader = classLoader;
+    this.baseResource = baseResource;
+  }
+  
+  @Override
+  public URL locate(String component, String path) {
+    String fullPath = component == null ? "" : component;
+    fullPath = this.baseResource == null ? fullPath : fullPath + "/" + this.baseResource;
+    fullPath = fullPath.isEmpty() ? path : fullPath + "/" + path;
+
+    return this.classLoader.getResource(fullPath);
+  }
+  
+  @Override
+  public int hashCode() {
+	return Objects.hash(this.classLoader, this.baseResource);
+  }
+  
+  @Override
+  public boolean equals(Object obj) {
+	if (!(obj instanceof ClassLoaderResourcePathLocator)) return false;
+	
+	ClassLoaderResourcePathLocator that = (ClassLoaderResourcePathLocator)obj;
+	return this.classLoader.equals(that.classLoader) && Objects.equals(this.baseResource, that.baseResource);
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/FileBasedPathLocator.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/FileBasedPathLocator.java
@@ -1,0 +1,49 @@
+package datadog.nativeloader;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class FileBasedPathLocator implements PathLocator {
+  private final File[] libDirs;
+  
+  public FileBasedPathLocator(File... libDirs) {
+    this.libDirs = libDirs;
+  }
+  
+  @Override
+  public URL locate(String component, String path) {
+    String fullPath = component == null ? path : component + "/" + path;
+    
+    for ( File libDir: this.libDirs ) {
+      File libFile = new File(libDir, fullPath);
+      if ( libFile.exists() ) return toUrl(libFile);
+    }
+    
+    return null;
+  }
+  
+  @SuppressWarnings("deprecation")
+  private static final URL toUrl(File file) {
+    try {
+      return file.toURL();
+    } catch ( MalformedURLException e ) {
+      return null;
+    }
+  }
+  
+  @Override
+  public int hashCode() {
+	return Objects.hash(this.libDirs);
+  }
+  
+  @Override
+  public boolean equals(Object obj) {
+	if (!(obj instanceof FileBasedPathLocator)) return false;
+	
+	FileBasedPathLocator that = (FileBasedPathLocator)obj;
+	return Arrays.equals(this.libDirs, that.libDirs);
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/FlatDirLibraryResolver.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/FlatDirLibraryResolver.java
@@ -1,0 +1,42 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+
+public final class FlatDirLibraryResolver implements LibraryResolver {
+  public static final LibraryResolver INSTANCE = new FlatDirLibraryResolver();
+  
+  private FlatDirLibraryResolver() {}
+  
+  @Override
+  public final URL resolve(PathLocator pathLocator, String component, PlatformSpec platformSpec, String libName) {
+    String libFileName = PathUtils.libFileName(platformSpec, libName);
+    
+    String osPath = PathUtils.osPartOf(platformSpec);
+    String archPath = PathUtils.archPartOf(platformSpec);
+    String libcPath = PathUtils.libcPartOf(platformSpec);
+    
+    URL url;
+    String regularPath = osPath + "-" + archPath;
+    
+    if ( libcPath != null ) {
+      String specializedPath = regularPath + "-" + libcPath;
+      url = pathLocator.locate(component, specializedPath + "/" + libFileName);
+      if ( url != null ) return url;
+    }
+    
+    url = pathLocator.locate(component, regularPath + "/" + libFileName);
+    if ( url != null ) return url;
+    
+    // fallback to searching at top-level, mostly concession to good out-of-box behavior
+    // with java.library.path
+    url = pathLocator.locate(component, libFileName);
+    if ( url != null ) return url;
+    
+    if ( component != null ) {
+      url = pathLocator.locate(null, libFileName);
+      if ( url != null ) return url;
+    }
+    
+    return null;
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/LibraryLoadException.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/LibraryLoadException.java
@@ -1,0 +1,28 @@
+package datadog.nativeloader;
+
+/**
+ * Exception raised when NativeLoader fails to resolve or load a library
+ */
+public class LibraryLoadException extends Exception {
+  private static final long serialVersionUID = 1L;
+
+  public LibraryLoadException(String libName) {
+    super(message(libName));
+  }
+  
+  public LibraryLoadException(String libName, Throwable cause) {
+    this(message(libName), cause.getMessage(), cause);
+  }
+  
+  public LibraryLoadException(String libName, String message) {
+    super(message(libName) + " - " + message);
+  }
+  
+  public LibraryLoadException(String libName, String message, Throwable cause) {
+    super(message(libName) + " - " + message, cause);
+  }
+  
+  static final String message(String libName) {
+    return "Unable to resolve library " + libName; 
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/LibraryResolver.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/LibraryResolver.java
@@ -1,0 +1,18 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+
+public interface LibraryResolver {
+  default boolean isPreloaded(
+   PlatformSpec platform,
+   String libName)
+  {
+    return false;
+  }
+  
+  URL resolve(
+   PathLocator pathLocator,
+   String component,
+   PlatformSpec platformSpec,
+   String libName);
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/LibraryResolvers.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/LibraryResolvers.java
@@ -1,0 +1,37 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class LibraryResolvers {
+  private LibraryResolvers() {}
+  
+  public static final LibraryResolver defaultLibraryResolver() {
+    return flatDirs();
+  }
+  
+  public static final LibraryResolver withPreloaded(LibraryResolver baseResolver, String... preloadedLibNames) {
+	Set<String> preloadedSet = new HashSet<>(Arrays.asList(preloadedLibNames));
+	return new LibraryResolver() {
+	  @Override
+	  public boolean isPreloaded(PlatformSpec platform, String libName) {
+		return preloadedSet.contains(libName);
+	  }
+	  
+	  @Override
+	  public URL resolve(PathLocator pathLocator, String component, PlatformSpec platformSpec, String libName) {
+		return baseResolver.resolve(pathLocator, component, platformSpec, libName);
+      }
+	};
+  }
+  
+  public static final LibraryResolver flatDirs() {
+    return FlatDirLibraryResolver.INSTANCE;
+  }
+  
+  public static final LibraryResolver nestedDirs() {
+    return NestedDirLibraryResolver.INSTANCE;
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/NativeLoader.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/NativeLoader.java
@@ -1,0 +1,331 @@
+package datadog.nativeloader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * NativeLoader is intended as more feature rich replacement for calling {@link System#loadLibrary(String)}
+ * directly.  NativeLoader can be used to find the corresponding platform specific library using pluggable 
+ * strategies -- for both path determination {@link LibraryResolver} and path resolution {@link PathLocator}
+ */
+public final class NativeLoader { 
+  public static final class Builder {
+    private PlatformSpec platformSpec;
+    private Path tempDir;
+    private String[] preloadedLibNames;
+    private LibraryResolver libResolver;
+    private PathLocator pathLocator;
+
+    Builder() {}
+    
+    /**
+     * Sets the default {@link PlatformSpec} used by the {@link NativeLoader}
+     */
+    public Builder platformSpec(PlatformSpec platform) {
+      this.platformSpec = platform;
+      return this;
+    }
+    
+    /**
+     * Uses a nested directory layout -- {@link LibraryResolvers#nestedDirs()}
+     */
+    public Builder nestedLayout() {
+      return this.libResolver(LibraryResolvers.nestedDirs());
+    }
+    
+    /**
+     * Uses a flat directory layout -- {@link LibraryResolvers#flatDirs()}
+     * @return
+     */
+    public Builder flatLayout() {
+      return this.libResolver(LibraryResolvers.flatDirs());
+    }
+    
+    /**
+     * Indicates that libraries (or signatures from those libraries) are already loaded into the JVM
+     * {@link LibraryResolver#isPreloaded}
+     * @param libNames - lib names
+     */
+    public Builder preloaded(String... libNames) {
+      this.preloadedLibNames = libNames;
+      return this;
+    }
+    
+    /**
+     * Uses the specified {@link LibraryResolver} can be used to implement an alternate file layout
+     */
+    public Builder libResolver(LibraryResolver libResolver) {
+      this.libResolver = libResolver;
+      return this;
+    }
+    
+    /**
+     * Searches for the native libraries in the provided {@link ClassLoader}
+     */
+    public Builder fromClassLoader(ClassLoader classLoader) {
+      return this.pathLocator(PathLocators.fromClassLoader(classLoader));
+    }
+    
+    /**
+     * Searches for the native libraries in the provided {@link ClassLoader} using the specified <code>baseResource</code>
+     */
+    public Builder fromClassLoader(ClassLoader classLoader, String baseResource) {
+      return this.pathLocator(PathLocators.fromClassLoader(classLoader, baseResource));
+    }
+    
+    /**
+     * Searches for the native libraries in the specified directory
+     */
+    public Builder fromDir(String includeDir) {
+      return this.pathLocator(PathLocators.fromLibDirs(includeDir));
+    }
+    
+    /**
+     * Searches for the native libraries in the specified directories
+     */
+    public Builder fromDirs(String... includeDirs) {
+      return this.pathLocator(PathLocators.fromLibDirs(includeDirs));
+    }
+
+    /**
+     * Searches for the native libraries in the specified directory
+     */
+    public Builder fromDir(File includeDir) {
+      return this.pathLocator(PathLocators.fromLibDirs(includeDir));
+    }
+
+    /**
+     * Searches for the native libraries in the specified directories
+     */
+    public Builder fromDirs(File... includeDirs) {
+      return this.pathLocator(PathLocators.fromLibDirs(includeDirs));
+    }
+    
+    /**
+     * Searches for the native libraries in the specified directory
+     */
+    public Builder fromDir(Path includeDir) {
+      return this.pathLocator(PathLocators.fromLibDirs(includeDir));
+    }
+
+    /**
+     * Searches for the native libraries in the specified directories
+     */
+    public Builder fromDirs(Path... paths) {
+      return this.pathLocator(PathLocators.fromLibDirs(paths));
+    }
+    
+    /**
+     * Searches for the native libraries using the provided {@link PathLocator}
+     */
+    public Builder pathLocator(PathLocator pathLocator) {
+      this.pathLocator = pathLocator;
+      return this;
+    }
+    
+    /**
+     * Specifies temporary directory where native libraries are copied if the {@link PathLocator}
+     * returns a non-file {@link URL}
+     */
+    public Builder tempDir(File tempDir) {
+      return this.tempDir(tempDir.toPath());
+    }
+    
+    /**
+     * Specifies temporary directory where native libraries are copied if the {@link PathLocator}
+     * returns a non-file {@link URL}
+     */
+    public Builder tempDir(Path tempPath) {
+      this.tempDir = tempPath;
+      return this;
+    }
+    
+    /**
+     * Specifies temporary directory where native libraries are copied if the {@link PathLocator}
+     * returns a non-file {@link URL}
+     */
+    public Builder tempDir(String tmpPath) {
+      return this.tempDir(Paths.get(tmpPath));
+    }
+    
+    /**
+     * Constructs and returns the {@link NativeLoader}
+     */
+    public NativeLoader build() {
+      return new NativeLoader(this);
+    }
+    
+    final PlatformSpec platformSpec() {
+      return ( this.platformSpec == null ) ? 
+    	PlatformSpec.defaultPlatformSpec() :
+        this.platformSpec;
+    }
+    
+    final PathLocator pathLocator() {
+      return ( this.pathLocator == null ) ?
+    	PathLocators.defaultPathLocator() :
+        this.pathLocator;
+    }
+    
+    final LibraryResolver libResolver() {
+      LibraryResolver baseResolver = ( this.libResolver == null ) ? 
+    	LibraryResolvers.defaultLibraryResolver() :
+        this.libResolver;
+      
+      return (this.preloadedLibNames == null) ?
+    	baseResolver :
+    	LibraryResolvers.withPreloaded(baseResolver, this.preloadedLibNames);
+    }
+    
+    final Path tempDir() {
+      return this.tempDir;
+    }
+  }
+  
+  public static final Builder builder() {
+    return new Builder();
+  }
+  
+  private final PlatformSpec defaultPlatformSpec;
+  private final LibraryResolver libResolver;
+  private final PathLocator pathResolver;
+  private final Path tempDir;
+  
+  private NativeLoader(Builder builder) {
+    this.defaultPlatformSpec = builder.platformSpec();
+    this.libResolver = builder.libResolver();
+    this.pathResolver = builder.pathLocator();
+    this.tempDir = builder.tempDir();
+  }
+  
+  public void load(String libName) throws LibraryLoadException {
+    this.load(null, libName);
+  }
+
+  public final void load(String component, String libName)
+    throws LibraryLoadException
+  {
+    try ( LibFile libFile = this.resolveDynamic(component, libName) ) {
+      libFile.load();
+    }
+  }
+  
+  public final LibFile resolveDynamic(String libName)
+    throws LibraryLoadException
+  {
+    return this.resolveDynamic((String)null, libName);
+  }
+  
+  public final LibFile resolveDynamic(String component, String libName)
+    throws LibraryLoadException
+  {
+	return this.resolveDynamic(component, this.defaultPlatformSpec, libName);
+  }
+
+  public LibFile resolveDynamic(
+    PlatformSpec platformSpec,
+    String libName)
+    throws LibraryLoadException
+  {
+    return this.resolveDynamic(null, platformSpec, libName);
+  }
+
+  public LibFile resolveDynamic(
+    String component,
+    PlatformSpec platformSpec,
+    String libName)
+    throws LibraryLoadException
+  {
+	if ( platformSpec.isUnknownOs() ) return null;
+	if ( platformSpec.isUnknownArch() ) return null;
+    
+    if (this.isPreloaded(platformSpec, libName)) {
+      return LibFile.preloaded(libName);
+    }
+    
+    URL url;
+    try {
+      url = this.libResolver.resolve(
+        this.pathResolver,
+        component,
+        platformSpec,
+        libName);
+    } catch ( Throwable t ) {
+      throw new LibraryLoadException(libName, t);
+    }
+    
+    if ( url == null ) {
+      throw new LibraryLoadException(libName);
+    }
+    return toLibFile(platformSpec, libName, url);
+  }
+  
+  public boolean isPreloaded(String libName) {
+    return this.libResolver.isPreloaded(this.defaultPlatformSpec, libName);
+  }
+  
+  public boolean isPreloaded(PlatformSpec platformSpec, String libName) {
+    return this.libResolver.isPreloaded(platformSpec, libName);
+  }
+  
+  private final LibFile toLibFile(PlatformSpec platformSpec, String libName, URL url)
+    throws LibraryLoadException
+  {
+    if ( url.getProtocol().equals("file") ) {
+      return LibFile.fromFile(libName, new File(url.getPath()));
+    } else {
+      String libExt = PathUtils.dynamicLibExtension(platformSpec);
+
+      try {
+        Path tempFile = TempFileHelper.createTempFile(this.tempDir, libName, libExt);
+
+        try ( InputStream in = url.openStream() ) {
+          Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return LibFile.fromTempFile(libName, tempFile.toFile());
+      } catch ( Throwable t ) {
+        throw new LibraryLoadException(libName, t);
+      }
+    }
+  }
+  
+  static final void delete(File tempFile) {
+    TempFileHelper.delete(tempFile); 
+  }
+  
+  static final class TempFileHelper {
+    private TempFileHelper() {}
+    
+    static final Path createTempFile(Path tempDir, String libname, String libExt)
+      throws IOException, SecurityException
+    {
+      FileAttribute<Set<PosixFilePermission>> permAttrs = 
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+    
+      if ( tempDir == null ) {
+        return Files.createTempFile(libname, "." + libExt, permAttrs);
+      } else {
+        return Files.createTempFile(tempDir, libname, "." + libExt, permAttrs);
+      }
+    }
+    
+    static final void delete(File tempFile) {
+      boolean deleted = tempFile.delete();
+      if ( !deleted ) tempFile.deleteOnExit();
+    }
+  }
+
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/NestedDirLibraryResolver.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/NestedDirLibraryResolver.java
@@ -1,0 +1,46 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+
+public final class NestedDirLibraryResolver implements LibraryResolver {
+  public static final NestedDirLibraryResolver INSTANCE = new NestedDirLibraryResolver();
+  
+  @Override
+  public final URL resolve(
+    PathLocator pathResolver, 
+    String component,
+    PlatformSpec platformSpec,
+    String libName)
+  {
+    String libFileName = PathUtils.libFileName(platformSpec, libName);
+    
+    String osPath = PathUtils.osPartOf(platformSpec);
+    String archPath = PathUtils.archPartOf(platformSpec);
+    
+    String libcPath = PathUtils.libcPartOf(platformSpec);
+    
+    URL url;
+    String regularPath = osPath + "/" + archPath;
+    
+    if ( libcPath != null ) {
+      String specializedPath = regularPath + "/" + libcPath;
+      url = pathResolver.locate(component, specializedPath + "/" + libFileName);
+      if ( url != null ) return url;
+    }
+    
+    url = pathResolver.locate(component, regularPath + "/" + libFileName);
+    if ( url != null ) return url;
+    
+    // fallback to searching at top-level, mostly concession to good out-of-box behavior
+    // with java.library.path
+    url = pathResolver.locate(component, libFileName);
+    if ( url != null ) return url;
+    
+    if ( component != null ) {
+      url = pathResolver.locate(null, libFileName);
+      if ( url != null ) return url;
+    }
+    
+    return null;
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/PathLocator.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/PathLocator.java
@@ -1,0 +1,10 @@
+package datadog.nativeloader;
+
+import java.net.URL;
+
+/**
+ * Resolves a component / path pair to a {@link URL}
+ */
+public interface PathLocator {
+  public URL locate(String component, String path);
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/PathLocators.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/PathLocators.java
@@ -1,0 +1,54 @@
+package datadog.nativeloader;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Helper factory class for common {@link PathLocator}
+ */
+public final class PathLocators {
+  private PathLocators() {}
+  
+  public static final PathLocator defaultPathLocator() {
+    return fromJavaLibraryPath();
+  }
+  
+  public static final PathLocator fromLibDirs(Path... libDirs) {
+    File[] libDirFiles = new File[libDirs.length];
+    for ( int i = 0; i < libDirs.length; ++i ) {
+      libDirFiles[i] = libDirs[i].toFile();
+    }
+    return fromLibDirs(libDirFiles);
+  }
+  
+  public static final PathLocator fromLibDirs(String... libDirs) {
+    File[] libDirFiles = new File[libDirs.length];
+    for ( int i = 0; i < libDirs.length; ++i ) {
+      libDirFiles[i] = new File(libDirs[i]);
+    }
+    return fromLibDirs(libDirFiles);
+  }
+
+  public static final PathLocator fromLibDirs(File... libDirs) {
+    return new FileBasedPathLocator(libDirs);
+  }
+  
+  public static final PathLocator fromJavaLibraryPath() {
+    String libPaths;
+    try {
+      libPaths = System.getProperty("java.library.path");
+    } catch ( SecurityException e ) {
+      return new FileBasedPathLocator();
+    }
+    return fromLibDirs(libPaths.split("\\:"));
+  }
+  
+  public static final PathLocator fromClassLoader(ClassLoader classLoader) {
+    return new ClassLoaderResourcePathLocator(classLoader, null); 
+  }
+  
+  public static final PathLocator fromClassLoader(
+    ClassLoader classLoader, String baseResource) {
+    return new ClassLoaderResourcePathLocator(classLoader, baseResource); 
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/PathUtils.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/PathUtils.java
@@ -1,0 +1,71 @@
+package datadog.nativeloader;
+
+/** 
+ * Utilities for generating library file paths to be requested from a {@link PathLocator}
+ */
+public final class PathUtils {
+  private PathUtils() {}
+  
+  public static final String libPrefix(PlatformSpec platformSpec) {
+	if (platformSpec.isMac() || platformSpec.isLinux()) {
+	  return "lib";	
+	} else {
+	  return "";
+	}
+  }
+  
+  public static final String libFileName(
+    PlatformSpec platformSpec,
+    String libName)
+  {
+     return libPrefix(platformSpec) + libName + "." + dynamicLibExtension(platformSpec);
+  }
+  
+  public static final String dynamicLibExtension(PlatformSpec platformSpec) {
+	if (platformSpec.isLinux()) {
+	  return "so";
+	} else if (platformSpec.isWindows()) {
+	  return "dll";
+	} else if (platformSpec.isMac()) {
+	  return "dylib";
+	}  else {
+	  throw new IllegalArgumentException("Unsupported OS");
+	}
+  }
+  
+  public static final String osPartOf(PlatformSpec platformSpec) {
+	if (platformSpec.isLinux()) {
+	  return "linux";	
+	} else if (platformSpec.isWindows()) {
+	  return "win";
+	} else if (platformSpec.isMac()) {
+	  return "macos";
+	} else {
+	  throw new IllegalArgumentException("Unsupported OS");
+	}
+  }
+  
+  public static final String archPartOf(PlatformSpec platformSpec) {
+	if (platformSpec.isX86_64()) {
+	  return "x86_64";
+	} else if (platformSpec.isAarch64()) {
+	  return "aarch64";
+	} else if (platformSpec.isX86_32()) {
+	  return "x86_32";
+	} else if (platformSpec.isArm32()) {
+	  return "arm32";
+	} else {
+	  return "";
+	}
+  }
+  
+  public static final String libcPartOf(PlatformSpec platformSpec) {
+	if (!platformSpec.isLinux()) {
+      return null;
+	} else if (platformSpec.isMusl()) {
+	  return "musl";
+	} else {
+	  return "libc";
+	}
+  }
+}

--- a/components/nativeloader/src/main/java/datadog/nativeloader/PlatformSpec.java
+++ b/components/nativeloader/src/main/java/datadog/nativeloader/PlatformSpec.java
@@ -1,0 +1,93 @@
+package datadog.nativeloader;
+
+import datadog.environment.OperatingSystem;
+
+/**
+ * Class that describes a native library "platform" -- including operating system, architecture, and libc variation
+ */
+public abstract class PlatformSpec {
+  public static final PlatformSpec defaultPlatformSpec() {
+	return DefaultPlatformSpec.INSTANCE;
+  }
+  
+  public abstract boolean isMac();
+  
+  public abstract boolean isWindows();
+  
+  public abstract boolean isLinux();
+  
+  public final boolean isUnknownOs() {
+	return !this.isLinux() && !this.isMac() && !this.isWindows();
+  }
+  
+  public abstract boolean isX86_32();
+  
+  public abstract boolean isX86_64();
+  
+  public abstract boolean isArm32();
+  
+  public abstract boolean isAarch64();
+  
+  public final boolean isUnknownArch() {
+	return !this.isX86_64() && !this.isAarch64() && !this.isX86_32() && !this.isArm32();
+  }
+  
+  public abstract boolean isMusl();
+}
+
+/*
+ * Default PlatformSpec used in dd-trace-java -- wraps detection code in component:environment
+ */
+final class DefaultPlatformSpec extends PlatformSpec {
+  static final PlatformSpec INSTANCE = new DefaultPlatformSpec();
+  
+  @Override
+  public boolean isLinux() {
+	return OperatingSystem.isLinux();
+  }
+  
+  @Override
+  public boolean isMac() {
+	return OperatingSystem.isMacOs();
+  }
+  
+  @Override
+  public boolean isWindows() {
+	return OperatingSystem.isWindows();
+  }
+  
+  @Override
+  public boolean isMusl() {
+	return OperatingSystem.isMusl();
+  }
+  
+  @Override
+  public boolean isAarch64() {
+	return OperatingSystem.isAarch64();
+  }
+  
+  @Override
+  public boolean isArm32() {
+	return false;
+  }
+  
+  @Override
+  public boolean isX86_32() {
+	return false;
+  }
+  
+  @Override
+  public boolean isX86_64() {
+	return false;
+  }
+  
+  @Override
+  public int hashCode() {
+	return DefaultPlatformSpec.class.hashCode();
+  }
+  
+  @Override
+  public boolean equals(Object obj) {
+	return (obj instanceof DefaultPlatformSpec);
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/CapturingPathResolver.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/CapturingPathResolver.java
@@ -1,0 +1,42 @@
+package datadog.nativeloader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public final class CapturingPathResolver implements PathLocator {
+  final int simulateNotFoundCount;
+  int numRequests;
+  
+  String requestedComponent;
+  String requestedPath;
+  
+  public CapturingPathResolver() {
+    this(0);
+  }
+  
+  public CapturingPathResolver(int simulateNotFoundCount) {
+    this.numRequests = 0;
+    this.simulateNotFoundCount = simulateNotFoundCount;
+  }
+  
+  @Override
+  public URL locate(String component, String path) {
+   if ( this.numRequests++ < this.simulateNotFoundCount ) return null;
+   
+   this.requestedComponent = component;
+   this.requestedPath = path;
+   
+    try {
+      return new URL("http://localhost");
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+  
+  void assertRequested(String expectedComponent, String expectedPath) {
+    assertEquals(expectedComponent, this.requestedComponent);
+    assertEquals(expectedPath, this.requestedPath);
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/FlatResolverTest.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/FlatResolverTest.java
@@ -1,0 +1,62 @@
+package datadog.nativeloader;
+
+import org.junit.jupiter.api.Test;
+
+import static datadog.nativeloader.TestPlatformSpec.AARCH64;
+import static datadog.nativeloader.TestPlatformSpec.GLIBC;
+import static datadog.nativeloader.TestPlatformSpec.LINUX;
+import static datadog.nativeloader.TestPlatformSpec.MAC;
+import static datadog.nativeloader.TestPlatformSpec.MUSL;
+import static datadog.nativeloader.TestPlatformSpec.WINDOWS;
+import static datadog.nativeloader.TestPlatformSpec.X86_64;
+
+public class FlatResolverTest {
+  @Test
+  public void linux_x86_64_libc() {
+    test(TestPlatformSpec.of(LINUX, X86_64, GLIBC), "linux-x86_64-libc/libtest.so");
+  }
+  
+  @Test
+  public void linux_x86_64_musl() {
+    test(TestPlatformSpec.of(LINUX, X86_64, MUSL), "linux-x86_64-musl/libtest.so");
+  }
+    
+  @Test
+  public void linux_x86_64_no_libc_flavor_fallback() {
+    testFallback(1, TestPlatformSpec.of(LINUX, X86_64, GLIBC), "linux-x86_64/libtest.so");
+  }
+  
+  @Test
+  public void full_fallback() {
+    testFallback(2, TestPlatformSpec.of(LINUX, X86_64, GLIBC), "libtest.so");
+  }
+
+  @Test
+  public void osx_x86_64() {
+    test(TestPlatformSpec.of(MAC, X86_64), "macos-x86_64/libtest.dylib");
+  }
+  
+  @Test
+  public void osx_aarch() {
+    test(TestPlatformSpec.of(MAC, AARCH64), "macos-aarch64/libtest.dylib");
+  }
+  
+  @Test
+  public void windows_x86_64() {
+    test(TestPlatformSpec.of(WINDOWS, X86_64), "win-x86_64/test.dll");
+  }
+  
+  static final void test(PlatformSpec platformSpec, String expectedPath) {
+    CapturingPathResolver locator = new CapturingPathResolver();
+    FlatDirLibraryResolver.INSTANCE.resolve(locator, null, platformSpec, "test");
+    
+    locator.assertRequested(null, expectedPath);
+  }
+  
+  static final void testFallback(int fallbackLevel, PlatformSpec platformSpec, String expectedPath) {
+    CapturingPathResolver locator = new CapturingPathResolver(fallbackLevel);
+    FlatDirLibraryResolver.INSTANCE.resolve(locator, null, platformSpec, "test");
+
+    locator.assertRequested(null, expectedPath);
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/NativeLoaderBuilderTest.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/NativeLoaderBuilderTest.java
@@ -1,0 +1,66 @@
+package datadog.nativeloader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class NativeLoaderBuilderTest {
+  @Test
+  public void defaultPlatformSpec() {
+	NativeLoader.Builder builder = NativeLoader.builder();
+	
+	assertEquals(PlatformSpec.defaultPlatformSpec(), builder.platformSpec());
+  }
+  
+  @Test
+  public void customPlatformSpec() {
+	PlatformSpec platformSpec = TestPlatformSpec.of(TestPlatformSpec.LINUX, TestPlatformSpec.ARM32, TestPlatformSpec.GLIBC);
+	
+	NativeLoader.Builder builder = NativeLoader.builder().platformSpec(platformSpec);
+	assertSame(platformSpec, builder.platformSpec());
+  }
+    
+  @Test
+  public void defaultLibraryResolver() {
+	NativeLoader.Builder builder = NativeLoader.builder();
+	
+	assertEquals(LibraryResolvers.defaultLibraryResolver(), builder.libResolver());
+  }
+  
+  @Test
+  public void flatLayout() {
+	NativeLoader.Builder builder = NativeLoader.builder().flatLayout();
+	
+	assertEquals(LibraryResolvers.flatDirs(), builder.libResolver());
+  }
+  
+  @Test
+  public void nestedLayout() {
+	NativeLoader.Builder builder = NativeLoader.builder().nestedLayout();
+	
+	assertEquals(LibraryResolvers.nestedDirs(), builder.libResolver());
+  }
+  
+  @Test
+  public void defaultPathLocator() {
+	NativeLoader.Builder builder = NativeLoader.builder();
+	
+	assertEquals(PathLocators.defaultPathLocator(), builder.pathLocator());
+  }
+  
+  @Test
+  public void dirBasedLocator() {
+	NativeLoader.Builder builder = NativeLoader.builder().fromDir("libs");
+	
+	assertEquals(PathLocators.fromLibDirs("libs"), builder.pathLocator());
+  }
+  
+  @Test
+  public void classLoaderBasedLocator() {
+	ClassLoader sysClassLoader = ClassLoader.getSystemClassLoader();
+	NativeLoader.Builder builder = NativeLoader.builder().fromClassLoader(sysClassLoader);
+	
+	assertEquals(PathLocators.fromClassLoader(sysClassLoader), builder.pathLocator());
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/NativeLoaderTest.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/NativeLoaderTest.java
@@ -1,0 +1,79 @@
+package datadog.nativeloader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+public class NativeLoaderTest {
+  static final PlatformSpec TEST_PLATFORM_SPEC = TestPlatformSpec.of(
+	TestPlatformSpec.MAC,
+	TestPlatformSpec.AARCH64);
+  
+  static final NativeLoader.Builder buildTestLoader() {
+	return NativeLoader.builder().platformSpec(TEST_PLATFORM_SPEC);
+  }
+  
+  @Test
+  public void preloaded() throws LibraryLoadException {
+	NativeLoader loader = buildTestLoader().preloaded("dne1", "dne2").build();
+	
+	try ( LibFile lib = loader.resolveDynamic("dne1") ) {
+	  assertTrue(lib.isPreloaded());
+	  
+	  assertNull(lib.file);
+	  assertFalse(lib.needsCleanup);
+	  
+	  // already consider loaded -- so this is a nop
+	  lib.load();
+	}
+	
+	// already consider loaded -- so this is a nop 
+	loader.load("dne2");
+  }
+  
+  @Test
+  public void fromFile() throws LibraryLoadException {
+//    NativeLoader loader = buildTestLoader().fromDir("native-lib").build();
+//    
+//    try ( LibFile lib = loader.resolveDynamic("test") ) {
+//      assertFalse(lib.needsCleanup);
+//    }
+  }
+  
+  @Test
+  public void fromDirBackedClassLoader() throws IOException, LibraryLoadException {
+//    // ClassLoader pulling from a directory, so there's still a normal file
+//    URL[] urls = {
+//      new File("native-lib").toURL()
+//    };
+//    
+//    URLClassLoader classLoader = new URLClassLoader(urls);
+//    
+//    NativeLoader loader = buildTestLoader().fromClassLoader(classLoader).build();
+//    try ( LibFile lib = loader.resolveDynamic("test") ) {
+//      // since there's a normal file, no need for clean-up
+//      assertFalse(lib.needsCleanup);
+//    }
+  }
+  
+  @Test
+  public void fromJarBackedClassLoader() throws IOException, LibraryLoadException {
+//    URL[] urls = {
+//      new File("native-lib/libdatadog_library_config.jar").toURL()
+//    };
+//    
+//    URLClassLoader classLoader = new URLClassLoader(urls);
+//    
+//    NativeLoader loader = buildTestLoader().fromClassLoader(classLoader).build();
+//    try ( LibFile lib = loader.resolveDynamic("test") ) {
+//      assertTrue(lib.needsCleanup);
+//    }
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/NestedResolverTest.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/NestedResolverTest.java
@@ -1,0 +1,62 @@
+package datadog.nativeloader;
+
+import static datadog.nativeloader.TestPlatformSpec.AARCH64;
+import static datadog.nativeloader.TestPlatformSpec.GLIBC;
+import static datadog.nativeloader.TestPlatformSpec.LINUX;
+import static datadog.nativeloader.TestPlatformSpec.MAC;
+import static datadog.nativeloader.TestPlatformSpec.MUSL;
+import static datadog.nativeloader.TestPlatformSpec.WINDOWS;
+import static datadog.nativeloader.TestPlatformSpec.X86_64;
+
+import org.junit.jupiter.api.Test;
+
+public class NestedResolverTest {
+  @Test
+  public void linux_x86_64_libc() {
+    test(TestPlatformSpec.of(LINUX, X86_64, GLIBC), "linux/x86_64/libc/libtest.so");
+  }
+  
+  @Test
+  public void linux_x86_64_musl() {
+    test(TestPlatformSpec.of(LINUX, X86_64, MUSL), "linux/x86_64/musl/libtest.so");
+  }
+    
+  @Test
+  public void linux_x86_64_no_libc_flavor_fallback() {
+    testFallback(1, TestPlatformSpec.of(LINUX, X86_64, GLIBC), "linux/x86_64/libtest.so");
+  }
+  
+  @Test
+  public void full_fallback() {
+    testFallback(2, TestPlatformSpec.of(LINUX, X86_64, GLIBC), "libtest.so");
+  }
+
+  @Test
+  public void osx_x86_64() {
+    test(TestPlatformSpec.of(MAC, X86_64), "macos/x86_64/libtest.dylib");
+  }
+  
+  @Test
+  public void osx_aarch() {
+    test(TestPlatformSpec.of(MAC, AARCH64), "macos/aarch64/libtest.dylib");
+  }
+  
+  @Test
+  public void windows_x86_64() {
+    test(TestPlatformSpec.of(WINDOWS, X86_64), "win/x86_64/test.dll");
+  }
+  
+  static final void test(PlatformSpec platformSpec, String expectedPath) {
+    CapturingPathResolver locator = new CapturingPathResolver();
+    NestedDirLibraryResolver.INSTANCE.resolve(locator, null, platformSpec, "test");
+    
+    locator.assertRequested(null, expectedPath);
+  }
+  
+  static final void testFallback(int fallbackLevel, PlatformSpec platformSpec, String expectedPath) {
+    CapturingPathResolver locator = new CapturingPathResolver(fallbackLevel);
+    NestedDirLibraryResolver.INSTANCE.resolve(locator, null, platformSpec, "test");
+
+    locator.assertRequested(null, expectedPath);
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/PathUtilsTest.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/PathUtilsTest.java
@@ -1,0 +1,33 @@
+package datadog.nativeloader;
+
+import org.junit.jupiter.api.Test;
+
+import static datadog.nativeloader.TestPlatformSpec.AARCH64;
+import static datadog.nativeloader.TestPlatformSpec.GLIBC;
+import static datadog.nativeloader.TestPlatformSpec.LINUX;
+import static datadog.nativeloader.TestPlatformSpec.MAC;
+import static datadog.nativeloader.TestPlatformSpec.MUSL;
+import static datadog.nativeloader.TestPlatformSpec.WINDOWS;
+import static datadog.nativeloader.TestPlatformSpec.X86_64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PathUtilsTest {
+  @Test
+  public void libFileName_mac() {
+	PlatformSpec macSpec = TestPlatformSpec.of(MAC, AARCH64);
+	assertEquals("libtest.dylib", PathUtils.libFileName(macSpec, "test"));
+  }
+  
+  @Test
+  public void libFileName_linux() {
+	PlatformSpec linuxSpec = TestPlatformSpec.of(LINUX, X86_64);
+	assertEquals("libtest.so", PathUtils.libFileName(linuxSpec, "test"));
+  }
+  
+  @Test
+  public void libFileName_windows() {
+	PlatformSpec linuxSpec = TestPlatformSpec.of(WINDOWS, X86_64);
+	assertEquals("test.dll", PathUtils.libFileName(linuxSpec, "test"));	  
+  }
+}

--- a/components/nativeloader/src/test/java/datadog/nativeloader/TestPlatformSpec.java
+++ b/components/nativeloader/src/test/java/datadog/nativeloader/TestPlatformSpec.java
@@ -1,0 +1,82 @@
+package datadog.nativeloader;
+
+public class TestPlatformSpec extends PlatformSpec {
+  public static final String MAC = "mac";
+  public static final String WINDOWS = "win";
+  public static final String LINUX = "linux";
+  
+  public static final String X86_32 = "x86_32";
+  public static final String X86_64 = "x86_64";
+  
+  public static final String ARM32 = "arm32";
+  public static final String AARCH64 = "aarch64";
+  
+  public static final boolean GLIBC = false;
+  public static final boolean MUSL = true;
+  
+  public static final PlatformSpec of(String os, String arch) {
+	return new TestPlatformSpec(os, arch, false);
+  }
+  
+  public static final PlatformSpec of(String os, String arch, boolean isMusl) {
+	return new TestPlatformSpec(os, arch, isMusl);  
+  }
+  
+  private final String os;
+  private final String arch;
+  private final boolean isMusl;
+  
+  private TestPlatformSpec(String os, String arch, boolean isMusl) {
+    this.os = os;
+    this.arch = arch;
+    this.isMusl = isMusl;
+  }
+  
+  @Override
+  public boolean isLinux() {
+	return this.isOs(LINUX);
+  }
+  
+  @Override
+  public boolean isMac() {
+	return this.isOs(MAC);
+  }
+  
+  @Override
+  public boolean isWindows() {
+	return this.isOs(WINDOWS);
+  }
+  
+  private boolean isOs(String osConst) {
+	return osConst.equals(this.os);
+  }
+  
+  @Override
+  public boolean isX86_32() {
+	return this.isArch(X86_32);
+  }
+  
+  @Override
+  public boolean isAarch64() {
+	return this.isArch(AARCH64);
+  }
+  
+  @Override
+  public boolean isArm32() {
+	return this.isArch(ARM32);
+  }
+  
+  @Override
+  public boolean isX86_64() {
+	return this.isArch(X86_64);
+  }
+  
+  @Override
+  public boolean isMusl() {
+	return this.isMusl;
+  }
+  
+  private boolean isArch(String archConst) {
+	return archConst.equals(this.arch);
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -104,6 +104,7 @@ include(
   ":components:context",
   ":components:environment",
   ":components:json",
+  ":components:nativeloader",
   ":components:yaml",
   ":telemetry",
   ":remote-config:remote-config-api",


### PR DESCRIPTION
Introducing NativeLoader API intended to standardize how native libraries are loaded in dd-trace-java
NativeLoader allows for using different file layout and file resolution strategies

# What Does This Do
Introduces a new API, subsequent pull requests will use this new to incorporate libdatadog.
Also intend to update profiling and ASM to use this new API

# Motivation
This API will help standardize how native libraries are loaded in dd-java-agent.
The API also provides the means to switch between loaded from the file system and ClassLoaders seamlessly without updating all of the client code.
