### PR TITLE
Simplify type outlines to not implement type.getDeclaringType() and type.getEnclosingType()

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -384,11 +384,6 @@ final class TypeFactory {
     }
 
     @Override
-    public boolean isAnonymousType() {
-      return outline().isAnonymousType();
-    }
-
-    @Override
     public boolean isPublic() {
       return isPublicFilter.contains(name) || super.isPublic();
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -384,8 +384,8 @@ final class TypeFactory {
     }
 
     @Override
-    public TypeDescription getDeclaringType() {
-      return outline().getDeclaringType();
+    public boolean isAnonymousType() {
+      return outline().isAnonymousType();
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -113,21 +113,6 @@ final class TypeOutline extends WithName {
     return declaredMethods.isEmpty() ? NO_METHODS : new MethodList.Explicit<>(declaredMethods);
   }
 
-  @Override
-  public boolean isAnonymousType() {
-    // this method is only used when dd.iast.anonymous-classes.enabled=false
-    // so take simple approach and look for '$number' at the end of the name
-    for (int end = name.length() - 1, i = end; i > 0; i--) {
-      char c = name.charAt(i);
-      if (c == '$' && i < end) {
-        return true; // only seen digits so far, assume anonymous
-      } else if (c < '0' || c > '9') {
-        break; // non-digit character found, assume not anonymous
-      }
-    }
-    return false;
-  }
-
   void declare(AnnotationDescription annotation) {
     if (null != annotation) {
       if (null == declaredAnnotations) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -4,7 +4,6 @@ import static datadog.trace.agent.tooling.bytebuddy.outline.TypeFactory.findType
 
 import java.util.ArrayList;
 import java.util.List;
-import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.description.annotation.AnnotationDescription;
 import net.bytebuddy.description.annotation.AnnotationList;
 import net.bytebuddy.description.field.FieldDescription;
@@ -27,21 +26,17 @@ final class TypeOutline extends WithName {
   private static final MethodList<MethodDescription.InDefinedShape> NO_METHODS =
       new MethodList.Empty<>();
 
-  private final int classFileVersion;
   private final int modifiers;
   private final String superName;
   private final String[] interfaces;
-  private String declaringName;
-  private boolean anonymousType;
 
   private List<AnnotationDescription> declaredAnnotations;
 
   private final List<FieldDescription.InDefinedShape> declaredFields = new ArrayList<>();
   private final List<MethodDescription.InDefinedShape> declaredMethods = new ArrayList<>();
 
-  TypeOutline(int version, int access, String internalName, String superName, String[] interfaces) {
+  TypeOutline(int access, String internalName, String superName, String[] interfaces) {
     super(internalName.replace('/', '.'));
-    this.classFileVersion = version;
     this.modifiers = access & ALLOWED_TYPE_MODIFIERS;
     this.superName = superName;
     this.interfaces = interfaces;
@@ -70,19 +65,6 @@ final class TypeOutline extends WithName {
       outlines.add(findType(iface.replace('/', '.')).asGenericType());
     }
     return new TypeList.Generic.Explicit(outlines);
-  }
-
-  @Override
-  public TypeDescription getDeclaringType() {
-    if (null != declaringName) {
-      return findType(declaringName.replace('/', '.'));
-    }
-    return null;
-  }
-
-  @Override
-  public TypeDescription getEnclosingType() {
-    return getDeclaringType(); // equivalent for outline purposes
   }
 
   @Override
@@ -115,11 +97,6 @@ final class TypeOutline extends WithName {
   }
 
   @Override
-  public ClassFileVersion getClassFileVersion() {
-    return ClassFileVersion.ofMinorMajor(classFileVersion);
-  }
-
-  @Override
   public AnnotationList getDeclaredAnnotations() {
     return null == declaredAnnotations
         ? NO_ANNOTATIONS
@@ -138,11 +115,17 @@ final class TypeOutline extends WithName {
 
   @Override
   public boolean isAnonymousType() {
-    return anonymousType;
-  }
-
-  void declaredBy(String declaringName) {
-    this.declaringName = declaringName;
+    // this method is only used when dd.iast.anonymous-classes.enabled=false
+    // so take simple approach and look for '$number' at the end of the name
+    for (int end = name.length() - 1, i = end; i > 0; i--) {
+      char c = name.charAt(i);
+      if (c == '$' && i < end) {
+        return true; // only seen digits so far, assume anonymous
+      } else if (c < '0' || c > '9') {
+        break; // non-digit character found, assume not anonymous
+      }
+    }
+    return false;
   }
 
   void declare(AnnotationDescription annotation) {
@@ -164,9 +147,5 @@ final class TypeOutline extends WithName {
     if (null != method) {
       declaredMethods.add(method);
     }
-  }
-
-  void anonymousType() {
-    anonymousType = true;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/OutlineTypeParserTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/OutlineTypeParserTest.groovy
@@ -5,7 +5,7 @@ import spock.lang.Specification
 
 class OutlineTypeParserTest extends Specification {
 
-  void 'test modifiers are correct and anonymous classes are detected'() {
+  void 'test modifiers are correct'() {
     setup:
     final parser = new OutlineTypeParser()
     final locator = ClassFileLocators.classFileLocator(Thread.currentThread().contextClassLoader)
@@ -15,11 +15,12 @@ class OutlineTypeParserTest extends Specification {
     final outline = parser.parse(bytes)
 
     then:
-    outline.anonymousType == anonymous
     outline.interface == isinterface
     outline.abstract == isabstract
     outline.annotation == annotation
     outline.enum == isenum
+
+    // isAnonymousType is no longer supported in outlines for performance reasons
 
     where:
     clazz                                                    | anonymous | isinterface | isabstract | annotation | isenum


### PR DESCRIPTION
# Motivation

These methods are not used for matching purposes, so don't need to be maintained in outlines.

There is one use of type.isAnonymousType() in IAST, but this is under a support flag - I could not find any active use of that support flag. To satisfy the original use-case (involving MyBatis) we add a simple anonymous type heuristic to that particular instrumentation, based on the '$number' Java language convention for anonymous class names.

( If necessary we can further enhance that specialized matcher without incurring overhead for all outline parsing )

Note: if anything does touch type.getDeclaringType() / type.getEnclosingType() later on when doing the final transformation then the outline type is automatically inflated to a full type. (This is already the case for other methods that aren't available in type outlines.)

We also drop type.getClassFileVersion() from outlines for the same reason.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
