### PR TITLE
Disable process context sharing when using native image

### DIFF
--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
@@ -36,6 +36,7 @@ public final class AnnotationSubstitutionProcessorInstrumentation
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".Target_com_datadog_profiling_agent_ProcessContext",
       packageName + ".Target_datadog_jctools_util_UnsafeRefArrayAccess",
       packageName + ".Target_org_datadog_jmxfetch_App",
       packageName + ".Target_org_datadog_jmxfetch_Status",
@@ -50,6 +51,7 @@ public final class AnnotationSubstitutionProcessorInstrumentation
       "jdk.vm.ci.meta.ResolvedJavaType",
       "jdk.vm.ci.meta.ResolvedJavaField",
       // ignore helper class names as usual
+      packageName + ".Target_com_datadog_profiling_agent_ProcessContext",
       packageName + ".Target_datadog_jctools_util_UnsafeRefArrayAccess",
       packageName + ".Target_org_datadog_jmxfetch_App",
       packageName + ".Target_org_datadog_jmxfetch_Status",
@@ -60,6 +62,7 @@ public final class AnnotationSubstitutionProcessorInstrumentation
   public static class FindTargetClassesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Return(readOnly = false) List<Class<?>> result) {
+      result.add(Target_com_datadog_profiling_agent_ProcessContext.class);
       result.add(Target_datadog_jctools_util_UnsafeRefArrayAccess.class);
       result.add(Target_org_datadog_jmxfetch_App.class);
       result.add(Target_org_datadog_jmxfetch_Status.class);

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_com_datadog_profiling_agent_ProcessContext.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_com_datadog_profiling_agent_ProcessContext.java
@@ -1,0 +1,16 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+@TargetClass(className = "com.datadog.profiling.agent.ProcessContext")
+public final class Target_com_datadog_profiling_agent_ProcessContext {
+  @Substitute
+  public static void register(ConfigProvider configProvider) {
+    // This method references com.datadoghq.profiler.OTelContext which is not available
+    // during native image build. OTelContext is part of the ddprof native library that's
+    // loaded at runtime. For native image builds, profiling context registration is disabled.
+    // No-op during native image build.
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR fixes the native build failure related to the process context sharing introduced in profiling: https://github.com/DataDog/dd-trace-java/pull/9472

# Motivation

Related error:
```
Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing com.datadog.profiling.agent.ProfilingAgent.run(ProfilingAgent.java:94)
Parsing context:
   3,303 types,   154 fields, and 3,224 methods registered for reflection
   at datadog.trace.agent.tooling.ProfilerInstaller.installProfiler(ProfilerInstaller.java:10)
   at datadog.trace.agent.tooling.nativeimage.TracerActivation.activate(TracerActivation.java:20)
       1 native library: -framework CoreServices
   at org.graalvm.nativeimage.VMRuntime.initialize(VMRuntime.java:65)

------------------------------------------------------------------------------------------------------------------------
   at com.oracle.svm.core.JavaMainWrapper.runCore0(JavaMainWrapper.java:152)
   at com.oracle.svm.core.JavaMainWrapper.doRun(JavaMainWrapper.java:243)
   at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_3148eece06270530b6e0d4d60311411342c82698(generated:0)
   at static root method.(Unknown Source)

        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:149)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:178)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:152)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraphInfo(MethodTypeFlow.java:110)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.lambda$update$0(DefaultStaticInvokeTypeFlow.java:67)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.LightImmutableCollection.forEach(LightImmutableCollection.java:90)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.update(DefaultStaticInvokeTypeFlow.java:66)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:474)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:187)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:171)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved type during parsing: com.datadoghq.profiler.OTelContext. This error is reported at image build time because class com.datadog.profiling.agent.ProcessContext is registered for linking at image build time by system default
        at parsing com.datadog.profiling.agent.ProcessContext.register(ProcessContext.java:23)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2531)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:169)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3409)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.iterateBytecodesForBlock(SharedGraphBuilderPhase.java:712)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3361)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3203)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1134)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.build(SharedGraphBuilderPhase.java:152)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1026)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:97)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:114)
        at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
        at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:434)
                        1.2s (7.0% of total time) in 26 GCs | Peak RSS: 1.98GB | CPU load: 5.92
        at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
```

# Additional Notes

I'm trying to find out while I get this failing in local build only and CI does not complain about it.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
