### PR TITLE
Adds a test for JDK-827271

### DIFF
--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -9,33 +9,35 @@ minimumBranchCoverage = 0.6
 excludedClassesCoverage += ['datadog.trace.agent.tooling.*']
 
 sourceSets {
-  test_java11 {
+  register("test_java11") {
     java {
       srcDirs = [file('src/test/java11')]
     }
   }
-  test {
-    groovy {
-      compileClasspath += sourceSets.test_java11.output
-      runtimeClasspath += sourceSets.test_java11.output
+  register("test_java21") {
+    java {
+      srcDirs = [file('src/test/java21')]
     }
+  }
+  named("test") {
+    compileClasspath += sourceSets.test_java11.output
+    runtimeClasspath += sourceSets.test_java11.output
+    compileClasspath += sourceSets.test_java21.output
+    runtimeClasspath += sourceSets.test_java21.output
   }
 }
 
 configurations {
-  instrumentPluginClasspath {
+  register("instrumentPluginClasspath") {
     canBeConsumed = true
     canBeResolved = false
     extendsFrom runtimeElements
   }
 
-  test_java11Implementation {
+  named("test_java11Implementation") {
     extendsFrom testImplementation
   }
 }
-
-compileJava.dependsOn 'generateClassNameTries'
-sourcesJar.dependsOn 'generateClassNameTries'
 
 dependencies {
   api(project(':dd-java-agent:agent-bootstrap')) {
@@ -67,8 +69,11 @@ jmh {
   jmhVersion = libs.versions.jmh.get()
   includeTests = true
 }
-compileJmhJava.dependsOn compileTestJava
-compileTestJava.dependsOn 'generateTestClassNameTries'
+
+tasks.named("compileJava") { dependsOn 'generateClassNameTries' }
+tasks.named("sourcesJar") { dependsOn 'generateClassNameTries' }
+
+tasks.named("compileJmhJava") { dependsOn tasks.named("compileTestJava") }
 
 tasks.named("forbiddenApisJmh") {
   ignoreFailures = true
@@ -80,17 +85,22 @@ tasks.named("forbiddenApisTest_java11") {
   failOnMissingClasses = false
 }
 
-project.tasks.compileTestJava.dependsOn(project.tasks.generateTestClassNameTries)
-project.tasks.compileTestGroovy.dependsOn(project.tasks.compileTest_java11Java)
-project.tasks.compileTest_java11Java.configure {
+tasks.named("compileTestJava") { dependsOn('generateTestClassNameTries') }
+tasks.named("compileTest_java11Java") {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
   setJavaVersion(it, 11)
 }
+tasks.named("compileTest_java21Java") {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+  setJavaVersion(it, 21)
+}
 
-final jmh = project.tasks.jmh
-jmh.outputs.upToDateWhen { false }
-jmh.dependsOn(compileTestJava)
+tasks.named("jmh") {
+  dependsOn(tasks.named("compileTestJava"))
+  outputs.upToDateWhen { false }
+}
 
 tasks.withType(Test).configureEach {
   // same setting as AgentInstaller to avoid spurious agent-tooling test failures

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/ReferenceCreatorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/ReferenceCreatorTest.groovy
@@ -53,6 +53,23 @@ class ReferenceCreatorTest extends DDSpecification {
     aFieldRefs.size() == 2
   }
 
+  def "ignore invocation of object methods on interface after JDK-8272715"() {
+    // After JDK 18/19 javac compiles differently Object methods, while there is a ignore mechanism on java.* packages
+    // after the key change is described in https://bugs.openjdk.org/browse/JDK-827271, object's methods
+    // are applied to interfaces which may belong to another package.
+    //
+    // Key change
+    // "invocations of java.lang.Object methods on interfaces in the classfile will use invokeinterface referring
+    // to the interface, which is consistent with JLS 9.2. This will be done regardless of whether the interface
+    // declares the method explicitly or not."
+
+    setup:
+    Map<String, Reference> references = ReferenceCreator.createReferencesFrom(CompiledWithInvokeinterfaceForObjectMethods.name, this.class.classLoader)
+
+    expect:
+    references.get(CompiledWithInvokeinterfaceForObjectMethods.DatadogInterface.name) == null
+  }
+
   def "protected ref test"() {
     setup:
     Map<String, Reference> references = ReferenceCreator.createReferencesFrom(MethodBodyAdvice.B2.name, this.class.classLoader)

--- a/dd-java-agent/agent-tooling/src/test/java21/datadog/trace/agent/tooling/muzzle/CompiledWithInvokeinterfaceForObjectMethods.java
+++ b/dd-java-agent/agent-tooling/src/test/java21/datadog/trace/agent/tooling/muzzle/CompiledWithInvokeinterfaceForObjectMethods.java
@@ -1,0 +1,11 @@
+package datadog.trace.agent.tooling.muzzle;
+
+public class CompiledWithInvokeinterfaceForObjectMethods {
+  interface DatadogInterface {}
+
+  public void doSomething(DatadogInterface itf) {
+    itf.hashCode();
+    itf.equals(new Object());
+    itf.getClass();
+  }
+}


### PR DESCRIPTION
# What Does This Do

Complement #9649 with a test.

After JDK 18/19 `javac` compiles differently `Object` methods, while there is a ignore mechanism on `java.*` packages after the key change is described in [JDK-827271](https://bugs.openjdk.org/browse/JDK-827271), `Object`'s methods are applied to interfaces which may belong to another package.

Key change of JDK-827271
> "invocations of `java.lang.Object methods` on interfaces in the classfile will use `invokeinterface` referring to the interface, which is consistent with JLS 9.2. This will be done regardless of whether the interface declares the method explicitly or not."

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
