### PR TITLE
Version file was not always generated on first jar generation

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,25 +1,34 @@
-def getGitHash = {
-  ->
-  def stdout = new ByteArrayOutputStream()
-  exec {
-    commandLine 'git', 'rev-parse', '--short', 'HEAD'
-    standardOutput = stdout
+abstract class WriteVersionNumberFile extends DefaultTask {
+  @Input
+  abstract Property<String> getVersion()
+
+  @Input
+  abstract Property<String> getGitHash()
+
+  @OutputDirectory
+  abstract DirectoryProperty getOutputDirectory()
+
+  WriteVersionNumberFile() {
+    // Set conventions (defaults)
+    this.version.convention(project.provider { project.version.toString() })
+    this.gitHash.convention(project.provider {
+      def stdout = new ByteArrayOutputStream()
+      project.exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+      }
+      return stdout.toString().trim()
+    })
+    this.outputDirectory.convention(project.layout.buildDirectory.dir("generated/version"))
   }
-  return stdout.toString().trim()
-}
 
-tasks.register("writeVersionNumberFile") {
-
-  def versionFile = file("${sourceSets.main.output.resourcesDir}/${project.name}.version")
-  inputs.property "version", project.version
-  outputs.file versionFile
-
-  doFirst {
-    assert versionFile.parentFile.mkdirs() || versionFile.parentFile.directory
-    versionFile.text = "${project.version}~${getGitHash()}"
+  @TaskAction
+  void writeVersionFile() {
+    def versionFile = outputDirectory.file("${project.name}.version").get().asFile
+    versionFile.parentFile.mkdirs()
+    versionFile.text = "${version.get()}~${gitHash.get()}"
   }
 }
 
-tasks.withType(JavaCompile).configureEach {
-  dependsOn "writeVersionNumberFile"
-}
+def versionTask = tasks.register("writeVersionNumberFile", WriteVersionNumberFile)
+sourceSets.main.resources.srcDir(versionTask)


### PR DESCRIPTION
# What Does This Do

The current version generation was writing directly to the output dir which could be replaced by a another tasks that runs later. This change makes this task generate the file in another location and makes the sourceSet use this task output as source dir.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
