### PR TITLE
Bump develocity plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.1"
+  id("com.gradle.develocity") version "4.2.1"
 }
 
 val isCI = providers.environmentVariable("CI")


### PR DESCRIPTION
# What Does This Do

Bumps develocity plugin to 4.2.1

* 4.2.1
   [FIX] IDE plugin integration: Wrong event stream can sometimes be generated
* 4.2
  [FIX] Test Distribution: Build may request more remote executors even after falling back to local execution
* 4.1.1
   [NEW] Test Distribution: Code coverage results from remote agents can be aggregated if JaCoCo is used in offline mode
   [FIX] Test Distribution: Unrecoverable test execution errors like "OutOfMemoryError" aren't reported if "System.exit" is called after the error occurs
   [FIX] Test Distribution: Fails to replace the path for any JVM argument file prefixed with `@`


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
