### PR TITLE
Create shared DD intake HTTP client

### DIFF
--- a/communication/src/main/java/datadog/communication/BackendApiFactory.java
+++ b/communication/src/main/java/datadog/communication/BackendApiFactory.java
@@ -39,7 +39,7 @@ public class BackendApiFactory {
           apiKey,
           traceId,
           retryPolicyFactory,
-          sharedCommunicationObjects.getIntakeHttpClient(config),
+          sharedCommunicationObjects.getIntakeHttpClient(),
           true);
     }
 

--- a/communication/src/main/java/datadog/communication/BackendApiFactory.java
+++ b/communication/src/main/java/datadog/communication/BackendApiFactory.java
@@ -3,13 +3,11 @@ package datadog.communication;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.communication.http.HttpRetryPolicy;
-import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.api.intake.Intake;
 import datadog.trace.util.throwable.FatalAgentMisconfigurationError;
 import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +34,13 @@ public class BackendApiFactory {
             "Agentless mode is enabled and api key is not set. Please set application key");
       }
       String traceId = config.getIdGenerationStrategy().generateTraceId().toString();
-      OkHttpClient httpClient =
-          OkHttpUtils.buildHttpClient(
-              agentlessUrl, config.getCiVisibilityBackendApiTimeoutMillis());
-      return new IntakeApi(agentlessUrl, apiKey, traceId, retryPolicyFactory, httpClient, true);
+      return new IntakeApi(
+          agentlessUrl,
+          apiKey,
+          traceId,
+          retryPolicyFactory,
+          sharedCommunicationObjects.getIntakeHttpClient(config),
+          true);
     }
 
     DDAgentFeaturesDiscovery featuresDiscovery =
@@ -55,7 +56,7 @@ public class BackendApiFactory {
           evpProxyUrl,
           subdomain,
           retryPolicyFactory,
-          sharedCommunicationObjects.okHttpClient,
+          sharedCommunicationObjects.agentHttpClient,
           true);
     }
 

--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -60,9 +60,9 @@ public class SharedCommunicationObjects {
     }
 
     httpClientTimeout =
-        !config.isCiVisibilityEnabled()
-            ? TimeUnit.SECONDS.toMillis(config.getAgentTimeout())
-            : config.getCiVisibilityBackendApiTimeoutMillis();
+        config.isCiVisibilityEnabled()
+            ? config.getCiVisibilityBackendApiTimeoutMillis()
+            : TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
 
     forceClearTextHttpForIntakeClient = config.isForceClearTextHttpForIntakeClient();
 
@@ -78,10 +78,7 @@ public class SharedCommunicationObjects {
       String namedPipe = config.getAgentNamedPipe();
       agentHttpClient =
           OkHttpUtils.buildHttpClient(
-              agentUrl != null && "http".equals(agentUrl.scheme()),
-              unixDomainSocket,
-              namedPipe,
-              httpClientTimeout);
+              OkHttpUtils.isPlainHttp(agentUrl), unixDomainSocket, namedPipe, httpClientTimeout);
     }
   }
 
@@ -228,9 +225,9 @@ public class SharedCommunicationObjects {
   }
 
   public OkHttpClient getIntakeHttpClient() {
-    OkHttpClient intakeHttpClient = this.intakeHttpClient;
-    if (intakeHttpClient != null) {
-      return intakeHttpClient;
+    OkHttpClient client = this.intakeHttpClient;
+    if (client != null) {
+      return client;
     }
 
     synchronized (this) {

--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -58,11 +58,11 @@ public final class OkHttpUtils {
       SystemProperties.getOrDefault("java.vm.vendor", "unknown");
 
   public static OkHttpClient buildHttpClient(final HttpUrl url, final long timeoutMillis) {
-    return buildHttpClient(url, null, null, timeoutMillis);
+    return buildHttpClient(url != null && "http".equals(url.scheme()), null, null, timeoutMillis);
   }
 
   public static OkHttpClient buildHttpClient(
-      final HttpUrl url,
+      final boolean isHttp,
       final String unixDomainSocketPath,
       final String namedPipe,
       final long timeoutMillis) {
@@ -70,7 +70,7 @@ public final class OkHttpUtils {
         unixDomainSocketPath,
         namedPipe,
         null,
-        url,
+        isHttp,
         null,
         null,
         null,
@@ -95,7 +95,7 @@ public final class OkHttpUtils {
         discoverApmSocket(config),
         config.getAgentNamedPipe(),
         dispatcher,
-        url,
+        url != null && "http".equals(url.scheme()),
         retryOnConnectionFailure,
         maxRunningRequests,
         proxyHost,
@@ -111,7 +111,7 @@ public final class OkHttpUtils {
       final String unixDomainSocketPath,
       final String namedPipe,
       final Dispatcher dispatcher,
-      final HttpUrl url,
+      final boolean isHttp,
       final Boolean retryOnConnectionFailure,
       final Integer maxRunningRequests,
       final String proxyHost,
@@ -151,7 +151,6 @@ public final class OkHttpUtils {
       log.debug("Using NamedPipe as http transport");
     }
 
-    boolean isHttp = url != null && "http".equals(url.scheme());
     if (isHttp) {
       // force clear text when using http to avoid failures for JVMs without TLS
       builder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));

--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -58,7 +58,7 @@ public final class OkHttpUtils {
       SystemProperties.getOrDefault("java.vm.vendor", "unknown");
 
   public static OkHttpClient buildHttpClient(final HttpUrl url, final long timeoutMillis) {
-    return buildHttpClient(url != null && "http".equals(url.scheme()), null, null, timeoutMillis);
+    return buildHttpClient(isPlainHttp(url), null, null, timeoutMillis);
   }
 
   public static OkHttpClient buildHttpClient(
@@ -95,7 +95,7 @@ public final class OkHttpUtils {
         discoverApmSocket(config),
         config.getAgentNamedPipe(),
         dispatcher,
-        url != null && "http".equals(url.scheme()),
+        isPlainHttp(url),
         retryOnConnectionFailure,
         maxRunningRequests,
         proxyHost,
@@ -391,5 +391,9 @@ public final class OkHttpUtils {
     } catch (Exception e) {
       // ignore
     }
+  }
+
+  public static boolean isPlainHttp(final HttpUrl url) {
+    return url != null && "http".equalsIgnoreCase(url.scheme());
   }
 }

--- a/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
@@ -24,7 +24,7 @@ class SharedCommunicationsObjectsSpecification extends DDSpecification {
     1 * config.agentTimeout >> 1
     1 * config.agentUnixDomainSocket >> null
     sco.agentUrl as String == 'http://example.com/'
-    sco.okHttpClient != null
+    sco.agentHttpClient != null
     sco.monitoring.is(Monitoring.DISABLED)
 
     when:
@@ -78,7 +78,7 @@ class SharedCommunicationsObjectsSpecification extends DDSpecification {
     DDAgentFeaturesDiscovery agentFeaturesDiscovery = Mock()
 
     sco.agentUrl = url
-    sco.okHttpClient = okHttpClient
+    sco.agentHttpClient = okHttpClient
     sco.monitoring = monitoring
     sco.featuresDiscovery = agentFeaturesDiscovery
 
@@ -88,7 +88,7 @@ class SharedCommunicationsObjectsSpecification extends DDSpecification {
     then:
     0 * _
     sco.agentUrl.is(url)
-    sco.okHttpClient.is(okHttpClient)
+    sco.agentHttpClient.is(okHttpClient)
     sco.monitoring.is(monitoring)
     sco.featuresDiscovery.is(agentFeaturesDiscovery)
   }

--- a/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
@@ -127,4 +127,12 @@ class SharedCommunicationsObjectsSpecification extends DDSpecification {
     1 * config.agentUnixDomainSocket >> null
     sco.agentUrl as String == 'http://[2600:1f18:19c0:bd07:d55b::17]:8126/'
   }
+
+  void 'creates intake http client'() {
+    when:
+    def client = sco.getIntakeHttpClient()
+
+    then:
+    client != null
+  }
 }

--- a/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
@@ -86,6 +86,9 @@ class SharedCommunicationsObjectsSpecification extends DDSpecification {
     sco.createRemaining(config)
 
     then:
+    1 * config.isCiVisibilityEnabled()
+    1 * config.getAgentTimeout()
+    1 * config.isForceClearTextHttpForIntakeClient()
     0 * _
     sco.agentUrl.is(url)
     sco.agentHttpClient.is(okHttpClient)

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
@@ -153,7 +153,7 @@ public class CiVisibilityServices {
       CiEnvironment remoteEnvironment =
           new CiEnvironmentImpl(
               getRemoteEnvironment(
-                  remoteEnvVarsProviderUrl, remoteEnvVarsProviderKey, sco.okHttpClient));
+                  remoteEnvVarsProviderUrl, remoteEnvVarsProviderKey, sco.agentHttpClient));
       return new CompositeCiEnvironment(remoteEnvironment, localEnvironment);
     } else {
       return localEnvironment;

--- a/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/AppSecBenchmark.java
+++ b/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/AppSecBenchmark.java
@@ -70,9 +70,9 @@ public class AppSecBenchmark {
     ss = gw.getSubscriptionService(RequestContextSlot.APPSEC);
     SharedCommunicationObjects sharedCommunicationObjects = new SharedCommunicationObjects();
     sharedCommunicationObjects.monitoring = Monitoring.DISABLED;
-    sharedCommunicationObjects.okHttpClient = new StubOkHttpClient();
+    sharedCommunicationObjects.agentHttpClient = new StubOkHttpClient();
     sharedCommunicationObjects.setFeaturesDiscovery(
-        new StubDDAgentFeaturesDiscovery(sharedCommunicationObjects.okHttpClient));
+        new StubDDAgentFeaturesDiscovery(sharedCommunicationObjects.agentHttpClient));
 
     AppSecSystem.start(ss, sharedCommunicationObjects);
     uri = new URIDefaultDataAdapter(new URI("http://localhost:8080/test"));

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -182,7 +182,7 @@ class AppSecSystemSpecification extends DDSpecification {
           poller
         }
       }
-    sco.okHttpClient = Stub(OkHttpClient)
+    sco.agentHttpClient = Stub(OkHttpClient)
     sco.monitoring = Mock(Monitoring)
     sco.featuresDiscovery = Stub(DDAgentFeaturesDiscovery)
     sco

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -371,7 +371,7 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
 
       // emit traces to the APM Test-Agent for Cross-Tracer Testing Trace Checks
       HttpUrl agentUrl = HttpUrl.get("http://" + agentHost + ":" + DEFAULT_TRACE_AGENT_PORT)
-      OkHttpClient client = buildHttpClient(agentUrl, null, null, TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT))
+      OkHttpClient client = buildHttpClient(true, null, null, TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT))
       DDAgentFeaturesDiscovery featureDiscovery = new DDAgentFeaturesDiscovery(client, Monitoring.DISABLED, agentUrl, Config.get().isTraceAgentV05Enabled(), Config.get().isTracerMetricsEnabled())
       TEST_AGENT_API = new DDAgentApi(client, agentUrl, featureDiscovery, Monitoring.DISABLED, Config.get().isTracerMetricsEnabled())
       TEST_AGENT_WRITER = DDAgentWriter.builder().agentApi(TEST_AGENT_API).build()

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -26,6 +26,8 @@ public final class TracerConfig {
   public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
   public static final String AGENT_NAMED_PIPE = "trace.pipe.name";
   public static final String AGENT_TIMEOUT = "trace.agent.timeout";
+  public static final String FORCE_CLEAR_TEXT_HTTP_FOR_INTAKE_CLIENT =
+      "force.clear.text.http.for.intake.client";
   public static final String PROXY_NO_PROXY = "proxy.no_proxy";
   public static final String TRACE_AGENT_PATH = "trace.agent.path";
   public static final String TRACE_AGENT_ARGS = "trace.agent.args";

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -113,7 +113,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         sharedCommunicationObjects.featuresDiscovery(config),
         healthMetrics,
         new OkHttpSink(
-            sharedCommunicationObjects.okHttpClient,
+            sharedCommunicationObjects.agentHttpClient,
             sharedCommunicationObjects.agentUrl.toString(),
             V6_METRICS_ENDPOINT,
             config.isTracerMetricsBufferingEnabled(),

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -138,7 +138,7 @@ public class DDAgentWriter extends RemoteWriter {
       final HttpUrl agentUrl = HttpUrl.get("http://" + agentHost + ":" + traceAgentPort);
       final OkHttpClient client =
           null == featureDiscovery || null == agentApi
-              ? buildHttpClient(agentUrl, unixDomainSocket, namedPipe, timeoutMillis)
+              ? buildHttpClient(true, unixDomainSocket, namedPipe, timeoutMillis)
               : null;
       if (null == featureDiscovery) {
         featureDiscovery =

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -143,7 +143,7 @@ public class WriterFactory {
 
       DDAgentApi ddAgentApi =
           new DDAgentApi(
-              commObjects.okHttpClient,
+              commObjects.agentHttpClient,
               commObjects.agentUrl,
               featuresDiscovery,
               commObjects.monitoring,
@@ -202,7 +202,7 @@ public class WriterFactory {
 
     if (useProxyApi) {
       return DDEvpProxyApi.builder()
-          .httpClient(commObjects.okHttpClient)
+          .httpClient(commObjects.agentHttpClient)
           .agentUrl(commObjects.agentUrl)
           .evpProxyEndpoint(featuresDiscovery.getEvpProxyEndpoint())
           .trackType(trackType)
@@ -224,6 +224,7 @@ public class WriterFactory {
       }
       return DDIntakeApi.builder()
           .hostUrl(hostUrl)
+          .httpClient(commObjects.getIntakeHttpClient(config))
           .apiKey(config.getApiKey())
           .trackType(trackType)
           .build();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -224,7 +224,7 @@ public class WriterFactory {
       }
       return DDIntakeApi.builder()
           .hostUrl(hostUrl)
-          .httpClient(commObjects.getIntakeHttpClient(config))
+          .httpClient(commObjects.getIntakeHttpClient())
           .apiKey(config.getApiKey())
           .trackType(trackType)
           .build();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -75,7 +75,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
       Supplier<TraceConfig> traceConfigSupplier) {
     this(
         new OkHttpSink(
-            sharedCommunicationObjects.okHttpClient,
+            sharedCommunicationObjects.agentHttpClient,
             sharedCommunicationObjects.agentUrl.toString(),
             V01_DATASTREAMS_ENDPOINT,
             false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
@@ -51,7 +51,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
     properties.put("trace.agent.port", Integer.toString(agentContainerPort))
     def sharedCommunicationObjects = new SharedCommunicationObjects()
     sharedCommunicationObjects.agentUrl = HttpUrl.get("http://localhost:" + agentContainerPort)
-    sharedCommunicationObjects.okHttpClient = client
+    sharedCommunicationObjects.agentHttpClient = client
     def fixedFeaturesDiscovery = new FixedTraceEndpointFeaturesDiscovery(sharedCommunicationObjects)
     sharedCommunicationObjects.setFeaturesDiscovery(fixedFeaturesDiscovery)
 
@@ -147,7 +147,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
 
   class FixedTraceEndpointFeaturesDiscovery extends DDAgentFeaturesDiscovery {
     FixedTraceEndpointFeaturesDiscovery(SharedCommunicationObjects objects) {
-      super(objects.okHttpClient, Monitoring.DISABLED, objects.agentUrl, false, false)
+      super(objects.agentHttpClient, Monitoring.DISABLED, objects.agentUrl, false, false)
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
@@ -51,7 +51,7 @@ class WriterFactoryTest extends DDSpecification {
 
     // Create SharedCommunicationObjects with mocked HTTP client
     def sharedComm = new SharedCommunicationObjects()
-    sharedComm.okHttpClient = mockHttpClient
+    sharedComm.agentHttpClient = mockHttpClient
     sharedComm.agentUrl = HttpUrl.parse(config.agentUrl)
     sharedComm.createRemaining(config)
 
@@ -127,7 +127,7 @@ class WriterFactoryTest extends DDSpecification {
 
     // Create SharedCommunicationObjects with mocked HTTP client
     def sharedComm = new SharedCommunicationObjects()
-    sharedComm.okHttpClient = mockHttpClient
+    sharedComm.agentHttpClient = mockHttpClient
     sharedComm.agentUrl = HttpUrl.parse(config.agentUrl)
     sharedComm.createRemaining(config)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -325,7 +325,7 @@ class CoreTracerTest extends DDCoreSpecification {
     def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
@@ -425,7 +425,7 @@ class CoreTracerTest extends DDCoreSpecification {
     def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
@@ -479,7 +479,7 @@ class CoreTracerTest extends DDCoreSpecification {
     def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
@@ -586,7 +586,7 @@ class CoreTracerTest extends DDCoreSpecification {
     def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TracingConfigPollerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TracingConfigPollerTest.groovy
@@ -106,7 +106,7 @@ class TracingConfigPollerTest extends DDCoreSpecification {
     def serviceKey = ParsedConfigKey.parse("datadog/2/APM_TRACING/service_config/config")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
@@ -216,7 +216,7 @@ class TracingConfigPollerTest extends DDCoreSpecification {
     def orgConfig2Key = ParsedConfigKey.parse("datadog/2/APM_TRACING/org_config/config2")
     def poller = Mock(ConfigurationPoller)
     def sco = new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery),

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
@@ -69,7 +69,7 @@ class DataStreamsWritingTest extends DDCoreSpecification {
 
     def sharedCommObjects = new SharedCommunicationObjects()
     sharedCommObjects.featuresDiscovery = features
-    sharedCommObjects.okHttpClient = testOkhttpClient
+    sharedCommObjects.agentHttpClient = testOkhttpClient
     sharedCommObjects.createRemaining(fakeConfig)
 
     def timeSource = new ControllableTimeSource()
@@ -129,7 +129,7 @@ class DataStreamsWritingTest extends DDCoreSpecification {
 
     def sharedCommObjects = new SharedCommunicationObjects()
     sharedCommObjects.featuresDiscovery = features
-    sharedCommObjects.okHttpClient = testOkhttpClient
+    sharedCommObjects.agentHttpClient = testOkhttpClient
     sharedCommObjects.createRemaining(fakeConfig)
 
     def timeSource = new ControllableTimeSource()

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -83,7 +83,7 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
     api = new DDAgentApi(httpClient, agentUrl, discovery, monitoring, false)
     api.addResponseListener(responseListener)
     HttpUrl udsAgentUrl = HttpUrl.get(String.format("http://%s:%d", SOMEHOST, SOMEPORT))
-    OkHttpClient udsClient = OkHttpUtils.buildHttpClient(udsAgentUrl, socketPath.toString(), null, 5000)
+    OkHttpClient udsClient = OkHttpUtils.buildHttpClient(true, socketPath.toString(), null, 5000)
     udsDiscovery = new DDAgentFeaturesDiscovery(udsClient, monitoring, agentUrl, enableV05, true)
     unixDomainSocketApi = new DDAgentApi(udsClient, udsAgentUrl, udsDiscovery, monitoring, false)
     unixDomainSocketApi.addResponseListener(responseListener)

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -561,6 +561,7 @@ import static datadog.trace.api.config.TracerConfig.BAGGAGE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.CLIENT_IP_ENABLED;
 import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
+import static datadog.trace.api.config.TracerConfig.FORCE_CLEAR_TEXT_HTTP_FOR_INTAKE_CLIENT;
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
@@ -790,6 +791,9 @@ public class Config {
   private final String agentUnixDomainSocket;
   private final String agentNamedPipe;
   private final int agentTimeout;
+  /** Should be set to {@code true} when running in agentless mode in a JVM without TLS */
+  private final boolean forceClearTextHttpForIntakeClient;
+
   private final Set<String> noProxyHosts;
   private final boolean prioritySamplingEnabled;
   private final String prioritySamplingForce;
@@ -1467,6 +1471,9 @@ public class Config {
             && agentNamedPipe == null;
 
     agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
+
+    forceClearTextHttpForIntakeClient =
+        configProvider.getBoolean(FORCE_CLEAR_TEXT_HTTP_FOR_INTAKE_CLIENT, false);
 
     // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
     noProxyHosts = tryMakeImmutableSet(configProvider.getSpacedList(PROXY_NO_PROXY));
@@ -2972,6 +2979,10 @@ public class Config {
 
   public int getAgentTimeout() {
     return agentTimeout;
+  }
+
+  public boolean isForceClearTextHttpForIntakeClient() {
+    return forceClearTextHttpForIntakeClient;
   }
 
   public Set<String> getNoProxyHosts() {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -6,6 +6,7 @@ import datadog.trace.api.Config;
 import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -29,7 +30,7 @@ public class TelemetryClient {
   }
 
   public static TelemetryClient buildIntakeClient(
-      Config config, OkHttpClient okHttpClient, HttpRetryPolicy.Factory httpRetryPolicy) {
+      Config config, HttpRetryPolicy.Factory httpRetryPolicy) {
     String apiKey = config.getApiKey();
     if (apiKey == null) {
       log.debug("Cannot create Telemetry Intake because DD_API_KEY unspecified.");
@@ -45,7 +46,9 @@ public class TelemetryClient {
       return null;
     }
 
-    return new TelemetryClient(okHttpClient, httpRetryPolicy, url, apiKey);
+    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
+    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(url, timeoutMillis);
+    return new TelemetryClient(httpClient, httpRetryPolicy, url, apiKey);
   }
 
   private static String buildIntakeTelemetryUrl(Config config) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -6,7 +6,6 @@ import datadog.trace.api.Config;
 import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -30,7 +29,7 @@ public class TelemetryClient {
   }
 
   public static TelemetryClient buildIntakeClient(
-      Config config, HttpRetryPolicy.Factory httpRetryPolicy) {
+      Config config, OkHttpClient okHttpClient, HttpRetryPolicy.Factory httpRetryPolicy) {
     String apiKey = config.getApiKey();
     if (apiKey == null) {
       log.debug("Cannot create Telemetry Intake because DD_API_KEY unspecified.");
@@ -46,9 +45,7 @@ public class TelemetryClient {
       return null;
     }
 
-    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
-    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(url, timeoutMillis);
-    return new TelemetryClient(httpClient, httpRetryPolicy, url, apiKey);
+    return new TelemetryClient(okHttpClient, httpRetryPolicy, url, apiKey);
   }
 
   private static String buildIntakeTelemetryUrl(Config config) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -101,8 +101,9 @@ public class TelemetrySystem {
             : HttpRetryPolicy.Factory.NEVER_RETRY;
 
     TelemetryClient agentClient =
-        TelemetryClient.buildAgentClient(sco.okHttpClient, sco.agentUrl, httpRetryPolicy);
-    TelemetryClient intakeClient = TelemetryClient.buildIntakeClient(config, httpRetryPolicy);
+        TelemetryClient.buildAgentClient(sco.agentHttpClient, sco.agentUrl, httpRetryPolicy);
+    TelemetryClient intakeClient =
+        TelemetryClient.buildIntakeClient(config, sco.getIntakeHttpClient(config), httpRetryPolicy);
 
     boolean useIntakeClientByDefault =
         config.isCiVisibilityEnabled() && config.isCiVisibilityAgentlessEnabled();

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -103,7 +103,7 @@ public class TelemetrySystem {
     TelemetryClient agentClient =
         TelemetryClient.buildAgentClient(sco.agentHttpClient, sco.agentUrl, httpRetryPolicy);
     TelemetryClient intakeClient =
-        TelemetryClient.buildIntakeClient(config, sco.getIntakeHttpClient(config), httpRetryPolicy);
+        TelemetryClient.buildIntakeClient(config, sco.getIntakeHttpClient(), httpRetryPolicy);
 
     boolean useIntakeClientByDefault =
         config.isCiVisibilityEnabled() && config.isCiVisibilityAgentlessEnabled();

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -102,8 +102,7 @@ public class TelemetrySystem {
 
     TelemetryClient agentClient =
         TelemetryClient.buildAgentClient(sco.agentHttpClient, sco.agentUrl, httpRetryPolicy);
-    TelemetryClient intakeClient =
-        TelemetryClient.buildIntakeClient(config, sco.getIntakeHttpClient(), httpRetryPolicy);
+    TelemetryClient intakeClient = TelemetryClient.buildIntakeClient(config, httpRetryPolicy);
 
     boolean useIntakeClientByDefault =
         config.isCiVisibilityEnabled() && config.isCiVisibilityAgentlessEnabled();

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -1,14 +1,11 @@
 package datadog.telemetry
 
 import datadog.communication.http.HttpRetryPolicy
-import datadog.communication.http.OkHttpUtils
 import datadog.telemetry.api.RequestType
 import datadog.trace.api.Config
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import spock.lang.Specification
-
-import java.util.concurrent.TimeUnit
 
 class TelemetryClientTest extends Specification {
 
@@ -19,11 +16,8 @@ class TelemetryClientTest extends Specification {
     config.getAgentTimeout() >> 123
     config.getSite() >> site
 
-    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout())
-    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(false, null, null, timeoutMillis)
-
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config, httpClient, HttpRetryPolicy.Factory.NEVER_RETRY)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl
@@ -48,11 +42,8 @@ class TelemetryClientTest extends Specification {
     config.isCiVisibilityAgentlessEnabled() >> ciVisAgentlessEnabled
     config.getCiVisibilityAgentlessUrl() >> ciVisAgentlessUrl
 
-    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout())
-    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(false, null, null, timeoutMillis)
-
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config, httpClient, HttpRetryPolicy.Factory.NEVER_RETRY)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -1,11 +1,14 @@
 package datadog.telemetry
 
 import datadog.communication.http.HttpRetryPolicy
+import datadog.communication.http.OkHttpUtils
 import datadog.telemetry.api.RequestType
 import datadog.trace.api.Config
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
 
 class TelemetryClientTest extends Specification {
 
@@ -16,8 +19,11 @@ class TelemetryClientTest extends Specification {
     config.getAgentTimeout() >> 123
     config.getSite() >> site
 
+    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout())
+    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(false, null, null, timeoutMillis)
+
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, httpClient, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl
@@ -42,8 +48,11 @@ class TelemetryClientTest extends Specification {
     config.isCiVisibilityAgentlessEnabled() >> ciVisAgentlessEnabled
     config.getCiVisibilityAgentlessUrl() >> ciVisAgentlessUrl
 
+    long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout())
+    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(false, null, null, timeoutMillis)
+
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, httpClient, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -64,7 +64,7 @@ class TelemetrySystemSpecification extends DDSpecification {
 
   private SharedCommunicationObjects sharedCommunicationObjects() {
     new SharedCommunicationObjects(
-      okHttpClient: Mock(OkHttpClient),
+      agentHttpClient: Mock(OkHttpClient),
       monitoring: Mock(Monitoring),
       agentUrl: HttpUrl.get('https://example.com'),
       featuresDiscovery: Mock(DDAgentFeaturesDiscovery)

--- a/utils/flare-utils/src/main/java/datadog/flare/TracerFlarePoller.java
+++ b/utils/flare-utils/src/main/java/datadog/flare/TracerFlarePoller.java
@@ -44,7 +44,7 @@ public final class TracerFlarePoller {
     Config config = Config.get();
     stopPreparer = new Preparer().register(config, sco);
     stopSubmitter = new Submitter().register(config, sco);
-    tracerFlareService = new TracerFlareService(config, sco.okHttpClient, sco.agentUrl);
+    tracerFlareService = new TracerFlareService(config, sco.agentHttpClient, sco.agentUrl);
   }
 
   private void doStop() {


### PR DESCRIPTION
# What Does This Do

Adds a single shared lazily-initialized HTTP client to send requests to Datadog backend.

# Motivation

Previously each component talking to the backend created its own HTTP client, so we ended up with 4-5 clients in agentless mode (tests intake, telemetry, API, logs intake, coverage report intake).
OKHTTP docs advice creating a single HTTP client per JVM (the client creates its own thread and connection pools, so having multiple clients adds some load).

# Additional Notes

By default the new single client does NOT force clear-text HTTP.
Prior to the changes, each component's URL was examined and if the schema was `http`, clear text connections were forced for corresponding client.
This was needed to support running in JVMs that had no modern TLS implementations.
This check is > 5 years old, nowadays it should be rare to encounter such a JVM.
Moreover, this check was introduced when the only communication the tracer did was to the agent, often running locally, which is why unencrypted HTTP was acceptable.
When talking to the backend we should not use unencrypted HTTP anyway.

In case there happens to be a customer using agentless mode and running a JVM that does not support TLS, they can set the `DD_FORCE_CLEAR_TEXT_HTTP_FOR_INTAKE_CLIENT` environment variable to force clear-text HTTP on the new client.

Communication to the agent is unaffected, as there's already a single dedicated client for it (which, depending on the config, can use UDS or named pipes, which we don't want for the intake client).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-2562](https://datadoghq.atlassian.net/browse/SDTEST-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-2562]: https://datadoghq.atlassian.net/browse/SDTEST-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ