### PR TITLE
DSMON-886: add Sqs spring messaging context propagation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ out/
 # Visual Studio Code #
 ######################
 .vscode
+.cursor
 
 # Others #
 ##########

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -334,6 +334,7 @@
 2 org.springframework.lang.*
 2 org.springframework.messaging.*
 0 org.springframework.messaging.handler.invocation.InvocableHandlerMethod
+0 org.springframework.messaging.support.GenericMessage
 2 org.springframework.objenesis.*
 2 org.springframework.orm.*
 2 org.springframework.remoting.*

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -18,9 +18,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.datastreams.DataStreamsTags;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,12 +31,18 @@ import software.amazon.awssdk.services.sqs.model.Message;
 public class TracingIterator<L extends Iterator<Message>> implements Iterator<Message> {
   private static final Logger log = LoggerFactory.getLogger(TracingIterator.class);
 
+  private final ContextStore<Message, State> messageStateStore;
   protected final L delegate;
   private final String queueUrl;
   private final String requestId;
   private AgentSpanContext batchContext;
 
-  public TracingIterator(L delegate, String queueUrl, String requestId) {
+  public TracingIterator(
+      ContextStore<Message, State> messageStateStore,
+      L delegate,
+      String queueUrl,
+      String requestId) {
+    this.messageStateStore = messageStateStore;
     this.delegate = delegate;
     this.queueUrl = queueUrl;
     this.requestId = requestId;
@@ -99,6 +107,11 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           BROKER_DECORATE.beforeFinish(queueSpan);
           queueSpan.finish();
         }
+
+        // Capture state after data streams checkpoint is set
+        State state = State.FACTORY.create();
+        state.captureAndSetContinuation(span);
+        messageStateStore.put(message, state);
       }
     } catch (Exception e) {
       log.debug("Problem tracing new SQS message span", e);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
@@ -2,14 +2,20 @@ package datadog.trace.instrumentation.aws.v2.sqs;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.ListIterator;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 public class TracingListIterator extends TracingIterator<ListIterator<Message>>
     implements ListIterator<Message> {
 
-  public TracingListIterator(ListIterator<Message> delegate, String queueUrl, String requestId) {
-    super(delegate, queueUrl, requestId);
+  public TracingListIterator(
+      ContextStore<Message, State> messageStateStore,
+      ListIterator<Message> delegate,
+      String queueUrl,
+      String requestId) {
+    super(messageStateStore, delegate, queueUrl, requestId);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-sqs/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-sqs/build.gradle
@@ -1,0 +1,59 @@
+muzzle {
+  pass {
+    group = 'io.awspring.cloud'
+    module = 'spring-cloud-aws-sqs'
+    versions = "[3.0.0,)"
+    assertInverse = true
+  }
+}
+
+def TEST_JAVA = 17
+
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly group: 'software.amazon.awssdk', name: 'sqs', version: '2.20.162'
+  compileOnly group: 'org.springframework', name: 'spring-messaging', version: '5.3.23'
+
+  testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+  testImplementation project(':dd-java-agent:instrumentation:aws-java:aws-java-sdk-2.2')
+  testImplementation project(':dd-java-agent:instrumentation:aws-java:aws-java-sqs-2.0')
+  testImplementation project(':dd-java-agent:instrumentation:spring:spring-messaging-4.0')
+
+  testImplementation group: 'org.springframework', name: 'spring-context', version: '6.1.10'
+  testImplementation group: 'org.springframework', name: 'spring-test',    version: '6.1.10'
+  testImplementation group: 'org.springframework', name: 'spring-core',    version: '6.1.10'
+  testImplementation group: 'io.awspring.cloud',  name: 'spring-cloud-aws-sqs', version: '3.1.0'
+  testImplementation group: 'software.amazon.awssdk', name: 'sqs',      version: '2.20.162'
+  testImplementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.20.162'
+  testImplementation group: 'org.testcontainers', name: 'localstack', version: libs.versions.testcontainers.get()
+  testImplementation 'org.slf4j:slf4j-api:2.0.13'
+  testImplementation 'ch.qos.logback:logback-classic:1.4.14'
+  testImplementation 'ch.qos.logback:logback-core:1.4.14'
+
+  latestDepTestImplementation group: 'org.springframework',      name: 'spring-context', version: '6.+'
+  latestDepTestImplementation group: 'org.springframework',      name: 'spring-test',    version: '6.+'
+  latestDepTestImplementation group: 'org.springframework',      name: 'spring-core',    version: '6.+'
+  latestDepTestImplementation group: 'software.amazon.awssdk',   name: 'sqs',            version: '2.+'
+  latestDepTestImplementation group: 'software.amazon.awssdk',   name: 'aws-core',       version: '2.+'
+}
+
+// Compile only *test* Groovy source sets (e.g., compileTestGroovy, compileLatestDepTestGroovy) with JDK 17
+tasks.withType(org.gradle.api.tasks.compile.GroovyCompile).configureEach {
+  if (name.endsWith('TestGroovy')) {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(TEST_JAVA)
+    }
+  }
+}
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+  javaLauncher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(TEST_JAVA)
+  }
+  jvmArgs += ['--add-opens=java.base/java.util=ALL-UNNAMED']
+}

--- a/dd-java-agent/instrumentation/spring/spring-sqs/src/main/java/datadog/trace/instrumentation/springsqs/AbstractMessagingMessageConverterToMessagingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-sqs/src/main/java/datadog/trace/instrumentation/springsqs/AbstractMessagingMessageConverterToMessagingInstrumentation.java
@@ -1,0 +1,78 @@
+package datadog.trace.instrumentation.springsqs;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.messaging.Message;
+
+@AutoService(InstrumenterModule.class)
+public class AbstractMessagingMessageConverterToMessagingInstrumentation
+    extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public AbstractMessagingMessageConverterToMessagingInstrumentation() {
+    super("spring-sqs");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod().and(named("toMessagingMessage")),
+        getClass().getName() + "$ToMessagingMessageAdvice");
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> contextStore = new HashMap<>(2);
+    contextStore.put("software.amazon.awssdk.services.sqs.model.Message", State.class.getName());
+    contextStore.put("org.springframework.messaging.Message", State.class.getName());
+    return contextStore;
+  }
+
+  public static class ToMessagingMessageAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(0) Object sqsMessage, @Advice.Return Message springMessage) {
+      // Transfer state from SQS message to Spring message
+      if (null != sqsMessage
+          && null != springMessage
+          && sqsMessage
+              .getClass()
+              .getName()
+              .equals("software.amazon.awssdk.services.sqs.model.Message")) {
+
+        ContextStore<software.amazon.awssdk.services.sqs.model.Message, State> from =
+            InstrumentationContext.get(
+                software.amazon.awssdk.services.sqs.model.Message.class, State.class);
+        State state = from.get((software.amazon.awssdk.services.sqs.model.Message) sqsMessage);
+        if (null != state) {
+          from.put((software.amazon.awssdk.services.sqs.model.Message) sqsMessage, null);
+          ContextStore<Message, State> to = InstrumentationContext.get(Message.class, State.class);
+          to.put(springMessage, state);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-sqs/src/test/groovy/SpringSqsTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-sqs/src/test/groovy/SpringSqsTest.groovy
@@ -1,0 +1,188 @@
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.agent.test.utils.PortUtils
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Component
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration
+import io.awspring.cloud.sqs.annotation.SqsListener
+import spock.lang.Shared
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS
+
+class SpringSqsTest extends InstrumentationSpecification {
+
+  static final String QUEUE_NAME = "test-queue"
+
+  @Shared
+  LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+  .withServices(SQS)
+
+  @Override
+  def setupSpec() {
+    localstack.start()
+
+    def endpoint = localstack.getEndpointOverride(SQS).toString()
+
+    PortUtils.waitForPortToOpen(
+      localstack.getHost(),
+      localstack.getMappedPort(4566),
+      10,
+      TimeUnit.SECONDS)
+
+    def sqsClient = SqsAsyncClient.builder()
+      .endpointOverride(new URI(endpoint))
+      .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+      .credentialsProvider(software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+      software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create("test", "test")))
+      .build()
+    sqsClient.createQueue(CreateQueueRequest.builder().queueName(QUEUE_NAME).build()).get()
+  }
+
+  @Override
+  def cleanupSpec() {
+    if (null != localstack) {
+      localstack.close()
+    }
+  }
+
+  def "test basic SQS message send and receive"() {
+    setup:
+    def endpoint = localstack.getEndpointOverride(SQS).toString()
+    def sqsClient = SqsAsyncClient.builder()
+      .endpointOverride(new URI(endpoint))
+      .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+      .credentialsProvider(software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+      software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create("test", "test")))
+      .build()
+    def queueUrl = sqsClient
+      .getQueueUrl(GetQueueUrlRequest.builder().queueName(QUEUE_NAME).build())
+      .get()
+      .queueUrl()
+
+
+    when:
+
+    def latch = new CountDownLatch(1)
+    def received = new AtomicReference<String>()
+
+    TestConfig.endpoint = endpoint
+    TestConfig.latch = latch
+    TestConfig.received = received
+
+    // Create a configuration class that properly sets up Spring SQS
+    def ctx = new AnnotationConfigApplicationContext(TestConfig)
+
+    // various setup actions are traced
+    TEST_WRITER.waitForTraces(2)
+    TEST_WRITER.clear()
+
+    runUnderTrace("parent") {
+      sqsClient
+        .sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("hello").build())
+        .get()
+    }
+
+    then:
+    latch.await(2, TimeUnit.SECONDS)
+    received.get() == "hello"
+    assertTraces(3) {
+      trace(2, true) {
+        span(0) {
+          childOf(span(1))
+          operationName "aws.http"
+          resourceName "Sqs.SendMessage"
+          spanType "http"
+        }
+        span(1) {
+          operationName "parent"
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "aws.http"
+          resourceName "Sqs.ReceiveMessage"
+          spanType "queue"
+        }
+        span(1) {
+          // the main test is here. spring.consume needs to be the child of ReceiveMessage
+          childOf(span(0))
+          operationName "spring.consume"
+          resourceName "TestListener.onMessage"
+          spanType "queue"
+        }
+      }
+      trace(1) {
+        span(0) {
+          operationName "aws.http"
+          resourceName "Sqs.DeleteMessageBatch"
+          spanType "http"
+        }
+      }
+    }
+
+    cleanup:
+    ctx?.close()
+    sqsClient?.close()
+  }
+
+  @Configuration
+  @Import(SqsBootstrapConfiguration)
+  static class TestConfig {
+    static String endpoint
+    static CountDownLatch latch
+    static AtomicReference<String> received
+
+    @Bean
+    SqsAsyncClient sqsAsyncClient() {
+      return SqsAsyncClient.builder()
+        .endpointOverride(new URI(endpoint))
+        .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+        .credentialsProvider(software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+        software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create("test", "test")))
+        .build()
+    }
+
+    @Bean
+    SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+      def factory = new SqsMessageListenerContainerFactory<Object>()
+      factory.setSqsAsyncClient(sqsAsyncClient())
+      return factory
+    }
+
+    @Bean
+    TestListener testListener() {
+      return new TestListener(latch, received)
+    }
+  }
+
+  @Component
+  static class TestListener {
+    private final CountDownLatch latch
+    private final AtomicReference<String> received
+
+    TestListener(CountDownLatch latch, AtomicReference<String> received) {
+      this.latch = latch
+      this.received = received
+    }
+
+    @SqsListener(queueNames = QUEUE_NAME)
+    void onMessage(String payload) {
+      received.set(payload)
+      latch.countDown()
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-sqs/src/test/resources/logback-test.xml
+++ b/dd-java-agent/instrumentation/spring/spring-sqs/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="io.awspring.cloud.sqs" level="INFO"/>
+  <logger name="software.amazon.awssdk.request" level="INFO"/>
+  <logger name="reactor.netty.http.client" level="INFO"/>
+  <logger name="SpringSqsTest" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -541,6 +541,7 @@ include(
   ":dd-java-agent:instrumentation:spring:spring-jms-3.1",
   ":dd-java-agent:instrumentation:spring:spring-messaging-4.0",
   ":dd-java-agent:instrumentation:spring:spring-rabbit-1.5",
+  ":dd-java-agent:instrumentation:spring:spring-sqs",
   ":dd-java-agent:instrumentation:spring:spring-scheduling-3.1",
   ":dd-java-agent:instrumentation:spring:spring-security:spring-security-5.0",
   ":dd-java-agent:instrumentation:spring:spring-security:spring-security-6.0",


### PR DESCRIPTION
# What Does This Do

Adds support for context propagation when using SQS with spring messaging.

# Motivation

Support ticket opened by customer with context propagation being broken for Data Streams monitoring.

# Additional Notes

Trace context was working thanks to [this PR](https://github.com/DataDog/dd-trace-java/pull/5631/files)
However, for Data Streams, it's important for the downstream checkpoint to be the direct child of the upstream checkpoint.

This PR fixes that with a continuation on an SQS message, which is then continued on a spring message.
This is very similar to the spring-rabbitmq fix.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
