### PR TITLE
Add akka repository token to update Gradle dependencies action.

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -34,9 +34,9 @@ jobs:
           git push -u origin $BRANCH_NAME --force
       - name: Update Gradle dependencies
         env:
-          AKKA_REPO_TOKEN: ${{ secrets.AKKA_REPO_TOKEN }}
+          ORG_GRADLE_PROJECT_akkaRepositoryToken: ${{ secrets.AKKA_REPO_TOKEN }}
         run: |
-          GRADLE_OPTS="-DakkaRepositoryToken=$AKKA_REPO_TOKEN -Dorg.gradle.jvmargs='-Xmx3G -Xms2G'" \
+          GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx3G -Xms2G'" \
           JAVA_HOME=$JAVA_HOME_8_X64 \
           JAVA_8_HOME=$JAVA_HOME_8_X64 \
           JAVA_11_HOME=$JAVA_HOME_11_X64 \


### PR DESCRIPTION
# What Does This Do
Add akka repository token to update Gradle dependencies action.

# Motivation
Akka locked down their repository so that requests without the token are blocked. This mirrors the change in [gitlab](https://github.com/DataDog/dd-trace-java/blob/6c26663efeb2f13effc62a30cc2a5b45d1c1e28c/.gitlab-ci.yml#L167-L179)

# Note
This is one more attempt to fix build (see #9661), as it could be tested only from master.
See Gradle [docs](http://sorcersoft.org/project/site/gradle/userguide/tutorial_this_and_that.html).