### PR TITLE
Akka instrumentation doesn't require call-site instrumentation.

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/build.gradle
@@ -5,8 +5,6 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala'
-apply plugin: 'call-site-instrumentation'
-
 
 muzzle {
   pass {


### PR DESCRIPTION
# What Does This Do
Akka instrumentation doesn't require call-site instrumentation.

# Motivation
Clean build.
