### PR TITLE
Fix fallback ExecutionRequest creator in JUnit 5 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/junit/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/ExecutionRequestFactory.java
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/ExecutionRequestFactory.java
@@ -6,8 +6,10 @@ import java.util.Arrays;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import org.junit.platform.commons.util.ClassLoaderUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
 
 public class ExecutionRequestFactory {
 
@@ -172,11 +174,16 @@ public class ExecutionRequestFactory {
 
   private static BiFunction<ExecutionRequest, EngineExecutionListener, ExecutionRequest>
       fallbackFactory() {
-    MethodHandle createMethod = findCreateMethod(PARAMETERS_FALLBACK);
+    MethodHandle constructor =
+        METHOD_HANDLES.constructor(
+            ExecutionRequest.class,
+            TestDescriptor.class,
+            EngineExecutionListener.class,
+            ConfigurationParameters.class);
 
     return (request, listener) ->
         METHOD_HANDLES.invoke(
-            createMethod,
+            constructor,
             request.getRootTestDescriptor(),
             listener,
             request.getConfigurationParameters());


### PR DESCRIPTION
# What Does This Do
- Fixes the fallback creator to correctly use the `ExecutionRequest` constructor

# Motivation
- Bug was introduced in #9664, and correctly identified with the test environment.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
