### PR TITLE
Provide full dependency plugin name and version for downloading dependencies in Maven smoke tests

### DIFF
--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -304,16 +304,22 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
    */
   private void givenMavenDependenciesAreLoaded(String projectName, String mavenVersion, Map<String, String> additionalEnvVars = [:]) {
     if (LOADED_DEPENDENCIES.add("$projectName:$mavenVersion")) {
-      retryUntilSuccessfulOrNoAttemptsLeft(["dependency:go-offline"], additionalEnvVars)
+      retryUntilSuccessfulOrNoAttemptsLeft(["org.apache.maven.plugins:maven-dependency-plugin:3.7.0:go-offline"], additionalEnvVars)
     }
     // dependencies below are download separately
     // because they are not declared in the project,
     // but are added at runtime by the tracer
     if (LOADED_DEPENDENCIES.add("com.datadoghq:dd-javac-plugin:$JAVAC_PLUGIN_VERSION")) {
-      retryUntilSuccessfulOrNoAttemptsLeft(["dependency:get", "-Dartifact=com.datadoghq:dd-javac-plugin:$JAVAC_PLUGIN_VERSION".toString()], additionalEnvVars)
+      retryUntilSuccessfulOrNoAttemptsLeft([
+        "org.apache.maven.plugins:maven-dependency-plugin:3.7.0:get",
+        "-Dartifact=com.datadoghq:dd-javac-plugin:$JAVAC_PLUGIN_VERSION".toString()
+      ], additionalEnvVars)
     }
     if (LOADED_DEPENDENCIES.add("org.jacoco:jacoco-maven-plugin:$JACOCO_PLUGIN_VERSION")) {
-      retryUntilSuccessfulOrNoAttemptsLeft(["dependency:get", "-Dartifact=org.jacoco:jacoco-maven-plugin:$JACOCO_PLUGIN_VERSION".toString()], additionalEnvVars)
+      retryUntilSuccessfulOrNoAttemptsLeft([
+        "org.apache.maven.plugins:maven-dependency-plugin:3.7.0:get",
+        "-Dartifact=org.jacoco:jacoco-maven-plugin:$JACOCO_PLUGIN_VERSION".toString()
+      ], additionalEnvVars)
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Fixes flakiness in Maven smoke tests.

# Additional Notes

Maven 4 parent pom does not seem to include `maven-dependency-plugin` by default.
As the result, when running `dependency:go-offline` the legacy `org.codehaus.mojo:dependency-maven-plugin:1.0` is used, which does not have the `go-offline` goal.
The fix is to specify full plugin name and version when running the dependency download task.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
