### PR TITLE
Add origin header to crashtracking telemetry

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
@@ -290,6 +290,7 @@ public final class CrashUploader {
         writer.name("tracer_time").value(Instant.now().getEpochSecond());
         writer.name("seq_id").value(1);
         writer.name("debug").value(true);
+        writer.name("origin").value("crashtracker");
         writer.name("payload");
         writer.beginArray();
         writer.beginObject();

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
@@ -298,6 +298,7 @@ public final class CrashUploader {
         writer.name("level").value("ERROR");
         writer.name("tags").value("severity:crash");
         writer.name("is_sensitive").value(true);
+        writer.name("is_crash").value(true);
         writer.endObject();
         writer.endArray();
         writer.name("application");

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
@@ -174,6 +174,7 @@ public class CrashUploaderTest {
     assertEquals("ERROR", event.get("payload").get(0).get("level").asText());
 
     assertTrue(event.get("payload").get(0).get("is_sensitive").asBoolean());
+    assertTrue(event.get("payload").get(0).get("is_crash").asBoolean());
     // we need to sanitize the UIID which keeps on changing
     String message = event.get("payload").get(0).get("message").asText();
     CrashLog extracted = CrashLog.fromJson(message);

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
@@ -169,6 +169,7 @@ public class CrashUploaderTest {
 
     assertEquals(CrashUploader.TELEMETRY_API_VERSION, event.get("api_version").asText());
     assertEquals("logs", event.get("request_type").asText());
+    assertEquals("crashtracker", event.get("origin").asText());
     // payload:
     assertEquals("ERROR", event.get("payload").get(0).get("level").asText());
 


### PR DESCRIPTION
# What Does This Do

Allows the telemetry intake to recognise properly as a crash

* Adds the `origin` header field set to `crashtracker` 
* Adds `is_crash` set to `true` to each Log entry

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
