### PR TITLE
Add akka repository token to fix gradle build.

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
         with:
           submodules: 'recursive'
-
       - name: Cache Gradle dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -41,6 +40,8 @@ jobs:
           build-mode: 'manual'
       
       - name: Build dd-trace-java for creating the CodeQL database
+        env:
+          ORG_GRADLE_PROJECT_akkaRepositoryToken: ${{ secrets.AKKA_REPO_TOKEN }}
         run: |
           GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx3G -Xms2G'" \
           JAVA_HOME=$JAVA_HOME_8_X64 \
@@ -85,6 +86,8 @@ jobs:
           rm -rf "${MVN_LOCAL_REPO}/com/datadoghq"
 
       - name: Build and publish artifacts locally
+        env:
+          ORG_GRADLE_PROJECT_akkaRepositoryToken: ${{ secrets.AKKA_REPO_TOKEN }}
         run: |
           GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx3G -Xms2G'" \
           JAVA_HOME=$JAVA_HOME_8_X64 \


### PR DESCRIPTION
# What Does This Do
Add akka repository token to fix gradle build.

# Motivation
Green CI.

# Additional Notes
Akka locked down their repository so that requests without the token are blocked. This mirrors the change in [gitlab](https://github.com/DataDog/dd-trace-java/blob/6c26663efeb2f13effc62a30cc2a5b45d1c1e28c/.gitlab-ci.yml#L167-L179)

