### PR TITLE
Add Capture Expressions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -34,7 +34,7 @@ public class CapturedContext implements ValueReferenceResolver {
   private String thisClassName;
   private long duration;
   private final Map<String, Status> statusByProbeId = new LinkedHashMap<>();
-  private Map<String, CapturedValue> watches;
+  private Map<String, CapturedValue> captureExpressions;
 
   public CapturedContext() {}
 
@@ -260,8 +260,8 @@ public class CapturedContext implements ValueReferenceResolver {
     return staticFields;
   }
 
-  public Map<String, CapturedValue> getWatches() {
-    return watches;
+  public Map<String, CapturedValue> getCaptureExpressions() {
+    return captureExpressions;
   }
 
   public Limits getLimits() {
@@ -277,9 +277,9 @@ public class CapturedContext implements ValueReferenceResolver {
    * instance representation into the corresponding string value.
    */
   public void freeze(TimeoutChecker timeoutChecker) {
-    if (watches != null) {
-      // freeze only watches
-      watches.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
+    if (captureExpressions != null) {
+      // freeze only capture expressions
+      captureExpressions.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
       return;
     }
     if (arguments != null) {
@@ -377,11 +377,11 @@ public class CapturedContext implements ValueReferenceResolver {
     staticFields.put(name, value);
   }
 
-  public void addWatch(CapturedValue value) {
-    if (watches == null) {
-      watches = new HashMap<>();
+  public void addCaptureExpression(CapturedValue value) {
+    if (captureExpressions == null) {
+      captureExpressions = new HashMap<>();
     }
-    watches.put(value.name, value);
+    captureExpressions.put(value.name, value);
   }
 
   public static class Status {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -46,7 +46,8 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
         // forcing a useless condition to be instrumented with captureEntry=false
         new ProbeCondition(DSL.when(DSL.TRUE), "true"),
         capture,
-        sampling);
+        sampling,
+        null);
     this.exceptionProbeManager = exceptionProbeManager;
     this.chainedExceptionIdx = chainedExceptionIdx;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -16,13 +16,11 @@ import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.Snapshot;
-import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.WeakIdentityHashMap;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
-import com.squareup.moshi.Types;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.bootstrap.debugger.CapturedContext;
@@ -42,10 +40,8 @@ import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDSpanContext;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -157,7 +153,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
   }
 
   /** Stores capture limits */
-  public static final class Capture {
+  public static class Capture {
     private int maxReferenceDepth = Limits.DEFAULT_REFERENCE_DEPTH;
     private int maxCollectionSize = Limits.DEFAULT_COLLECTION_SIZE;
     private int maxLength = Limits.DEFAULT_LENGTH;
@@ -236,7 +232,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
   }
 
   /** Stores sampling configuration */
-  public static final class Sampling extends com.datadog.debugger.probe.Sampling {
+  public static class Sampling extends com.datadog.debugger.probe.Sampling {
     private double snapshotsPerSecond;
 
     public Sampling(double snapshotsPerSecond) {
@@ -274,10 +270,48 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     }
   }
 
+  public static class CaptureExpression {
+    private final String name;
+    private final ValueScript expr;
+    private final Capture capture;
+
+    public CaptureExpression(String name, ValueScript expr, Capture capture) {
+      this.name = name;
+      this.expr = expr;
+      this.capture = capture;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public ValueScript getExpr() {
+      return expr;
+    }
+
+    public Capture getCapture() {
+      return capture;
+    }
+
+    @Generated
+    @Override
+    public String toString() {
+      return "CaptureExpression{"
+          + "name='"
+          + name
+          + '\''
+          + ", expr="
+          + expr
+          + ", capture="
+          + capture
+          + '}';
+    }
+  }
+
   private final String template;
   private final List<Segment> segments;
   private final boolean captureSnapshot;
-  private transient List<ValueScript> watches;
+  private final List<CaptureExpression> captureExpressions;
 
   @Json(name = "when")
   private final ProbeCondition probeCondition;
@@ -302,6 +336,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
         false,
         null,
         null,
+        null,
         null);
   }
 
@@ -316,7 +351,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       boolean captureSnapshot,
       ProbeCondition probeCondition,
       Capture capture,
-      Sampling sampling) {
+      Sampling sampling,
+      List<CaptureExpression> captureExpressions) {
     this(
         language,
         probeId,
@@ -328,7 +364,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
         captureSnapshot,
         probeCondition,
         capture,
-        sampling);
+        sampling,
+        captureExpressions);
   }
 
   private LogProbe(
@@ -342,7 +379,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       boolean captureSnapshot,
       ProbeCondition probeCondition,
       Capture capture,
-      Sampling sampling) {
+      Sampling sampling,
+      List<CaptureExpression> captureExpressions) {
     super(language, probeId, tags, where, evaluateAt);
     this.template = template;
     this.segments = segments;
@@ -350,6 +388,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     this.probeCondition = probeCondition;
     this.capture = capture;
     this.sampling = sampling;
+    this.captureExpressions = captureExpressions;
   }
 
   public LogProbe(LogProbe.Builder builder) {
@@ -364,38 +403,9 @@ public class LogProbe extends ProbeDefinition implements Sampled {
         builder.captureSnapshot,
         builder.probeCondition,
         builder.capture,
-        builder.sampling);
+        builder.sampling,
+        builder.captureExpressions);
     this.snapshotProcessor = builder.snapshotProcessor;
-  }
-
-  @SuppressForbidden // String#split(String)
-  private static List<ValueScript> parseWatchesFromTags(Tag[] tags) {
-    if (tags == null || tags.length == 0) {
-      return Collections.emptyList();
-    }
-    List<ValueScript> result = new ArrayList<>();
-    for (Tag tag : tags) {
-      if ("dd_watches_dsl".equals(tag.getKey())) {
-        String ddWatches = tag.getValue();
-        // this for POC only, parsing is not robust!
-        String[] splitWatches = ddWatches.split(",");
-        for (String watchDef : splitWatches) {
-          // remove curly braces
-          String refPath = watchDef.substring(1, watchDef.length() - 1);
-          result.add(new ValueScript(ValueScript.parseRefPath(refPath), refPath));
-        }
-      } else if ("dd_watches_json".equals(tag.getKey())) {
-        String json = tag.getValue();
-        try {
-          ParameterizedType type = Types.newParameterizedType(List.class, ValueScript.class);
-          result.addAll(
-              MoshiHelper.createMoshiWatches().<List<ValueScript>>adapter(type).fromJson(json));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    }
-    return result;
   }
 
   public LogProbe copy() {
@@ -410,7 +420,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
         captureSnapshot,
         probeCondition,
         capture,
-        sampling);
+        sampling,
+        captureExpressions);
   }
 
   public String getTemplate() {
@@ -425,10 +436,6 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     return captureSnapshot;
   }
 
-  public List<ValueScript> getWatches() {
-    return watches;
-  }
-
   public ProbeCondition getProbeCondition() {
     return probeCondition;
   }
@@ -439,6 +446,10 @@ public class LogProbe extends ProbeDefinition implements Sampled {
 
   public Sampling getSampling() {
     return sampling;
+  }
+
+  public List<CaptureExpression> getCaptureExpressions() {
+    return captureExpressions;
   }
 
   @Override
@@ -481,7 +492,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       sample(logStatus, methodLocation);
     }
     processMsgTemplate(context, logStatus);
-    processWatches(context, logStatus);
+    processCaptureExpressions(context, logStatus);
   }
 
   private void processMsgTemplate(CapturedContext context, LogStatus logStatus) {
@@ -497,37 +508,6 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       msg = sb.toString();
     }
     logStatus.setMessage(msg);
-  }
-
-  private void processWatches(CapturedContext context, LogStatus logStatus) {
-    if (watches == null) {
-      watches = parseWatchesFromTags(tags);
-    }
-    if (watches.isEmpty()) {
-      return;
-    }
-    if (!logStatus.isSampled()) {
-      return;
-    }
-    for (ValueScript watch : watches) {
-      try {
-        Value<?> result = watch.execute(context);
-        if (result.isUndefined()) {
-          throw new EvaluationException("UNDEFINED", watch.getDsl());
-        }
-        if (result.isNull()) {
-          context.addWatch(
-              CapturedContext.CapturedValue.of(watch.getDsl(), Object.class.getTypeName(), null));
-        } else {
-          context.addWatch(
-              CapturedContext.CapturedValue.of(
-                  watch.getDsl(), Object.class.getTypeName(), result.getValue()));
-        }
-      } catch (EvaluationException ex) {
-        logStatus.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
-        logStatus.setLogTemplateErrors(true);
-      }
-    }
   }
 
   private void sample(LogStatus logStatus, MethodLocation methodLocation) {
@@ -616,7 +596,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     if (entryStatus.shouldSend() && exitStatus.shouldSend()) {
       snapshot.setTraceId(CorrelationAccess.instance().getTraceId());
       snapshot.setSpanId(CorrelationAccess.instance().getSpanId());
-      if (isCaptureSnapshot()) {
+      if (isFullSnapshot()) {
         snapshot.setEntry(entryContext);
         snapshot.setExit(exitContext);
       }
@@ -634,6 +614,45 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       shouldCommit = true;
     }
     return shouldCommit;
+  }
+
+  private void processCaptureExpressions(CapturedContext context, LogStatus logStatus) {
+    if (captureExpressions == null) {
+      return;
+    }
+    for (CaptureExpression captureExpression : captureExpressions) {
+      LOGGER.debug("processing capture expressions: {}", captureExpression);
+      try {
+        Value<?> result = captureExpression.expr.execute(context);
+        if (result.isUndefined()) {
+          throw new EvaluationException("UNDEFINED", captureExpression.getExpr().getDsl());
+        }
+        if (result.isNull()) {
+          context.addCaptureExpression(
+              CapturedContext.CapturedValue.of(
+                  captureExpression.getName(), Object.class.getTypeName(), null));
+        } else {
+          if (captureExpression.capture != null) {
+            context.addCaptureExpression(
+                CapturedContext.CapturedValue.of(
+                    captureExpression.getName(),
+                    Object.class.getTypeName(),
+                    result.getValue(),
+                    captureExpression.capture.maxReferenceDepth,
+                    captureExpression.capture.maxCollectionSize,
+                    captureExpression.capture.maxLength,
+                    captureExpression.capture.maxFieldCount));
+          } else {
+            context.addCaptureExpression(
+                CapturedContext.CapturedValue.of(
+                    captureExpression.getName(), Object.class.getTypeName(), result.getValue()));
+          }
+        }
+      } catch (EvaluationException ex) {
+        logStatus.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
+        logStatus.setLogTemplateErrors(true);
+      }
+    }
   }
 
   private static void populateErrors(
@@ -673,7 +692,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
      * - ProbeDefinition.commit()
      * - DebuggerContext.commit() or DebuggerContext.evalAndCommit()
      */
-    if (isCaptureSnapshot()) {
+    if (isFullSnapshot()) {
       snapshot.recordStackTrace(5);
       sink.addSnapshot(snapshot);
     } else {
@@ -897,6 +916,10 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     }
   }
 
+  private boolean isFullSnapshot() {
+    return isCaptureSnapshot() || captureExpressions != null;
+  }
+
   @Generated
   @Override
   public boolean equals(Object o) {
@@ -968,6 +991,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
         + capture
         + ", sampling="
         + sampling
+        + ", captureExpressions="
+        + captureExpressions
         + "} ";
   }
 
@@ -979,10 +1004,10 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     private String template;
     private List<Segment> segments;
     private boolean captureSnapshot;
-    private List<ValueScript> watches;
     private ProbeCondition probeCondition;
     private Capture capture;
     private Sampling sampling;
+    private List<CaptureExpression> captureExpressions;
     private Consumer<Snapshot> snapshotProcessor;
 
     public Builder snapshotProcessor(Consumer<Snapshot> processor) {
@@ -1023,6 +1048,11 @@ public class LogProbe extends ProbeDefinition implements Sampled {
 
     public Builder sampling(double rateLimit) {
       return sampling(new Sampling(rateLimit));
+    }
+
+    public Builder captureExpressions(List<CaptureExpression> captureExpressions) {
+      this.captureExpressions = captureExpressions;
+      return this;
     }
 
     public LogProbe build() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -38,7 +38,7 @@ public class MoshiSnapshotHelper {
   public static final String CAUGHT_EXCEPTIONS = "caughtExceptions";
   public static final String ARGUMENTS = "arguments";
   public static final String LOCALS = "locals";
-  public static final String WATCHES = "watches";
+  public static final String CAPTURE_EXPRESSIONS = "captureExpressions";
   public static final String THROWABLE = "throwable";
   public static final String STATIC_FIELDS = "staticFields";
   public static final String THIS = "this";
@@ -161,17 +161,18 @@ public class MoshiSnapshotHelper {
         return;
       }
       jsonWriter.beginObject();
-      if (capturedContext.getWatches() != null) {
-        // only watches are serialized into the snapshot
-        jsonWriter.name(WATCHES);
+      if (capturedContext.getCaptureExpressions() != null) {
+        // only capture expressions are serialized into the snapshot
+        jsonWriter.name(CAPTURE_EXPRESSIONS);
         jsonWriter.beginObject();
-        SerializationResult resultWatches =
+        SerializationResult resultCaptureExpressions =
             toJsonCapturedValues(
                 jsonWriter,
-                capturedContext.getWatches(),
+                capturedContext.getCaptureExpressions(),
                 capturedContext.getLimits(),
                 timeoutChecker);
-        jsonWriter.endObject(); // / watches
+        jsonWriter.endObject(); // captureExpressions
+        handleSerializationResult(jsonWriter, resultCaptureExpressions);
         jsonWriter.endObject();
         return;
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -7,6 +7,7 @@ import static com.datadog.debugger.util.MoshiSnapshotHelper.NOT_CAPTURED_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotTestHelper.VALUE_ADAPTER;
+import static com.datadog.debugger.util.MoshiSnapshotTestHelper.deserializeCapturedValue;
 import static datadog.trace.bootstrap.debugger.util.Redaction.REDACTED_VALUE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,6 +31,7 @@ import static utils.TestHelper.setFieldInConfig;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
@@ -2697,33 +2699,80 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
-  public void watches() throws IOException, URISyntaxException {
+  public void captureExpressions() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot08";
     LogProbe probe =
         createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", null)
             .evaluateAt(MethodLocation.EXIT)
-            .tags(
-                "dd_watches_dsl:{typed.fld.fld.msg},{nullTyped.fld}",
-                "dd_watches_json:[{\"dsl\":\"typed.fld.fld.msg_json\",\"json\":{\"getmember\":[{\"getmember\":[{\"getmember\":[{\"ref\":\"typed\"},\"fld\"]},\"fld\"]},\"msg\"]}}]")
+            .captureExpressions(
+                Arrays.asList(
+                    new LogProbe.CaptureExpression(
+                        "typed_fld_fld_msg",
+                        new ValueScript(
+                            DSL.getMember(
+                                DSL.getMember(DSL.getMember(DSL.ref("typed"), "fld"), "fld"),
+                                "msg"),
+                            "typed.fld.fld.msg"),
+                        null),
+                    new LogProbe.CaptureExpression(
+                        "nullTyped_fld",
+                        new ValueScript(
+                            DSL.getMember(DSL.ref("nullTyped"), "fld"), "nullTyped.fld"),
+                        null)))
             .build();
     TestSnapshotListener listener = installProbes(probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.onClass(testClass).call("main", "1").get();
     assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    assertEquals(3, snapshot.getCaptures().getReturn().getWatches().size());
-    assertCaptureWatches(
+    assertEquals(2, snapshot.getCaptures().getReturn().getCaptureExpressions().size());
+    assertCaptureExpressions(
         snapshot.getCaptures().getReturn(),
-        "typed.fld.fld.msg",
+        "typed_fld_fld_msg",
         String.class.getTypeName(),
         "hello");
-    assertCaptureWatches(
-        snapshot.getCaptures().getReturn(), "nullTyped.fld", Object.class.getTypeName(), null);
-    assertCaptureWatches(
-        snapshot.getCaptures().getReturn(),
-        "typed.fld.fld.msg_json",
-        String.class.getTypeName(),
-        "hello");
+    assertCaptureExpressions(
+        snapshot.getCaptures().getReturn(), "nullTyped_fld", Object.class.getTypeName(), null);
+  }
+
+  @Test
+  public void captureExpressionsWithCaptureLimits() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe probe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", null)
+            .evaluateAt(MethodLocation.EXIT)
+            .captureExpressions(
+                Arrays.asList(
+                    new LogProbe.CaptureExpression(
+                        "typed_fld_fld_msg",
+                        new ValueScript(
+                            DSL.getMember(
+                                DSL.getMember(DSL.getMember(DSL.ref("typed"), "fld"), "fld"),
+                                "msg"),
+                            "typed.fld.fld.msg"),
+                        new LogProbe.Capture(3, 100, 3, 20)),
+                    new LogProbe.CaptureExpression(
+                        "typed",
+                        new ValueScript(DSL.ref("typed"), "typed"),
+                        new LogProbe.Capture(1, 1, 3, 20))))
+            .build();
+    TestSnapshotListener listener = installProbes(probe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "1").get();
+    assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    CapturedContext.CapturedValue msgValue =
+        deserializeCapturedValue(
+            snapshot.getCaptures().getReturn().getCaptureExpressions().get("typed_fld_fld_msg"));
+    assertEquals("hel", msgValue.getValue());
+    assertEquals("truncated", msgValue.getNotCapturedReason());
+    CapturedContext.CapturedValue typedValue =
+        deserializeCapturedValue(
+            snapshot.getCaptures().getReturn().getCaptureExpressions().get("typed"));
+    Map<String, CapturedContext.CapturedValue> fields =
+        (Map<String, CapturedContext.CapturedValue>) typedValue.getValue();
+    CapturedContext.CapturedValue fldValue = fields.get("fld");
+    assertEquals("depth", fldValue.getNotCapturedReason());
   }
 
   private TestSnapshotListener setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -292,11 +292,11 @@ public class CapturingTestBase {
     assertEquals(lineNumber, throwable.getStacktrace().get(0).getLineNumber());
   }
 
-  protected void assertCaptureWatches(
+  protected void assertCaptureExpressions(
       CapturedContext context, String name, String typeName, String value) {
-    CapturedContext.CapturedValue watch = context.getWatches().get(name);
-    assertEquals(typeName, watch.getType());
-    assertEquals(value, MoshiSnapshotTestHelper.getValue(watch));
+    CapturedContext.CapturedValue expression = context.getCaptureExpressions().get(name);
+    assertEquals(typeName, expression.getType());
+    assertEquals(value, MoshiSnapshotTestHelper.getValue(expression));
   }
 
   protected TestSnapshotListener installMethodProbe(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -122,7 +122,7 @@ public class ConfigurationTest {
         MoshiHelper.createMoshiConfig().adapter(Configuration.class);
     Configuration config = adapter.fromJson(content);
     ArrayList<LogProbe> logProbes = new ArrayList<>(config.getLogProbes());
-    assertEquals(1, logProbes.size());
+    assertEquals(2, logProbes.size());
     LogProbe logProbe0 = logProbes.get(0);
     assertEquals(2, logProbe0.getTags().length);
     assertEquals("dd_watches_dsl", logProbe0.getTags()[0].getKey());
@@ -138,6 +138,16 @@ public class ConfigurationTest {
     assertEquals("garbageStart", logProbe0.getSegments().get(5).getExpr());
     assertEquals(" contain=", logProbe0.getSegments().get(6).getStr());
     assertEquals("contains(arg, 'foo')", logProbe0.getSegments().get(7).getExpr());
+    LogProbe logProbe1 = logProbes.get(1);
+    assertEquals(2, logProbe1.getCaptureExpressions().size());
+    LogProbe.CaptureExpression captureExpression0 = logProbe1.getCaptureExpressions().get(0);
+    assertEquals("uuid", captureExpression0.getName());
+    assertEquals("uuid", captureExpression0.getExpr().getDsl());
+    assertEquals(5, captureExpression0.getCapture().getMaxReferenceDepth());
+    LogProbe.CaptureExpression captureExpression1 = logProbe1.getCaptureExpressions().get(1);
+    assertEquals("field1_map_key_array_3_field2", captureExpression1.getName());
+    assertEquals("field1.map['key'].array[3].field2", captureExpression1.getExpr().getDsl());
+    assertNull(captureExpression1.getCapture());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.util.MoshiSnapshotHelper.ARGUMENTS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.CAPTURES;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.CAPTURE_EXPRESSIONS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.COLLECTION_SIZE_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.DEPTH_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.ELEMENTS;
@@ -20,7 +21,6 @@ import static com.datadog.debugger.util.MoshiSnapshotHelper.TIMEOUT_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.TRUNCATED;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.TYPE;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.VALUE;
-import static com.datadog.debugger.util.MoshiSnapshotHelper.WATCHES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -972,7 +972,7 @@ public class SnapshotSerializationTest {
   }
 
   @Test
-  public void watches() throws IOException {
+  public void captureExpressions() throws IOException {
     JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     CapturedContext context = new CapturedContext();
@@ -980,24 +980,27 @@ public class SnapshotSerializationTest {
     map.put("foo1", "bar1");
     map.put("foo2", "bar2");
     map.put("foo3", "bar3");
-    context.addWatch(CapturedContext.CapturedValue.of("watch1", Map.class.getTypeName(), map));
-    context.addWatch(
+    context.addCaptureExpression(
+        CapturedContext.CapturedValue.of("expr1", Map.class.getTypeName(), map));
+    context.addCaptureExpression(
         CapturedContext.CapturedValue.of(
-            "watch2", List.class.getTypeName(), Arrays.asList("1", "2", "3")));
-    context.addWatch(CapturedContext.CapturedValue.of("watch3", Integer.TYPE.getTypeName(), 42));
+            "expr2", List.class.getTypeName(), Arrays.asList("1", "2", "3")));
+    context.addCaptureExpression(
+        CapturedContext.CapturedValue.of("expr3", Integer.TYPE.getTypeName(), 42));
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
     Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
     Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
     Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
-    Map<String, Object> watches = (Map<String, Object>) returnJson.get(WATCHES);
+    Map<String, Object> captureExpressions =
+        (Map<String, Object>) returnJson.get(CAPTURE_EXPRESSIONS);
     assertNull(returnJson.get(LOCALS));
     assertNull(returnJson.get(ARGUMENTS));
-    assertEquals(3, watches.size());
-    assertMapItems(watches, "watch1", "foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    assertArrayItem(watches, "watch2", "1", "2", "3");
-    assertPrimitiveValue(watches, "watch3", Integer.TYPE.getTypeName(), "42");
+    assertEquals(3, captureExpressions.size());
+    assertMapItems(captureExpressions, "expr1", "foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
+    assertArrayItem(captureExpressions, "expr2", "1", "2", "3");
+    assertPrimitiveValue(captureExpressions, "expr3", Integer.TYPE.getTypeName(), "42");
   }
 
   private Map<String, Object> doFieldCount(int maxFieldCount) throws IOException {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.util;
 
 import static com.datadog.debugger.util.MoshiSnapshotHelper.ARGUMENTS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.CAPTURE_EXPRESSIONS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.CAUGHT_EXCEPTIONS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.ELEMENTS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.ENTRIES;
@@ -51,6 +52,16 @@ public class MoshiSnapshotTestHelper {
 
   public static final JsonAdapter<CapturedContext.CapturedValue> VALUE_ADAPTER =
       new MoshiSnapshotTestHelper.CapturedValueAdapter();
+
+  public static CapturedContext.CapturedValue deserializeCapturedValue(
+      CapturedContext.CapturedValue capturedValue) {
+    try {
+      return VALUE_ADAPTER.fromJson(capturedValue.getStrValue());
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
 
   public static String getValue(CapturedContext.CapturedValue capturedValue) {
     CapturedContext.CapturedValue valued = null;
@@ -218,6 +229,11 @@ public class MoshiSnapshotTestHelper {
             break;
           case THROWABLE:
             capturedContext.addThrowable(throwableAdapter.fromJson(jsonReader));
+            break;
+          case CAPTURE_EXPRESSIONS:
+            for (CapturedContext.CapturedValue value : fromJsonCapturedValues(jsonReader)) {
+              capturedContext.addCaptureExpression(value);
+            }
             break;
           default:
             throw new IllegalArgumentException("Unknown field name for Captures object: " + name);

--- a/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
+++ b/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
@@ -43,5 +43,45 @@
         "json": {"contains": [{"ref": "arg"}, "foo"]}
       }
     ]
+  },{
+    "id": "04692489-c21a-40d3-a378-a602f8205bc0",
+    "created": "2021-03-31T13:26:52.519150+00:00",
+    "active": true,
+    "language": "java",
+    "tags": [],
+    "where": {
+      "typeName": "VetController",
+      "methodName": "showVetList"
+    },
+    "captureSnapshot": false,
+    "captureExpressions": [
+      {
+        "name": "uuid",
+        "expr": {
+          "dsl": "uuid",
+          "json": {"ref": "uuid"}
+        },
+        "capture": {
+          "maxReferenceDepth": 5
+        }
+      },
+      {
+        "name": "field1_map_key_array_3_field2",
+        "expr": {
+          "dsl": "field1.map['key'].array[3].field2",
+          "json": {
+            "getmember": [{
+              "index": [{
+                "index": [{
+                  "getmember": [{
+                    "ref": "field1"
+                  }, "map"]
+                }, "key"]
+              }, 3]
+            }, "field2"]
+          }
+        }
+      }
+    ]
   }]
 }


### PR DESCRIPTION
# What Does This Do
Previously watches, capture expressions allow to describe what exactly
 we want to capture and put into a snapshot for a log probe.
When one or more capture expressions is defined, only the capture expressions are added to the Captures part of the snapshot. Expressions can be complex using the expression language and must return a value from which we start to capture the object graph following the limits that can be defined per capture expressions. A new attribute captureExpressions is added into the snapshot.

# Motivation

implementation of the [Capture Expressions RFC](https://docs.google.com/document/d/1sxP3ed5W2nlzsJ7ln_FpvVnHwkA6_2XhvFRlypdvdRA/edit?pli=1&tab=t.0#heading=h.pf6o5aa6zpcr)

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4261]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4261]: https://datadoghq.atlassian.net/browse/DEBUG-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ