### PR TITLE
Reach 100% patch coverage: CapturedContext & LogProbe

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeCaptureExpressionsUndefinedTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeCaptureExpressionsUndefinedTest.java
@@ -1,0 +1,43 @@
+package com.datadog.debugger.probe;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.ValueScript;
+import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.EvaluationError;
+import datadog.trace.bootstrap.debugger.MethodLocation;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.el.Values;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class LogProbeCaptureExpressionsUndefinedTest {
+  @Test
+  void captureExpressionUndefinedAddsError() {
+    LogProbe.CaptureExpression ce =
+        new LogProbe.CaptureExpression(
+            "ce", new ValueScript(DSL.value(Values.UNDEFINED_OBJECT), "exprUndefined"), null);
+
+    LogProbe probe =
+        LogProbe.builder()
+            .language("java")
+            .probeId(ProbeId.newId())
+            .template(null, emptyList())
+            .captureExpressions(Arrays.asList(ce))
+            .build();
+
+    CapturedContext context = new CapturedContext();
+    LogProbe.LogStatus status = new LogProbe.LogStatus(probe);
+
+    probe.evaluate(context, status, MethodLocation.DEFAULT);
+
+    assertTrue(status.hasLogTemplateErrors());
+    assertEquals(1, status.getErrors().size());
+    EvaluationError err = status.getErrors().get(0);
+    assertEquals("exprUndefined", err.getExpr());
+    assertEquals("UNDEFINED", err.getMessage());
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/datadog/trace/bootstrap/debugger/CapturedContextCaptureExpressionsTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/datadog/trace/bootstrap/debugger/CapturedContextCaptureExpressionsTest.java
@@ -1,0 +1,46 @@
+package datadog.trace.bootstrap.debugger;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.debugger.agent.JsonSnapshotSerializer;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CapturedContextCaptureExpressionsTest {
+  @BeforeAll
+  static void initSerializer() {
+    // Ensure freeze() has a serializer to produce strValue
+    DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
+  }
+
+  @Test
+  void addGetAndFreezeCaptureExpressions() {
+    CapturedContext ctx = new CapturedContext();
+
+    CapturedContext.CapturedValue exprVal =
+        CapturedContext.CapturedValue.of("expr1", Object.class.getTypeName(), 42);
+
+    // addCaptureExpression should lazily init the map and put the value
+    ctx.addCaptureExpression(exprVal);
+
+    // getCaptureExpressions should return the map (covering getter line)
+    Map<String, CapturedContext.CapturedValue> exprs = ctx.getCaptureExpressions();
+    assertNotNull(exprs);
+    assertTrue(exprs.containsKey("expr1"));
+    assertSame(exprVal, exprs.get("expr1"));
+
+    // freeze should only freeze captureExpressions branch when present
+    ctx.freeze(new TimeoutChecker(Duration.of(50, ChronoUnit.MILLIS)));
+
+    CapturedContext.CapturedValue frozen = exprs.get("expr1");
+    assertNotNull(frozen.getStrValue());
+    assertNull(frozen.getValue()); // value released after serialization
+  }
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"604940be-cf3a-45a1-985e-0b98291c247a","source":"chat","resourceId":"18a24d28-a849-4b28-bcd7-db8d0cbfcacd","workflowId":"01a8c8d2-6899-4370-b05f-c6ccd5cbffff","codeChangeId":"01a8c8d2-6899-4370-b05f-c6ccd5cbffff","sourceType":"code_coverage"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=604940be-cf3a-45a1-985e-0b98291c247a) for chat [18a24d28-a849-4b28-bcd7-db8d0cbfcacd](https://app.datadoghq.com/code/18a24d28-a849-4b28-bcd7-db8d0cbfcacd).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

# What Does This Do

- Adds unit tests to increase patch coverage to 100% for:
  - datadog.trace.bootstrap.debugger.CapturedContext (captureExpressions path)
  - com.datadog.debugger.probe.LogProbe (captureExpressions handling)
- Tests added:
  - LogProbeCaptureExpressionsUndefinedTest: verifies that an undefined capture expression produces an EvaluationError with the correct expr and message.
  - CapturedContextCaptureExpressionsTest: verifies add/get behavior for captureExpressions and the freeze() behavior (serialization sets strValue and clears value) with a JsonSnapshotSerializer initialized.

# Motivation

- Ensure full patch coverage and prevent regressions in:
  - Error reporting when capture expressions evaluate to UNDEFINED.
  - Safe freezing/serialization of captureExpressions in CapturedContext.
- Historically, gaps in tests around these paths could allow regressions where:
  - Undefined capture expressions fail to surface as errors in LogStatus.
  - CapturedContext.freeze() doesn’t exercise the captureExpressions branch or fails to serialize values properly without an initialized serializer.

# Additional Notes

- No production code changes; test-only additions.
- The serializer is initialized in a @BeforeAll to avoid null serializer issues during freeze() and to validate strValue generation.
- No public documentation or configuration flags are impacted.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](#removed-for-safety) when referencing an issue.  
Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.