### PR TITLE
Fix issue with call sites on constructors without DUP bytecode

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -193,6 +193,14 @@ class BaseCallSiteTest extends DDSpecification {
   final CallSiteTransformer transformer,
   final ClassLoader loader = Thread.currentThread().contextClassLoader) {
     final classContent = loader.getResourceAsStream("${source.getInternalName()}.class").bytes
+    return transformType(source, classContent, target, transformer, loader)
+  }
+
+  protected static byte[] transformType(final Type source,
+  final byte[] classContent,
+  final Type target,
+  final CallSiteTransformer transformer,
+  final ClassLoader loader = Thread.currentThread().contextClassLoader) {
     final classFileTransformer = new AgentBuilder.Default()
     .type(named(source.className))
     .transform(new AgentBuilder.Transformer() {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -1,9 +1,22 @@
 package datadog.trace.agent.tooling.csi
 
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteTransformer
+import net.bytebuddy.ByteBuddy
 import net.bytebuddy.asm.AsmVisitorWrapper
+import net.bytebuddy.description.method.MethodDescription
+import net.bytebuddy.description.modifier.Ownership
+import net.bytebuddy.description.modifier.Visibility
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.Implementation
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender
+import net.bytebuddy.implementation.bytecode.StackManipulation
+import net.bytebuddy.implementation.bytecode.TypeCreation
+import net.bytebuddy.implementation.bytecode.member.MethodInvocation
+import net.bytebuddy.implementation.bytecode.member.MethodReturn
+import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess
+import net.bytebuddy.jar.asm.MethodVisitor
 import net.bytebuddy.jar.asm.Type
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -101,6 +114,56 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     param                     | test
     "test"                    | "Operand stack underflow"
     new StringBuilder("test") | "Inconsistent stackmap frames"
+  }
+
+  void 'test new invocation without dup'() {
+    setup:
+    def (clazz, bytes) = buildConsumerWithNewAndNoDup()
+    final source = Type.getType(clazz)
+    final target = renameType(source, 'Test')
+    final pointcut = stringReaderPointcut()
+    final advice = Mock(InvokeAdvice)
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([mockCallSites(AFTER, advice, pointcut)]))
+
+    when:
+    final transformedClass = transformType(source, bytes, target, callSiteTransformer)
+    final transformed = loadClass(target, transformedClass)
+    final instance = transformed.newInstance()
+    instance.accept('test')
+
+    then:
+    0 * advice._
+  }
+
+
+  private static Tuple2<Class<?>, byte[]> buildConsumerWithNewAndNoDup() {
+    final newType = new ByteBuddy()
+      .subclass(Cloneable)
+      .name('foo.CtorIssue')
+      .modifiers(Visibility.PUBLIC)
+      .defineMethod("accept", void, Visibility.PUBLIC, Ownership.MEMBER)
+      .withParameters(String)
+      .intercept(
+      new Implementation.Simple(new ByteCodeAppender() {
+        @Override
+        ByteCodeAppender.Size apply(MethodVisitor mv,
+          Implementation.Context ctx,
+          MethodDescription method) {
+          StackManipulation compound = new StackManipulation.Compound(
+            TypeCreation.of(new TypeDescription.ForLoadedType(StringReader)),
+            // ignore DUP opcode
+            MethodVariableAccess.REFERENCE.loadFrom(1),
+            MethodInvocation.invoke(new MethodDescription.ForLoadedConstructor(StringReader.getConstructor(String))),
+            MethodReturn.VOID
+            )
+          final size = compound.apply(mv, ctx)
+          return new ByteCodeAppender.Size(size.getMaximalSize(), method.getStackSize())
+        }
+      })
+      )
+      .make()
+      .load(Thread.currentThread().contextClassLoader, ClassLoadingStrategy.Default.INJECTION)
+    return Tuple.tuple(newType.loaded, newType.bytes)
   }
 
   static class StringCallSites implements CallSites, TestCallSites {


### PR DESCRIPTION
# What Does This Do

Ignores constructor call sites when there is no corresponding `DUP` instruction following a `NEW`. This can occur when the created instance is immediately discarded and never used in the code.

# Motivation

We've received an escalation related to a verification error:
```
Attempt to pop empty stack.
Current Frame:
bci: @24
flags: { }
locals: { 'java/lang/String', 'java/lang/String' }
stack: { uninitialized 10, '[Ljava/lang/Object;' }
```

The issue is caused by stack manipulation operations performed by IAST when applying call site advices. In the case of constructors, the instrumentation expects a `DUP` instruction to follow the `NEW` operation. However, in this particular instance, the bytecode sequence was:

```
new java/net/URI
aload 1
invokespecial java/net/URI.<init>(Ljava/lang/String;)V
```

Since the created instance is immediately discarded by the Java code, we can safely ignore these call sites.

# Additional Notes

As a future improvement, we could revisit this logic and explore applying call site advices to this case as well.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-17315]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-17315]: https://datadoghq.atlassian.net/browse/APMS-17315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ