### PR TITLE
Replace jctools NonBlockingHashMap with ConcurrentHashMap

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -181,11 +181,5 @@
     "fields": [
       {"name": "consumerIndex", "allowUnsafeAccess": true}
     ]
-  },
-  {
-    "name" : "datadog.jctools.maps.NonBlockingHashMap",
-    "fields": [
-      {"name": "_kvs", "allowUnsafeAccess": true}
-    ]
   }
 ]

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/MetadataEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/MetadataEvent.java
@@ -2,7 +2,7 @@ package com.datadog.profiling.controller.jfr.parser;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.jctools.maps.NonBlockingHashMapLong;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * JFR Chunk metadata
@@ -17,8 +17,8 @@ public final class MetadataEvent {
   public final long duration;
   public final long metadataId;
 
-  private final NonBlockingHashMapLong<String> eventTypeNameMapBacking =
-      new NonBlockingHashMapLong<>(256);
+  private final ConcurrentHashMap<Long, String> eventTypeNameMapBacking =
+      new ConcurrentHashMap<>(256);
   private final LongMapping<String> eventTypeMap;
 
   MetadataEvent(RecordingStream stream) throws IOException {

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/NonBlockingHashMapBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/NonBlockingHashMapBenchmark.java
@@ -1,0 +1,68 @@
+package datadog.trace.common;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/*
+JDK 1.8
+Benchmark                                            Mode  Cnt  Score   Error  Units
+NonBlockingHashMapBenchmark.benchConcurrentHashMap   avgt       1.153          us/op
+NonBlockingHashMapBenchmark.benchNonBlockingHashMap  avgt       1.457          us/op
+
+JDK 21
+Benchmark                                            Mode  Cnt  Score   Error  Units
+NonBlockingHashMapBenchmark.benchConcurrentHashMap   avgt       1.088          us/op
+NonBlockingHashMapBenchmark.benchNonBlockingHashMap  avgt       1.278          us/op
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 30, timeUnit = SECONDS)
+@Measurement(iterations = 1, time = 30, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+@SuppressForbidden
+public class NonBlockingHashMapBenchmark {
+  private NonBlockingHashMap nonBlockingHashMap;
+  private ConcurrentHashMap concurrentHashMap;
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    nonBlockingHashMap = new NonBlockingHashMap(512);
+    concurrentHashMap = new ConcurrentHashMap(512);
+    for (int i = 0; i < 256; i++) {
+      nonBlockingHashMap.put("test" + i, "test");
+      concurrentHashMap.put("test" + i, "test");
+    }
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void benchNonBlockingHashMap(Blackhole blackhole) {
+    nonBlockingHashMap.put("test", "test");
+    blackhole.consume(nonBlockingHashMap.remove("test"));
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void benchConcurrentHashMap(Blackhole blackhole) {
+    concurrentHashMap.put("test", "test");
+    blackhole.consume(concurrentHashMap.remove("test"));
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -8,8 +8,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import org.jctools.maps.NonBlockingHashMap;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscCompoundQueue;
 import org.slf4j.Logger;
@@ -24,7 +24,7 @@ final class Aggregator implements Runnable {
   private final Queue<Batch> batchPool;
   private final MpscCompoundQueue<InboxItem> inbox;
   private final LRUCache<MetricKey, AggregateMetric> aggregates;
-  private final NonBlockingHashMap<MetricKey, Batch> pending;
+  private final ConcurrentMap<MetricKey, Batch> pending;
   private final Set<MetricKey> commonKeys;
   private final MetricWriter writer;
   // the reporting interval controls how much history will be buffered
@@ -40,7 +40,7 @@ final class Aggregator implements Runnable {
       MetricWriter writer,
       Queue<Batch> batchPool,
       MpscCompoundQueue<InboxItem> inbox,
-      NonBlockingHashMap<MetricKey, Batch> pending,
+      ConcurrentMap<MetricKey, Batch> pending,
       final Set<MetricKey> commonKeys,
       int maxAggregates,
       long reportingInterval,
@@ -61,7 +61,7 @@ final class Aggregator implements Runnable {
       MetricWriter writer,
       Queue<Batch> batchPool,
       MpscCompoundQueue<InboxItem> inbox,
-      NonBlockingHashMap<MetricKey, Batch> pending,
+      ConcurrentMap<MetricKey, Batch> pending,
       final Set<MetricKey> commonKeys,
       int maxAggregates,
       long reportingInterval,

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -42,10 +42,10 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import org.jctools.maps.NonBlockingHashMap;
 import org.jctools.queues.MpscCompoundQueue;
 import org.jctools.queues.SpmcArrayQueue;
 import org.slf4j.Logger;
@@ -90,8 +90,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   private final Set<String> ignoredResources;
   private final Queue<Batch> batchPool;
-  private final NonBlockingHashMap<MetricKey, Batch> pending;
-  private final NonBlockingHashMap<MetricKey, MetricKey> keys;
+  private final ConcurrentHashMap<MetricKey, Batch> pending;
+  private final ConcurrentHashMap<MetricKey, MetricKey> keys;
   private final Thread thread;
   private final MpscCompoundQueue<InboxItem> inbox;
   private final Sink sink;
@@ -178,8 +178,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this.ignoredResources = ignoredResources;
     this.inbox = new MpscCompoundQueue<>(queueSize);
     this.batchPool = new SpmcArrayQueue<>(maxAggregates);
-    this.pending = new NonBlockingHashMap<>(maxAggregates * 4 / 3);
-    this.keys = new NonBlockingHashMap<>();
+    this.pending = new ConcurrentHashMap<>(maxAggregates * 4 / 3);
+    this.keys = new ConcurrentHashMap<>();
     this.features = features;
     this.healthMetrics = healthMetric;
     this.sink = sink;


### PR DESCRIPTION
# What Does This Do

Replace NonBlockingHashMap with JDK equivalent. The jctools class, despite being a little more performant, is making use of Unsafe that's not future proof.

I ran benchmarks with JDK 1.8 and 21

```
JDK 1.8
Benchmark                                            Mode  Cnt  Score   Error  Units
NonBlockingHashMapBenchmark.benchConcurrentHashMap   avgt       1.153          us/op
NonBlockingHashMapBenchmark.benchNonBlockingHashMap  avgt       1.457          us/op

JDK 21
Benchmark                                            Mode  Cnt  Score   Error  Units
NonBlockingHashMapBenchmark.benchConcurrentHashMap   avgt       1.088          us/op
NonBlockingHashMapBenchmark.benchNonBlockingHashMap  avgt       1.278          us/op
```

There is an overhead but in absolute time it is acceptable comparing to the global overhead we might add for tracing

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
