### PR TITLE
chore: Align compiler configuration

### DIFF
--- a/dd-java-agent/instrumentation/armeria/armeria-jetty-1.24/build.gradle
+++ b/dd-java-agent/instrumentation/armeria/armeria-jetty-1.24/build.gradle
@@ -27,7 +27,7 @@ addTestSuiteExtendingForDir("jetty11LatestDepTest", "latestDepTest", "test/jetty
 
 ["compileJetty11TestGroovy", "compileJetty11LatestDepTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/axis2-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/axis2-1.3/build.gradle
@@ -25,7 +25,7 @@ configurations.configureEach {
 
 ["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
   tasks.named(it, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/cxf-2.1/build.gradle
+++ b/dd-java-agent/instrumentation/cxf-2.1/build.gradle
@@ -32,7 +32,7 @@ tasks.named("compileLatestDepTestJava", JavaCompile) {
 }
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(17)
+  configureCompiler(it, 17)
 }
 
 tasks.named("latestDepTest", Test) {
@@ -40,7 +40,7 @@ tasks.named("latestDepTest", Test) {
 }
 
 tasks.named("compileCxf3LatestDepTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
 }
 
 tasks.named("cxf3LatestDepTest", Test) {

--- a/dd-java-agent/instrumentation/ignite-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ignite-2.0/build.gradle
@@ -45,6 +45,6 @@ dependencies {
 
 for (task in ['compileLatestDepTestGroovy', 'compileLatestDepForkedTestGroovy']) {
   tasks.named(task, GroovyCompile) {
-    it.javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }

--- a/dd-java-agent/instrumentation/jakarta-jms/build.gradle
+++ b/dd-java-agent/instrumentation/jakarta-jms/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  it.javaLauncher = getJavaLauncherFor(17)
+  configureCompiler(it, 17)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
@@ -17,7 +17,7 @@ tasks.named("compileLatestDepJava11TestJava", JavaCompile) {
 }
 
 tasks.named("compileLatestDepJava11TestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
 }
 
 tasks.named("latestDepJava11Test", Test) {

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
@@ -17,7 +17,7 @@ tasks.named("compileMain_java11Java", JavaCompile) {
 }
 
 tasks.named("compileTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
 }
 
 tasks.named("forbiddenApisMain_java11") {

--- a/dd-java-agent/instrumentation/jersey/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/build.gradle
@@ -20,7 +20,7 @@ addTestSuiteForDir('jersey2JettyTest', 'jersey2JettyTest')
 addTestSuiteForDir('jersey3JettyTest', 'jersey3JettyTest')
 
 tasks.named("compileJersey3JettyTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
 }
 
 compileTestJava.configure {

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
@@ -49,7 +49,7 @@ tasks.named("forbiddenApisMain_java17") {
 }
 
 tasks.withType(GroovyCompile).configureEach {
-  javaLauncher = getJavaLauncherFor(17)
+  configureCompiler(it, 17)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/play/play-2.4/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.4/build.gradle
@@ -46,8 +46,8 @@ repositories {
   }
 }
 
-tasks.withType(org.gradle.api.tasks.scala.ScalaCompile) {
-  it.javaLauncher = getJavaLauncherFor(8)
+tasks.withType(ScalaCompile).configureEach {
+  configureCompiler(it, 8)
 }
 
 addTestSuiteForDir('latestDepTest', 'test')

--- a/dd-java-agent/instrumentation/play/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.6/build.gradle
@@ -139,7 +139,7 @@ tasks.named("compileLatestDepTestJava", JavaCompile) {
 }
 
 tasks.named("compileLatestDepTestScala", ScalaCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
   classpath = classpath + files(compileBaseTestJava.destinationDirectory)
   dependsOn 'compileBaseTestJava'
 }
@@ -192,7 +192,7 @@ tasks.register('buildLatestDepTestRoutes', JavaExec) {
 }
 
 tasks.named("compileLatestDepTestGeneratedScala", ScalaCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
   classpath = classpath + files(compileLatestDepTestScala.destinationDirectory)
   dependsOn buildLatestDepTestRoutes, compileLatestDepTestScala
 }
@@ -202,7 +202,7 @@ tasks.named("forbiddenApisLatestDepTestGenerated") {
 }
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
-  javaLauncher = getJavaLauncherFor(11)
+  configureCompiler(it, 11)
   classpath = classpath +
     files(compileLatestDepTestScala.destinationDirectory) +
     files(compileBaseTestGroovy.destinationDirectory) +

--- a/dd-java-agent/instrumentation/spring/spring-boot-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-boot-1.3/build.gradle
@@ -33,7 +33,7 @@ addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "test")
 
 ["compileLatestDepTestGroovy", "compileBoot3TestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+    configureCompiler(it, 17)
   }
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/build.gradle
@@ -18,7 +18,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 ["compileTestGroovy", "compileLatestDepTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+    configureCompiler(it, 17)
   }
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
@@ -35,7 +35,7 @@ addTestSuiteForDir('latestSpring5Test', 'test')
 
 ["compileSpring6TestGroovy", "compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+    configureCompiler(it, 17)
   }
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-security/spring-security-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-security/spring-security-6.0/build.gradle
@@ -12,7 +12,7 @@ tasks.withType(AbstractCompile).configureEach {
 }
 
 tasks.withType(GroovyCompile).configureEach {
-  javaLauncher = getJavaLauncherFor(17)
+  configureCompiler(it, 17)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.withType(GroovyCompile).configureEach {
-  it.javaLauncher = getJavaLauncherFor(17)
+  configureCompiler(it, 17)
 }
 
 tasks.named("iastTest", Test) {

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
@@ -74,13 +74,13 @@ configurations.configureEach {
 
 ["compileLatest10TestGroovy", "compileLatest10ForkedTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }
 
 ["compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+    configureCompiler(it, 17)
   }
 }
 

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-11/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-11/build.gradle
@@ -19,7 +19,7 @@ addTestSuite("latestDepTest")
 
 ["compileTestGroovy", "compileLatestDepTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(11)
+    configureCompiler(it, 11)
   }
 }
 

--- a/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-12/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/jetty-websocket/jetty-websocket-12/build.gradle
@@ -32,7 +32,7 @@ addTestSuiteForDir("latestDepTest", "test")
 
 ["compileTestGroovy", "compileLatestDepTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
-    javaLauncher = getJavaLauncherFor(17)
+    configureCompiler(it, 17)
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Align compiler configuration, replaces `getJavaLauncher` by `configureCompiler`.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
