### PR TITLE
Fix workflow to update gradle dependencies

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Pick a branch name
         if: steps.check-changes.outputs.commit_changes == 'true'
         id: define-branch
-        run: echo "BRANCH_NAME=ci/update-gradle-dependencies-$(date +'%Y%m%d')" >> $GITHUB_ENV
+        run: echo "branch=ci/update-gradle-dependencies-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Commit changes
         if: steps.check-changes.outputs.commit_changes == 'true'
         id: create-commit
@@ -76,7 +76,7 @@ jobs:
           echo -e "This PR updates the Gradle dependencies. ⚠️ Don't forget to squash commits before merging. ⚠️\n\n- [ ] Update PR title if a code change is needed to support one of those new dependencies" | \
             gh pr create --title "Update Gradle dependencies" \
             --base master \
-            --head $BRANCH_NAME \
+            --head ${{ steps.define-branch.outputs.branch }} \
             --label "tag: dependencies" \
             --label "tag: no release notes" \
             --body-file -


### PR DESCRIPTION
# What Does This Do

Export branch name to `GITHUB_OUTPUT` rather than as a `GITHUB_ENV`

# Motivation

Fix the `Update Gradle dependencies` workflow following #9702. Note that the workflow was failing on line 64 `branch: "${{ steps.define-branch.outputs.branch }}"` because the branch name was not outputted in the `define-branch` step. Failure: https://github.com/DataDog/dd-trace-java/actions/runs/18380151271/job/52364398441

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-701

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
