### PR TITLE
Add support for Guava and FastUtil

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -187,6 +188,22 @@ public class WellKnownClasses {
     THROWABLE_SPECIAL_FIELDS.put("cause", ThrowableFields::cause);
   }
 
+  private static final List<String> SAFE_COLLECTION_PACKAGES =
+      Arrays.asList(
+          "java.", // JDK base module
+          "com.google.protobuf.", // Google ProtoBuf
+          "com.google.common.collect.", // Google Guava
+          "it.unimi.dsi.fastutil." // fastutil
+          );
+
+  private static final List<String> SAFE_MAP_PACKAGES =
+      Arrays.asList(
+          "java.", // JDK base module
+          "com.google.protobuf.", // Google ProtoBuf
+          "com.google.common.collect.", // Google Guava
+          "it.unimi.dsi.fastutil." // fastutil
+          );
+
   /**
    * @return true if type is a final class and toString implementation is well known and side effect
    *     free
@@ -207,21 +224,10 @@ public class WellKnownClasses {
   /** @return true if collection implementation is safe to call (only in-memory) */
   public static boolean isSafe(Collection<?> collection) {
     String className = collection.getClass().getTypeName();
-    if (className.startsWith("java.")) {
-      // All Collection implementations from JDK base module are considered as safe
-      return true;
-    }
-    if (className.startsWith("com.google.protobuf.")) {
-      // All Collection implementations from Google ProtoBuf are considered as safe
-      return true;
-    }
-    if (className.startsWith("com.google.common.collect.")) {
-      // All Collection implementations from Google Guava are considered as safe
-      return true;
-    }
-    if (className.startsWith("it.unimi.dsi.fastutil.")) {
-      // All Collection implementations from fastutil are considered as safe
-      return true;
+    for (String safePackage : SAFE_COLLECTION_PACKAGES) {
+      if (className.startsWith(safePackage)) {
+        return true;
+      }
     }
     return false;
   }
@@ -229,21 +235,10 @@ public class WellKnownClasses {
   /** @return true if map implementation is safe to call (only in-memory) */
   public static boolean isSafe(Map<?, ?> map) {
     String className = map.getClass().getTypeName();
-    if (className.startsWith("java.")) {
-      // All Map implementations from JDK base module are considered as safe
-      return true;
-    }
-    if (className.startsWith("com.google.protobuf.")) {
-      // All Map implementations from Google ProtoBuf are considered as safe
-      return true;
-    }
-    if (className.startsWith("com.google.common.collect.")) {
-      // All Map implementations from Google Guava are considered as safe
-      return true;
-    }
-    if (className.startsWith("it.unimi.dsi.fastutil.")) {
-      // All Map implementations from fastutil are considered as safe
-      return true;
+    for (String safePackage : SAFE_MAP_PACKAGES) {
+      if (className.startsWith(safePackage)) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
# What Does This Do
Consider guava and fastutil collections and maps as safe so they can be treated as regular collections and maps and use in expression and captured as well

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4576]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4576]: https://datadoghq.atlassian.net/browse/DEBUG-4576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ