### PR TITLE
Lazier way to configure grpc tasks

### DIFF
--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -28,7 +28,9 @@ protobuf {
     grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
   }
   generateProtoTasks {
-    all()*.plugins { grpc {} }
+    ofSourceSet("test").configureEach {
+      plugins { grpc {} }
+    }
   }
 }
 

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
@@ -31,8 +31,8 @@ protobuf {
     }
   }
   generateProtoTasks {
-    all()*.plugins {
-      grpc {}
+    ofSourceSet("test").configureEach {
+      plugins { grpc {} }
     }
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -26,7 +26,9 @@ protobuf {
     grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
   }
   generateProtoTasks {
-    all()*.plugins { grpc {} }
+    ofSourceSet("test").configureEach {
+      plugins { grpc {} }
+    }
   }
 }
 

--- a/dd-smoke-tests/grpc-1.5/build.gradle
+++ b/dd-smoke-tests/grpc-1.5/build.gradle
@@ -32,7 +32,9 @@ protobuf {
     grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
   }
   generateProtoTasks {
-    all()*.plugins { grpc {} }
+    ofSourceSet("main").configureEach {
+      plugins { grpc {} }
+    }
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Proper API usage to generate the GRPC tasks

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
