### PR TITLE
Simplify InstanceStore implementation to use simple, synchronized HashMaps

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstanceStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstanceStore.java
@@ -1,25 +1,61 @@
 package datadog.trace.bootstrap;
 
 import datadog.trace.api.GenericClassValue;
-import java.util.function.Function;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An {@code InstanceStore} is a class global map for registering instances. This can be useful when
- * helper classes are injected into multiple class loaders but need to share unique keys of a type
+ * helper classes are injected into multiple class loaders and need to share instances of a type
  * from a common parent class loader.
  *
- * <p>The {@code InstanceStore} is backed by a {@code WeakMapContextStore} that has a max size of
- * 100 keys.
+ * <p>Instance keys are expected to be string literals, defined as constants in the helper classes.
  */
-public final class InstanceStore {
-  private InstanceStore() {}
+public final class InstanceStore<T> implements ContextStore<String, T> {
 
   private static final ClassValue<? super ContextStore<String, ?>> classInstanceStore =
-      GenericClassValue.of(
-          (Function<Class<?>, ContextStore<String, ?>>) input -> new WeakMapContextStore<>(100));
+      GenericClassValue.of(input -> new InstanceStore<>());
 
+  /** @return global store of instances with the same common type */
   @SuppressWarnings("unchecked")
-  public static <T> ContextStore<String, T> of(Class<T> type) {
-    return (ContextStore<String, T>) classInstanceStore.get(type);
+  public static <T> InstanceStore<T> of(Class<T> type) {
+    return (InstanceStore<T>) classInstanceStore.get(type);
+  }
+
+  // simple approach; instance stores don't need highly concurrent access or weak keys
+  private final Map<String, T> store = Collections.synchronizedMap(new HashMap<>());
+
+  private InstanceStore() {}
+
+  @Override
+  public T get(String key) {
+    return store.get(key);
+  }
+
+  @Override
+  public void put(String key, T instance) {
+    store.put(key, instance);
+  }
+
+  @Override
+  public T putIfAbsent(String key, T instance) {
+    T existing = store.putIfAbsent(key, instance);
+    return existing != null ? existing : instance;
+  }
+
+  @Override
+  public T putIfAbsent(String key, Factory<T> instanceFactory) {
+    return store.computeIfAbsent(key, instanceFactory::create);
+  }
+
+  @Override
+  public T computeIfAbsent(String key, KeyAwareFactory<? super String, T> instanceFactory) {
+    return store.computeIfAbsent(key, instanceFactory::create);
+  }
+
+  @Override
+  public T remove(String key) {
+    return store.remove(key);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InstanceStoreTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InstanceStoreTest.groovy
@@ -1,15 +1,11 @@
 package datadog.trace.bootstrap
 
-import datadog.trace.agent.tooling.WeakMaps
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicInteger
 
 class InstanceStoreTest extends DDSpecification {
-  static {
-    WeakMaps.registerAsSupplier()
-  }
 
   @Shared
   private AtomicInteger counter = new AtomicInteger()
@@ -17,14 +13,6 @@ class InstanceStoreTest extends DDSpecification {
   // Since the InstanceStore is a per Class singleton, every test case needs new keys
   String nextKey() {
     "key-${counter.incrementAndGet()}"
-  }
-
-  def "test empty InstanceStore"() {
-    setup:
-    WeakMapContextStore<String, Some> someStore = InstanceStore.of(Some) as WeakMapContextStore<String, Some>
-
-    expect:
-    someStore.size() == 0
   }
 
   def "test returns existing value"() {


### PR DESCRIPTION
# Motivation

The keys used to lookup instances are always string literals, bounded in code by a fixed number of calls. These keys are never collected, so we don't need to use a weak map. The instance store is accessed when setting up helpers to guarantee the same instance is used by different instrumentations sharing a common type (via their parent class-loader.) Therefore each store just needs basic synchronization to guarantee it only creates one instance per-key.

# Additional Notes

Making this change reduces the places we (indirectly) use `com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap`

Note that each instance store is maintained as a `ClassValue` of the class being implemented / extended.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
