### PR TITLE
Enables logging on agent indexer

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -221,6 +221,10 @@ tasks.named("shadowJar", ShadowJar) {
   }
 }
 
+project.configurations.register('slf4j-simple') {
+  it.dependencies.add(project.dependencyFactory.create("org.slf4j:slf4j-simple:${libs.versions.slf4j.get()}"))
+}
+
 tasks.register('generateAgentJarIndex', JavaExec) {
   def indexName = 'dd-java-agent.index'
   def contentDir = "${sourceSets.main.output.resourcesDir}"
@@ -231,7 +235,9 @@ tasks.register('generateAgentJarIndex', JavaExec) {
   it.inputs.files(fileTree(contentDir).exclude(indexName))
   it.outputs.files(indexFile)
   it.mainClass = 'datadog.trace.bootstrap.AgentJarIndex$IndexGenerator'
-  it.classpath = project.configurations.shadowInclude
+  it.classpath = objects.fileCollection()
+    .from(project.configurations.named("shadowInclude"))
+    .from(project.configurations.named('slf4j-simple'))
   it.args = [contentDir]
 
   dependsOn 'processResources'


### PR DESCRIPTION
# What Does This Do

It simply enables logging on the agent indexer.

# Motivation

Need to understand the following warnings when running ` ./gradlew :dd-java-agent:generateAgentJarIndex`, see https://github.com/DataDog/dd-trace-java/pull/9725#discussion_r2420250029

<details><summary>Output of <code>:dd-java-agent:generateAgentJarIndex</code> on <code>master</code> 06ae965e51 on 2025-10-13 13:33</summary>

```
> Task :dd-java-agent:generateAgentJarIndex
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.jmxfetch.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.civisibility.writer.ddintake.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.civisibility.interceptor.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.payloadtags.json.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.core.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.common.metrics.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.common.sampling.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.common.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.llmobs.writer.ddintake.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.lambda.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.cws.tls.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.cws.erpc.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.okio.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jctools.maps.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jctools.util.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jctools.queues.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jctools.counters.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.remoteconfig.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.io.airlift.compress.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.okhttp3.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.crashtracking.dto.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.crashtracking.parsers.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.crashtracking.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.libs.ddprof.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.common.container.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.common.version.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.common.socket.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jpountz.util.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jpountz.lz4.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.jpountz.xxhash.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.telemetry.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.communication.monitor.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.communication.util.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.communication.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.flare.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.logging.intake.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'META-INF.AL2.0'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'META-INF.LGPL2.1'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.agent.tooling.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.instrumentation.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.opentelemetry.tooling.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.opentelemetry.shim.context.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.opentelemetry.shim.trace.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.exceptions.instrumentation.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.civisibility.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.bootstrap.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.trace.llmobs.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.utils.*'. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content under 'datadog.compiler.annotations.*'. Ensure your content is under a distinct directory.
```

</details>

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
