### PR TITLE
Don't calculate stats if dropping is disabled

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -356,7 +356,9 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   }
 
   public boolean supportsMetrics() {
-    return metricsEnabled && null != discoveryState.metricsEndpoint;
+    return metricsEnabled
+        && null != discoveryState.metricsEndpoint
+        && discoveryState.supportsDropping;
   }
 
   public boolean supportsDebugger() {
@@ -439,7 +441,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   @Override
   public boolean active() {
-    return supportsMetrics() && discoveryState.supportsDropping;
+    return supportsMetrics();
   }
 
   public boolean supportsTelemetryProxy() {

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -58,7 +58,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
-    features.supportsMetrics()
+    !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
     features.getDataStreamsEndpoint() == V01_DATASTREAMS_ENDPOINT
@@ -87,7 +87,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then: "info returned"
     1 * client.newCall(_) >> {
-      Request request -> infoResponse(request, INFO_RESPONSE)
+      Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE)
     }
     features.supportsMetrics()
 
@@ -116,7 +116,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
-    features.supportsMetrics()
+    !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
     features.getDataStreamsEndpoint() == V01_DATASTREAMS_ENDPOINT
@@ -162,7 +162,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITHOUT_DATA_STREAMS_RESPONSE) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
-    features.supportsMetrics()
+    !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     features.getDataStreamsEndpoint() == null
     !features.supportsDataStreams()


### PR DESCRIPTION
# What Does This Do

Disable client stats if the agent does not support p0 drops. This is an optimisation since, in this case, we're going to calculate the stats AND send everything in any case to the agent. At this point we can just let the agent calculate the stats (since it has all the spans) and avoid an extra overhead on tracer side for the stats calculation

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
