### PR TITLE
Fix client stats payload

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 public final class SerializingMetricWriter implements MetricWriter {
 
-  private static final byte[] SEQUENCE = "Seq".getBytes(ISO_8859_1);
-  private static final byte[] RUNTIME_ID = "RuntimeId".getBytes(ISO_8859_1);
+  private static final byte[] SEQUENCE = "Sequence".getBytes(ISO_8859_1);
+  private static final byte[] RUNTIME_ID = "RuntimeID".getBytes(ISO_8859_1);
   private static final byte[] HOSTNAME = "Hostname".getBytes(ISO_8859_1);
   private static final byte[] NAME = "Name".getBytes(ISO_8859_1);
   private static final byte[] ENV = "Env".getBytes(ISO_8859_1);
@@ -61,7 +61,7 @@ public final class SerializingMetricWriter implements MetricWriter {
   public void startBucket(int metricCount, long start, long duration) {
     final UTF8BytesString processTags = ProcessTags.getTagsForSerialization();
     final boolean writeProcessTags = processTags != null;
-    writer.startMap(6 + (writeProcessTags ? 1 : 0));
+    writer.startMap(7 + (writeProcessTags ? 1 : 0));
 
     writer.writeUTF8(RUNTIME_ID);
     writer.writeUTF8(wellKnownTags.getRuntimeId());
@@ -71,6 +71,9 @@ public final class SerializingMetricWriter implements MetricWriter {
 
     writer.writeUTF8(HOSTNAME);
     writer.writeUTF8(wellKnownTags.getHostname());
+
+    writer.writeUTF8(SERVICE);
+    writer.writeUTF8(wellKnownTags.getService());
 
     writer.writeUTF8(ENV);
     writer.writeUTF8(wellKnownTags.getEnv());

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -125,13 +125,15 @@ class SerializingMetricWriterTest extends DDSpecification {
     void accept(int messageCount, ByteBuffer buffer) {
       MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
       int mapSize = unpacker.unpackMapHeader()
-      assert mapSize == (6 + (Config.get().isExperimentalPropagateProcessTagsEnabled() ? 1 : 0))
-      assert unpacker.unpackString() == "RuntimeId"
+      assert mapSize == (7 + (Config.get().isExperimentalPropagateProcessTagsEnabled() ? 1 : 0))
+      assert unpacker.unpackString() == "RuntimeID"
       assert unpacker.unpackString() == wellKnownTags.getRuntimeId() as String
-      assert unpacker.unpackString() == "Seq"
+      assert unpacker.unpackString() == "Sequence"
       assert unpacker.unpackLong() == 0L
       assert unpacker.unpackString() == "Hostname"
       assert unpacker.unpackString() == wellKnownTags.getHostname() as String
+      assert unpacker.unpackString() == "Service"
+      assert unpacker.unpackString() == wellKnownTags.getService() as String
       assert unpacker.unpackString() == "Env"
       assert unpacker.unpackString() == wellKnownTags.getEnv() as String
       assert unpacker.unpackString() == "Version"


### PR DESCRIPTION
# What Does This Do

Fix the following misses on the tracer stat payload:
* Add a global `Service` field at top level (service is however repeated at bucket level)
* Fixes the naming for `Sequence` (was sending `Seq`)
* FIxes the naming for `RuntimeID` (was sending `RuntimeId`)

Notes: testing will be enforced on System tests

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
