### PR TITLE
Remove instrumentation `afterEvaluate`

### DIFF
--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -1,3 +1,6 @@
+import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME
+import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
+
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
@@ -11,51 +14,56 @@ tasks.register("latestDepTest", Test)
 
 Project parent_project = project
 subprojects { Project subProj ->
-  apply plugin: 'dd-trace-java.instrument'
-  apply plugin: 'dd-trace-java.muzzle'
+  subProj.pluginManager.withPlugin("dd-trace-java.instrument") {
+    subProj.extensions.configure(InstrumentExtension) {
+      it.plugins.addAll(
+        'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin',
+        'datadog.trace.agent.tooling.bytebuddy.NewTaskForGradlePlugin',
+        'datadog.trace.agent.tooling.bytebuddy.reqctx.RewriteRequestContextAdvicePlugin',
+        )
+    }
 
-  configurations {
-    instrumentPluginClasspath {
-      visible = false
-      canBeConsumed = false
-      canBeResolved = true
+    subProj.configurations.register("instrumentPluginClasspath") {
+      it.visible = false
+      it.canBeConsumed = false
+      it.canBeResolved = true
+
+      it.dependencies.add(subProj.dependencies.project(path: ':dd-java-agent:agent-tooling', configuration: 'instrumentPluginClasspath'))
     }
   }
 
-  instrument.plugins = [
-    'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin',
-    'datadog.trace.agent.tooling.bytebuddy.NewTaskForGradlePlugin',
-    'datadog.trace.agent.tooling.bytebuddy.reqctx.RewriteRequestContextAdvicePlugin',
-  ]
-
-  subProj.tasks.withType(Javadoc).configureEach { enabled = false }
-
-  subProj.afterEvaluate {
-    if (!plugins.hasPlugin("java")) {
-      return
+  subProj.pluginManager.withPlugin("java") {
+    subProj.pluginManager.withPlugin("dd-trace-java.muzzle") {
+      subProj.configurations.matching { it.name == 'muzzleBootstrap' }.configureEach {
+        exclude group: 'org.snakeyaml', module: 'snakeyaml-engine' // we vendor this in the agent jar
+      }
     }
 
+    subProj.tasks.withType(Javadoc).configureEach { enabled = false }
+
     // Configures base dependencies for additional sourceSet
-    configurations
-      .matching { it.name.matches("${SourceSet.MAIN_SOURCE_SET_NAME}_java\\d+${JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME.capitalize()}") }
+    subProj.configurations
+      .matching { it.name.matches("${MAIN_SOURCE_SET_NAME}_java\\d+${IMPLEMENTATION_CONFIGURATION_NAME.capitalize()}") }
       .configureEach {
-        it.dependencies.add(project.dependencyFactory.create(project(':dd-trace-api')))
-        it.dependencies.add(project.dependencyFactory.create(project(':dd-java-agent:agent-tooling')))
+        it.dependencies.add(subProj.dependencyFactory.create(project(':dd-trace-api')))
+        it.dependencies.add(subProj.dependencyFactory.create(project(':dd-java-agent:agent-tooling')))
         it.dependencies.addLater(libs.bytebuddy)
       }
 
-    configurations.named('muzzleBootstrap') {
-      exclude group: 'org.snakeyaml', module: 'snakeyaml-engine' // we vendor this in the agent jar
-    }
     dependencies {
+      // Main
+      annotationProcessor project(':dd-java-agent:instrumentation-annotation-processor')
+      annotationProcessor libs.autoservice.processor
+      compileOnly libs.autoservice.annotation
+
       // Apply common dependencies for instrumentation.
       implementation project(':dd-trace-api')
       implementation project(':dd-java-agent:agent-tooling')
       implementation libs.bytebuddy
 
-      annotationProcessor project(':dd-java-agent:instrumentation-annotation-processor')
-      annotationProcessor libs.autoservice.processor
-      compileOnly libs.autoservice.annotation
+      // Tests
+      testAnnotationProcessor libs.autoservice.processor
+      testCompileOnly libs.autoservice.annotation
 
       // Include instrumentations instrumenting core JDK classes to ensure interoperability with other instrumentation
       testImplementation project(':dd-java-agent:instrumentation:java:java-concurrent:java-concurrent-1.8')
@@ -64,10 +72,6 @@ subprojects { Project subProj ->
       testImplementation project(':dd-java-agent:instrumentation:classloading')
 
       testImplementation project(':dd-java-agent:instrumentation-testing')
-      testAnnotationProcessor libs.autoservice.processor
-      testCompileOnly libs.autoservice.annotation
-
-      instrumentPluginClasspath project(path: ':dd-java-agent:agent-tooling', configuration: 'instrumentPluginClasspath')
     }
 
     subProj.tasks.withType(Test).configureEach { subTask ->
@@ -75,17 +79,17 @@ subprojects { Project subProj ->
         subTask.jvmArgs '-Dtest.dd.latestDepTest=true'
       }
     }
-  }
 
-  def path = subProj.getPath()
-  subProj.plugins.withId("java") {
-    if (!path.equals(':dd-java-agent:instrumentation:vertx:vertx-redis-client:vertx-redis-client-stubs')) {
-      // don't include the redis RequestImpl stub
+    if (subProj.path != ':dd-java-agent:instrumentation:vertx:vertx-redis-client:vertx-redis-client-stubs') {
+      // don't include the redis RequestImpl stubs
       parent_project.dependencies {
-        implementation project(path)
+        addProvider("implementation", providers.provider { project(subProj.path) })
       }
     }
   }
+
+  subProj.apply plugin: 'dd-trace-java.instrument'
+  subProj.apply plugin: 'dd-trace-java.muzzle'
 }
 
 dependencies {


### PR DESCRIPTION
# What Does This Do

Removes instrumentation module's `afterEvaluate`. 

This looks like it is reducing sync time to ~1min on my M1
<img width="791" height="154" alt="image" src="https://github.com/user-attachments/assets/b77b1c14-3f58-48e3-8bf8-ca1b6dfc624d" />


# Motivation

Using `afterEvaluate` is a bad practice and has tighter restriction in Gradle 9+.

https://docs.gradle.org/9.1.0/userguide/task_configuration_avoidance.html#8_some_apis_may_be_disallowed_if_you_try_to_access_them_from_the_new_apis_configuration_blocks

It introduces subtle ordering issues which can be very challenging to debug.

From my notes:

> 1. Anyone wanting to use code in an `afterEvaluate {}` now also needs to use `afterEvaluate {}` all the way down.
> 2. It becomes even more complicated as more plugins/scripts are involved
> 3. More generally, it makes dependencies between plugins/scripts implicit and error prone
> 
> Abusing `afterEvaluate` causes many things that will try to run later and later after each other **when order is not guaranteed**. In almost all situations, `afterEvaluate` is a work-around that introduces timing problems and race conditions and just treats symptoms.
> 
> Usually, `afterEvaluate {}` is good in this occasion:
> * consistency checks, i.e. ensure that something is not misconfigured.


# Additional Notes

Blocked by 
* #9892 
* #9955 
* #10218

Blocks
* #9475 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
