### PR TITLE
Use `.configureEach` lazy API

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 }
 
 // gradle can't downgrade the akka dependencies with `strictly`
-configurations.matching({ it.name.startsWith('akka23') }).each({
+configurations.matching({ it.name.startsWith('akka23') }).configureEach({
   it.resolutionStrategy {
     force group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version :'2.3.16'
     force group: 'com.typesafe.akka', name: "akka-testkit_$scalaVersion", version :'2.3.16'

--- a/dd-java-agent/instrumentation/junit/junit-5.3/cucumber-junit-5/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/cucumber-junit-5/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   latestDepTestImplementation group: 'io.cucumber', name: 'cucumber-junit-platform-engine', version: '+'
 }
 
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching({ it.name.startsWith('test') }).configureEach({
   it.resolutionStrategy {
     force group: 'org.junit.platform', name: 'junit-platform-launcher', version: libs.versions.junit.platform.get()
     force group: 'org.junit.platform', name: 'junit-platform-suite', version: libs.versions.junit.platform.get()

--- a/dd-java-agent/instrumentation/junit/junit-5.3/spock-junit-5/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/spock-junit-5/build.gradle
@@ -28,14 +28,14 @@ dependencies {
   latestDepTestImplementation group: 'org.spockframework', name: 'spock-core', version: '2.+'
 }
 
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching({ it.name.startsWith('test') }).configureEach({
   it.resolutionStrategy {
     force group: 'org.junit.platform', name: 'junit-platform-launcher', version: libs.versions.junit.platform.get()
     force group: 'org.spockframework', name: 'spock-core', version: "2.2-groovy-${spockGroovyVersion}"
   }
 })
 
-configurations.matching({ it.name.startsWith('latestDepTest') }).each({
+configurations.matching({ it.name.startsWith('latestDepTest') }).configureEach({
   it.resolutionStrategy.componentSelection.all { ComponentSelection selection ->
     if (selection.candidate.group == 'org.spockframework' && selection.candidate.module == 'spock-core' && !selection.candidate.version.endsWith("-groovy-${spockGroovyVersion}")) {
       selection.reject('Spock groovy version mismatch')

--- a/dd-java-agent/instrumentation/play/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play/play-2.6/build.gradle
@@ -127,7 +127,7 @@ dependencies {
   latestDepTestImplementation group: 'com.typesafe.play', name: 'play-akka-http-server_2.13', version: '2.+'
 }
 
-configurations.matching({ it.name.startsWith('latestDepTest') }).each({
+configurations.matching({ it.name.startsWith('latestDepTest') }).configureEach({
   it.resolutionStrategy {
     // logback-classic 1.4.11 doesn't like being loaded in the bootstrap classloader (NPE)
     force group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.5'

--- a/dd-java-agent/instrumentation/selenium/build.gradle
+++ b/dd-java-agent/instrumentation/selenium/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   latestDepTestImplementation group: 'org.seleniumhq.selenium', name: 'htmlunit-driver', version: '+'
 }
 
-configurations.matching({ it.name.startsWith('test') || it.name.startsWith('latestDepTest') }).each({
+configurations.matching({ it.name.startsWith('test') || it.name.startsWith('latestDepTest') }).configureEach({
   it.resolutionStrategy {
     // There is a conflict between the version used by HTMLUnit and the one used by :dd-java-agent:testing
     force group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.50.v20221201'

--- a/dd-java-agent/instrumentation/testng/build.gradle
+++ b/dd-java-agent/instrumentation/testng/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
 // gradle can't downgrade the testng dependencies with `strictly` and IntelliJ IDEA reports
 // an error when importing the project, so pretty please DON'T change this back to strictly
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching({ it.name.startsWith('test') }).configureEach({
   it.resolutionStrategy {
     force group: 'org.testng', name: 'testng', version: '6.4'
   }

--- a/dd-java-agent/instrumentation/testng/testng-6/build.gradle
+++ b/dd-java-agent/instrumentation/testng/testng-6/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 // gradle can't downgrade the testng dependencies with `strictly`
 // and IntelliJ IDEA reports an error when importing the project
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching({ it.name.startsWith('test') }).configureEach({
   it.resolutionStrategy {
     force group: 'org.testng', name: 'testng', version: '6.4'
   }

--- a/dd-java-agent/instrumentation/testng/testng-7/build.gradle
+++ b/dd-java-agent/instrumentation/testng/testng-7/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
 // gradle can't downgrade the testng dependencies with `strictly`
 // and IntelliJ IDEA reports an error when importing the project
-configurations.matching({ it.name.startsWith('test') }).each({
+configurations.matching({ it.name.startsWith('test') }).configureEach({
   it.resolutionStrategy {
     force group: 'org.testng', name: 'testng', version: '7.0.0'
   }


### PR DESCRIPTION
# What Does This Do

Replace `.each` with `.configureEach` in gradle builds

# Motivation

Use lazy API

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
