### PR TITLE
Update io.opentelemetry.opentelemetry-api to 1.47.0

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/build.gradle
+++ b/dd-java-agent/agent-otel/otel-shim/build.gradle
@@ -5,7 +5,7 @@ minimumBranchCoverage = 0.0
 
 dependencies {
   // minimum OpenTelemetry API version this shim is compatible with
-  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.4.0'
+  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.47.0'
 
   implementation project(':internal-api')
 }


### PR DESCRIPTION

# What Does This Do
Bump the version of the `io.opentelemetry.opentelemetry-api `dependency from 1.4.0  to 1.47.0.

# Motivation
1.47.0 is the minimum version to target according to our RFC for OpenTelemetry Metrics API support.

# Additional Notes
Jira ticket: [APMAPI-1671](https://datadoghq.atlassian.net/browse/APMAPI-1671)

[APMAPI-1671]: https://datadoghq.atlassian.net/browse/APMAPI-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ