### PR TITLE
Fix CPU overhead in LLM Obs eval processor 

### DIFF
--- a/dd-java-agent/agent-llmobs/src/main/java/datadog/trace/llmobs/EvalProcessingWorker.java
+++ b/dd-java-agent/agent-llmobs/src/main/java/datadog/trace/llmobs/EvalProcessingWorker.java
@@ -145,14 +145,12 @@ public class EvalProcessingWorker implements AutoCloseable {
     private void runDutyCycle() throws InterruptedException {
       Thread thread = Thread.currentThread();
       while (!thread.isInterrupted()) {
-        LLMObsEval eval = queue.poll(ticksRequiredToFlush, TimeUnit.NANOSECONDS);
+        LLMObsEval eval = queue.poll(100, TimeUnit.MILLISECONDS);
         if (eval != null) {
           buffer.add(eval);
           consumeBatch();
-          flushIfNecessary();
-        } else if (!buffer.isEmpty()) {
-          flushIfNecessary();
         }
+        flushIfNecessary();
       }
     }
 


### PR DESCRIPTION
# What Does This Do
Enabling LLM observability on an application will result in CPU overhead when the evaluation metrics processor thread is idle. 
This PR polls the queue with a timeout to prevent constant attempts to drain the queue and flush.

Testing:
1. Run an application that doesn't submit llmobs evaluation metrics on a docker container.

Before: the CPU usage was above 100%:
<img width="664" height="271" alt="image" src="https://github.com/user-attachments/assets/83e3ea8d-d633-429f-9df8-1be6ccf14655" />

After: it decreased to 8%, then dropped further to around 2%.
<img width="891" height="286" alt="image" src="https://github.com/user-attachments/assets/56e802fd-efc6-41e5-9b40-57dc8ce3c34a" />

2. Run an application that submits LLM evaluation metrics locally on a Mac machine.

The CPU usage is around 8.6% after this new implementation.
<img width="1021" height="318" alt="image" src="https://github.com/user-attachments/assets/b52dd320-e2c8-4c69-8572-0f9df45fb295" />



# Motivation
Solves MLOS-268
# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [MLOS-268]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[MLOS-268]: https://datadoghq.atlassian.net/browse/MLOS-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ