### PR TITLE
Fix possible IndexOutOfBoundsException in ExceptionReplay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
@@ -146,6 +146,15 @@ public abstract class AbstractExceptionDebugger implements DebuggerContext.Excep
     int maxSnapshotSize = Math.min(snapshots.size(), maxCapturedFrames);
     for (int i = 0; i < maxSnapshotSize; i++) {
       Snapshot snapshot = snapshots.get(i);
+      int chainedExceptionIdx = snapshot.getChainedExceptionIdx();
+      if (chainedExceptionIdx >= chainedExceptions.size()) {
+        LOGGER.debug(
+            "Chained exception for snapshot={} is out of bounds: {}/{}",
+            snapshot.getId(),
+            chainedExceptionIdx,
+            chainedExceptions.size());
+        continue;
+      }
       Throwable currentEx = chainedExceptions.get(snapshot.getChainedExceptionIdx());
       int[] mapping = createThrowableMapping(currentEx, t);
       StackTraceElement[] innerTrace = currentEx.getStackTrace();


### PR DESCRIPTION
# What Does This Do
if chainedExceptionIndex stored into the snapshot is incorrect, it can lead to an IndexOutOfBoundsException. Protect against it

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
