### PR TITLE
Drop 'rare sampling' support on CSS

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsReliabilityTest.groovy
@@ -82,8 +82,8 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "should have sent statistics and informed the agent that we calculate the stats"
     assert state.receivedClientComputedHeader
     assert state.receivedStats
-    // 1 trace processed. not a p0 drop (first time we see it). No errors
-    assertMetrics(healthMetrics, 1, 0, 1, 0, 0)
+    // 1 trace processed. 1 p0 drop No errors
+    assertMetrics(healthMetrics, 1, 1, 1, 0, 0)
 
 
     when: "simulate an agent downgrade"
@@ -95,8 +95,8 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     then: "a discovery should have done - we do not support anymore stats calculation"
     state.latch.await()
     assert !featuresDiscovery.supportsMetrics()
-    // 2 traces processed. 1 p0 dropped. 2 requests and 1 downgrade no errors
-    assertMetrics(healthMetrics, 2, 1, 2, 0, 1)
+    // 2 traces processed. 2 p0 dropped. 2 requests and 1 downgrade no errors
+    assertMetrics(healthMetrics, 2, 2, 2, 0, 1)
 
 
     when: "a span is published"
@@ -109,7 +109,7 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     assert !state.receivedClientComputedHeader
     assert !state.receivedStats
     // 2 traces processed. 1 p0 dropped. 2 requests and 1 downgrade no errors
-    assertMetrics(healthMetrics, 2, 1, 2, 0, 1)
+    assertMetrics(healthMetrics, 2, 2, 2, 0, 1)
 
     when: "we detect that the agent can calculate the stats again"
     state.reset(true)
@@ -128,7 +128,7 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     assert state.receivedClientComputedHeader
     assert state.receivedStats
     // 3 traces processed. 2 p0 dropped. 3 requests and 1 downgrade no errors
-    assertMetrics(healthMetrics, 3, 2, 3, 0, 1)
+    assertMetrics(healthMetrics, 3, 3, 3, 0, 1)
 
     when: "an error occurred on the agent stats endpoint"
     state.reset(true, 500)
@@ -140,7 +140,7 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     assert state.receivedClientComputedHeader
     assert state.receivedStats
     // 4 traces processed. 3 p0 dropped. 4 requests and 1 downgrade - 1 error
-    assertMetrics(healthMetrics, 4, 3, 4, 1, 1)
+    assertMetrics(healthMetrics, 4, 4, 4, 1, 1)
 
     when: "the next call succeed"
     state.reset(true)
@@ -153,7 +153,7 @@ class MetricsReliabilityTest extends DDCoreSpecification {
     assert state.receivedStats
     // 5 traces processed. 3 p0 dropped (this one is errored so it's not dropped).
     // 5 requests and 1 downgrade - 1 error
-    assertMetrics(healthMetrics, 5, 3, 5, 1, 1)
+    assertMetrics(healthMetrics, 5, 4, 5, 1, 1)
 
     cleanup:
     tracer.close()


### PR DESCRIPTION
# What Does This Do

It avoid force keeping the first seen spans even if they are p0. The rationale behind is that _rare sampling_ is going to be discontinued. This feature is also not part of CSS hence we're removing from the old implementation.

The fact that _rare sampling_ is not compatible hence with CSS is a known limitation.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
