### PR TITLE
Split CapturedContext instrumenters

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContextProbe.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContextProbe.java
@@ -1,0 +1,9 @@
+package datadog.trace.bootstrap.debugger;
+
+public interface CapturedContextProbe {
+  boolean isCaptureSnapshot();
+
+  boolean hasCondition();
+
+  boolean isReadyToCapture();
+}

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
@@ -28,10 +28,6 @@ public interface ProbeImplementation {
 
   MethodLocation getEvaluateAt();
 
-  boolean isCaptureSnapshot();
-
-  boolean hasCondition();
-
   CapturedContext.Status createStatus();
 
   class NoopProbeImplementation implements ProbeImplementation {
@@ -100,16 +96,6 @@ public interface ProbeImplementation {
     @Override
     public MethodLocation getEvaluateAt() {
       return evaluateAt;
-    }
-
-    @Override
-    public boolean isCaptureSnapshot() {
-      return captureSnapshot;
-    }
-
-    @Override
-    public boolean hasCondition() {
-      return script != null;
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
@@ -60,19 +60,19 @@ import org.objectweb.asm.tree.VarInsnNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CapturedContextInstrumentor extends Instrumentor {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CapturedContextInstrumentor.class);
+public class CapturedContextInstrumenter extends Instrumenter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CapturedContextInstrumenter.class);
   private final boolean captureSnapshot;
   private final boolean captureEntry;
   private final Limits limits;
-  private final LabelNode contextInitLabel = new LabelNode();
+  protected final LabelNode contextInitLabel = new LabelNode();
   private int entryContextVar = -1;
   private int exitContextVar = -1;
   private int timestampStartVar = -1;
   private int throwableListVar = -1;
   private Collection<LocalVariableNode> hoistedLocalVars = Collections.emptyList();
 
-  public CapturedContextInstrumentor(
+  public CapturedContextInstrumenter(
       ProbeDefinition definition,
       MethodInfo methodInfo,
       List<DiagnosticMessage> diagnostics,
@@ -140,40 +140,14 @@ public class CapturedContextInstrumentor extends Instrumentor {
             // stack [exception]
           }
         }
-        ldc(insnList, Type.getObjectType(classNode.name));
-        // stack [class, array]
-        pushProbeIndices(insnList);
-        // stack [array]
-        invokeStatic(
-            insnList,
-            DEBUGGER_CONTEXT_TYPE,
-            "isReadyToCapture",
-            Type.BOOLEAN_TYPE,
-            CLASS_TYPE,
-            INT_ARRAY_TYPE);
+        addIsReadyToCaptureCall(insnList);
         // stack [boolean]
         LabelNode targetNode = new LabelNode();
         insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
         LabelNode inProbeStartLabel = new LabelNode();
         insnList.add(inProbeStartLabel);
         // stack []
-        insnList.add(collectCapturedContext(Snapshot.Kind.BEFORE, beforeLabel));
-        // stack [capturedcontext]
-        ldc(insnList, Type.getObjectType(classNode.name));
-        // stack [capturedcontext, class]
-        ldc(insnList, sourceLine.getFrom());
-        // stack [capturedcontext, class, int]
-        pushProbeIndices(insnList);
-        // stack [capturedcontext, class, int, array]
-        invokeStatic(
-            insnList,
-            DEBUGGER_CONTEXT_TYPE,
-            "evalContextAndCommit",
-            VOID_TYPE,
-            CAPTURED_CONTEXT_TYPE,
-            CLASS_TYPE,
-            INT_TYPE,
-            INT_ARRAY_TYPE);
+        addEvalContextAndCommitCall(sourceLine, insnList, beforeLabel);
         // stack []
         invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
         LabelNode inProbeEndLabel = new LabelNode();
@@ -188,6 +162,28 @@ public class CapturedContextInstrumentor extends Instrumentor {
       }
     }
     return true;
+  }
+
+  protected void addEvalContextAndCommitCall(
+      Where.SourceLine sourceLine, InsnList insnList, LabelNode beforeLabel) {
+    insnList.add(collectCapturedContext(Snapshot.Kind.BEFORE, beforeLabel));
+    // stack [capturedcontext]
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [capturedcontext, class]
+    ldc(insnList, sourceLine.getFrom());
+    // stack [capturedcontext, class, int]
+    pushProbeIndices(insnList);
+    // stack [capturedcontext, class, int, array]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "evalContextAndCommit",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CLASS_TYPE,
+        INT_TYPE,
+        INT_ARRAY_TYPE);
+    // stack []
   }
 
   private int addExceptionLocal(TryCatchBlockNode catchHandler, MethodNode methodNode) {
@@ -271,26 +267,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack [ret_value, boolean]
     insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
     // stack [ret_value]
-    insnList.add(collectCapturedContext(Snapshot.Kind.RETURN, node));
-    // stack [ret_value, capturedcontext]
-    ldc(insnList, Type.getObjectType(classNode.name));
-    // stack [ret_value, capturedcontext, class]
-    insnList.add(new VarInsnNode(Opcodes.LLOAD, timestampStartVar));
-    // stack [ret_value, capturedcontext, class, long]
-    getStatic(insnList, METHOD_LOCATION_TYPE, "EXIT");
-    // stack [ret_value, capturedcontext, class, long, methodlocation]
-    pushProbeIndices(insnList);
-    // stack [ret_value, capturedcontext, class, long, methodlocation, array]
-    invokeStatic(
-        insnList,
-        DEBUGGER_CONTEXT_TYPE,
-        "evalContext",
-        VOID_TYPE,
-        CAPTURED_CONTEXT_TYPE,
-        CLASS_TYPE,
-        LONG_TYPE,
-        METHOD_LOCATION_TYPE,
-        INT_ARRAY_TYPE);
+    addEvalContextCall(insnList, Snapshot.Kind.RETURN, node, timestampStartVar, "EXIT");
     // stack [ret_value]
     invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
     insnList.add(new JumpInsnNode(Opcodes.GOTO, gotoNode));
@@ -325,8 +302,15 @@ public class CapturedContextInstrumentor extends Instrumentor {
       insnList.add(new InsnNode(Opcodes.ACONST_NULL));
     }
     // stack [capturedcontext, capturedcontext, list]
+    addCommitCall(insnList);
+    // stack []
+    return insnList;
+  }
+
+  protected void addCommitCall(InsnList insnList) {
+    // stack [capturedcontext, capturedcontext, list]
     pushProbeIndices(insnList);
-    // stack [capturedcontext, capturedcontext, array]
+    // stack [capturedcontext, capturedcontext, list, array]
     invokeStatic(
         insnList,
         DEBUGGER_CONTEXT_TYPE,
@@ -337,7 +321,6 @@ public class CapturedContextInstrumentor extends Instrumentor {
         getType(List.class),
         INT_ARRAY_TYPE);
     // stack []
-    return insnList;
   }
 
   protected void addFinallyHandler(LabelNode startLabel, LabelNode endLabel) {
@@ -362,30 +345,8 @@ public class CapturedContextInstrumentor extends Instrumentor {
       exitContextVar = newVar(CAPTURED_CONTEXT_TYPE);
     }
     // stack [exception]
-    handler.add(collectCapturedContext(Snapshot.Kind.UNHANDLED_EXCEPTION, endLabel));
-    // stack: [exception, capturedcontext]
-    ldc(handler, Type.getObjectType(classNode.name));
-    // stack [exception, capturedcontext, class]
-    if (timestampStartVar != -1) {
-      handler.add(new VarInsnNode(Opcodes.LLOAD, timestampStartVar));
-    } else {
-      ldc(handler, -1L);
-    }
-    // stack [exception, capturedcontext, class, long]
-    getStatic(handler, METHOD_LOCATION_TYPE, "EXIT");
-    // stack [exception, capturedcontext, class, long, methodlocation]
-    pushProbeIndices(handler);
-    // stack [exception, capturedcontext, class, long, methodlocation, array]
-    invokeStatic(
-        handler,
-        DEBUGGER_CONTEXT_TYPE,
-        "evalContext",
-        VOID_TYPE,
-        CAPTURED_CONTEXT_TYPE,
-        CLASS_TYPE,
-        LONG_TYPE,
-        METHOD_LOCATION_TYPE,
-        INT_ARRAY_TYPE);
+    addEvalContextCall(
+        handler, Snapshot.Kind.UNHANDLED_EXCEPTION, endLabel, timestampStartVar, "EXIT");
     // stack [exception]
     invokeStatic(handler, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
     // stack [exception]
@@ -398,6 +359,40 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack: []
     methodNode.instructions.add(handler);
     finallyBlocks.add(new FinallyBlock(startLabel, endLabel, handlerLabel));
+  }
+
+  protected void addEvalContextCall(
+      InsnList insnList,
+      Snapshot.Kind snapshotKind,
+      AbstractInsnNode endLabel,
+      int timestampVar,
+      String methodLocation) {
+    // stack []
+    insnList.add(collectCapturedContext(snapshotKind, endLabel));
+    // stack: [capturedcontext]
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [capturedcontext, class]
+    if (timestampVar != -1) {
+      insnList.add(new VarInsnNode(Opcodes.LLOAD, timestampVar));
+    } else {
+      ldc(insnList, -1L);
+    }
+    // stack [capturedcontext, class, long]
+    getStatic(insnList, METHOD_LOCATION_TYPE, methodLocation);
+    // stack [capturedcontext, class, long, methodlocation]
+    pushProbeIndices(insnList);
+    // stack [capturedcontext, class, long, methodlocation, array]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "evalContext",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CLASS_TYPE,
+        LONG_TYPE,
+        METHOD_LOCATION_TYPE,
+        INT_ARRAY_TYPE);
+    // stack []
   }
 
   private void instrumentMethodEnter() {
@@ -416,18 +411,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
       methodNode.instructions.insert(methodEnterLabel, insnList);
       return;
     }
-    ldc(insnList, Type.getObjectType(classNode.name));
-    // stack [class]
-    pushProbeIndices(insnList);
-    // stack [class, array]
-    invokeStatic(
-        insnList,
-        DEBUGGER_CONTEXT_TYPE,
-        "isReadyToCapture",
-        Type.BOOLEAN_TYPE,
-        CLASS_TYPE,
-        INT_ARRAY_TYPE);
-    // stack [boolean]
+    addIsReadyToCaptureCall(insnList);
     LabelNode targetNode = new LabelNode();
     LabelNode gotoNode = new LabelNode();
     insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
@@ -435,26 +419,8 @@ public class CapturedContextInstrumentor extends Instrumentor {
       LabelNode inProbeStartLabel = new LabelNode();
       insnList.add(inProbeStartLabel);
       // stack []
-      insnList.add(collectCapturedContext(Snapshot.Kind.ENTER, null));
-      // stack [capturedcontext]
-      ldc(insnList, Type.getObjectType(classNode.name));
-      // stack [capturedcontext, class]
-      ldc(insnList, -1L);
-      // stack [capturedcontext, class, long]
-      getStatic(insnList, METHOD_LOCATION_TYPE, "ENTRY");
-      // stack [capturedcontext, class, long, methodlocation]
-      pushProbeIndices(insnList);
-      // stack [capturedcontext, class, long, methodlocation, array]
-      invokeStatic(
-          insnList,
-          DEBUGGER_CONTEXT_TYPE,
-          "evalContext",
-          VOID_TYPE,
-          CAPTURED_CONTEXT_TYPE,
-          CLASS_TYPE,
-          LONG_TYPE,
-          METHOD_LOCATION_TYPE,
-          INT_ARRAY_TYPE);
+      addEvalContextCall(insnList, Snapshot.Kind.ENTER, null, -1, "ENTRY");
+      // stack []
       invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
       LabelNode inProbeEndLabel = new LabelNode();
       insnList.add(inProbeEndLabel);
@@ -471,6 +437,21 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack []
     insnList.add(gotoNode);
     methodNode.instructions.insert(methodEnterLabel, insnList);
+  }
+
+  protected void addIsReadyToCaptureCall(InsnList insnList) {
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [class]
+    pushProbeIndices(insnList);
+    // stack [class, array]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "isReadyToCapture",
+        Type.BOOLEAN_TYPE,
+        CLASS_TYPE,
+        INT_ARRAY_TYPE);
+    // stack [boolean]
   }
 
   // Initialize and hoist local variables to the top of the method
@@ -572,7 +553,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack []
   }
 
-  private InsnList collectCapturedContext(Snapshot.Kind kind, AbstractInsnNode location) {
+  protected InsnList collectCapturedContext(Snapshot.Kind kind, AbstractInsnNode location) {
     InsnList insnList = new InsnList();
     if (kind == Snapshot.Kind.ENTER) {
       createContext(insnList, entryContextVar);
@@ -845,7 +826,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
   }
 
   private void collectStaticFields(InsnList insnList) {
-    List<FieldNode> fieldsToCapture = extractStaticFields(classNode, classLoader, limits);
+    List<FieldNode> fieldsToCapture = extractStaticFields(classNode, limits);
     if (fieldsToCapture.isEmpty()) {
       // bail out if no fields
       return;
@@ -916,8 +897,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     return true;
   }
 
-  private static List<FieldNode> extractStaticFields(
-      ClassNode classNode, ClassLoader classLoader, Limits limits) {
+  private static List<FieldNode> extractStaticFields(ClassNode classNode, Limits limits) {
     int fieldCount = 0;
     List<FieldNode> results = new ArrayList<>();
     for (FieldNode fieldNode : classNode.fields) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CodeOriginInstrumenter.java
@@ -21,10 +21,10 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CodeOriginInstrumentor extends Instrumentor {
+public class CodeOriginInstrumenter extends Instrumenter {
   private static final String CAPTURE;
   private static final String MARKER;
-  private static final Logger LOGGER = LoggerFactory.getLogger(CodeOriginInstrumentor.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CodeOriginInstrumenter.class);
 
   static {
     String className = DebuggerContext.class.getName().replace('.', '/');
@@ -32,7 +32,7 @@ public class CodeOriginInstrumentor extends Instrumentor {
     MARKER = format("%s#%s", className, "marker");
   }
 
-  public CodeOriginInstrumentor(
+  public CodeOriginInstrumenter(
       ProbeDefinition definition, MethodInfo methodInfo, List<Integer> probeIndices) {
     super(definition, methodInfo, null, probeIndices);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
@@ -6,9 +6,9 @@ import java.util.List;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
 
-public class ExceptionInstrumentor extends CapturedContextInstrumentor {
+public class ExceptionInstrumenter extends CapturedContextInstrumenter {
 
-  public ExceptionInstrumentor(
+  public ExceptionInstrumenter(
       ProbeDefinition definition,
       MethodInfo methodInfo,
       List<DiagnosticMessage> diagnostics,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -29,7 +29,7 @@ import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
 /** Common class for generating instrumentation */
-public abstract class Instrumentor {
+public abstract class Instrumenter {
   protected static final String CONSTRUCTOR_NAME = "<init>";
   protected static final String PROBEID_TAG_NAME = "debugger.probeid";
 
@@ -47,9 +47,9 @@ public abstract class Instrumentor {
   protected final LocalVariableNode[] localVarsBySlotArray;
   protected final JvmLanguage language;
   protected LabelNode returnHandlerLabel;
-  protected final List<CapturedContextInstrumentor.FinallyBlock> finallyBlocks = new ArrayList<>();
+  protected final List<CapturedContextInstrumenter.FinallyBlock> finallyBlocks = new ArrayList<>();
 
-  public Instrumentor(
+  public Instrumenter(
       ProbeDefinition definition,
       MethodInfo methodInfo,
       List<DiagnosticMessage> diagnostics,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
@@ -75,15 +75,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Handles generating instrumentation for metric probes */
-public class MetricInstrumentor extends Instrumentor {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MetricInstrumentor.class);
+public class MetricInstrumenter extends Instrumenter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricInstrumenter.class);
   private static final InsnList EMPTY_INSN_LIST = new InsnList();
 
   private final MetricProbe metricProbe;
   private int durationStartVar = -1;
   private LabelNode durationStartLabel;
 
-  public MetricInstrumentor(
+  public MetricInstrumenter(
       MetricProbe metricProbe,
       MethodInfo methodInfo,
       List<DiagnosticMessage> diagnostics,
@@ -389,13 +389,13 @@ public class MetricInstrumentor extends Instrumentor {
   }
 
   private class MetricValueVisitor implements Visitor<VisitorResult> {
-    private final MetricInstrumentor instrumentor;
+    private final MetricInstrumenter instrumentor;
     private final InsnList nullBranch;
     private final AbstractInsnNode targetLocation;
     private final ReturnContext returnContext;
 
     public MetricValueVisitor(
-        MetricInstrumentor instrumentor,
+        MetricInstrumenter instrumentor,
         InsnList nullBranch,
         AbstractInsnNode targetLocation,
         ReturnContext returnContext) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MultiCapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MultiCapturedContextInstrumenter.java
@@ -1,0 +1,18 @@
+package com.datadog.debugger.instrumentation;
+
+import com.datadog.debugger.probe.ProbeDefinition;
+import datadog.trace.bootstrap.debugger.Limits;
+import java.util.List;
+
+public class MultiCapturedContextInstrumenter extends CapturedContextInstrumenter {
+  public MultiCapturedContextInstrumenter(
+      ProbeDefinition definition,
+      MethodInfo methodInfo,
+      List<DiagnosticMessage> diagnostics,
+      List<Integer> probeIndices,
+      boolean captureSnapshot,
+      boolean captureEntry,
+      Limits limits) {
+    super(definition, methodInfo, diagnostics, probeIndices, captureSnapshot, captureEntry, limits);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SingleCapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SingleCapturedContextInstrumenter.java
@@ -1,0 +1,141 @@
+package com.datadog.debugger.instrumentation;
+
+import static com.datadog.debugger.instrumentation.ASMHelper.getStatic;
+import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
+import static com.datadog.debugger.instrumentation.ASMHelper.ldc;
+import static com.datadog.debugger.instrumentation.Types.CAPTURED_CONTEXT_TYPE;
+import static com.datadog.debugger.instrumentation.Types.CLASS_TYPE;
+import static com.datadog.debugger.instrumentation.Types.DEBUGGER_CONTEXT_TYPE;
+import static com.datadog.debugger.instrumentation.Types.METHOD_LOCATION_TYPE;
+import static org.objectweb.asm.Type.INT_TYPE;
+import static org.objectweb.asm.Type.LONG_TYPE;
+import static org.objectweb.asm.Type.VOID_TYPE;
+import static org.objectweb.asm.Type.getType;
+
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Where;
+import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.bootstrap.debugger.Limits;
+import java.util.List;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Specialized version of {@link CapturedContextInstrumenter} for single probe */
+public class SingleCapturedContextInstrumenter extends CapturedContextInstrumenter {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SingleCapturedContextInstrumenter.class);
+  private final boolean captureSnapshot;
+  private final boolean captureEntry;
+  private final Limits limits;
+
+  public SingleCapturedContextInstrumenter(
+      ProbeDefinition definition,
+      MethodInfo methodInfo,
+      List<DiagnosticMessage> diagnostics,
+      List<Integer> probeIndices,
+      boolean captureSnapshot,
+      boolean captureEntry,
+      Limits limits) {
+    super(definition, methodInfo, diagnostics, probeIndices, captureSnapshot, captureEntry, limits);
+    this.captureSnapshot = captureSnapshot;
+    this.captureEntry = captureEntry;
+    this.limits = limits;
+  }
+
+  @Override
+  protected void addIsReadyToCaptureCall(InsnList insnList) {
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [class]
+    ldc(insnList, probeIndices.get(0));
+    // stack [class, int]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "isReadyToCapture",
+        Type.BOOLEAN_TYPE,
+        CLASS_TYPE,
+        Type.INT_TYPE);
+    // stack [boolean]
+  }
+
+  @Override
+  protected void addEvalContextCall(
+      InsnList insnList,
+      Snapshot.Kind snapshotKind,
+      AbstractInsnNode endLabel,
+      int timestampVar,
+      String methodLocation) {
+    // stack []
+    insnList.add(collectCapturedContext(snapshotKind, endLabel));
+    // stack: [capturedcontext]
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [capturedcontext, class]
+    if (timestampVar != -1) {
+      insnList.add(new VarInsnNode(Opcodes.LLOAD, timestampVar));
+    } else {
+      ldc(insnList, -1L);
+    }
+    // stack [capturedcontext, class, long]
+    getStatic(insnList, METHOD_LOCATION_TYPE, methodLocation);
+    // stack [capturedcontext, class, long, methodlocation]
+    ldc(insnList, probeIndices.get(0));
+    // stack [capturedcontext, class, long, methodlocation, int]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "evalContext",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CLASS_TYPE,
+        LONG_TYPE,
+        METHOD_LOCATION_TYPE,
+        Type.INT_TYPE);
+    // stack []
+  }
+
+  @Override
+  protected void addEvalContextAndCommitCall(
+      Where.SourceLine sourceLine, InsnList insnList, LabelNode beforeLabel) {
+    insnList.add(collectCapturedContext(Snapshot.Kind.BEFORE, beforeLabel));
+    // stack [capturedcontext]
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [capturedcontext, class]
+    ldc(insnList, sourceLine.getFrom());
+    // stack [capturedcontext, class, int]
+    ldc(insnList, probeIndices.get(0));
+    // stack [capturedcontext, class, int, int]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "evalContextAndCommit",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CLASS_TYPE,
+        INT_TYPE,
+        INT_TYPE);
+    // stack []
+  }
+
+  @Override
+  protected void addCommitCall(InsnList insnList) {
+    // stack [capturedcontext, capturedcontext, list]
+    ldc(insnList, probeIndices.get(0));
+    // stack [capturedcontext, capturedcontext, list, int]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "commit",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        getType(List.class),
+        INT_TYPE);
+    // stack []
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
@@ -21,10 +21,10 @@ import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.VarInsnNode;
 
-public class SpanInstrumentor extends Instrumentor {
+public class SpanInstrumenter extends Instrumenter {
   private int spanVar;
 
-  public SpanInstrumentor(
+  public SpanInstrumenter(
       SpanProbe spanProbe,
       MethodInfo methodInfo,
       List<DiagnosticMessage> diagnostics,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -5,7 +5,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.datadog.debugger.agent.Generated;
-import com.datadog.debugger.instrumentation.CodeOriginInstrumentor;
+import com.datadog.debugger.instrumentation.CodeOriginInstrumenter;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult.Status;
 import com.datadog.debugger.instrumentation.MethodInfo;
@@ -36,7 +36,7 @@ public class CodeOriginProbe extends ProbeDefinition {
   @Override
   public Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-    return new CodeOriginInstrumentor(this, methodInfo, probeIndices).instrument();
+    return new CodeOriginInstrumenter(this, methodInfo, probeIndices).instrument();
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -8,7 +8,7 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.exception.Fingerprinter;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
-import com.datadog.debugger.instrumentation.ExceptionInstrumentor;
+import com.datadog.debugger.instrumentation.ExceptionInstrumenter;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.sink.Snapshot;
@@ -55,7 +55,7 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
   @Override
   public InstrumentationResult.Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-    return new ExceptionInstrumentor(this, methodInfo, diagnostics, probeIndices).instrument();
+    return new ExceptionInstrumenter(this, methodInfo, diagnostics, probeIndices).instrument();
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -5,7 +5,7 @@ import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
-import com.datadog.debugger.instrumentation.MetricInstrumentor;
+import com.datadog.debugger.instrumentation.MetricInstrumenter;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.Arrays;
@@ -137,7 +137,7 @@ public class MetricProbe extends ProbeDefinition {
   @Override
   public InstrumentationResult.Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-    return new MetricInstrumentor(this, methodInfo, diagnostics, probeIndices).instrument();
+    return new MetricInstrumenter(this, methodInfo, diagnostics, probeIndices).instrument();
   }
 
   public static Builder builder() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -150,16 +150,6 @@ public abstract class ProbeDefinition implements ProbeImplementation {
   public void commit(CapturedContext lineContext, int line) {}
 
   @Override
-  public boolean isCaptureSnapshot() {
-    return false;
-  }
-
-  @Override
-  public boolean hasCondition() {
-    return false;
-  }
-
-  @Override
   public CapturedContext.Status createStatus() {
     return null;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -5,7 +5,7 @@ import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.agent.StringTemplateBuilder;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
-import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
+import com.datadog.debugger.instrumentation.CapturedContextInstrumenter;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
@@ -136,7 +136,7 @@ public class SpanDecorationProbe extends ProbeDefinition {
   public InstrumentationResult.Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
     boolean captureEntry = evaluateAt != MethodLocation.EXIT;
-    return new CapturedContextInstrumentor(
+    return new CapturedContextInstrumenter(
             this, methodInfo, diagnostics, probeIndices, false, captureEntry, Limits.DEFAULT)
         .instrument();
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -4,7 +4,7 @@ import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
-import com.datadog.debugger.instrumentation.SpanInstrumentor;
+import com.datadog.debugger.instrumentation.SpanInstrumenter;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.Arrays;
@@ -25,7 +25,7 @@ public class SpanProbe extends ProbeDefinition {
   @Override
   public InstrumentationResult.Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-    return new SpanInstrumentor(this, methodInfo, diagnostics, probeIndices).instrument();
+    return new SpanInstrumenter(this, methodInfo, diagnostics, probeIndices).instrument();
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -6,11 +6,12 @@ import com.datadog.debugger.agent.DebuggerAgent;
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
-import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
+import com.datadog.debugger.instrumentation.CapturedContextInstrumenter;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.CapturedContextProbe;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeRateLimiter;
@@ -23,7 +24,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TriggerProbe extends ProbeDefinition implements Sampled {
+public class TriggerProbe extends ProbeDefinition implements Sampled, CapturedContextProbe {
   private static final Logger LOGGER = LoggerFactory.getLogger(TriggerProbe.class);
 
   private ProbeCondition probeCondition;
@@ -54,7 +55,7 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
   @Override
   public InstrumentationResult.Status instrument(
       MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-    return new CapturedContextInstrumentor(
+    return new CapturedContextInstrumenter(
             this, methodInfo, diagnostics, probeIndices, false, false, null)
         .instrument();
   }
@@ -66,6 +67,21 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
 
   public Sampling getSampling() {
     return sampling;
+  }
+
+  @Override
+  public boolean isCaptureSnapshot() {
+    return false;
+  }
+
+  @Override
+  public boolean hasCondition() {
+    return probeCondition != null;
+  }
+
+  @Override
+  public boolean isReadyToCapture() {
+    return true;
   }
 
   public TriggerProbe setSampling(Sampling sampling) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -50,6 +50,7 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.CapturedContextProbe;
 import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
@@ -1772,7 +1773,7 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     assertEquals(2, result);
     assertEquals(1, listener.snapshots.size());
     ProbeImplementation probeImplementation = listener.snapshots.get(0).getProbe();
-    assertFalse(probeImplementation.isCaptureSnapshot());
+    assertFalse(((CapturedContextProbe) probeImplementation).isCaptureSnapshot());
     assertEquals("main", probeImplementation.getLocation().getMethod());
   }
 


### PR DESCRIPTION
# What Does This Do
make it a specialized version for single probe and keep the previous one as the fallback when multiple probes need to be instrumented for the same location.
Introduced SingleCapturedContextIntrumenter and
MultipleCapturedContextInstrumenter based on current CapturedContextInstrumenter. Introduced specialized version with only one probe index of methods in DebuggerContext called from the instrumentation. Introduced CapturedContextProbe interface and move some specific methods for LogProbe from ProbeImplementation. This allow to implement later some optimized version of the instrumentation which is not the case right now. This for now just a refactoring for preparing the next ones

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
