### PR TITLE
Eagerly loading/initializing pthread library to prevent a race that may crash JVM

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -291,6 +291,12 @@ public class Agent {
       startCwsAgent();
     }
 
+    // To workaround JDK-8345810, we want to trigger loading/initializing of pthread library on
+    // main thread (Linux only)
+    if (OperatingSystem.isLinux()) {
+      FileSystems.getDefault();
+    }
+
     /*
      * Force the task scheduler init early. The exception profiling instrumentation may get in way of the initialization
      * when it will happen after the class transformers were added.
@@ -796,10 +802,6 @@ public class Agent {
       if (forceEarlyStart) {
         initializeCrashTrackingDefault();
       } else {
-        // To workaround JDK-8345810, we want to initialize nio early,
-        // which has dependence on libpthread. Creating a small nio ByteBuffer
-        // to force nio initialization.
-        FileSystems.getDefault();
         AgentTaskScheduler.get().execute(Agent::initializeCrashTrackingDefault);
       }
     } else {


### PR DESCRIPTION
# What Does This Do

Eagerly initializing `java.nio` on main thread to avoid a race that may result in crashing JVM.

# Motivation
Improve stability.

# Additional Notes

This is a workaround of upstream JDK bug: https://bugs.openjdk.org/browse/JDK-8345810

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]
https://datadoghq.atlassian.net/browse/PROF-12749

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
