### PR TITLE
Avoid UnsatisfiedLinkError when constructing statsd client

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
@@ -162,7 +162,6 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
             log.debug("StatsD connected to {}", statsDAddress());
           }
         } catch (final Exception e) {
-          log.error("Unable to create StatsD client - {}", statsDAddress(), e);
           if (retries.getAndIncrement() < MAX_RETRIES) {
             if (log.isDebugEnabled()) {
               log.debug(
@@ -173,6 +172,8 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
           } else {
             log.debug("Max retries have been reached. Will not attempt again.");
           }
+        } catch (Throwable t) {
+          log.error("Unable to create StatsD client - {} - Will not retry", statsDAddress(), t);
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

Widen to throwable when constructing a statsD client. In this case will not retry to schedule a new build.

Fixes:

```
java.lang.UnsatisfiedLinkError
  at (redacted: 14 frames)
  at datadog.communication.monitor.DDAgentStatsDConnection.doConnect(DDAgentStatsDConnection.java:160)
  at datadog.communication.monitor.DDAgentStatsDConnection.access$000(DDAgentStatsDConnection.java:22)
  at datadog.communication.monitor.DDAgentStatsDConnection$ConnectTask.run(DDAgentStatsDConnection.java:255)
  at datadog.communication.monitor.DDAgentStatsDConnection$ConnectTask.run(DDAgentStatsDConnection.java:249)
  at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:329)
  at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:284)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
