### PR TITLE
Ensure blocking exceptions are propagated for SSRF

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -104,10 +104,13 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
         } else if (shouldSetResourceName()) {
           span.setResourceName(DEFAULT_RESOURCE_NAME);
         }
+      } catch (final BlockingException e) {
+        throw e;
       } catch (final Exception e) {
         log.debug("Error tagging url", e);
+      } finally {
+        ssrfIastCheck(request);
       }
-      ssrfIastCheck(request);
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/okhttp/okhttp-2.2/src/main/java/datadog/trace/instrumentation/okhttp2/AppSecInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp/okhttp-2.2/src/main/java/datadog/trace/instrumentation/okhttp2/AppSecInterceptor.java
@@ -56,6 +56,8 @@ public class AppSecInterceptor implements Interceptor {
       final Request request = onRequest(span, sampled, chain.request());
       final Response response = chain.proceed(request);
       return onResponse(span, sampled, response);
+    } catch (final BlockingException e) {
+      throw e;
     } catch (final Exception e) {
       LOGGER.debug("Failed to intercept request", e);
       return chain.proceed(chain.request());

--- a/dd-java-agent/instrumentation/okhttp/okhttp-3.0/src/main/java/datadog/trace/instrumentation/okhttp3/AppSecInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp/okhttp-3.0/src/main/java/datadog/trace/instrumentation/okhttp3/AppSecInterceptor.java
@@ -56,6 +56,8 @@ public class AppSecInterceptor implements Interceptor {
       final Request request = onRequest(span, sampled, chain.request());
       final Response response = chain.proceed(request);
       return onResponse(span, sampled, response);
+    } catch (final BlockingException e) {
+      throw e;
     } catch (final Exception e) {
       LOGGER.debug("Failed to intercept request", e);
       return chain.proceed(chain.request());

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.smoketest.appsec.springboot.service.AsyncService;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -93,7 +94,9 @@ public class WebController {
   public String ssrfQuery(@RequestParam("domain") final String domain) {
     try {
       new URL("http://" + domain).openStream().close();
-    } catch (Throwable e) {
+    } catch (final BlockingException e) {
+      throw e;
+    } catch (final Throwable e) {
       // ignore errors opening connection
     }
     return "EXECUTED";
@@ -105,7 +108,9 @@ public class WebController {
     try {
       final HttpGet request = new HttpGet("http://" + domain);
       client.execute(request);
-    } catch (Exception e) {
+    } catch (final BlockingException e) {
+      throw e;
+    } catch (final Exception e) {
       // ignore errors opening connection
     }
     client.getConnectionManager().shutdown();
@@ -118,6 +123,8 @@ public class WebController {
     final HttpMethod method = new GetMethod("http://" + domain);
     try {
       client.executeMethod(method);
+    } catch (final BlockingException e) {
+      throw e;
     } catch (final Exception e) {
       // ignore errors opening connection
     }
@@ -131,6 +138,8 @@ public class WebController {
     final Request request = new Request.Builder().url("http://" + domain).build();
     try {
       client.newCall(request).execute();
+    } catch (final BlockingException e) {
+      throw e;
     } catch (final Exception e) {
       // ignore errors opening connection
     }
@@ -145,6 +154,8 @@ public class WebController {
     final okhttp3.Request request = new okhttp3.Request.Builder().url("http://" + domain).build();
     try {
       client.newCall(request).execute();
+    } catch (final BlockingException e) {
+      throw e;
     } catch (final Exception e) {
       // ignore errors opening connection
     }

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -1,5 +1,6 @@
 package datadog.smoketest.appsec
 
+import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.ThreadUtils
 import groovy.json.JsonSlurper
@@ -650,6 +651,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     def rootSpans = this.rootSpans.toList()
     rootSpans.size() == 1
     def rootSpan = rootSpans[0]
+    assert rootSpan.meta.get('error.message').contains(BlockingException.name) // ensure the block was propagated
     assert rootSpan.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
     assert rootSpan.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     def trigger = null


### PR DESCRIPTION
# What Does This Do
Ensures that blocking exceptions are properly propagated when testing RASP protections against SSRF attacks.

# Motivation
If the exception isn’t propagated, execution continues and the attack may succeed, even if the response is eventually blocked.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
