### PR TITLE
Add quick 'datadog.' prefix check before applying delegation fix

### DIFF
--- a/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
@@ -83,6 +83,10 @@ public final class ClassloadingInstrumentation extends InstrumenterModule
   public static class LoadClassAdvice {
     @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class, suppress = Throwable.class)
     public static Class<?> onEnter(@Advice.Argument(0) final String name) {
+      if (!name.startsWith("datadog.")) {
+        return null; // ignore packages that won't be bundled on the dd-java-agent bootstrap
+      }
+
       // we must access agent types used in the call-depth block like 'Constants' before entering it
       // - otherwise we risk loading these agent types with a non-zero call-depth, which will fail
       final String[] bootstrapPrefixes = Constants.BOOTSTRAP_PACKAGE_PREFIXES;


### PR DESCRIPTION
# Motivation

We know all the packages listed under `Constants.BOOTSTRAP_PACKAGE_PREFIXES` start with `"datadog."` so we can do that quick check inline without touching any other types. This avoids book-keeping overhead for the majority of classes, limiting it to only those we suspect we might need to apply the delegation fix.

(Especially as the list of `BOOTSTRAP_PACKAGE_PREFIXES` continues to grow...)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
