### PR TITLE
Keep generic signature aligned when adding `TaskWrapper` interface

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
@@ -56,7 +56,7 @@ public class UnwrappingVisitor implements AsmVisitorWrapper {
             classVisitor, instrumentedType.getInternalName(), fieldName);
   }
 
-  private static class ImplementTaskWrapperClassVisitor extends ClassVisitor {
+  static class ImplementTaskWrapperClassVisitor extends ClassVisitor {
 
     private static final String TASK_WRAPPER =
         "datadog/trace/bootstrap/instrumentation/api/TaskWrapper";

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitorTest.groovy
@@ -1,0 +1,69 @@
+package datadog.trace.agent.tooling.bytebuddy.profiling
+
+import static net.bytebuddy.utility.OpenedClassReader.ASM_API
+
+import java.util.concurrent.FutureTask
+import net.bytebuddy.jar.asm.ClassReader
+import net.bytebuddy.jar.asm.ClassVisitor
+import net.bytebuddy.jar.asm.ClassWriter
+import net.bytebuddy.jar.asm.signature.SignatureReader
+import net.bytebuddy.jar.asm.signature.SignatureVisitor
+import org.apache.commons.io.IOUtils
+import spock.lang.Specification
+
+class UnwrappingVisitorTest extends Specification {
+
+  void 'test generic signature is kept in sync'(){
+    setup:
+    def classFile = readClassBytes(FutureTask)
+    def classReader = new ClassReader(classFile)
+    def classWriter = new ClassWriter(classReader, 0)
+
+    def declaredInterfaces = []
+    def genericInterfaces = []
+
+    // visitor that captures interface types defined inside a generic type signature
+    def signatureVisitor = new SignatureVisitor(ASM_API) {
+        @Override
+        SignatureVisitor visitInterface() {
+          return new SignatureVisitor(ASM_API) {
+              @Override
+              void visitClassType(String name) {
+                genericInterfaces += name
+              }
+            }
+        }
+      }
+
+    // visitor that captures declared and generic interface types
+    def classVisitor = new ClassVisitor(ASM_API, classWriter) {
+        @Override
+        void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+          declaredInterfaces = interfaces
+          new SignatureReader(signature).accept(signatureVisitor)
+          super.visit(version, access, name, signature, superName, interfaces)
+        }
+      }
+
+    // apply TaskWrapper transformation and check both declared and generic interfaces are updated
+    def taskVisitor = new UnwrappingVisitor.ImplementTaskWrapperClassVisitor(
+      classVisitor, 'java.util.concurrent.FutureTask', 'callable')
+
+    when:
+    classReader.accept(taskVisitor, 0)
+
+    then:
+    genericInterfaces == declaredInterfaces
+    genericInterfaces.last() == 'datadog/trace/bootstrap/instrumentation/api/TaskWrapper'
+  }
+
+  static byte [] readClassBytes(Class<?> clazz){
+    final String classResourceName = '/' + clazz.getName().replace('.', '/') + '.class'
+    try (InputStream is = clazz.getResourceAsStream(classResourceName)) {
+      if(is == null) {
+        throw new IllegalStateException("Could not find class resource: " + classResourceName)
+      }
+      return IOUtils.toByteArray(is)
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

When adding `TaskWrapper` to the declared interfaces, make sure we also add it to the generic signature

# Motivation

Avoid causing issues with introspection tools/agents that expect the interface list and generic signature to be aligned.

We did a similar fix for field-injection in https://github.com/DataDog/dd-trace-java/pull/2203

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-12675]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-12675]: https://datadoghq.atlassian.net/browse/PROF-12675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ