### PR TITLE
Safely set context classloader on final blocks

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -184,6 +184,14 @@ public class Agent {
   private static boolean distributedDebuggerEnabled = false;
   private static boolean agentlessLogSubmissionEnabled = false;
 
+  private static void safelySetContextClassLoader(ClassLoader classLoader) {
+    try {
+      // this method call can cause a SecurityException if a security manager is installed.
+      Thread.currentThread().setContextClassLoader(classLoader);
+    } catch (final Throwable ignored) {
+    }
+  }
+
   /**
    * Starts the agent; returns a boolean indicating if Agent started successfully
    *
@@ -924,7 +932,7 @@ public class Agent {
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting JmxFetch", ex);
     } finally {
-      Thread.currentThread().setContextClassLoader(contextLoader);
+      safelySetContextClassLoader(contextLoader);
     }
   }
 
@@ -1305,7 +1313,7 @@ public class Agent {
       } catch (final Throwable ex) {
         log.error(SEND_TELEMETRY, "Throwable thrown while starting profiling agent", ex);
       } finally {
-        Thread.currentThread().setContextClassLoader(contextLoader);
+        safelySetContextClassLoader(contextLoader);
       }
       StaticEventLogger.end("ProfilingAgent");
     }
@@ -1349,7 +1357,7 @@ public class Agent {
     } catch (final Throwable ex) {
       log.error("Throwable thrown while shutting down profiling agent", ex);
     } finally {
-      Thread.currentThread().setContextClassLoader(contextLoader);
+      safelySetContextClassLoader(contextLoader);
     }
   }
 
@@ -1383,7 +1391,7 @@ public class Agent {
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting debugger agent", ex);
     } finally {
-      Thread.currentThread().setContextClassLoader(contextLoader);
+      safelySetContextClassLoader(contextLoader);
     }
 
     StaticEventLogger.end("Debugger");


### PR DESCRIPTION
# What Does This Do

When a security manager is installed, this method call can cause a SecurityException. At least, on the finally block, we should do it safely.

Example::

```
java.security.AccessControlException
  at java.base/java.security.AccessControlContext.checkPermission(Unknown Source)
  at java.base/java.security.AccessController.checkPermission(Unknown Source)
  at java.base/java.lang.SecurityManager.checkPermission(Unknown Source)
  at java.base/java.lang.Thread.setContextClassLoader(Unknown Source)
  at datadog.trace.bootstrap.Agent.startJmxFetch(Agent.java:918)
  at datadog.trace.bootstrap.Agent.startJmx(Agent.java:831)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
