### PR TITLE
Fix test classes logger initialization

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatCategory2Example.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatCategory2Example.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 
 public class StringConcatCategory2Example implements BiFunction<String, String, String> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(StringConcatExample.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringConcatCategory2Example.class);
 
   public String apply(final String first, final String second) {
     LOGGER.debug("Before apply : " + (System.currentTimeMillis() / 1000L));

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 
 public class StringPlusLoadWithTagsExample implements TriFunction<String, String, String, String> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(StringPlusConstantsExample.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringPlusLoadWithTagsExample.class);
 
   public String apply(final String first, final String second, final String third) {
     LOGGER.debug("Before apply");

--- a/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/TestDirContextSuite.java
+++ b/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/TestDirContextSuite.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestDirContextSuite implements DirContextSuite {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestInitialDirContextSuite.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestDirContextSuite.class);
 
   private final DirContext ctx;
 


### PR DESCRIPTION
# What Does This Do
This pull request corrects logger initializations in several test and example classes that were referencing incorrect or foreign class names in their `LoggerFactory.getLogger()` calls.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
