### PR TITLE
Update GHA workflow commit-headless syntax

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -79,6 +79,6 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
-          branch-from: "${{ github.sha }}"
+          create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"

--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -76,9 +76,7 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
-          branch-from: "${{ github.sha }}"
+          create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"
       - name: Create pull request

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -62,9 +62,7 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
-          branch-from: "${{ github.sha }}"
+          create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"
       - name: Create pull request

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -52,9 +52,7 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
-          branch-from: "${{ github.sha }}"
+          create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"
       - name: Create pull request


### PR DESCRIPTION
# What Does This Do

Change `branch-from:` parameter to `create-branch:`

# Motivation

Update to `commit-headless` action changed the syntax. 

Related test failure: https://github.com/DataDog/dd-trace-java/actions/runs/18689489918/job/53291119089

[Commit-headless documentation](https://github.com/DataDog/commit-headless/tree/action?tab=readme-ov-file#:~:text=If%20you%20primarily%20create%20commits%20on%20new%20branches%2C%20you%27ll%20want%20to%20use%20the%20create%2Dbranch%20option.)

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
