### PR TITLE
Specify head SHA in GHA workflows

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -79,6 +79,9 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
+          # for scheduled runs, sha is the tip of the default branch
+          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"

--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -76,6 +76,9 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
+          # for scheduled runs, sha is the tip of the default branch
+          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -62,6 +62,9 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
+          # for scheduled runs, sha is the tip of the default branch
+          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -52,6 +52,9 @@ jobs:
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
+          # for scheduled runs, sha is the tip of the default branch
+          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"


### PR DESCRIPTION
# What Does This Do

Specify the `head-sha:` parameter for `commit-headless` workflows

# Motivation

`head-sha:` is required when creating a new branch with `create-branch:true`

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
