### PR TITLE
Remove ref_protected requirement in trust policy

### DIFF
--- a/.github/chainguard/self.update-jmxfetch-submodule.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-jmxfetch-submodule.create-pr.sts.yaml
@@ -5,7 +5,6 @@ subject: repo:DataDog/dd-trace-java:ref:refs/heads/master
 claim_pattern:
   event_name: (schedule|workflow_dispatch)
   ref: refs/heads/master
-  ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/update-jmxfetch-submodule\.yaml@refs/heads/master
 
 permissions:


### PR DESCRIPTION
# What Does This Do

Remove the `ref_protected:` requirement from the trust policy

# Motivation

The workflow that corresponds to this trust policy is triggered off of tags. I believe these tags are not considered "protected" which is causing the error `Resource not accessible by integration`: https://github.com/DataDog/dd-trace-java/actions/runs/18696181534/job/53314152512

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
