### PR TITLE
Don't attach parent run context when data.jobs.openlineage not enabled

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/OpenlineageParentContext.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/OpenlineageParentContext.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.spark;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.datastreams.PathwayContext;
@@ -43,6 +44,11 @@ public class OpenlineageParentContext implements AgentSpanContext {
   public static final String OPENLINEAGE_ROOT_PARENT_RUN_ID = "spark.openlineage.rootParentRunId";
 
   public static Optional<OpenlineageParentContext> from(SparkConf sparkConf) {
+    if (!Config.get().isDataJobsOpenLineageEnabled()) {
+      log.debug(
+          "OpenLineage - Data Jobs integration disabled. Not returning OpenlineageParentContext");
+      return Optional.empty();
+    }
     if (!sparkConf.contains(OPENLINEAGE_PARENT_JOB_NAMESPACE)
         || !sparkConf.contains(OPENLINEAGE_PARENT_JOB_NAME)
         || !sparkConf.contains(OPENLINEAGE_PARENT_RUN_ID)) {

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/OpenlineageParentContextTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/OpenlineageParentContextTest.groovy
@@ -1,11 +1,12 @@
 package datadog.trace.instrumentation.spark
 
+import datadog.trace.test.util.DDSpecification
 import org.apache.spark.SparkConf
-import spock.lang.Specification
 
-class OpenlineageParentContextTest extends Specification {
+class OpenlineageParentContextTest extends DDSpecification {
   def "should create OpenLineageParentContext with particular trace id based on root parent id" () {
     given:
+    injectSysConfig("data.jobs.openlineage.enabled", "true")
     SparkConf mockSparkConf = Mock(SparkConf)
 
     when:
@@ -38,6 +39,7 @@ class OpenlineageParentContextTest extends Specification {
 
   def "should create empty OpenLineageParentContext if any required field is missing" () {
     given:
+    injectSysConfig("data.jobs.openlineage.enabled", "true")
     SparkConf mockSparkConf = Mock(SparkConf)
 
     when:
@@ -66,6 +68,7 @@ class OpenlineageParentContextTest extends Specification {
 
   def "should only generate a non-empty OpenlineageParentContext if parentRunId is a valid UUID" () {
     given:
+    injectSysConfig("data.jobs.openlineage.enabled", "true")
     SparkConf mockSparkConf = Mock(SparkConf)
 
     when:
@@ -94,6 +97,7 @@ class OpenlineageParentContextTest extends Specification {
 
   def "should only generate a non-empty OpenlineageParentContext if rootParentRunId is a valid UUID" () {
     given:
+    injectSysConfig("data.jobs.openlineage.enabled", "true")
     SparkConf mockSparkConf = Mock(SparkConf)
 
     when:
@@ -118,6 +122,22 @@ class OpenlineageParentContextTest extends Specification {
     "invalid-uuid"                         | false
     "6afeb6ee-729d-37f7-b8e6f47ca694"      | false
     "6AFEB6EE-729D-37F7-AD73-B8E6F47CA694" | true
+  }
+
+  def "should create empty OpenLineageParentContext if data jobs openlineage not enabled" () {
+    given:
+    injectSysConfig("data.jobs.openlineage.enabled", "falsebrn")
+    SparkConf mockSparkConf = Mock(SparkConf)
+
+    when:
+    mockSparkConf.contains(OpenlineageParentContext.OPENLINEAGE_PARENT_JOB_NAMESPACE) >> true
+    mockSparkConf.contains(OpenlineageParentContext.OPENLINEAGE_PARENT_JOB_NAME) >> true
+    mockSparkConf.contains(OpenlineageParentContext.OPENLINEAGE_PARENT_RUN_ID) >> true
+    mockSparkConf.contains(OpenlineageParentContext.OPENLINEAGE_ROOT_PARENT_RUN_ID) >> true
+
+    then:
+    Optional<OpenlineageParentContext> parentContext = OpenlineageParentContext.from(mockSparkConf)
+    !parentContext.isPresent()
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Assure `OpenlineageParentContext` is not attached if `data.jobs.openlineage.enabled` not enabled. 
Currently, this is happening within `initApplicationSpanIfNotInitialized` method. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
