### PR TITLE
Adjust `create-release-branch` workflow

### DIFF
--- a/.github/chainguard/self.update-system-tests.push.sts.yaml
+++ b/.github/chainguard/self.update-system-tests.push.sts.yaml
@@ -9,3 +9,4 @@ claim_pattern:
 
 permissions:
   contents: write
+  pull_requests: write

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -60,6 +60,24 @@ jobs:
             echo "Branch $BRANCH does not exist - proceeding with following steps"
           fi
 
+      - name: Push empty release branch
+        if: steps.check-branch.outputs.creating_new_branch == 'true'
+        uses: DataDog/commit-headless@5a0f3876e0fbdd3a86b3e008acf4ec562db59eee # action/v2.0.1
+        with:
+          token: "${{ steps.octo-sts.outputs.token }}"
+          branch: "${{ steps.define-branch.outputs.branch }}"
+          head-sha: "${{ github.sha }}"
+          create-branch: true
+          command: push
+          commits: ""
+
+      - name: Define temp branch name
+        if: steps.check-branch.outputs.creating_new_branch == 'true'
+        id: define-temp-branch
+        run: |
+          TEMP_BRANCH="${{ steps.define-branch.outputs.branch }}-pin-system-tests"
+          echo "branch=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
+
       - name: Update system-tests references to latest commit SHA on main
         if: steps.check-branch.outputs.creating_new_branch == 'true'
         run: BRANCH=main ./tooling/update_system_test_reference.sh
@@ -73,15 +91,25 @@ jobs:
           git commit -m "chore: Pin system-tests for release branch" .github/workflows/run-system-tests.yaml
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       
-      - name: Push changes
+      - name: Push changes to temp branch
         if: steps.check-branch.outputs.creating_new_branch == 'true'
         uses: DataDog/commit-headless@5a0f3876e0fbdd3a86b3e008acf4ec562db59eee # action/v2.0.1
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
-          branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          branch: "${{ steps.define-temp-branch.outputs.branch }}"
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
           commits: "${{ steps.create-commit.outputs.commit }}"
+
+      - name: Create pull request from temp branch to release branch
+        if: steps.check-branch.outputs.creating_new_branch == 'true'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          gh pr create  --title "Pin system-tests for ${{ steps.define-branch.outputs.branch }}" \
+            --base "${{ steps.define-branch.outputs.branch }}" \
+            --head "${{ steps.define-temp-branch.outputs.branch }}" \
+            --label "tag: dependencies" \
+            --label "tag: no release notes" \
+            --body "This PR pins the system-tests reference for the release branch."


### PR DESCRIPTION
# What Does This Do

Adjust the `create-release-branch` workflow such that instead of:
* pinning the latest system-tests SHA directly to the release branch and then pushing this release branch up,

it now:
* pushes the release branch first with no commit, pins the latest system-tests SHA to a temp branch, and finally pushes this temp branch (that requires approval) up

# Motivation

The release branch is protected and requires changes, such as pinning system tests, to be made through a separate branch that is then approved and merged into the release branch, instead of committed directly to the branch.

# Additional Notes

Sigh, I confirmed again that I can only test on `master`: https://github.com/DataDog/dd-trace-java/actions/runs/18723984882/job/53403708326

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
