### PR TITLE
Optimize method probe without condition

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -297,7 +297,8 @@ public class CapturedContext implements ValueReferenceResolver {
       ProbeImplementation probeImplementation,
       String thisClassName,
       long startTimestamp,
-      MethodLocation methodLocation) {
+      MethodLocation methodLocation,
+      boolean singleProbe) {
     Status status =
         statusByProbeId.computeIfAbsent(
             probeImplementation.getProbeId().getEncodedId(),
@@ -311,7 +312,7 @@ public class CapturedContext implements ValueReferenceResolver {
     boolean shouldEvaluate =
         MethodLocation.isSame(methodLocation, probeImplementation.getEvaluateAt());
     if (shouldEvaluate) {
-      probeImplementation.evaluate(this, status, methodLocation);
+      probeImplementation.evaluate(this, status, methodLocation, singleProbe);
     }
     return status;
   }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -311,7 +311,11 @@ public class DebuggerContext {
         }
         CapturedContext.Status status =
             context.evaluate(
-                probeImplementation, callingClass.getTypeName(), startTimestamp, methodLocation);
+                probeImplementation,
+                callingClass.getTypeName(),
+                startTimestamp,
+                methodLocation,
+                false);
         needFreeze |= status.shouldFreezeContext();
       }
       // only freeze the context when we have at lest one snapshot probe, and we should send
@@ -343,7 +347,11 @@ public class DebuggerContext {
       }
       CapturedContext.Status status =
           context.evaluate(
-              probeImplementation, callingClass.getTypeName(), startTimestamp, methodLocation);
+              probeImplementation,
+              callingClass.getTypeName(),
+              startTimestamp,
+              methodLocation,
+              true);
       boolean needFreeze = status.shouldFreezeContext();
       // only freeze the context when we have at lest one snapshot probe, and we should send
       // snapshot
@@ -371,7 +379,7 @@ public class DebuggerContext {
           continue;
         }
         context.evaluate(
-            probeImplementation, callingClass.getTypeName(), -1, MethodLocation.DEFAULT);
+            probeImplementation, callingClass.getTypeName(), -1, MethodLocation.DEFAULT, false);
         probeImplementations.add(probeImplementation);
       }
       for (ProbeImplementation probeImplementation : probeImplementations) {
@@ -395,7 +403,8 @@ public class DebuggerContext {
       if (probeImplementation == null) {
         return;
       }
-      context.evaluate(probeImplementation, callingClass.getTypeName(), -1, MethodLocation.DEFAULT);
+      context.evaluate(
+          probeImplementation, callingClass.getTypeName(), -1, MethodLocation.DEFAULT, true);
       probeImplementation.commit(context, line);
     } catch (Exception ex) {
       LOGGER.debug("Error in evalContextAndCommit: ", ex);

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
@@ -17,7 +17,10 @@ public interface ProbeImplementation {
   String getStrTags();
 
   void evaluate(
-      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation);
+      CapturedContext context,
+      CapturedContext.Status status,
+      MethodLocation methodLocation,
+      boolean singleProbe);
 
   void commit(
       CapturedContext entryContext,
@@ -82,7 +85,10 @@ public interface ProbeImplementation {
 
     @Override
     public void evaluate(
-        CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {}
+        CapturedContext context,
+        CapturedContext.Status status,
+        MethodLocation methodLocation,
+        boolean singleProbe) {}
 
     @Override
     public void commit(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -71,7 +71,10 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
 
   @Override
   public void evaluate(
-      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {
+      CapturedContext context,
+      CapturedContext.Status status,
+      MethodLocation methodLocation,
+      boolean singleProbe) {
     ExceptionProbeStatus exceptionStatus;
     if (status instanceof ExceptionProbeStatus) {
       exceptionStatus = (ExceptionProbeStatus) status;
@@ -108,7 +111,7 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
         exceptionStatus.setForceSampling(true);
       }
       exceptionStatus.setCapture(true);
-      super.evaluate(context, status, methodLocation);
+      super.evaluate(context, status, methodLocation, singleProbe);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -137,7 +137,10 @@ public abstract class ProbeDefinition implements ProbeImplementation {
 
   @Override
   public void evaluate(
-      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {}
+      CapturedContext context,
+      CapturedContext.Status status,
+      MethodLocation methodLocation,
+      boolean singleProbe) {}
 
   @Override
   public void commit(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -143,7 +143,10 @@ public class SpanDecorationProbe extends ProbeDefinition {
 
   @Override
   public void evaluate(
-      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {
+      CapturedContext context,
+      CapturedContext.Status status,
+      MethodLocation methodLocation,
+      boolean singleProbe) {
     for (Decoration decoration : decorations) {
       if (decoration.when != null) {
         try {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -96,7 +96,10 @@ public class TriggerProbe extends ProbeDefinition implements Sampled, CapturedCo
 
   @Override
   public void evaluate(
-      CapturedContext context, CapturedContext.Status status, MethodLocation location) {
+      CapturedContext context,
+      CapturedContext.Status status,
+      MethodLocation location,
+      boolean singleProbe) {
 
     Sampling sampling = getSampling();
     if (sampling == null || !sampling.inCoolDown()) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -127,7 +127,8 @@ public class SnapshotSerializationTest {
         new ProbeImplementation.NoopProbeImplementation(PROBE_ID, PROBE_LOCATION),
         String.class.getTypeName(),
         -1,
-        MethodLocation.EXIT);
+        MethodLocation.EXIT,
+        false);
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -367,7 +367,8 @@ public class DefaultExceptionDebuggerTest {
     exceptionProbe.buildLocation(null);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addThrowable(exception);
-    capturedContext.evaluate(exceptionProbe, "", System.currentTimeMillis(), MethodLocation.EXIT);
+    capturedContext.evaluate(
+        exceptionProbe, "", System.currentTimeMillis(), MethodLocation.EXIT, false);
     exceptionProbe.commit(CapturedContext.EMPTY_CAPTURING_CONTEXT, capturedContext, emptyList());
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -147,8 +147,8 @@ public class LogProbeTest {
 
       CapturedContext entryContext = capturedContext(span, logProbe);
       CapturedContext exitContext = capturedContext(span, logProbe);
-      logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY);
-      logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT);
+      logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY, false);
+      logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT, false);
 
       int budget =
           logProbe.isCaptureSnapshot()
@@ -193,8 +193,8 @@ public class LogProbeTest {
 
       CapturedContext entryContext = capturedContext(span, logProbe);
       CapturedContext exitContext = capturedContext(span, logProbe);
-      logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY);
-      logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT);
+      logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY, false);
+      logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT, false);
 
       return logProbe.fillSnapshot(
           entryContext, exitContext, emptyList(), new Snapshot(currentThread(), logProbe, 3));
@@ -204,7 +204,11 @@ public class LogProbeTest {
   private static CapturedContext capturedContext(AgentSpan span, ProbeDefinition probeDefinition) {
     CapturedContext context = new CapturedContext();
     context.evaluate(
-        probeDefinition, "Log Probe test", System.currentTimeMillis(), MethodLocation.DEFAULT);
+        probeDefinition,
+        "Log Probe test",
+        System.currentTimeMillis(),
+        MethodLocation.DEFAULT,
+        false);
     return context;
   }
 
@@ -283,7 +287,7 @@ public class LogProbeTest {
 
   private LogStatus prepareContext(
       CapturedContext context, LogProbe logProbe, MethodLocation methodLocation) {
-    context.evaluate(logProbe, "", 0, methodLocation);
+    context.evaluate(logProbe, "", 0, methodLocation, false);
     return (LogStatus) context.getStatus(PROBE_ID.getEncodedId());
   }
 


### PR DESCRIPTION
# What Does This Do
In case of a method probe without condition we can move the sampling is currently done in LogProbe::evaluate to LogProbe::isReadToCapture. This way if the sample fails we return false on isReadyTocapture and no CapturedContext is created and nothing captured. If we sample the execution the CapturedContext will be created we capture the context and serialize the result, but we are sure that we are not doing for nothing.
We introduce also a differentiation for single probe/multiple probe in calling evaluate that is propagated to probe implementation. it helps to differentiate the behavior based on the instrumentation

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
