### PR TITLE
Remove `commits:` parameter

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -69,7 +69,6 @@ jobs:
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: ""
 
       - name: Define temp branch name
         if: steps.check-branch.outputs.creating_new_branch == 'true'


### PR DESCRIPTION
# What Does This Do

Removes the `commits:` parameter when trying to push a branch with no commits.

# Motivation

`commits:` fails on an empty string ([failure](https://github.com/DataDog/dd-trace-java/actions/runs/18725437395/job/53408728658)), but since it is not a required parameter ([doc](https://github.com/DataDog/commit-headless/blob/main/action-template/action.yml#L35-L36)), I removed it entirely

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
