### PR TITLE
Avoid using `commit-headless` to push a branch with no commits

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -15,7 +15,7 @@ jobs:
   create-release-branch:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Allow pushing the empty release branch
       id-token: write # Required for OIDC token federation
     steps:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
@@ -45,8 +45,10 @@ jobs:
           BRANCH="release/${TAG%.0}.x"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout dd-trace-java
+      - name: Checkout dd-trace-java at tag
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
+        with:
+          ref: ${{ github.sha }}
 
       - name: Check if branch already exists
         id: check-branch
@@ -60,15 +62,11 @@ jobs:
             echo "Branch $BRANCH does not exist - proceeding with following steps"
           fi
 
-      - name: Push empty release branch
+      - name: Create and push empty release branch
         if: steps.check-branch.outputs.creating_new_branch == 'true'
-        uses: DataDog/commit-headless@5a0f3876e0fbdd3a86b3e008acf4ec562db59eee # action/v2.0.1
-        with:
-          token: "${{ steps.octo-sts.outputs.token }}"
-          branch: "${{ steps.define-branch.outputs.branch }}"
-          head-sha: "${{ github.sha }}"
-          create-branch: true
-          command: push
+        run: |
+          git checkout -b "${{ steps.define-branch.outputs.branch }}"
+          git push -u origin "${{ steps.define-branch.outputs.branch }}"
 
       - name: Define temp branch name
         if: steps.check-branch.outputs.creating_new_branch == 'true'


### PR DESCRIPTION
# What Does This Do

When pushing the `release/v*` branch, now we use just `git push -u origin branchName` instead of the `commit-headless` tool. I also changed the job permissions to allow pushing branches and specify the `dd-trace-java` checkout point to the commit SHA that triggered the workflow.

# Motivation

I mistakenly thought #9836 addressed the issue of an empty commit, but turns out `commit-headless` does not allow pushing a branch with no commit specified either ([failure](https://github.com/DataDog/dd-trace-java/actions/runs/18726875550/job/53413715389)). So, we remove `commit-headless` entirely and use just `git checkout && git push` instead.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
