### PR TITLE
Change temp branch name for system tests workflow

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -71,9 +71,7 @@ jobs:
       - name: Define temp branch name
         if: steps.check-branch.outputs.creating_new_branch == 'true'
         id: define-temp-branch
-        run: |
-          TEMP_BRANCH="${{ steps.define-branch.outputs.branch }}-pin-system-tests"
-          echo "branch=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
+        run: echo "branch=ci/pin-system-tests-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Update system-tests references to latest commit SHA on main
         if: steps.check-branch.outputs.creating_new_branch == 'true'


### PR DESCRIPTION
# What Does This Do

Change the temp branch name from `release/v*` to `ci/pin-system-tests*`

# Motivation

I was confused why I am still getting a Resource Accessibility [failure](https://github.com/DataDog/dd-trace-java/actions/runs/18731689718/job/53429917917), even after #9833. Then, I realized -- I am still starting my temp branch with `release/vN.M.x-*`, so this branch likely still matches the protected pattern that prevents direct commits! This PR changes the temp branch name to test this theory.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
