### PR TITLE
Extract line information as injectible lines

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Scope.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Scope.java
@@ -4,6 +4,17 @@ import com.squareup.moshi.Json;
 import java.util.List;
 
 public class Scope {
+
+  public static class LineRange {
+    final int start;
+    final int end;
+
+    public LineRange(int start, int end) {
+      this.start = start;
+      this.end = end;
+    }
+  }
+
   @Json(name = "scope_type")
   private final ScopeType scopeType;
 
@@ -15,6 +26,12 @@ public class Scope {
 
   @Json(name = "end_line")
   private final int endLine;
+
+  @Json(name = "has_injectible_lines")
+  private final boolean hasInjectibleLines;
+
+  @Json(name = "injectible_lines")
+  private final List<LineRange> injectibleLines;
 
   private final String name;
 
@@ -30,6 +47,8 @@ public class Scope {
       int startLine,
       int endLine,
       String name,
+      boolean hasInjectibleLines,
+      List<LineRange> injectibleLines,
       LanguageSpecifics languageSpecifics,
       List<Symbol> symbols,
       List<Scope> scopes) {
@@ -38,6 +57,8 @@ public class Scope {
     this.startLine = startLine;
     this.endLine = endLine;
     this.name = name;
+    this.hasInjectibleLines = hasInjectibleLines;
+    this.injectibleLines = injectibleLines;
     this.languageSpecifics = languageSpecifics;
     this.symbols = symbols;
     this.scopes = scopes;
@@ -61,6 +82,14 @@ public class Scope {
 
   public String getName() {
     return name;
+  }
+
+  public boolean hasInjectibleLines() {
+    return hasInjectibleLines;
+  }
+
+  public List<LineRange> getInjectibleLines() {
+    return injectibleLines;
   }
 
   public LanguageSpecifics getLanguageSpecifics() {
@@ -110,6 +139,8 @@ public class Scope {
     private final int startLine;
     private final int endLine;
     private String name;
+    private boolean hasInjectibleLines;
+    private List<LineRange> injectibleLines;
     private LanguageSpecifics languageSpecifics;
     private List<Symbol> symbols;
     private List<Scope> scopes;
@@ -123,6 +154,16 @@ public class Scope {
 
     public Builder name(String name) {
       this.name = name;
+      return this;
+    }
+
+    public Builder hasInjectibleLines(boolean hasInjectibleLines) {
+      this.hasInjectibleLines = hasInjectibleLines;
+      return this;
+    }
+
+    public Builder injectibleLines(List<LineRange> injectibleLines) {
+      this.injectibleLines = injectibleLines;
       return this;
     }
 
@@ -143,7 +184,16 @@ public class Scope {
 
     public Scope build() {
       return new Scope(
-          scopeType, sourceFile, startLine, endLine, name, languageSpecifics, symbols, scopes);
+          scopeType,
+          sourceFile,
+          startLine,
+          endLine,
+          name,
+          hasInjectibleLines,
+          injectibleLines,
+          languageSpecifics,
+          symbols,
+          scopes);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Label;
@@ -124,6 +126,8 @@ public class SymbolExtractor {
               .name(method.name)
               .scopes(varScopes)
               .symbols(methodSymbols)
+              .hasInjectibleLines(!methodLineInfo.ranges.isEmpty())
+              .injectibleLines(methodLineInfo.ranges)
               .languageSpecifics(methodSpecifics)
               .build();
       methodScopes.add(methodScope);
@@ -431,26 +435,47 @@ public class SymbolExtractor {
         : scope1;
   }
 
-  private static int getFirstLine(MethodNode methodNode) {
-    AbstractInsnNode node = methodNode.instructions.getFirst();
-    while (node != null) {
-      if (node.getType() == AbstractInsnNode.LINE) {
-        LineNumberNode lineNumberNode = (LineNumberNode) node;
-        return lineNumberNode.line;
-      }
-      node = node.getNext();
+  static List<Scope.LineRange> buildRanges(List<Integer> sortedLineNo) {
+    if (sortedLineNo.isEmpty()) {
+      return Collections.emptyList();
     }
-    return 0;
+    List<Scope.LineRange> ranges = new ArrayList<>();
+    int start = sortedLineNo.get(0);
+    int previous = start;
+    int i = 1;
+    outer:
+    while (i < sortedLineNo.size()) {
+      int currentLineNo = sortedLineNo.get(i);
+      while (currentLineNo == previous + 1) {
+        i++;
+        previous++;
+        if (i < sortedLineNo.size()) {
+          currentLineNo = sortedLineNo.get(i);
+        } else {
+          break outer;
+        }
+      }
+      ranges.add(new Scope.LineRange(start, previous));
+      start = currentLineNo;
+      previous = start;
+      i++;
+    }
+    ranges.add(new Scope.LineRange(start, previous));
+    return ranges;
   }
 
   private static MethodLineInfo extractMethodLineInfo(MethodNode methodNode) {
     Map<Label, Integer> map = new HashMap<>();
-    int startLine = getFirstLine(methodNode);
-    int maxLine = startLine;
+    List<Integer> lineNo = new ArrayList<>();
+    Set<Integer> dedupSet = new HashSet<>();
     AbstractInsnNode node = methodNode.instructions.getFirst();
+    int maxLine = 0;
     while (node != null) {
       if (node.getType() == AbstractInsnNode.LINE) {
         LineNumberNode lineNumberNode = (LineNumberNode) node;
+        if (dedupSet.add(lineNumberNode.line)) {
+          lineNo.add(lineNumberNode.line);
+        }
         maxLine = Math.max(lineNumberNode.line, maxLine);
       }
       if (node.getType() == AbstractInsnNode.LABEL) {
@@ -461,7 +486,10 @@ public class SymbolExtractor {
       }
       node = node.getNext();
     }
-    return new MethodLineInfo(startLine, maxLine, map);
+    lineNo.sort(Integer::compareTo);
+    int startLine = lineNo.isEmpty() ? 0 : lineNo.get(0);
+    List<Scope.LineRange> ranges = buildRanges(lineNo);
+    return new MethodLineInfo(startLine, maxLine, map, ranges);
   }
 
   private static ClassNode parseClassFile(byte[] classfileBuffer) {
@@ -475,11 +503,15 @@ public class SymbolExtractor {
     final int start;
     final int end;
     final Map<Label, Integer> lineMap;
+    final List<Scope.LineRange> ranges;
 
-    public MethodLineInfo(int start, int end, Map<Label, Integer> lineMap) {
+    public MethodLineInfo(
+        int start, int end, Map<Label, Integer> lineMap, List<Scope.LineRange> ranges) {
       this.start = start;
       this.end = end;
       this.lineMap = lineMap;
+
+      this.ranges = ranges;
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -40,7 +40,7 @@ class SymbolSinkTest {
     assertEquals("file", symbolContent.getPartName());
     assertEquals("file.json", symbolContent.getFileName());
     assertEquals(
-        "{\"language\":\"JAVA\",\"scopes\":[{\"end_line\":0,\"scope_type\":\"JAR\",\"start_line\":0}],\"service\":\"service1\"}",
+        "{\"language\":\"JAVA\",\"scopes\":[{\"end_line\":0,\"has_injectible_lines\":false,\"scope_type\":\"JAR\",\"start_line\":0}],\"service\":\"service1\"}",
         new String(symbolContent.getContent()));
   }
 
@@ -109,12 +109,12 @@ class SymbolSinkTest {
   }
 
   @Test
-  public void splitTootManyJarScopes() {
+  public void splitTooManyJarScopes() {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
     when(config.isSymbolDatabaseCompressed()).thenReturn(false);
-    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 2048);
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 4096);
     final int NUM_JAR_SCOPES = 21;
     for (int i = 0; i < NUM_JAR_SCOPES; i++) {
       symbolSink.addScope(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -73,8 +73,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 2, 20, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 2, 2, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "2-2");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 4, 20, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "4-15", "17-17", "19-20");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 4);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -140,8 +142,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-6");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -169,8 +173,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 4, 28, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 4, 4, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "4-4");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 28, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "6-21", "23-24", "27-28");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 6);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -238,8 +244,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 18, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 18, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-12", "14-15", "18-18");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -311,8 +319,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 15, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 15, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-15");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -358,8 +368,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 13, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 13, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-5", "7-11", "13-13");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -405,8 +417,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 10, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 10, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-5", "7-10");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -438,8 +452,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 11, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-5", "7-9", "11-11");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -486,8 +502,10 @@ class SymbolExtractionTransformerTest {
         0);
     assertScope(
         classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 5, 17, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "5-5", "17-17");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 8, 14, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "8-10", "14-14");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 8);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -512,6 +530,7 @@ class SymbolExtractionTransformerTest {
         10);
     Scope processMethodScope = classScope.getScopes().get(2);
     assertScope(processMethodScope, ScopeType.METHOD, "process", 19, 23, SOURCE_FILE, 1, 0);
+    assertLineRanges(processMethodScope, "19-19", "23-23");
     Scope processMethodLocalScope = processMethodScope.getScopes().get(0);
     assertScope(processMethodLocalScope, ScopeType.LOCAL, null, 19, 23, SOURCE_FILE, 0, 1);
     assertSymbol(
@@ -523,6 +542,7 @@ class SymbolExtractionTransformerTest {
     Scope supplierClosureScope = classScope.getScopes().get(3);
     assertScope(
         supplierClosureScope, ScopeType.CLOSURE, "lambda$process$*", 20, 21, SOURCE_FILE, 1, 0);
+    assertLineRanges(supplierClosureScope, "20-21");
     Scope supplierClosureLocalScope = supplierClosureScope.getScopes().get(0);
     assertScope(supplierClosureLocalScope, ScopeType.LOCAL, null, 20, 21, SOURCE_FILE, 0, 1);
     assertSymbol(
@@ -533,6 +553,7 @@ class SymbolExtractionTransformerTest {
         20);
     Scope lambdaClosureScope = classScope.getScopes().get(4);
     assertScope(lambdaClosureScope, ScopeType.CLOSURE, "lambda$main$0", 11, 12, SOURCE_FILE, 1, 1);
+    assertLineRanges(lambdaClosureScope, "11-12");
     assertSymbol(
         lambdaClosureScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -549,6 +570,7 @@ class SymbolExtractionTransformerTest {
         11);
     Scope clinitMethodScope = classScope.getScopes().get(5);
     assertScope(clinitMethodScope, ScopeType.METHOD, "<clinit>", 6, 6, SOURCE_FILE, 0, 0);
+    assertLineRanges(clinitMethodScope, "6-6");
   }
 
   @Test
@@ -567,8 +589,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-3");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "5-6");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -589,8 +613,10 @@ class SymbolExtractionTransformerTest {
         0);
     assertScope(
         innerClassScope.getScopes().get(0), ScopeType.METHOD, "<init>", 9, 10, SOURCE_FILE, 0, 0);
+    assertLineRanges(innerClassScope.getScopes().get(0), "9-10");
     Scope addToMethod = innerClassScope.getScopes().get(1);
     assertScope(addToMethod, ScopeType.METHOD, "addTo", 12, 13, SOURCE_FILE, 1, 1);
+    assertLineRanges(addToMethod, "12-13");
     assertSymbol(
         addToMethod.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 12);
     Scope addToMethodLocalScope = addToMethod.getScopes().get(0);
@@ -620,8 +646,10 @@ class SymbolExtractionTransformerTest {
     assertSymbol(
         classScope.getSymbols().get(0), SymbolType.FIELD, "field1", Integer.TYPE.getTypeName(), 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 4, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "3-4");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 11, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "6-9", "11-11");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 6);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -653,8 +681,10 @@ class SymbolExtractionTransformerTest {
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 6, 20, SOURCE_FILE, 7, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 6, 6, SOURCE_FILE, 0, 0);
+    assertLineRanges(classScope.getScopes().get(0), "6-6");
     Scope mainMethodScope = classScope.getScopes().get(1);
     assertScope(mainMethodScope, ScopeType.METHOD, "main", 8, 13, SOURCE_FILE, 1, 1);
+    assertLineRanges(mainMethodScope, "8-13");
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 8);
     Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
@@ -673,11 +703,13 @@ class SymbolExtractionTransformerTest {
         12);
     Scope fooMethodScope = classScope.getScopes().get(2);
     assertScope(fooMethodScope, ScopeType.METHOD, "foo", 17, 20, SOURCE_FILE, 0, 1);
+    assertLineRanges(fooMethodScope, "17-20");
     assertSymbol(
         fooMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 17);
     Scope lambdaFoo3MethodScope = classScope.getScopes().get(3);
     assertScope(
         lambdaFoo3MethodScope, ScopeType.CLOSURE, "lambda$foo$*", 19, 19, SOURCE_FILE, 0, 1);
+    assertLineRanges(lambdaFoo3MethodScope, "19-19");
     assertSymbol(
         lambdaFoo3MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -687,6 +719,7 @@ class SymbolExtractionTransformerTest {
     Scope lambdaFoo2MethodScope = classScope.getScopes().get(4);
     assertScope(
         lambdaFoo2MethodScope, ScopeType.CLOSURE, "lambda$foo$*", 19, 19, SOURCE_FILE, 0, 1);
+    assertLineRanges(lambdaFoo2MethodScope, "19-19");
     assertSymbol(
         lambdaFoo2MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -696,6 +729,7 @@ class SymbolExtractionTransformerTest {
     Scope lambdaMain1MethodScope = classScope.getScopes().get(5);
     assertScope(
         lambdaMain1MethodScope, ScopeType.CLOSURE, "lambda$main$1", 11, 11, SOURCE_FILE, 0, 1);
+    assertLineRanges(lambdaMain1MethodScope, "11-11");
     assertSymbol(
         lambdaMain1MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -705,6 +739,7 @@ class SymbolExtractionTransformerTest {
     Scope lambdaMain0MethodScope = classScope.getScopes().get(6);
     assertScope(
         lambdaMain0MethodScope, ScopeType.CLOSURE, "lambda$main$0", 11, 11, SOURCE_FILE, 0, 1);
+    assertLineRanges(lambdaMain0MethodScope, "11-11");
     assertSymbol(
         lambdaMain0MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -1019,6 +1054,18 @@ class SymbolExtractionTransformerTest {
     assertEquals(name, symbol.getName());
     assertEquals(type, symbol.getType());
     assertEquals(line, symbol.getLine());
+  }
+
+  private void assertLineRanges(Scope scope, String... expectedRanges) {
+    assertTrue(scope.hasInjectibleLines());
+    assertEquals(expectedRanges.length, scope.getInjectibleLines().size());
+    int idx = 0;
+    for (String expectedRange : expectedRanges) {
+      String[] range = expectedRange.split("-");
+      assertEquals(Integer.parseInt(range[0]), scope.getInjectibleLines().get(idx).start);
+      assertEquals(Integer.parseInt(range[1]), scope.getInjectibleLines().get(idx).end);
+      idx++;
+    }
   }
 
   private SymbolExtractionTransformer createTransformer(SymbolSink symbolSink) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractorTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractorTest.java
@@ -1,0 +1,37 @@
+package com.datadog.debugger.symbol;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SymbolExtractorTest {
+
+  @Test
+  void ranges() {
+    List<Scope.LineRange> ranges =
+        SymbolExtractor.buildRanges(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    assertEquals(1, ranges.size());
+    assertEquals(1, ranges.get(0).start);
+    assertEquals(10, ranges.get(0).end);
+    ranges = SymbolExtractor.buildRanges(Arrays.asList(1, 3, 5, 7, 9));
+    assertEquals(5, ranges.size());
+    assertLineRange(ranges.get(0), 1, 1);
+    assertLineRange(ranges.get(1), 3, 3);
+    assertLineRange(ranges.get(2), 5, 5);
+    assertLineRange(ranges.get(3), 7, 7);
+    assertLineRange(ranges.get(4), 9, 9);
+    ranges = SymbolExtractor.buildRanges(Arrays.asList(1, 2, 4, 5, 7, 9, 10));
+    assertEquals(4, ranges.size());
+    assertLineRange(ranges.get(0), 1, 2);
+    assertLineRange(ranges.get(1), 4, 5);
+    assertLineRange(ranges.get(2), 7, 7);
+    assertLineRange(ranges.get(3), 9, 10);
+  }
+
+  private static void assertLineRange(Scope.LineRange range, int expectedStart, int expectedEnd) {
+    assertEquals(expectedStart, range.start);
+    assertEquals(expectedEnd, range.end);
+  }
+}


### PR DESCRIPTION

# What Does This Do
For SymDB we add injectible lines into method scope to provide information about executable line of code where we can put a line probe.
We are using the LineNumberTable of each method, sort and make ranges about them.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
