### PR TITLE
Bump `develocity` Gradle plugin to `4.2.2`.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.2.1"
+  id("com.gradle.develocity") version "4.2.2"
 }
 
 val isCI = providers.environmentVariable("CI")


### PR DESCRIPTION
# What Does This Do
Updates the project to use the latest version of the `develocity` Gradle plugin.

# Motivation
The update ensures compatibility with the newest features and improvements in the Build Scan Web UI, providing better integration and enhanced visibility into build performance.
