### PR TITLE
Simplify configuration of Groovy compiler for non Java 8 code.

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/aerospike-4.0/build.gradle
@@ -13,12 +13,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-
 addTestSuiteForDir("latestDepTest", "test")
 addTestSuiteForDir("latest7DepTest", "test")
 addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "test")
 addTestSuiteExtendingForDir("latest7DepForkedTest", "latest7DepTest", "test")
-
 
 dependencies {
   compileOnly group: 'com.aerospike', name: 'aerospike-client', version: '4.0.0'

--- a/dd-java-agent/instrumentation/armeria/armeria-jetty-1.24/build.gradle
+++ b/dd-java-agent/instrumentation/armeria/armeria-jetty-1.24/build.gradle
@@ -25,11 +25,7 @@ addTestSuiteForDir("jetty11Test", "test/jetty11")
 addTestSuiteExtendingForDir("jetty9LatestDepTest", "latestDepTest", "test/jetty9")
 addTestSuiteExtendingForDir("jetty11LatestDepTest", "latestDepTest", "test/jetty11")
 
-["compileJetty11TestGroovy", "compileJetty11LatestDepTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    configureCompiler(it, 11)
-  }
-}
+configureGroovyCompiler(11, "compileJetty11TestGroovy", "compileJetty11LatestDepTestGroovy")
 
 ["jetty11Test", "jetty11LatestDepTest"].each { name ->
   tasks.named(name, Test) {

--- a/dd-java-agent/instrumentation/axis2-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/axis2-1.3/build.gradle
@@ -23,11 +23,7 @@ configurations.configureEach {
   }
 }
 
-["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
-  tasks.named(it, GroovyCompile) {
-    configureCompiler(it, 11)
-  }
-}
+configureGroovyCompiler(11, "compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy")
 
 ["compileLatestDepForkedTestJava", "compileLatestDepTestJava"].each {
   tasks.named(it, JavaCompile) {

--- a/dd-java-agent/instrumentation/cxf-2.1/build.gradle
+++ b/dd-java-agent/instrumentation/cxf-2.1/build.gradle
@@ -27,21 +27,17 @@ tasks.named("compileCxf3LatestDepTestJava", JavaCompile) {
   configureCompiler(it, 11, JavaVersion.VERSION_1_8)
 }
 
+configureGroovyCompiler(11, "compileCxf3LatestDepTestGroovy")
+
 tasks.named("compileLatestDepTestJava", JavaCompile) {
   configureCompiler(it, 17, JavaVersion.VERSION_1_8)
-}
-
-tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
-  configureCompiler(it, 17)
 }
 
 tasks.named("latestDepTest", Test) {
   javaLauncher = getJavaLauncherFor(17)
 }
 
-tasks.named("compileCxf3LatestDepTestGroovy", GroovyCompile) {
-  configureCompiler(it, 11)
-}
+configureGroovyCompiler(17, "compileLatestDepTestGroovy")
 
 tasks.named("cxf3LatestDepTest", Test) {
   javaLauncher = getJavaLauncherFor(11)

--- a/dd-java-agent/instrumentation/spring/spring-boot-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-boot-1.3/build.gradle
@@ -31,11 +31,7 @@ addTestSuiteExtendingForDir("boot2LatestDepForkedTest", "boot2LatestDepTest", "t
 addTestSuiteExtendingForDir("boot3ForkedTest", "boot3Test", "test")
 addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "test")
 
-["compileLatestDepTestGroovy", "compileBoot3TestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    configureCompiler(it, 17)
-  }
-}
+configureGroovyCompiler(17, "compileLatestDepTestGroovy", "compileBoot3TestGroovy")
 
 dependencies {
   implementation project(':dd-java-agent:instrumentation:span-origin')

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -1,6 +1,3 @@
-import java.time.Duration
-import java.time.temporal.ChronoUnit
-
 plugins {
   id 'com.gradleup.shadow'
 }

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -403,6 +403,14 @@ ext.configureCompiler = (AbstractCompile it, int toolchainVersion, JavaVersion c
   }
 } as Closure<Void>
 
+ext.configureGroovyCompiler = (int toolchainVersion, String... taskNames) -> {
+  taskNames.each { taskName ->
+    tasks.named(taskName, GroovyCompile) {
+      configureCompiler(it, toolchainVersion)
+    }
+  }
+} as Closure<Void>
+
 ext.getJavaLauncherFor = (javaVersionInteger) -> {
   def launcher = javaToolchains.launcherFor {
     languageVersion = JavaLanguageVersion.of(javaVersionInteger)


### PR DESCRIPTION
# What Does This Do
Introduces a small utility function to simplify and reduce verbosity when configuring the Groovy compiler.

# Motivation
Simplify and streamline build scripts.

# Additional Notes
As Java 11+ adoption increases, we may need to configure the Groovy compiler more extensively, so having a cleaner setup will help future maintenance.
