### PR TITLE
Removed not needed spotbugs dependency from test classpath.

### DIFF
--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -49,9 +49,6 @@ afterEvaluate {
 }
 
 dependencies {
-  compileOnly 'net.jcip:jcip-annotations:1.0'
   compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.0'
-
-  testImplementation 'net.jcip:jcip-annotations:1.0'
-  testImplementation 'com.github.spotbugs:spotbugs-annotations:4.2.0'
+  testImplementation 'com.google.code.findbugs:jsr305'
 }


### PR DESCRIPTION
# What Does This Do
Removes an unnecessary dependency from the test classpath.

# Motivation
Reduces classpath pollution, which was complicating the upgrade to the latest version of SpotBugs.

# Additional Notes
Identified as part of the ongoing build modernization effort.

