### PR TITLE
Job `test_flaky` should use `smoke` cache to utilize cached maven dependencies.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -438,6 +438,7 @@ check_smoke:
   parallel: 4
   variables:
     GRADLE_TARGET: ":smokeCheck"
+    CACHE_TYPE: "smoke"
 
 check_profiling:
   extends: .check_job


### PR DESCRIPTION
# What Does This Do
This change updates the `test_flaky` job to use the `smoke` cache, allowing it to reuse cached Maven dependencies instead of downloading them each time.

# Motivation
Using the existing cache improves CI performance and reliability.

# Additional Notes
No changes to job logic or test behavior — only the caching source has been updated.