### PR TITLE
Add Databricks support

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -795,8 +795,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
       return;
     }
 
-    if (isRunningOnDatabricks || isStreamingJob) {
-      log.debug("Not emitting event when running on databricks or on streaming jobs");
+    if (isStreamingJob) {
+      log.debug("Not emitting event when running streaming jobs");
       return;
     }
     if (openLineageSparkListener != null) {
@@ -1298,12 +1298,10 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
     return sparkAppName;
   }
 
-  private static String getServiceForOpenLineage(SparkConf conf, boolean isRunningOnDatabricks) {
-    // Service for OpenLineage in Databricks is not supported yet
+  private String getServiceForOpenLineage(SparkConf conf, boolean isRunningOnDatabricks) {
     if (isRunningOnDatabricks) {
-      return null;
+      return databricksServiceName;
     }
-
     // Keep service set by user, except if it is only "spark" or "hadoop" that can be set by USM
     String serviceName = Config.get().getServiceName();
     if (Config.get().isServiceNameSetByUser()

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
@@ -10,7 +10,9 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.InstanceStore;
+import java.lang.reflect.InvocationTargetException;
 import net.bytebuddy.asm.Advice;
+import org.apache.spark.SparkConf;
 import org.apache.spark.deploy.SparkSubmitArguments;
 import org.apache.spark.scheduler.SparkListenerInterface;
 import org.slf4j.Logger;
@@ -128,6 +130,23 @@ public abstract class AbstractSparkInstrumentation extends InstrumenterModule.Tr
           && "io.openlineage.spark.agent.OpenLineageSparkListener"
               .equals(listener.getClass().getCanonicalName())) {
         log.debug("Detected OpenLineage listener, skipping adding it to ListenerBus");
+
+        // Spark config does not get captured on databricks env, possibly bcz of other listener's
+        // constructor used.
+        // Reflection is used here to get the config.
+        try {
+          log.debug("Getting OpenLineage conf from the listener");
+          Object openLineageConf = listener.getClass().getMethod("getConf").invoke(listener);
+          if (openLineageConf != null) {
+            InstanceStore.of(SparkConf.class)
+                .put("openLineageSparkConf", (SparkConf) openLineageConf);
+          }
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+          log.warn(
+              "Issue when obtaining OpenLineage conf (possibly unsupported OpenLineage version): {}",
+              e.getMessage());
+        }
+
         InstanceStore.of(SparkListenerInterface.class).put("openLineageListener", listener);
         return true;
       }

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
@@ -553,6 +553,26 @@ abstract class AbstractSparkListenerTest extends InstrumentationSpecification {
     true                 | "hadoop"                | "expected-service-name"
   }
 
+  def "test setupOpenLineage gets service name on databricks environment"() {
+    setup:
+    SparkConf sparkConf = new SparkConf()
+    sparkConf.set("spark.databricks.sparkContextId", "some-context")
+    sparkConf.set("spark.databricks.clusterUsageTags.clusterAllTags", "[{\"key\":\"RunName\",\"value\":\"some-run-name\"}]")
+
+
+    def listener = getTestDatadogSparkListener(sparkConf)
+    listener.openLineageSparkListener = Mock(SparkListenerInterface)
+    listener.openLineageSparkConf = new SparkConf()
+    listener.setupOpenLineage(Mock(DDTraceId))
+
+    expect:
+    assert listener
+    .openLineageSparkConf
+    .get("spark.openlineage.run.tags")
+    .split(";")
+    .contains("_dd.ol_service:databricks.job-cluster.some-run-name")
+  }
+
   def "test setupOpenLineage fills ProcessTags"() {
     setup:
     def listener = getTestDatadogSparkListener()


### PR DESCRIPTION
# What Does This Do

Spark listeners on databricks environments are instantiated in slightly different way than on regular vanilla Spark setups. This PR assures the datadog listener instruments Openlineage listener correctly on the databricks environment. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
