### PR TITLE
Fix NullPointerException in AppSecRequestContext#close

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -646,9 +646,15 @@ public class AppSecRequestContext implements DataBundle, Closeable {
         closeWafContext();
       }
       collectedCookies = null;
-      requestHeaders.clear();
-      responseHeaders.clear();
-      persistentData.clear();
+      if (requestHeaders != null) {
+        requestHeaders.clear();
+      }
+      if (responseHeaders != null) {
+        responseHeaders.clear();
+      }
+      if (persistentData != null) {
+        persistentData.clear();
+      }
       if (derivatives != null) {
         derivatives.clear();
         derivatives = null;


### PR DESCRIPTION
# What Does This Do

Added defensive null checks before calling clear() on requestHeaders, responseHeaders, and persistentData in the close() method, following the same pattern already used for the derivatives field.

# Motivation

[Error tracking report](https://app.datadoghq.com/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%222411fa78-b69a-11f0-ae64-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1761904242753&to_ts=1761990642753&live=true)

stack trace

```
java.lang.NullPointerException
  at com.datadog.appsec.gateway.AppSecRequestContext.close(AppSecRequestContext.java:649)
  at com.datadog.appsec.api.security.AppSecSpanPostProcessor.process(AppSecSpanPostProcessor.java:65)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.maybeTracePostProcessing(TraceProcessingWorker.java:270)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.onEvent(TraceProcessingWorker.java:187)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.consumeFromPrimaryQueue(TraceProcessingWorker.java:208)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.runDutyCycle(TraceProcessingWorker.java:173)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.run(TraceProcessingWorker.java:161)
  at java.base/java.lang.Thread.run(Unknown Source)
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-59884](https://datadoghq.atlassian.net/browse/APPSEC-59884)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-59884]: https://datadoghq.atlassian.net/browse/APPSEC-59884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ