### PR TITLE
Limit the number of verified tag vectors in CI Visibility metric tests

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/telemetry/CiVisibilityMetricCollectorTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/telemetry/CiVisibilityMetricCollectorTest.groovy
@@ -149,18 +149,18 @@ class CiVisibilityMetricCollectorTest extends Specification {
   }
 
   /**
-   * This test enumerates all possible metric+tags variants,
-   * then tries submitting all possible variant pairs (combinations of 2 different metric+tags).
+   * This test enumerates a few different tag combinations for every metric,
+   * then submits a metric count for each one.
    * The goal is to ensure that index calculation logic and card-marking are done right.
    */
-  def "test submission of all possible count metric pairs"() {
+  def "test submission of different count metric pairs"() {
     setup:
     List<PossibleMetric> possibleMetrics = []
 
     for (CiVisibilityCountMetric metric : CiVisibilityCountMetric.values()) {
       def metricTags = metric.getTags()
 
-      int cartesianProductSizeLimit = 2000 // limiting the number of combinations to avoid OOM/timeout
+      int cartesianProductSizeLimit = 20 // limiting the number of combinations to avoid OOM/timeout
       for (TagValue[] tags : cartesianProduct(metricTags, cartesianProductSizeLimit)) { // iterate over combinations of metric tags
         possibleMetrics += new PossibleMetric(metric, tags)
       }


### PR DESCRIPTION
# What Does This Do

Updates `datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorTest` to limit the number of tested metric/tags pairs.

# Motivation

The test is verifying all the possible metric/tag pairs, which is redundant. As the number of metrics grew over time, the test execution time increased non-linearly. It now takes more than 10 minutes to run.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
