### PR TITLE
Fix npe on ConflatingMetricsAggregator when the resource is null

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -277,7 +277,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       for (CoreSpan<?> span : trace) {
         boolean isTopLevel = span.isTopLevel();
         if (shouldComputeMetric(span)) {
-          if (ignoredResources.contains(span.getResourceName().toString())) {
+          final CharSequence resourceName = span.getResourceName();
+          if (resourceName != null && ignoredResources.contains(resourceName.toString())) {
             // skip publishing all children
             forceKeep = false;
             break;

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -1,22 +1,21 @@
 package datadog.trace.common.metrics
 
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.SECONDS
+
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.WellKnownTags
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Shared
-
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.function.Supplier
-
-import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
-import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static java.util.concurrent.TimeUnit.SECONDS
+import spock.lang.Shared
 
 class ConflatingMetricAggregatorTest extends DDSpecification {
 
@@ -91,6 +90,48 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     reportAndWaitUntilEmpty(aggregator)
     then:
     0 * sink._
+
+    cleanup:
+    aggregator.close()
+  }
+
+  def "should be resilient to null resource names"() {
+    setup:
+    MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
+    features.peerTags() >> []
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS)
+    aggregator.start()
+
+    when:
+    CountDownLatch latch = new CountDownLatch(1)
+    aggregator.publish([
+      new SimpleSpan("service", "operation", null, "type", false, true, false, 0, 100, HTTP_OK)
+      .setTag(SPAN_KIND, "baz")
+    ])
+    aggregator.report()
+    def latchTriggered = latch.await(2, SECONDS)
+
+    then:
+    latchTriggered
+    1 * writer.startBucket(1, _, _)
+    1 * writer.add(new MetricKey(
+      null,
+      "service",
+      "operation",
+      "type",
+      HTTP_OK,
+      false,
+      false,
+      "baz",
+      []
+      ), _) >> { MetricKey key, AggregateMetric value ->
+        value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
+      }
+    1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
     aggregator.close()


### PR DESCRIPTION
# What Does This Do

Fixes:

```
java.lang.NullPointerException
  at metrics.ConflatingMetricsAggregator.publish(ConflatingMetricsAggregator.java:280)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
