### PR TITLE
Put activePartitioning in ci-jobs plugin

### DIFF
--- a/buildSrc/src/main/kotlin/datadog.ci-jobs.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.ci-jobs.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import datadog.gradle.plugin.ci.findAffectedTaskPath
+import org.gradle.api.tasks.testing.Test
 import java.io.File
 import kotlin.math.abs
 
@@ -19,6 +20,15 @@ allprojects {
     val taskPartition = taskPartitionProvider.get()
     val currentTaskPartition = abs(project.path.hashCode() % taskPartitionCount.toInt())
     extra.set("activePartition", currentTaskPartition == taskPartition.toInt())
+  }
+  
+  // Disable test tasks if not in active partition
+  val activePartitionProvider = providers.provider {
+    project.extra.properties["activePartition"] as? Boolean ?: true
+  }
+  
+  tasks.withType<Test>().configureEach {
+    enabled = activePartitionProvider.get()
   }
 }
 

--- a/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
@@ -32,14 +32,9 @@ val skipTestsProvider = rootProject.providers.gradleProperty("skipTests")
 val skipForkedTestsProvider = rootProject.providers.gradleProperty("skipForkedTests")
 val skipFlakyTestsProvider = rootProject.providers.gradleProperty("skipFlakyTests")
 val runFlakyTestsProvider = rootProject.providers.gradleProperty("runFlakyTests")
-val activePartitionProvider = providers.provider {
-  project.extra.properties["activePartition"] as? Boolean ?: true
-}
 
 // Go through the Test tasks and configure them
 tasks.withType<Test>().configureEach {
-  enabled = activePartitionProvider.get()
-  
   // Disable all tests if skipTests property was specified
   onlyIf("skipTests are undefined or false") { !skipTestsProvider.isPresent }
 


### PR DESCRIPTION
# What Does This Do

Move active partitioning logic from `configure-tests` plug-in to `ci-jobs` plugin where the rest of the partitioning logic for CI is

# Motivation

Follow-up of Brice's [comment](https://github.com/DataDog/dd-trace-java/pull/9859#discussion_r2470662539) in #9859 

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
