### PR TITLE
Modify Kotlin file and run formatter and linter

### DIFF
--- a/buildSrc/src/main/kotlin/CIJobsExtensions.kt
+++ b/buildSrc/src/main/kotlin/CIJobsExtensions.kt
@@ -13,10 +13,9 @@ internal fun findAffectedTaskPath(baseTask: Task, affectedProjects: Map<Project,
   
   while (queue.isNotEmpty()) {
     val t = queue.removeAt(0)
-    if (visited.contains(t)) {
+    if (!visited.add(t)) {
       continue
     }
-    visited.add(t)
     
     val affectedTasks = affectedProjects[t.project]
     if (affectedTasks != null) {
@@ -50,7 +49,7 @@ private fun Project.createRootTask(
       if (
         activePartition &&
         includePrefixes.any { subproject.path.startsWith(it) } &&
-        !excludePrefixes.any { subproject.path.startsWith(it) }
+        excludePrefixes.none { subproject.path.startsWith(it) }
       ) {
         val testTask = subproject.tasks.findByName(subProjTaskName)
         var isAffected = true


### PR DESCRIPTION
<!-- dd-meta {"pullId":"28bdb194-5ea8-42c6-b155-6dbfcdd9d0a9","source":"chat","resourceId":"ad6e9e37-1446-4641-af31-a3b1637ec84f","workflowId":"6f3d90be-10cc-40e9-a31a-efff6e7a67c4","codeChangeId":"6f3d90be-10cc-40e9-a31a-efff6e7a67c4","sourceType":"chat"} -->
[![Open Bits Dev Session](https://img.shields.io/badge/Open%20Bits%20Dev%20Session-%20?logo=datadog&logoColor=%23632CA6&labelColor=white&color=%23632CA6)](https://app.datadoghq.com/code/ad6e9e37-1446-4641-af31-a3b1637ec84f)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

# What Does This Do

Refactors the `findAffectedTaskPath` function and project filtering logic to use more idiomatic Kotlin constructs, improving code clarity and conciseness.

# Motivation

The changes simplify the visited task tracking by leveraging `Set.add()` return value instead of explicit contains checks. Additionally, the exclusion prefix logic is made more readable by using `none` instead of negating `any`.

# Additional Notes

- Changed `if (visited.contains(t))` to `if (!visited.add(t))` to eliminate redundant operations
- Replaced `!excludePrefixes.any { ... }` with `excludePrefixes.none { ... }` for better readability
- These are stylistic improvements that maintain equivalent functionality while following Kotlin best practices

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior