### PR TITLE
Use dd-instrument-java's embedded copy of ASM

### DIFF
--- a/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelInstrumentationMapper.java
+++ b/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelInstrumentationMapper.java
@@ -141,7 +141,9 @@ public final class OtelInstrumentationMapper extends ClassRemapper {
       RENAMED_PACKAGES.put(
           "io/opentelemetry/javaagent/bootstrap/", "datadog/trace/bootstrap/otel/instrumentation/");
 
-      RENAMED_PACKAGES.put("org/objectweb/asm/", "net/bytebuddy/jar/asm/");
+      // we want to keep this package unchanged so it matches against any unshaded extensions
+      // dropped in at runtime; use replace to stop it being transformed by the shadow plugin
+      RENAMED_PACKAGES.put("org|objectweb|asm|".replace('|', '/'), "net/bytebuddy/jar/asm/");
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExtensionHandler.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExtensionHandler.java
@@ -126,8 +126,9 @@ public class ExtensionHandler {
   /** Maps logging references in the extension to use the tracer's embedded logger. */
   public static final Function<String, String> MAP_LOGGING =
       new Function<String, String>() {
-        // substring stops string literal from being changed by shadow plugin
-        private final String ORG_SLF4J = "_org/slf4j/".substring(1);
+        // we want to keep this package unchanged so it matches against any unshaded extensions
+        // dropped in at runtime; use replace to stop it being transformed by the shadow plugin
+        private final String ORG_SLF4J = "org|slf4j|".replace('|', '/');
 
         @Override
         public String apply(String internalName) {

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -93,6 +93,8 @@ def generalShadowJarConfig(ShadowJar shadowJarTask) {
     // patch JFFI loading mechanism to maintain isolation
     exclude '**/com/kenai/jffi/Init.class'
     relocate('com.kenai.jffi.Init', 'com.kenai.jffi.PatchInit')
+    // use dd-instrument-java's embedded copy of asm
+    relocate('org.objectweb.asm', 'datadog.instrument.asm')
 
     // Minimize and relocate the airlift compressor dependency for ZSTD
     exclude '**/io/airlift/compress/bzip2/**'
@@ -205,6 +207,8 @@ def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
     exclude(project(':utils:config-utils'))
     exclude(project(':utils:time-utils'))
     exclude(dependency('org.slf4j::'))
+    // use dd-instrument-java's embedded copy of asm
+    exclude(dependency('org.ow2.asm:asm:'))
   }
 }
 includeShadowJar(sharedShadowJar, 'shared', includedJarFileTree)

--- a/dd-trace-ot/build.gradle.kts
+++ b/dd-trace-ot/build.gradle.kts
@@ -120,6 +120,8 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
     exclude(dependency("io.opentracing.contrib:"))
     exclude(dependency("org.slf4j:"))
     exclude(dependency("com.github.jnr:"))
+    // indirect dependency of JNR, no need to embed
+    exclude(dependency("org.ow2.asm:"))
   }
 
   relocate("com.", "ddtrot.com.") {


### PR DESCRIPTION
# What Does This Do

Relocates all references to `org.objectweb.asm` to use the same repackaged copy of ASM courtesy of the `dd-instrument-java` dependency, which reduces the number of copies of ASM included in the final `dd-java-agent` jar.

# Motivation

Reduces the final jar size by 120k, as well as fewer classes loaded during startup.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
