### PR TITLE
Fix flaky test configuration

### DIFF
--- a/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
@@ -107,16 +107,15 @@ tasks.named("check") {
 
 tasks.withType<Test>().configureEach {
   // Flaky tests management for JUnit 5
-  if (testFramework is JUnitPlatformOptions) {
-    val junitPlatform = testFramework as JUnitPlatformOptions
+  (options as? JUnitPlatformOptions)?.apply {
     if (skipFlakyTestsProvider.isPresent) {
-      junitPlatform.excludeTags("flaky")
+      excludeTags("flaky")
     } else if (runFlakyTestsProvider.isPresent) {
-      junitPlatform.includeTags("flaky")
+      includeTags("flaky")
     }
   }
 
-  // Flaky tests management for Spock
+  // Set system property flag that is checked from tests to determine if they should be skipped or run
   if (skipFlakyTestsProvider.isPresent) {
     jvmArgs("-Drun.flaky.tests=false")
   } else if (runFlakyTestsProvider.isPresent) {


### PR DESCRIPTION
# What Does This Do

Use a safe `instanceOf` check with `options as? JUnitPlatformOptions` instead of the wrong `testFramework is JUnitPlatformOptions` evaluation to check if tests marked as `@Flaky` should be skipped or not.

# Motivation
Previously when using `testFramework`, it had the wrong type, and the check always evaluated as `false`, skipping the test configuration entirely.

# Additional Notes
After converting `configure-tests` to a convention plug-in in #9859, JUnit flaky test configurations were skipped and causing failures on the `master` branch of CI. This PR restores the functionality. 

