### PR TITLE
Using ddprof nightly snapshot for nightly test

### DIFF
--- a/dd-java-agent/ddprof-lib/build.gradle
+++ b/dd-java-agent/ddprof-lib/build.gradle
@@ -6,12 +6,22 @@ plugins {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+configurations {
+  def nightly = register('nightlyTestImplementation') {
+    visible = false
+    canBeConsumed = false
+    canBeResolved = true
+    extendsFrom(testImplementation)
+  }
+}
+
 dependencies {
   // This module provides the ddprof library as an api dependency
   // so that other modules can easily depend on it.
   implementation project.hasProperty('ddprof.jar') ? files(project.findProperty('ddprof.jar')) : libs.ddprof
   api project(':internal-api')
   api project(':dd-trace-api')
+  nightlyTestImplementation group: 'com.datadoghq', name: 'ddprof', version: 'latest.integration'
 }
 
 tasks.named("shadowJar", ShadowJar) {


### PR DESCRIPTION
# What Does This Do

Allows `dd-trace-java`'s nightly test to use `java-profiler`'s latest snapshot.

# Motivation
Up to now, `dd-trace-java` always uses latest release version of `java-profiler` for testing, that means `java-profiler` does not get any integration tests until it has been released.

With the PR, `java-profiler` gets early exposure to `dd-trace-java`'s nightly test, should help to catch any integration problems and improve test coverage.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
