### PR TITLE
Remove load and add dacapo benchmarks to check-big-regressions

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -86,7 +86,7 @@ check-big-regressions:
   script:
     - !reference [ .benchmarks, script ]
     - | 
-      for benchmarkType in startup load; do
+      for benchmarkType in startup dacapo; do
           find "$ARTIFACTS_DIR/$benchmarkType" -name "benchmark-baseline.json" -o -name "benchmark-candidate.json" | while read file; do
             relpath="${file#$ARTIFACTS_DIR/$benchmarkType/}"
             prefix="${relpath%/benchmark-*}" # Remove the trailing /benchmark-(baseline|candidate).json


### PR DESCRIPTION
# What Does This Do

Removes the `load` benchmarks and adds `dacapo` benchmarks to the `check-big-regressions` PR gate.

# Motivation

The `load` benchmarks are very unstable, causing false positives and PRs to be blocked on `check-big-regressions` even when the changes are un-related to these benchmarks.

On the contrary, it seems like `dacapo` benchmarks are very stable, so we can add those in.

# Additional Notes

We're currently looking into stabilizing the `load` benchmarks. We will add `load` benchmarks back in ASAP once this is achieved.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
