### PR TITLE
Revert "Put activePartitioning in ci-jobs plugin"

### DIFF
--- a/buildSrc/src/main/kotlin/datadog.ci-jobs.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.ci-jobs.gradle.kts
@@ -5,7 +5,6 @@
  */
 
 import datadog.gradle.plugin.ci.findAffectedTaskPath
-import org.gradle.api.tasks.testing.Test
 import java.io.File
 import kotlin.math.abs
 
@@ -20,15 +19,6 @@ allprojects {
     val taskPartition = taskPartitionProvider.get()
     val currentTaskPartition = abs(project.path.hashCode() % taskPartitionCount.toInt())
     extra.set("activePartition", currentTaskPartition == taskPartition.toInt())
-  }
-  
-  // Disable test tasks if not in active partition
-  val activePartitionProvider = providers.provider {
-    project.extra.properties["activePartition"] as? Boolean ?: true
-  }
-  
-  tasks.withType<Test>().configureEach {
-    enabled = activePartitionProvider.get()
   }
 }
 

--- a/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.configure-tests.gradle.kts
@@ -32,9 +32,14 @@ val skipTestsProvider = rootProject.providers.gradleProperty("skipTests")
 val skipForkedTestsProvider = rootProject.providers.gradleProperty("skipForkedTests")
 val skipFlakyTestsProvider = rootProject.providers.gradleProperty("skipFlakyTests")
 val runFlakyTestsProvider = rootProject.providers.gradleProperty("runFlakyTests")
+val activePartitionProvider = providers.provider {
+  project.extra.properties["activePartition"] as? Boolean ?: true
+}
 
 // Go through the Test tasks and configure them
 tasks.withType<Test>().configureEach {
+  enabled = activePartitionProvider.get()
+  
   // Disable all tests if skipTests property was specified
   onlyIf("skipTests are undefined or false") { !skipTestsProvider.isPresent }
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#9912

`ci-jobs` is applied to the root whereas `configure_tests` is applied to sub-projects, so active partitions may not be working with the change made in #9912. Marking this PR a draft, as I investigate...