### PR TITLE
In opentelemetry's WithSpan integration, reuse SpanBuilders

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanDecorator.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanDecorator.java
@@ -77,7 +77,7 @@ public class WithSpanDecorator extends AsyncResultDecorator {
     }
 
     AgentTracer.SpanBuilder spanBuilder =
-        AgentTracer.get().buildSpan(INSTRUMENTATION_NAME, operationName);
+        AgentTracer.get().singleSpanBuilder(INSTRUMENTATION_NAME, operationName);
 
     if (!inheritContext) {
       spanBuilder = spanBuilder.ignoreActiveSpan();


### PR DESCRIPTION
# What Does This Do

Uses singleSpanBuilder instead of buildSpan, since singleSpanBuilder can recycle SpanBuilders to reduce overhead

# Motivation

SpanBuilder reuse creates less allocation and therefore less garbage collection

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
