### PR TITLE
Reuse SpanBuilder in Couchbase Client

### DIFF
--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestTracer.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestTracer.java
@@ -50,7 +50,7 @@ public class DatadogRequestTracer implements RequestTracer {
       seedNodes = parent.getTag(InstrumentationTags.COUCHBASE_SEED_NODES);
     }
 
-    AgentTracer.SpanBuilder builder = tracer.buildSpan(spanName);
+    AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder(spanName);
     if (null != parent) {
       builder.asChildOf(parent.context());
     }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestTracer.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestTracer.java
@@ -54,7 +54,7 @@ public class DatadogRequestTracer implements RequestTracer {
       }
     }
     if (requestSpan == null) {
-      AgentTracer.SpanBuilder builder = tracer.buildSpan(spanName);
+      AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder(spanName);
       if (null != parent) {
         builder.asChildOf(parent.context());
       }


### PR DESCRIPTION
# What Does This Do

Changes couchbase client instrumentation to use singleSpanBuilder instead of buildSpan
singleSpanBuilder can reuse the underlying SpanBuilder

# Motivation

SpanBuilder reuse reduces allocation and therefore garbage collection

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
