### PR TITLE
Update system tests pinning trust policy

### DIFF
--- a/.github/chainguard/self.update-system-tests.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-system-tests.create-pr.sts.yaml
@@ -5,7 +5,7 @@ subject_pattern: repo:DataDog/dd-trace-java:ref:refs/(heads/master|tags/v[0-9]+.
 claim_pattern:
   event_name: (push|workflow_dispatch)
   ref: refs/(heads/master|tags/v[0-9]+\.[0-9]+\.0)
-  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/create-release-branch\.yaml@refs/heads/master
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/create-release-branch\.yaml@refs/(heads/master|tags/v[0-9]+\.[0-9]+\.0)
 
 permissions:
   contents: write


### PR DESCRIPTION
# What Does This Do

Update the trust policy to account for cases when the `job_workflow_ref` is triggered by a git tag.

# Motivation

The previous trust policy failed in the latest release ([link](https://github.com/DataDog/dd-trace-java/actions/runs/19072454225)), so this should fix it. The updates here pass the recommended command [For local debugging](https://github.com/DataDog/dd-trace-java/actions/runs/19072454225#:~:text=For%20local%20debugging%20via%20dd%2Dcoto%2Dsts%20cli%2C%20run%3A).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/APMLP-598

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
