### PR TITLE
Migrate V1 Config Inversion CI Jobs to V2 CI Jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -982,25 +982,11 @@ create_key:
     paths:
       - pubkeys
 
-validate_supported_configurations_local_file:
-  extends: .validate_supported_configurations_local_file
-  variables:
-    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
-
-update_central_configurations_version_range:
-  extends: .update_central_configurations_version_range
-  variables:
-    LOCAL_REPO_NAME: "dd-trace-java"
-    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
-    LANGUAGE_NAME: "java"
-    MULTIPLE_RELEASE_LINES: "false"
-
 validate_supported_configurations_v2_local_file:
   extends: .validate_supported_configurations_v2_local_file
   variables:
     LOCAL_JSON_PATH: "metadata/supported-configurations.json"
     BACKFILLED: "false"
-
 
 update_central_configurations_version_range_v2:
   extends: .update_central_configurations_version_range_v2


### PR DESCRIPTION
# What Does This Do
Currently, dd-trace-java has CI jobs in place to enforce and update the documentation of configurations in the Feature Parity Dashboard. With the introduction of a [v2 format](https://docs.google.com/document/d/1j0X4QYHnk9ifv-lRW9k5XUjxoLgC6pUol9uTOJcrjuk/edit?pli=1&tab=t.0) for the local `metadata/supported-configurations.json` file, we need to verify additional fields against the FPD. This is done in new CI [jobs](https://github.com/DataDog/libdatadog-build/blob/main/templates/one-pipeline.yml#L542-L590) in libdatadog-build.

This PR migrates the CI jobs used in dd-trace-java from the v1 versions to v2 versions. Note that the local `metadata/supported-configurations.json` file does not have to be in v2 format in order to use the v2 CI jobs.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
