### PR TITLE
Fix GitClientTest.test git diff when diff.noprefix=true is used

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 public class GitDiffParser {
 
   private static final Pattern CHANGED_FILE_PATTERN =
-      Pattern.compile("^diff --git a/(?<oldfilename>.+) b/(?<newfilename>.+)$");
+      Pattern.compile("^diff --git (?<oldfilename>.+) (?<newfilename>.+)$");
   private static final Pattern CHANGED_LINES_PATTERN =
       Pattern.compile("^@@ -\\d+(,\\d+)? \\+(?<startline>\\d+)(,(?<count>\\d+))? @@");
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
@@ -929,6 +929,7 @@ public class ShellGitClient implements GitClient {
                   "diff",
                   "-U0",
                   "--word-diff=porcelain",
+                  "--no-prefix",
                   baseCommit,
                   targetCommit));
     } else {
@@ -936,7 +937,13 @@ public class ShellGitClient implements GitClient {
           Command.DIFF,
           () ->
               commandExecutor.executeCommand(
-                  GitDiffParser::parse, "git", "diff", "-U0", "--word-diff=porcelain", baseCommit));
+                  GitDiffParser::parse,
+                  "git",
+                  "diff",
+                  "-U0",
+                  "--word-diff=porcelain",
+                  "--no-prefix",
+                  baseCommit));
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/git-diff.txt
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/git-diff.txt
@@ -1,16 +1,16 @@
-diff --git a/java/maven-junit4/pom.xml b/java/maven-junit4/pom.xml
+diff --git java/maven-junit4/pom.xml java/maven-junit4/pom.xml
 index 6d73cda..2a1f220 100644
---- a/java/maven-junit4/pom.xml
-+++ b/java/maven-junit4/pom.xml
+--- java/maven-junit4/pom.xml
++++ java/maven-junit4/pom.xml
 @@ -10 +10 @@
 
 -<name>java-maven-junit4</name>
 +<name>java-maven-junit4-test-project</name>
 ~
-diff --git a/java/maven-junit5/pom.xml b/java/maven-junit5/pom.xml
+diff --git java/maven-junit5/pom.xml java/maven-junit5/pom.xml
 index 7b92d64..834a61c 100644
---- a/java/maven-junit5/pom.xml
-+++ b/java/maven-junit5/pom.xml
+--- java/maven-junit5/pom.xml
++++ java/maven-junit5/pom.xml
 @@ -14 +14 @@
 
 -<module>module-b</module>

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/larger-git-diff.txt
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/larger-git-diff.txt
@@ -1,16 +1,16 @@
-diff --git a/java/maven-junit4/pom.xml b/java/maven-junit4/pom.xml
+diff --git java/maven-junit4/pom.xml java/maven-junit4/pom.xml
 index 6d73cda..2a1f220 100644
---- a/java/maven-junit4/pom.xml
-+++ b/java/maven-junit4/pom.xml
+--- java/maven-junit4/pom.xml
++++ java/maven-junit4/pom.xml
 @@ -10 +10 @@
      
 -<name>java-maven-junit4</name>
 +<name>java-maven-junit4-test-project</name>
 ~
-diff --git a/java/maven-junit5/module-a/pom.xml b/java/maven-junit5/module-a/pom.xml
+diff --git java/maven-junit5/module-a/pom.xml java/maven-junit5/module-a/pom.xml
 index 29a3a73..4567037 100644
---- a/java/maven-junit5/module-a/pom.xml
-+++ b/java/maven-junit5/module-a/pom.xml
+--- java/maven-junit5/module-a/pom.xml
++++ java/maven-junit5/module-a/pom.xml
 @@ -8,3 +8,3 @@
          
 -<groupId>com.datadog.ci.test</groupId>
@@ -53,10 +53,10 @@ index 29a3a73..4567037 100644
 @@ -34 +40 @@
  </project>
 ~
-diff --git a/java/maven-junit5/module-b/pom.xml b/java/maven-junit5/module-b/pom.xml
+diff --git java/maven-junit5/module-b/pom.xml java/maven-junit5/module-b/pom.xml
 deleted file mode 100644
 index f18dd09..0000000
---- a/java/maven-junit5/module-b/pom.xml
+--- java/maven-junit5/module-b/pom.xml
 +++ /dev/null
 @@ -1,17 +0,0 @@
 -<?xml version="1.0"?>
@@ -91,10 +91,10 @@ index f18dd09..0000000
 ~
 -</project>
 ~
-diff --git a/java/maven-junit5/pom.xml b/java/maven-junit5/pom.xml
+diff --git java/maven-junit5/pom.xml java/maven-junit5/pom.xml
 index 7b92d64..834a61c 100644
---- a/java/maven-junit5/pom.xml
-+++ b/java/maven-junit5/pom.xml
+--- java/maven-junit5/pom.xml
++++ java/maven-junit5/pom.xml
 @@ -14 +14 @@
          
 -<module>module-b</module>


### PR DESCRIPTION
# What Does This Do

This adds `--no-prefix` when `ShellGitClient` runs `git diff`, updates the regex in `GitDiffParser`, and adjusts test files.

# Motivation

When `diff.noprefix=true` (or other git diff parameters that change the prefix format) used, it changes the output from `git diff` and and the test failure below is seen in `GitClientTest.test git diff`. I have used this git setting in my `~/.gitconfig` file for years as it makes copying and pasting file names simpler.

```
java.lang.IllegalStateException: Line @@ -26 +26 @@ namespace Datadog.Trace.Logging contains changed lines information, but no changed file info is available
	at datadog.trace.civisibility.git.tree.GitDiffParser.parse(GitDiffParser.java:48)
	at datadog.trace.civisibility.utils.ShellCommandExecutor.executeCommand(ShellCommandExecutor.java:153)
	at datadog.trace.civisibility.utils.ShellCommandExecutor.executeCommand(ShellCommandExecutor.java:57)
	at datadog.trace.civisibility.git.tree.ShellGitClient.lambda$getGitDiff$18(ShellGitClient.java:926)
	at datadog.trace.civisibility.git.tree.ShellGitClient.executeCommand(ShellGitClient.java:980)
	at datadog.trace.civisibility.git.tree.ShellGitClient.getGitDiff(ShellGitClient.java:923)
	at datadog.trace.civisibility.git.tree.GitClientTest.test git diff(GitClientTest.groovy:264)
```

# Additional Notes

Setting `diff.noprefix=true` changes the file name pattern and it fails to match `GitDiffParser.CHANGED_FILE_PATTERN`.

```
$ git diff | grep ^diff
diff --git a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java

$ GIT_CONFIG_PARAMETERS="'diff.noprefix=true'" git diff | grep ^diff diff --git dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
```

Notice the lack of `a/` and `b/` on the latter output, but you'll see that the pattern expects that:

```
  private static final Pattern CHANGED_FILE_PATTERN =
      Pattern.compile("^diff --git a/(?<oldfilename>.+) b/(?<newfilename>.+)$");
```

The simple workaround is to pass `--default-prefix` to `git diff`, however this option has only been present since 2023: https://github.com/git/git/commit/b39a5697296659c344cd0a286b51303fd5375fab

A safer option would be to use `--no-prefix`, which has existed since 2007: https://github.com/git/git/commit/eab9a40b6dd5c1c571b1deb264133db47bb4794d

To reproduce this error, you can run the test this way:

```
GIT_CONFIG_PARAMETERS="'diff.noprefix=true'" ./gradlew \
    --no-build-cache \
    :dd-java-agent:agent-ci-visibility:cleanTest \
    :dd-java-agent:agent-ci-visibility:test \
    --tests datadog.trace.civisibility.git.tree.GitClientTest
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
