### PR TITLE
Switch Code-Origin startup logging from INFO to DEBUG

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -242,20 +242,20 @@ public class DebuggerAgent {
     if (!codeOriginEnabled.compareAndSet(false, true)) {
       return;
     }
-    LOGGER.info("Starting Code Origin for spans");
+    LOGGER.debug("Starting Code Origin for spans");
     Config config = Config.get();
     commonInit(config);
     initClassNameFilter();
     DebuggerContext.initClassNameFilter(classNameFilter);
     DebuggerContext.initCodeOrigin(new DefaultCodeOriginRecorder(config, configurationUpdater));
-    LOGGER.info("Started Code Origin for spans");
+    LOGGER.debug("Started Code Origin for spans");
   }
 
   public static void stopCodeOriginForSpans() {
     if (!codeOriginEnabled.compareAndSet(true, false)) {
       return;
     }
-    LOGGER.info("Stopping Code Origin for spans");
+    LOGGER.debug("Stopping Code Origin for spans");
     if (configurationUpdater != null) {
       // uninstall all code origin probes by providing empty configuration
       configurationUpdater.accept(CODE_ORIGIN, Collections.emptyList());


### PR DESCRIPTION
# What Does This Do

With the Code-Origin feature on by default, we now get two INFO log messages every time a JVM starts with `dd-java-agent` attached:
```
[dd.trace 2025-11-13 12:36:22:300 +0000] [main] INFO com.datadog.debugger.agent.DebuggerAgent - Starting Code Origin for spans
[dd.trace 2025-11-13 12:36:22:396 +0000] [main] INFO com.datadog.debugger.agent.DebuggerAgent - Started Code Origin for spans
```
These log messages should be switched to DEBUG so they are still available for triage purposes, but don't contribute to unwanted log-spam.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
