### PR TITLE
Drop fromEnv toolchain restriction for local environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,9 +171,12 @@ default:
     - export ORG_GRADLE_PROJECT_akkaRepositoryToken=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.akka_repo_token --with-decryption --query "Parameter.Value" --out text)
     - export ORG_GRADLE_PROJECT_mavenRepositoryProxy=$MAVEN_REPOSITORY_PROXY
     - export ORG_GRADLE_PROJECT_gradlePluginProxy=$GRADLE_PLUGIN_PROXY
-    - export ORG_GRADLE_PROJECT_org.gradle.java.installations.auto-detect=false
-    - export ORG_GRADLE_PROJECT_org.gradle.java.installations.auto-download=false
-    - export ORG_GRADLE_PROJECT_org.gradle.java.installations.fromEnv=JAVA_8_HOME,JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_25_HOME
+    - |
+      cat >> gradle.properties <<'EOF'
+      org.gradle.java.installations.auto-detect=false
+      org.gradle.java.installations.auto-download=false
+      org.gradle.java.installations.fromEnv=JAVA_8_HOME,JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_25_HOME
+      EOF
     - mkdir -p .gradle
     - export GRADLE_USER_HOME=$(pwd)/.gradle
     # replace maven central part by MAVEN_REPOSITORY_PROXY in .mvn/wrapper/maven-wrapper.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
 
-# CI use constrained org.gradle.java.installations settings
-
 # Toggle on to get more details during IJ sync
 #org.gradle.logging.level=info
+
+# CI use constrained org.gradle.java.installations settings


### PR DESCRIPTION
# What Does This Do

Drop the restrictions on the toolchain lookup features. However maintain the restrictions when running in CI.

This reduce the friction when setting up a new project ; this still requires to have the environment variables when using the `testJvm` property.


# Motivation

In order to allow running on later JDK, we need to drop some constraints on which JDK to look for. This will help in particular 

* #9748 
* #9881 

Maybe we can even drive the actual JVM used by gradle with 
* #9747


# Additional Notes

A follow-up PR, removes the need to have `JAVA_xx_HOME` environment variables locally, to use the `testJvm` feature.
* #9968

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
