### PR TITLE
Fix DebuggerAgent tests

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1396,8 +1396,8 @@ public class Agent {
       final Class<?> debuggerAgentClass =
           AGENT_CLASSLOADER.loadClass("com.datadog.debugger.agent.DebuggerAgent");
       final Method debuggerInstallerMethod =
-          debuggerAgentClass.getMethod("run", Instrumentation.class, scoClass);
-      debuggerInstallerMethod.invoke(null, inst, sco);
+          debuggerAgentClass.getMethod("run", Config.class, Instrumentation.class, scoClass);
+      debuggerInstallerMethod.invoke(null, Config.get(), inst, sco);
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting debugger agent", ex);
     } finally {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -697,7 +697,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
       // Log and span decoration probe shared the same instrumentor: CaptureContextInstrumentor
       // and therefore need to be instrumented once
       // note: exception probes are log probes and are handled the same way
-      if (!Config.get().isDistributedDebuggerEnabled() && definition instanceof TriggerProbe) {
+      if (!config.isDistributedDebuggerEnabled() && definition instanceof TriggerProbe) {
         LOGGER.debug(
             "The distributed debugger feature is disabled. Trigger probes will not be installed.");
       } else if (isCapturedContextProbe(definition)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdater.java
@@ -5,6 +5,7 @@ import datadog.trace.api.config.DebuggerConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
 import datadog.trace.api.debugger.DebuggerConfigUpdate;
 import datadog.trace.api.debugger.DebuggerConfigUpdater;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,24 +13,34 @@ class DefaultDebuggerConfigUpdater implements DebuggerConfigUpdater {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDebuggerConfigUpdater.class);
 
+  private final Config config;
+
+  public DefaultDebuggerConfigUpdater(Config config) {
+    this.config = config;
+  }
+
   @Override
   public void updateConfig(DebuggerConfigUpdate update) {
     startOrStopFeature(
+        config,
         DebuggerConfig.DYNAMIC_INSTRUMENTATION_ENABLED,
         update.getDynamicInstrumentationEnabled(),
         DebuggerAgent::startDynamicInstrumentation,
         DebuggerAgent::stopDynamicInstrumentation);
     startOrStopFeature(
+        config,
         DebuggerConfig.EXCEPTION_REPLAY_ENABLED,
         update.getExceptionReplayEnabled(),
         DebuggerAgent::startExceptionReplay,
         DebuggerAgent::stopExceptionReplay);
     startOrStopFeature(
+        config,
         TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED,
         update.getCodeOriginEnabled(),
         DebuggerAgent::startCodeOriginForSpans,
         DebuggerAgent::stopCodeOriginForSpans);
     startOrStopFeature(
+        config,
         DebuggerConfig.DISTRIBUTED_DEBUGGER_ENABLED,
         update.getDistributedDebuggerEnabled(),
         DebuggerAgent::startDistributedDebugger,
@@ -62,14 +73,18 @@ class DefaultDebuggerConfigUpdater implements DebuggerConfigUpdater {
   }
 
   private static void startOrStopFeature(
-      String booleanKey, Boolean currentStatus, Runnable start, Runnable stop) {
+      Config config,
+      String booleanKey,
+      Boolean currentStatus,
+      Consumer<Config> start,
+      Runnable stop) {
     if (isExplicitlyDisabled(booleanKey)) {
       LOGGER.debug("Feature {} is explicitly disabled", booleanKey);
       return;
     }
     if (currentStatus != null) {
       if (currentStatus) {
-        start.run();
+        start.accept(config);
       } else {
         stop.run();
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdaterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
+import datadog.trace.api.Config;
 import datadog.trace.api.debugger.DebuggerConfigUpdate;
 import java.lang.instrument.Instrumentation;
 import org.junit.jupiter.api.Test;
@@ -17,8 +18,9 @@ class DefaultDebuggerConfigUpdaterTest {
   public void enableDisable() {
     SharedCommunicationObjects sco = mock(SharedCommunicationObjects.class);
     when(sco.featuresDiscovery(any())).thenReturn(mock(DDAgentFeaturesDiscovery.class));
-    DebuggerAgent.run(mock(Instrumentation.class), sco);
-    DefaultDebuggerConfigUpdater productConfigUpdater = new DefaultDebuggerConfigUpdater();
+    DebuggerAgent.run(Config.get(), mock(Instrumentation.class), sco);
+    DefaultDebuggerConfigUpdater productConfigUpdater =
+        new DefaultDebuggerConfigUpdater(Config.get());
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate());
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate(true, true, true, true));
     assertTrue(productConfigUpdater.isDynamicInstrumentationEnabled());


### PR DESCRIPTION
# What Does This Do
Inject a config instance to DebuggerAgent and stop rely on Config.get() to be able to provide clean config at any time. add some reset method for reseting static fields
Fix readFromFile test that wasn't at all executed

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
