### PR TITLE
Fix HttpServer AppSec Flaky Tests

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2432,15 +2432,18 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     final BiFunction<RequestContext, IGSpanInfo, Flow<Void>> requestEndedCb =
     ({ RequestContext rqCtxt, IGSpanInfo info ->
-      Context context = rqCtxt.getData(RequestContextSlot.APPSEC)
-      if (context.responseBodyTag) {
-        rqCtxt.traceSegment.setTagTop('response.body', context.responseBody)
-      }
-      if (context.extraSpanName) {
-        runUnderTrace(context.extraSpanName, false) {
-          def span = activeSpan()
-          context.tags.each { key, val ->
-            span.setTag(key, val)
+      Object contextObj = rqCtxt.getData(RequestContextSlot.APPSEC)
+      if (contextObj instanceof Context) {
+        Context context = (Context) contextObj
+        if (context.responseBodyTag) {
+          rqCtxt.traceSegment.setTagTop('response.body', context.responseBody)
+        }
+        if (context.extraSpanName) {
+          runUnderTrace(context.extraSpanName, false) {
+            def span = activeSpan()
+            context.tags.each { key, val ->
+              span.setTag(key, val)
+            }
           }
         }
       }
@@ -2649,8 +2652,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     final BiFunction<RequestContext, String, Flow<Void>> requestSessionCb =
     { RequestContext rqCtxt, String sessionId ->
-      Context context = rqCtxt.getData(RequestContextSlot.APPSEC)
-      if (sessionId != null) {
+      Object contextObj = rqCtxt.getData(RequestContextSlot.APPSEC)
+      if (contextObj instanceof Context && sessionId != null) {
+        Context context = (Context) contextObj
         context.extraSpanName = 'appsec-span'
         context.tags.put(IG_SESSION_ID_TAG, sessionId)
       }


### PR DESCRIPTION
# What Does This Do

Fix flaky tests for HttpServer AppSec by adding proper type checks in Instrumentation Gateway (IG) callbacks. The test callbacks in `HttpServerTest` were accessing the context from `RequestContextSlot.APPSEC` without verifying it was the test's `IGCallbacks.Context` type. When AppSec is enabled, it stores its own `AppSecRequestContext` in that slot, causing the callbacks to fail when trying to access test-specific properties like `extraSpanName` and `tags`.

This fix adds `instanceof Context` checks in both `requestSessionCb` and `requestEndedCb` to ensure the callbacks only operate when the test's context is present, preventing `NullPointerException` and property access errors.

# Motivation

The test `test session id publishes to IG` in `Jetty10V1ForkedTest` (and potentially other HTTP server tests) was flaky, failing intermittently with:
```
Condition not satisfied:
span != null
|    |
null false
```

This occurred because the `appsec-span` span was never created when AppSec's context was stored instead of the test's context. By adding proper type checks, the callbacks gracefully handle both scenarios and only create the span when the test's context is available.

# Additional Notes

- The fix ensures backward compatibility - if the test's context is not present, the callbacks simply return without error
- This affects all HTTP server tests that extend `HttpServerTest`, including Jetty, Tomcat, Vert.x, and others
- The fix is defensive programming that prevents failures when AppSec instrumentation is active during tests

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
