### PR TITLE
Replace `groovy.servlet` with `javax.servlet` to reduce dependency on Groovy.

### DIFF
--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/src/test/groovy/TestServlet2.groovy
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/src/test/groovy/TestServlet2.groovy
@@ -1,7 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
-import groovy.servlet.AbstractHttpServlet
 
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -19,7 +19,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_B
 
 class TestServlet2 {
 
-  static class Sync extends AbstractHttpServlet {
+  static class Sync extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       req.getRequestDispatcher()

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/test/groovy/JettyServlet3Test.groovy
@@ -13,7 +13,6 @@ import datadog.context.Context
 
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_CONTEXT_ATTRIBUTE
-import groovy.servlet.AbstractHttpServlet
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
@@ -26,6 +25,7 @@ import javax.servlet.AsyncListener
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 import javax.servlet.annotation.WebServlet
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -423,7 +423,7 @@ class JettyServlet3TestDispatchAsync extends JettyServlet3Test {
 
 
 @WebServlet(asyncSupported = true)
-class DispatchTimeoutAsync extends AbstractHttpServlet {
+class DispatchTimeoutAsync extends HttpServlet {
   @Override
   protected void service(HttpServletRequest req, HttpServletResponse resp) {
     def target = req.servletPath.replace("/dispatch", "")
@@ -518,7 +518,7 @@ class JettyServlet3TestAsyncDispatchOnAsyncTimeout extends JettyServlet3Test {
 }
 
 @WebServlet(asyncSupported = true)
-class ServeFromOnAsyncTimeout extends AbstractHttpServlet {
+class ServeFromOnAsyncTimeout extends HttpServlet {
   @Override
   protected void service(HttpServletRequest req, HttpServletResponse resp) {
     def context = req.startAsync()

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
@@ -3,11 +3,11 @@ package datadog.trace.instrumentation.servlet3
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint
-import groovy.servlet.AbstractHttpServlet
 
 import javax.servlet.AsyncEvent
 import javax.servlet.AsyncListener
 import javax.servlet.annotation.WebServlet
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.lang.reflect.Field
@@ -49,7 +49,7 @@ class TestServlet3 {
   }
 
   @WebServlet
-  static class Sync extends AbstractHttpServlet {
+  static class Sync extends HttpServlet {
     ServerEndpoint determineEndpoint(HttpServletRequest req) {
       getEndpoint(req)
     }
@@ -129,7 +129,7 @@ class TestServlet3 {
   }
 
   @WebServlet(asyncSupported = true)
-  static class Async extends AbstractHttpServlet {
+  static class Async extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       HttpServerTest.ServerEndpoint endpoint = getEndpoint(req)
@@ -216,7 +216,7 @@ class TestServlet3 {
   }
 
   @WebServlet(asyncSupported = true)
-  static class FakeAsync extends AbstractHttpServlet {
+  static class FakeAsync extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       def context = req.startAsync()
@@ -276,7 +276,7 @@ class TestServlet3 {
   }
 
   @WebServlet(asyncSupported = true)
-  static class DispatchImmediate extends AbstractHttpServlet {
+  static class DispatchImmediate extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       def target = req.servletPath.replace("/dispatch", "")
@@ -285,7 +285,7 @@ class TestServlet3 {
   }
 
   @WebServlet(asyncSupported = true)
-  static class DispatchAsync extends AbstractHttpServlet {
+  static class DispatchAsync extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       def target = req.servletPath.replace("/dispatch", "")
@@ -298,7 +298,7 @@ class TestServlet3 {
 
   // TODO: Add tests for this!
   @WebServlet(asyncSupported = true)
-  static class DispatchRecursive extends AbstractHttpServlet {
+  static class DispatchRecursive extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       if (req.servletPath == "/recursive") {

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/test/groovy/HttpServletResponseTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/test/groovy/HttpServletResponseTest.groovy
@@ -1,11 +1,11 @@
 import datadog.trace.agent.test.InstrumentationSpecification
-import groovy.servlet.AbstractHttpServlet
 
 import javax.servlet.ServletException
 import javax.servlet.ServletOutputStream
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -21,7 +21,7 @@ class HttpServletResponseTest extends InstrumentationSpecification {
   }
 
   def doService(HttpServletRequest request, TestResponse response, Closure<HttpServletResponse> testHandler) {
-    def servlet = new AbstractHttpServlet() {
+    def servlet = new HttpServlet() {
         @Override
         protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
           testHandler(resp)

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/test/groovy/HttpServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/test/groovy/HttpServletTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.InstrumentationSpecification
-import groovy.servlet.AbstractHttpServlet
 
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -124,7 +124,7 @@ class HttpServletTest extends InstrumentationSpecification {
     }
   }
 
-  static class TestServlet extends AbstractHttpServlet {
+  static class TestServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
     }


### PR DESCRIPTION
# What Does This Do
Replace `groovy.servlet.AbstractHttpServlet` with `javax.servlet.HttpServlet`.

# Motivation
Reduce dependency on Groovy.

# Additional Notes
Found no evidence that we need to use groovy servlet.