### PR TITLE
🍒 9952 - exclude check-big-regression when merging backport PRs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -78,6 +78,8 @@ check-big-regressions:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
+    - if: '$CI_COMMIT_BRANCH =~ /backport-pr-/'
+      when: never
     - if: '$CI_COMMIT_BRANCH !~ /^(master|release\/)/'
       when: on_success
     - when: never


### PR DESCRIPTION
Backport #9952 to release/v1.55.x