### PR TITLE
Use `ClassFile` parser when pre-loading class hierarchies

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/PreloadHierarchy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/PreloadHierarchy.java
@@ -1,7 +1,8 @@
 package datadog.trace.agent.tooling.bytebuddy.memoize;
 
+import datadog.instrument.classmatch.ClassFile;
+import datadog.instrument.classmatch.ClassHeader;
 import datadog.trace.bootstrap.instrumentation.classloading.ClassDefining;
-import net.bytebuddy.jar.asm.ClassReader;
 
 /** Ensures superclasses and interfaces are loaded before classes that extend/implement them. */
 final class PreloadHierarchy implements ClassDefining.Observer {
@@ -22,12 +23,12 @@ final class PreloadHierarchy implements ClassDefining.Observer {
         return; // ignore non-standard formats like J9 ROMs
       }
       // minimal parsing of bytecode to get name of superclass and any interfaces
-      ClassReader cr = new ClassReader(bytecode, offset, length);
-      String superName = cr.getSuperName();
+      ClassHeader header = ClassFile.header(bytecode, offset);
+      String superName = header.superName;
       if (null != superName && !"java/lang/Object".equals(superName)) {
         preload(loader, superName);
       }
-      for (String interfaceName : cr.getInterfaces()) {
+      for (String interfaceName : header.interfaces) {
         preload(loader, interfaceName);
       }
     } catch (Throwable ignore) {


### PR DESCRIPTION
# Motivation

We already parse bytecode just before classes are defined so we can pre-load super-classes and interfaces before the type using them (this ordering is not necessarily guaranteed by the JVM.) This pre-loading helps get the most out of type hierarchy optimizations such as memoization.

This PR switches this parsing to use our optimized class header parser instead of ASM.

The difference is more noticeable in large applications that load lots of classes.

For example, time taken to parse the classes in `spring-web` - lower number is better:
```
ClassFileBenchmark.testAsmHeader     avgt    5   974.185 ± 28.863  us/op
ClassFileBenchmark.testClassHeader   avgt    5   747.816 ± 14.464  us/op
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
