### PR TITLE
Instrumentation test error visibility

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationContext.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationContext.java
@@ -24,7 +24,10 @@ public class InstrumentationContext {
   public static <K, C> ContextStore<K, C> get(
       final Class<K> keyClass, final Class<C> contextClass) {
     throw new RuntimeException(
-        "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)");
+        "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)."
+            + " If you get this exception, this method has not been rewritten."
+            + " Ensure instrumentation class has a contextStore method and the call to InstrumentationContext.get happens directly in an instrumentation Advice class."
+            + " See how_instrumentations_work.md for details.");
   }
 
   /**
@@ -35,6 +38,9 @@ public class InstrumentationContext {
    */
   public static <K, C> ContextStore<K, C> get(final String keyClass, final String contextClass) {
     throw new RuntimeException(
-        "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)");
+        "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)."
+            + " If you get this exception, this method has not been rewritten."
+            + " Ensure instrumentation class has a contextStore method and the call to InstrumentationContext.get happens directly in an instrumentation Advice class."
+            + " See how_instrumentations_work.md for details.");
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationErrors.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationErrors.java
@@ -1,21 +1,36 @@
 package datadog.trace.bootstrap;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class InstrumentationErrors {
-  private static final AtomicLong COUNTER = new AtomicLong();
+  private static final List<String> ERRORS = new CopyOnWriteArrayList<>();
+  private static volatile boolean recordErrors = false;
 
-  public static long getErrorCount() {
-    return COUNTER.get();
-  }
-
+  /**
+   * Record an error from {@link datadog.trace.agent.tooling.bytebuddy.ExceptionHandlers} for test
+   * visibility.
+   */
   @SuppressWarnings("unused")
-  public static void incrementErrorCount() {
-    COUNTER.incrementAndGet();
+  public static void recordError(final Throwable throwable) {
+    if (recordErrors) {
+      StringWriter stackTrace = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(stackTrace));
+      ERRORS.add(stackTrace.toString());
+    }
   }
 
   // Visible for testing
-  public static void resetErrorCount() {
-    COUNTER.set(0);
+  public static void enableRecordingAndReset() {
+    recordErrors = true;
+    ERRORS.clear();
+  }
+
+  // Visible for testing
+  public static List<String> getErrors() {
+    return Collections.unmodifiableList(ERRORS);
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
@@ -43,7 +43,7 @@ public class ExceptionHandlers {
               //
               // BlockingExceptionHandler.rethrowIfBlockingException(t); // when appSecEnabled=true
               // try {
-              //   InstrumentationErrors.incrementErrorCount();
+              //   InstrumentationErrors.recordError(t);
               //   org.slf4j.LoggerFactory.getLogger((Class)ExceptionLogger.class)
               //     .error("Failed to handle exception in instrumentation for ...", t);
               //   System.exit(1); // when exitOnFailure=true
@@ -71,12 +71,14 @@ public class ExceptionHandlers {
 
               mv.visitTryCatchBlock(logStart, logEnd, eatException, "java/lang/Throwable");
               mv.visitLabel(logStart);
-              // invoke incrementAndGet on our exception counter
+              mv.visitInsn(Opcodes.DUP); // stack: (top) throwable,throwable
+              // invoke recordError on our exception tracker
               mv.visitMethodInsn(
                   Opcodes.INVOKESTATIC,
                   "datadog/trace/bootstrap/InstrumentationErrors",
-                  "incrementErrorCount",
-                  "()V");
+                  "recordError",
+                  "(Ljava/lang/Throwable;)V");
+
               // stack: (top) throwable
               mv.visitLdcInsn(Type.getType("L" + HANDLER_NAME + ";"));
               mv.visitMethodInsn(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
@@ -39,24 +39,14 @@ public class ExceptionHandlers {
               final boolean exitOnFailure = InstrumenterConfig.get().isInternalExitOnFailure();
               final String logMethod = exitOnFailure ? "error" : "debug";
 
-              // Writes the following bytecode if exitOnFailure is false:
+              // Writes the following bytecode (note that two statements are conditionally written):
               //
-              // BlockingExceptionHandler.rethrowIfBlockingException(t);
-              // try {
-              //   InstrumentationErrors.incrementErrorCount();
-              //   org.slf4j.LoggerFactory.getLogger((Class)ExceptionLogger.class)
-              //     .debug("Failed to handle exception in instrumentation for ...", t);
-              // } catch (Throwable t2) {
-              // }
-              //
-              // And the following bytecode if exitOnFailure is true:
-              //
-              // BlockingExceptionHandler.rethrowIfBlockingException(t);
+              // BlockingExceptionHandler.rethrowIfBlockingException(t); // when appSecEnabled=true
               // try {
               //   InstrumentationErrors.incrementErrorCount();
               //   org.slf4j.LoggerFactory.getLogger((Class)ExceptionLogger.class)
               //     .error("Failed to handle exception in instrumentation for ...", t);
-              //   System.exit(1);
+              //   System.exit(1); // when exitOnFailure=true
               // } catch (Throwable t2) {
               // }
               //

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleCheck.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleCheck.java
@@ -3,13 +3,18 @@ package datadog.trace.agent.tooling.muzzle;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.InstrumenterState;
 import datadog.trace.agent.tooling.Utils;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MuzzleCheck implements ElementMatcher<ClassLoader> {
   private static final Logger log = LoggerFactory.getLogger(MuzzleCheck.class);
+
+  private static final List<String> ERRORS = new CopyOnWriteArrayList<>();
+  private static volatile boolean recordErrors = false;
 
   private final int instrumentationId;
   private final String instrumentationClass;
@@ -33,9 +38,13 @@ public class MuzzleCheck implements ElementMatcher<ClassLoader> {
       InstrumenterState.applyInstrumentation(classLoader, instrumentationId);
     } else {
       InstrumenterState.blockInstrumentation(classLoader, instrumentationId);
-      if (log.isDebugEnabled()) {
+      if (recordErrors || log.isDebugEnabled()) {
         final List<Reference.Mismatch> mismatches =
             muzzle.getMismatchedReferenceSources(classLoader);
+        if (recordErrors) {
+          recordMuzzleMismatch(
+              InstrumenterState.describe(instrumentationId), classLoader, mismatches);
+        }
         log.debug(
             "Muzzled - {} instrumentation.target.classloader={}",
             InstrumenterState.describe(instrumentationId),
@@ -60,5 +69,39 @@ public class MuzzleCheck implements ElementMatcher<ClassLoader> {
               .withReferenceProvider(runtimeMuzzleReferences);
     }
     return muzzle;
+  }
+
+  /**
+   * Record a muzzle mismatch error for test visibility.
+   *
+   * @param instrumentationDescription the description of the instrumentation that was blocked
+   * @param classLoader the classloader where the instrumentation was blocked
+   * @param mismatches the list of mismatch details
+   */
+  private static void recordMuzzleMismatch(
+      String instrumentationDescription,
+      ClassLoader classLoader,
+      List<Reference.Mismatch> mismatches) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Muzzled - ")
+        .append(instrumentationDescription)
+        .append(" instrumentation.target.classloader=")
+        .append(classLoader)
+        .append("\n");
+    for (Reference.Mismatch mismatch : mismatches) {
+      sb.append("  Mismatch: ").append(mismatch).append("\n");
+    }
+    ERRORS.add(sb.toString());
+  }
+
+  // Visible for testing
+  public static void enableRecordingAndReset() {
+    recordErrors = true;
+    ERRORS.clear();
+  }
+
+  // Visible for testing
+  public static List<String> getErrors() {
+    return Collections.unmodifiableList(ERRORS);
   }
 }

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -25,6 +25,7 @@ import datadog.trace.agent.tooling.InstrumenterModule
 import datadog.trace.agent.tooling.TracerInstaller
 import datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers
 import datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnores
+import datadog.trace.agent.tooling.muzzle.MuzzleCheck
 import datadog.trace.api.Config
 import datadog.trace.api.IdGenerationStrategy
 import datadog.trace.api.ProcessTags
@@ -463,6 +464,7 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
       ActiveSubsystems.APPSEC_ACTIVE = true
     }
     InstrumentationErrors.enableRecordingAndReset()
+    MuzzleCheck.enableRecordingAndReset()
     ProcessTags.reset()
   }
 
@@ -506,6 +508,8 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     }
     def instrumentationErrorCount = InstrumentationErrors.getErrors().size()
     assert instrumentationErrorCount == 0, "${instrumentationErrorCount} instrumentation errors were seen:\n${InstrumentationErrors.getErrors().join("\n---\n")}"
+    def muzzleErrorCount = MuzzleCheck.getErrors().size()
+    assert muzzleErrorCount == 0, "${muzzleErrorCount} muzzle errors were seen:\n${MuzzleCheck.getErrors().join("\n---\n")}"
   }
 
   private void doCheckRepeatedFinish() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 
 /** List writer used by tests mostly */
 public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Writer {
+  public static final int WAIT_FOR_TRACES_TIMEOUT_SECONDS = 20;
+
   private static final Logger log = LoggerFactory.getLogger(ListWriter.class);
   private static final Filter ACCEPT_ALL = trace -> true;
 
@@ -83,7 +85,12 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   public void waitForTraces(final int number) throws InterruptedException, TimeoutException {
-    if (!waitForTracesMax(number, 20)) {
+    waitForTraces(number, WAIT_FOR_TRACES_TIMEOUT_SECONDS);
+  }
+
+  public void waitForTraces(final int number, final int seconds)
+      throws InterruptedException, TimeoutException {
+    if (!waitForTracesMax(number, seconds)) {
       String msg =
           "Timeout waiting for "
               + number


### PR DESCRIPTION
# What Does This Do

This improves visibility of errors in instrumentation tests built on top of `InstrumentationSpecification` by failing the test with details of the errors, in particular these cases:

1. Instrumentation blocked due to MuzzleCheck errors.
2. Throwables caught from instrumentation code and reported to `InstrumentationErrors` by the Byte Buddy `ExceptionHandlers` class.
3. Byte Buddy nstrumentation errors reported to `InstrumentationSpecification`'s `AgentBuilder.Listener.onError`.

Also, `ListWriterAssert.assertTraces` will now fail fast when the errors from the first two cases above are reported.

Lastly, the code comment in `ExceptionHandlers` has been updated to reflect the current implementation and `InstrumentationContext` exceptions are more explicit about the likely causes of why the methods might not have been rewritten.

# Motivation

These changes should reduce discovery and investigation time during development when there are instrumentation errors. Every single one of these issues are ones that I've run while developing instrumentations (most of them I've run into multiple times). ;-) These changes have helped me out enough (particularly for the first two use cases above) that I realized I **really** should see about contributing this back to help others--especially for those new to developing instrumentation, but also to assist those that have been doing it awhile when the inevitable error slips through.

Previously, the first error case above was not checked in tests using `InstrumentationSpecification`, and was only visible in log output, and the other two error cases just included error counts. In all of these cases, the developer would have to go digging in log output to find existence and/or details of errors.

When `ListWriterAssert.assertTraces` was used previously, if there were instrumentation errors that led to traces not being properly generated, tests will often fail due to failed assertions (missing spans, incorrect tags, etc.) and the developer might spend significant time chasing down the cause of the assertion failures to learn it was an instrumentation error. With these changes, if the cause was an underlying instrumentation error, `ListWriterAssert.assertTraces` will fail fast for the first two use cases above and clearly indicate there was an instrumentation error.

These changes will not only help our human developers by giving better context when there are failures, but also when using AI coding assistants.

# Additional Notes

One possible improvement: The fail fast change could easily apply to all of the use cases above including the last use case if `InstrumentationSpecification`'s `AgentBuilder.Listener.onError` recorded the error to `InstrumentationErrors`.

Best reviewed commit-by-commit:

* [ExceptionHandlers: Fix code in bytecode comment](https://github.com/DataDog/dd-trace-java/pull/9979/commits/9e598acaab9f54111c1ebae08237e3d1cb2d0276)
* [InstrumentationContext: be more explicit about the reasons for failure](https://github.com/DataDog/dd-trace-java/pull/9979/commits/2a05f636b695ea01fd5d1a5bb3bccf3e4ebbb209)
* [Add instrumentation error details on test failures](https://github.com/DataDog/dd-trace-java/pull/9979/commits/bc8c0c5c5a7e5accf8da5e794a026d4ef6dd8ca0)
* [Check for blocked instrumentation in tests](https://github.com/DataDog/dd-trace-java/pull/9979/commits/a87cc738e7dce922e7a0e496bbf536bf24909160)
* [Fail fast on muzzle or instrumentation errors](https://github.com/DataDog/dd-trace-java/pull/9979/commits/547e34d0fc2b65341cbc56ee81464d903bbfcee1)

## Example output

### InstrumentationErrors and InstrumentationContext exception

I commented-out the `contextStore` method on `HikariPoolInstrumentation`.

```
Condition not satisfied:

instrumentationErrorCount == 0
|                         |
1                         false

1 instrumentation errors were seen:
java.lang.RuntimeException: Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider). If you get this exception, this method has not been rewritten. Ensure instrumentation class has a contextStore method and the call to InstrumentationContext.get happens directly in an instrumentation Advice class. See how_instrumentations_work.md for details.
	at datadog.trace.bootstrap.InstrumentationContext.get(InstrumentationContext.java:26)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:151)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:73)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:72)

```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
