### PR TITLE
Enable debug logging for JUnitConsoleSmokeTest

### DIFF
--- a/dd-smoke-tests/junit-console/src/test/groovy/datadog/smoketest/JUnitConsoleSmokeTest.groovy
+++ b/dd-smoke-tests/junit-console/src/test/groovy/datadog/smoketest/JUnitConsoleSmokeTest.groovy
@@ -192,6 +192,7 @@ class JUnitConsoleSmokeTest extends CiVisibilitySmokeTest {
 
     List<String> command = new ArrayList<>()
     command.add(javaPath())
+    command.add("-Ddatadog.slf4j.simpleLogger.defaultLogLevel=DEBUG")
     command.addAll((String[]) ["-jar", JUNIT_CONSOLE_JAR_PATH])
     command.addAll(consoleCommand)
     command.addAll([


### PR DESCRIPTION
# What Does This Do

- Enables debug logging for the smoke test.

# Motivation

- The test is flaking more or less consistently (error rate of <2% over the last week), so I'd like to get better context on the failures.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
