### PR TITLE
Fixed right bound for `scala-library` to correctly update latest dependencies.

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   testImplementation libs.scala
 
   latestDepTestImplementation group: 'org.scalikejdbc', name: 'scalikejdbc_2.13', version: '3.+'
-  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '+'
+  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.+' // scala-lang 3.x requires scala 3.x compiler
 
   // jdbc unit testing
   testImplementation group: 'com.h2database', name: 'h2', version: '1.3.169'

--- a/dd-java-agent/instrumentation/scala-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/scala-concurrent/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
   latest11TestImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.11.+'
   latest12TestImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.12.+'
-  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '+'
+  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.+' // scala-lang 3.x requires scala 3.x compiler
   latestDepTestImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
 }
 

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
@@ -70,6 +70,6 @@ dependencies {
   testImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.13.0'
   testImplementation project(':dd-java-agent:instrumentation:scala-promise')
 
-  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '+'
+  latestDepTestImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.+' // scala-lang 3.x requires scala 3.x compiler
   latestDepTestImplementation project(':dd-java-agent:instrumentation:scala-promise')
 }


### PR DESCRIPTION
# What Does This Do
Fixes the version constraint for `scala-library` to correctly resolve the latest dependencies.

# Motivation
Our weekly job that updates the latest dependencies for the dd-trace-java project failed during Scala compilation. The failure occurred because the dependency resolution applied as `v3.8.0`:
```
org.scala-lang:scala-library:3.8.0-RC1=latestDepTestCompileClasspath,latestDepTestRuntimeClasspath
```

# Additional Notes
To address this issue, the right bound for the `scala-library` version was changed from `+` to `2.+`.