### PR TITLE
Fix Java version requirements for OpenFeature tests

### DIFF
--- a/products/feature-flagging/api/build.gradle.kts
+++ b/products/feature-flagging/api/build.gradle.kts
@@ -1,3 +1,4 @@
+import datadog.gradle.plugin.testJvmConstraints.TestJvmConstraintsExtension
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 import groovy.lang.Closure
 
@@ -10,7 +11,9 @@ plugins {
 apply(from = "$rootDir/gradle/java.gradle")
 apply(from = "$rootDir/gradle/publish.gradle")
 
-val minJavaVersionForTests by extra(JavaVersion.VERSION_11)
+configure<TestJvmConstraintsExtension> {
+  minJavaVersion.set(JavaVersion.VERSION_11)
+}
 
 description = "Implementation of the OpenFeature Provider interface."
 


### PR DESCRIPTION
# What Does This Do

This PR fixes the tests requirements for one of the new OpenFeatures modules.

# Motivation

The `master` build is failing on `master`:

> org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':products:feature-flagging:api:test'.

```
org.gradle.api.internal.tasks.testing.TestSuiteExecutionException: Could not execute test class 'datadog.trace.api.openfeature.DDEvaluatorTest'.
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.UnsupportedClassVersionError: JVMCFRE199E bad major version 55.0 of class=datadog/trace/api/openfeature/DDEvaluatorTest, the maximum supported major version is 52.0; offset=6
	at java.lang.ClassLoader.defineClassImpl(Native Method)
```

# Additional Notes

Manual CI trigger with the non default VMs: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/83300885

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
