### PR TITLE
Using stable config when a security manager is enabled should not prevent tracer startup

### DIFF
--- a/utils/config-utils/src/main/java/datadog/trace/bootstrap/config/provider/StableConfigSource.java
+++ b/utils/config-utils/src/main/java/datadog/trace/bootstrap/config/provider/StableConfigSource.java
@@ -28,16 +28,14 @@ public final class StableConfigSource extends ConfigProvider.Source {
   private final StableConfig config;
 
   StableConfigSource(String filePath, ConfigOrigin origin) {
+    StableConfig cfg = StableConfig.EMPTY;
     this.fileOrigin = origin;
-    File file = new File(filePath);
-    if (!file.exists()) {
-      this.config = StableConfig.EMPTY;
-      return;
-    }
-    StableConfig cfg;
     try {
+      File file = new File(filePath);
       log.debug("Stable configuration file found at path: {}", file);
-      cfg = StableConfigParser.parse(filePath);
+      if (file.exists()) {
+        cfg = StableConfigParser.parse(filePath);
+      }
     } catch (Throwable e) {
       if (e instanceof StableConfigMappingException
           || e instanceof IllegalArgumentException
@@ -55,8 +53,6 @@ public final class StableConfigSource extends ConfigProvider.Source {
             filePath,
             e.getMessage());
       }
-
-      cfg = StableConfig.EMPTY;
     }
     this.config = cfg;
   }


### PR DESCRIPTION
# What Does This Do

It avoid prematurely exiting on the premain when a security manager is enabled.

Prevents:

```
RROR datadog.trace.bootstrap.AgentBootstrap
java.lang.IllegalStateException: Unable to start DD Java Agent.
	at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:161)
	at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:73)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at datadog.trace.bootstrap.AgentPreCheck.continueBootstrap(AgentPreCheck.java:169)
	at datadog.trace.bootstrap.AgentPreCheck.agentmain(AgentPreCheck.java:24)
	at datadog.trace.bootstrap.AgentPreCheck.premain(AgentPreCheck.java:17)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:560)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:572)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:159)
	... 10 more
Caused by: java.lang.ExceptionInInitializerError
	at datadog.trace.bootstrap.Agent.isFeatureEnabled(Agent.java:1507)
	at datadog.trace.bootstrap.Agent.configureCiVisibility(Agent.java:470)
	at datadog.trace.bootstrap.Agent.start(Agent.java:241)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	... 12 more
Caused by: java.security.AccessControlException: access denied ("java.io.FilePermission" "/etc/datadog-agent/application_monitoring.yaml" "read")
	at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:488)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:1071)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:411)
	at java.base/java.lang.SecurityManager.checkRead(SecurityManager.java:742)
	at java.base/java.io.File.exists(File.java:831)
	at datadog.trace.bootstrap.config.provider.StableConfigSource.<init>(StableConfigSource.java:33)
	at datadog.trace.bootstrap.config.provider.StableConfigSource.<clinit>(StableConfigSource.java:21)
	... 16 more
```

# Motivation

Avoid exiting the agent premain too early because the config throws an unexpected SecurityException

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
