### PR TITLE
Fix race condition Exception Replay smoke tests

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
@@ -114,6 +114,7 @@ public abstract class AbstractExceptionDebugger implements DebuggerContext.Excep
   private void applyExceptionConfiguration(String fingerprint) {
     configurationUpdater.accept(EXCEPTION, exceptionProbeManager.getProbes());
     exceptionProbeManager.addFingerprint(fingerprint);
+    LOGGER.debug("Exception Fingerprint {} added", fingerprint);
   }
 
   protected void addStackFrameTags(

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -98,6 +98,16 @@ public class ServerDebuggerTestApplication {
     }
   }
 
+  protected void waitForExceptionFingerprint() {
+    System.out.println("waitForExceptionFingerprint");
+    try {
+      TestApplicationHelper.waitForExceptionFingerprint(LOG_FILENAME);
+      System.out.println("fingerprint added!");
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+  }
+
   protected void waitForSpecificLine(String line) {
     System.out.println("waitForSpecificLine...");
     try {
@@ -279,6 +289,11 @@ public class ServerDebuggerTestApplication {
           {
             String className = request.getRequestUrl().queryParameter("classname");
             app.waitForReTransformation(className);
+            break;
+          }
+        case "/app/waitForExceptionFingerprint":
+          {
+            app.waitForExceptionFingerprint();
             break;
           }
         case "/app/waitForSpecificLine":

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
@@ -23,6 +23,8 @@ public class TestApplicationHelper {
       "[dd-remote-config] DEBUG com.datadog.debugger.agent.ConfigurationUpdater - Re-transforming class: %s";
   private static final String RETRANSFORMATION_DONE =
       "com.datadog.debugger.agent.ConfigurationUpdater - Re-transformation done";
+  private static final String EXCEPTION_FINGERPRINT_ADDED =
+      "DEBUG com.datadog.debugger.exception.AbstractExceptionDebugger - Exception Fingerprint ";
   private static final long SLEEP_MS = 100;
   private static final long TIMEOUT_S = 10;
 
@@ -88,6 +90,10 @@ public class TestApplicationHelper {
         () -> {},
         Duration.ofMillis(SLEEP_MS),
         Duration.ofSeconds(TIMEOUT_S));
+  }
+
+  public static String waitForExceptionFingerprint(String logFileName) throws IOException {
+    return waitForSpecificLine(logFileName, EXCEPTION_FINGERPRINT_ADDED, null);
   }
 
   public static String waitForSpecificLine(String logFileName, String specificLine, String fromLine)

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/AgentDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/AgentDebuggerIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.probe.LogProbe;
+import datadog.trace.test.util.NonRetryable;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@NonRetryable
 public class AgentDebuggerIntegrationTest extends SimpleAppDebuggerIntegrationTest {
   @Test
   @DisplayName("testLatestJdk")

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
@@ -8,12 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.test.agent.decoder.DecodedSpan;
+import datadog.trace.test.util.NonRetryable;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@NonRetryable
 public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest {
 
   @Override
@@ -45,7 +47,7 @@ public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAME_METHOD));
                 assertEquals(
                     "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAME_SIGNATURE));
-                assertEquals("146", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
+                assertEquals("156", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
                 codeOrigin.set(true);
               }
             }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
@@ -10,7 +10,6 @@ import datadog.environment.JavaVirtualMachine;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.test.agent.decoder.DecodedSpan;
 import datadog.trace.test.agent.decoder.DecodedTrace;
-import datadog.trace.test.util.Flaky;
 import datadog.trace.test.util.NonRetryable;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
 @NonRetryable
-@Flaky
 public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrationTest {
 
   private List<String> snapshotIdTags = new ArrayList<>();
@@ -59,7 +57,7 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
   void testSimpleSingleFrameException() throws Exception {
     appUrl = startAppAndAndGetUrl();
     execute(appUrl, TRACED_METHOD_NAME, "oops"); // instrumenting first exception
-    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS, false);
+    waitForExceptionFingerprint();
     execute(appUrl, TRACED_METHOD_NAME, "oops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);
@@ -127,7 +125,7 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
   void test3CapturedFrames() throws Exception {
     appUrl = startAppAndAndGetUrl();
     execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // instrumenting first exception
-    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS, false);
+    waitForExceptionFingerprint();
     execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);
@@ -185,7 +183,7 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
     additionalJvmArgs.add("-Ddd.exception.replay.capture.max.frames=5");
     appUrl = startAppAndAndGetUrl();
     execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // instrumenting first exception
-    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS, false);
+    waitForExceptionFingerprint();
     execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);
@@ -262,7 +260,7 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
   void test3CapturedRecursiveFrames() throws Exception {
     appUrl = startAppAndAndGetUrl();
     execute(appUrl, TRACED_METHOD_NAME, "recursiveOops"); // instrumenting first exception
-    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS, false);
+    waitForExceptionFingerprint();
     execute(appUrl, TRACED_METHOD_NAME, "recursiveOops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);
@@ -310,7 +308,7 @@ public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrati
     additionalJvmArgs.add("-XX:+ShowHiddenFrames");
     appUrl = startAppAndAndGetUrl();
     execute(appUrl, TRACED_METHOD_NAME, "lambdaOops"); // instrumenting first exception
-    waitForInstrumentation(appUrl, SERVER_DEBUGGER_TEST_APP_CLASS, false);
+    waitForExceptionFingerprint();
     execute(appUrl, TRACED_METHOD_NAME, "lambdaOops"); // collecting snapshots and sending them
     registerTraceListener(this::receiveExceptionReplayTrace);
     registerSnapshotListener(this::receiveSnapshot);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -1,6 +1,7 @@
 package datadog.smoketest;
 
 import com.datadog.debugger.probe.LogProbe;
+import datadog.trace.test.util.NonRetryable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@NonRetryable
 public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegrationTest {
   private List<String> additionalJvmArgs = new ArrayList<>();
 
@@ -46,7 +48,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
     LogProbe probe =
         LogProbe.builder()
             .probeId(LINE_PROBE_ID1)
-            .where("ServerDebuggerTestApplication.java", 312)
+            .where("ServerDebuggerTestApplication.java", 327)
             .build();
     setCurrentConfiguration(createConfig(probe));
     waitForFeatureStarted(appUrl, "Dynamic Instrumentation");

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -24,6 +24,7 @@ import datadog.environment.JavaVirtualMachine;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.test.util.NonRetryable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+@NonRetryable
 public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
   @Test
   @DisplayName("testInaccessibleObject")

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -7,12 +7,14 @@ import com.datadog.debugger.agent.ProbeStatus;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.MetricProbe;
+import datadog.trace.test.util.NonRetryable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@NonRetryable
 public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
 
   @AfterEach

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.agent.ProbeStatus;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.test.util.NonRetryable;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+@NonRetryable
 public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest {
 
   @BeforeEach

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
@@ -128,6 +128,13 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
     LOG.info("instrumentation done");
   }
 
+  protected void waitForExceptionFingerprint() throws Exception {
+    String url = String.format(appUrl + "/waitForExceptionFingerprint");
+    LOG.info("waitForExceptionFingerprint with url={}", url);
+    sendRequest(url);
+    LOG.info("exceptionFingerprint added");
+  }
+
   protected void waitForAProbeStatus(ProbeStatus.Status status) throws Exception {
     AtomicBoolean statusResult = new AtomicBoolean();
     registerProbeStatusListener(

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
@@ -18,6 +18,7 @@ import com.datadog.debugger.el.expressions.BooleanExpression;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.test.agent.decoder.DecodedSpan;
+import datadog.trace.test.util.NonRetryable;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+@NonRetryable
 public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerIntegrationTest {
 
   @BeforeEach

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.datadog.debugger.agent.ProbeStatus;
 import com.datadog.debugger.probe.SpanProbe;
 import datadog.trace.test.agent.decoder.DecodedSpan;
+import datadog.trace.test.util.NonRetryable;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+@NonRetryable
 public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
 
   @Override

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.agent.test.utils.PortUtils;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.test.util.NonRetryable;
 import datadog.trace.util.TagsHelper;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@NonRetryable
 public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
 
   private static final String DEBUGGER_TEST_APP_CLASS =


### PR DESCRIPTION
# What Does This Do
need to wait for having added the fingerprint into the Concurrent Map otherwise it will try to reinstrument the exception on the second call Generalize the usage of NonRetryable annotation because all debugger smoke tests rely on the fact that they are run only once (log file naming)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
