### PR TITLE
Avoid expensive `Class.getMethod` call in code-origin advice

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.debugger;
 
+import datadog.instrument.asm.Type;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -100,7 +101,7 @@ public class DebuggerContext {
   public interface CodeOriginRecorder {
     String captureCodeOrigin(boolean entry);
 
-    String captureCodeOrigin(Method method, boolean entry);
+    String captureCodeOrigin(String typeName, String methodName, String descriptor, boolean entry);
   }
 
   private static volatile ProbeResolver probeResolver;
@@ -506,11 +507,27 @@ public class DebuggerContext {
     }
   }
 
+  public static void captureCodeOrigin(
+      String typeName, String methodName, String descriptor, boolean entry) {
+    try {
+      CodeOriginRecorder recorder = codeOriginRecorder;
+      if (recorder != null) {
+        recorder.captureCodeOrigin(typeName, methodName, descriptor, entry);
+      }
+    } catch (Exception ex) {
+      LOGGER.debug("Error in captureCodeOrigin: ", ex);
+    }
+  }
+
   public static void captureCodeOrigin(Method method, boolean entry) {
     try {
       CodeOriginRecorder recorder = codeOriginRecorder;
       if (recorder != null) {
-        recorder.captureCodeOrigin(method, entry);
+        recorder.captureCodeOrigin(
+            method.getDeclaringClass().getName(),
+            method.getName(),
+            Type.getMethodDescriptor(method),
+            entry);
       }
     } catch (Exception ex) {
       LOGGER.debug("Error in captureCodeOrigin: ", ex);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.DDTags.*;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
 import com.datadog.debugger.exception.Fingerprinter;
+import com.datadog.debugger.instrumentation.Types;
 import com.datadog.debugger.probe.CodeOriginProbe;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.LogProbe.Builder;
@@ -20,7 +21,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -82,11 +82,13 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   }
 
   @Override
-  public String captureCodeOrigin(Method method, boolean entry) {
-    String fingerprint = method.toString();
+  public String captureCodeOrigin(
+      String typeName, String methodName, String descriptor, boolean entry) {
+    String fingerprint = typeName + "." + methodName + descriptor;
     CodeOriginProbe probe = probesByFingerprint.get(fingerprint);
     if (probe == null) {
-      probe = createProbe(fingerprint, entry, Where.of(method));
+      String signature = Types.descriptorToSignature(descriptor);
+      probe = createProbe(fingerprint, entry, Where.of(typeName, methodName, signature));
       LOG.debug("Creating probe for method {}", fingerprint);
     }
     return probe.getId();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -1,7 +1,5 @@
 package com.datadog.debugger.probe;
 
-import static java.util.Arrays.stream;
-
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.Types;
 import com.datadog.debugger.util.ClassFileLines;
@@ -9,14 +7,12 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -50,13 +46,8 @@ public class Where {
     return new Where(typeName, methodName, signature, lines, null);
   }
 
-  public static Where of(Method method) {
-    return of(
-        method.getDeclaringClass().getName(),
-        method.getName(),
-        stream(method.getParameterTypes())
-            .map(Class::getTypeName)
-            .collect(Collectors.joining(", ", "(", ")")));
+  public static Where of(String typeName, String methodName, String signature) {
+    return new Where(typeName, methodName, signature, (SourceLine[]) null, null);
   }
 
   protected static SourceLine[] sourceLines(String[] defs) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -133,8 +133,8 @@ public class CodeOriginTest extends CapturingTestBase {
     final String className = "com.datadog.debugger.CodeOrigin02";
     installProbes();
     final Class<?> testClass = compileAndLoadClass(className);
-    codeOriginRecorder.captureCodeOrigin(testClass.getMethod("entry"), true);
-    codeOriginRecorder.captureCodeOrigin(testClass.getMethod("exit"), false);
+    codeOriginRecorder.captureCodeOrigin(className, "entry", "()", true);
+    codeOriginRecorder.captureCodeOrigin(className, "exit", "()", false);
     checkResults(testClass, "fullTrace", 0);
     checkResults(testClass, "debug_1", 2);
   }
@@ -145,8 +145,8 @@ public class CodeOriginTest extends CapturingTestBase {
     installProbes(
         createProbeBuilder(PROBE_ID, CLASS_NAME, "entry", "()").captureSnapshot(true).build());
     final Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    codeOriginRecorder.captureCodeOrigin(testClass.getMethod("entry"), true);
-    codeOriginRecorder.captureCodeOrigin(testClass.getMethod("exit"), false);
+    codeOriginRecorder.captureCodeOrigin(CLASS_NAME, "entry", "()", true);
+    codeOriginRecorder.captureCodeOrigin(CLASS_NAME, "exit", "()", false);
     checkResults(testClass, "debug_1", 3);
   }
 
@@ -230,7 +230,7 @@ public class CodeOriginTest extends CapturingTestBase {
     installProbes();
     CodeOriginProbe probe =
         codeOriginRecorder.getProbe(
-            codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true));
+            codeOriginRecorder.captureCodeOrigin(CLASS_NAME, "main", "(I)", true));
     assertNotNull(probe, "The probe should have been created.");
     assertTrue(probe.entrySpanProbe(), "Should be an entry probe.");
   }
@@ -241,10 +241,8 @@ public class CodeOriginTest extends CapturingTestBase {
     final String CLASS_NAME = "com.datadog.debugger.CodeOrigin04";
     final Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     installProbes();
-    String probe1 =
-        codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true);
-    String probe2 =
-        codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true);
+    String probe1 = codeOriginRecorder.captureCodeOrigin(CLASS_NAME, "main", "(I)", true);
+    String probe2 = codeOriginRecorder.captureCodeOrigin(CLASS_NAME, "main", "(I)", true);
     assertEquals(probe1, probe2);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTestAdvice.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTestAdvice.java
@@ -3,15 +3,17 @@ package com.datadog.debugger.origin;
 import static datadog.trace.bootstrap.debugger.DebuggerContext.captureCodeOrigin;
 import static datadog.trace.bootstrap.debugger.DebuggerContext.marker;
 
-import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 
 public class CodeOriginTestAdvice {
 
   @Advice.OnMethodEnter
   @SuppressWarnings("bytebuddy-exception-suppression")
-  public static void onEnter(@Advice.Origin final Method method) {
+  public static void onEnter(
+      @Advice.Origin("#t") String typeName,
+      @Advice.Origin("#m") String methodName,
+      @Advice.Origin("#d") String descriptor) {
     marker();
-    captureCodeOrigin(method, true);
+    captureCodeOrigin(typeName, methodName, descriptor, true);
   }
 }

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
@@ -8,8 +8,6 @@ import datadog.trace.instrumentation.micronaut.v4_0.MicronautDecorator
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import test.MicronautServer
 
-import java.lang.reflect.Method
-
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -35,7 +33,7 @@ class MicronautTest extends HttpServerTest<Object> {
         }
 
         @Override
-        String captureCodeOrigin(Method method, boolean entry) {
+        String captureCodeOrigin(String typeName, String methodName, String descriptor, boolean entry) {
           invoked = true
           return "done"
         }

--- a/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/EntrySpanOriginAdvice.java
+++ b/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/EntrySpanOriginAdvice.java
@@ -3,15 +3,17 @@ package datadog.trace.instrumentation.codeorigin;
 import static datadog.trace.bootstrap.debugger.DebuggerContext.captureCodeOrigin;
 import static datadog.trace.bootstrap.debugger.DebuggerContext.marker;
 
-import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 
 public class EntrySpanOriginAdvice {
 
   @Advice.OnMethodEnter
   @SuppressWarnings("bytebuddy-exception-suppression")
-  public static void onEnter(@Advice.Origin final Method method) {
+  public static void onEnter(
+      @Advice.Origin("#t") String typeName,
+      @Advice.Origin("#m") String methodName,
+      @Advice.Origin("#d") String descriptor) {
     marker();
-    captureCodeOrigin(method, true);
+    captureCodeOrigin(typeName, methodName, descriptor, true);
   }
 }


### PR DESCRIPTION
# What Does This Do

Avoids repeated calls to `Class.getMethod(...)` when setting up code-origins.

# Motivation

We don't need the full `Method` reflection data; only the declaring type, method name, and method descriptor. Changing the `@Advice.Origin` byte-buddy annotation to provide them as separate strings means byte-buddy can store them as constants.

Before this PR, the bytecode inserted by `EntrySpanOriginAdvice` looked like:
```
      stack=7, locals=3, args_size=2
         0: invokestatic  #223                // Method datadog/trace/bootstrap/debugger/DebuggerContext.marker:()V
         3: ldc           #10                 // class org/springframework/samples/petclinic/owner/OwnerController
         5: ldc           #246                // String showOwner
         7: iconst_1
         8: anewarray     #226                // class java/lang/Class
        11: dup
        12: iconst_0
        13: getstatic     #231                // Field java/lang/Integer.TYPE:Ljava/lang/Class;
        16: aastore
        17: invokevirtual #236                // Method java/lang/Class.getMethod:(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
        20: iconst_1
        21: invokestatic  #240                // Method datadog/trace/bootstrap/debugger/DebuggerContext.captureCodeOrigin:(Ljava/lang/reflect/Method;Z)V
```

After this PR it looks like:
```
      stack=4, locals=3, args_size=2
         0: invokestatic  #223                // Method datadog/trace/bootstrap/debugger/DebuggerContext.marker:()V
         3: ldc           #225                // String org.springframework.samples.petclinic.owner.OwnerController
         5: ldc           #242                // String showOwner
         7: ldc           #243                // String (I)Lorg/springframework/web/servlet/ModelAndView;
         9: iconst_1
        10: invokestatic  #231                // Method datadog/trace/bootstrap/debugger/DebuggerContext.captureCodeOrigin:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
```

The Java 8 JDK also appears to have an intermittent class redefinition bug which is triggered by these repeated calls to `getMethod`. Transforming a class that's in the middle of calling `Class.getMethod(...)` seems in rare situations on Java 8 to either cause that `getMethod` call to throw `NegativeArraySizeException` or lead to a native error as reported in https://github.com/DataDog/dd-trace-java/issues/10017

Note that this link has not been confirmed because we have not been able to recreate the error locally in order to verify this fix. However, given the current data simplifying the code-origin setup advice should also help with the reported issue.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4768]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4768]: https://datadoghq.atlassian.net/browse/DEBUG-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ