### PR TITLE
Disable CodeOrigin by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -49,7 +49,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_WRITER_BAGGAGE_INJECT = true;
   static final String DEFAULT_SITE = "datadoghq.com";
 
-  static final boolean DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED = true;
+  static final boolean DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED = false;
   static final int DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES = 8;
   static final boolean DEFAULT_TRACE_SPAN_ORIGIN_ENRICHED = false;
   static final boolean DEFAULT_TRACE_ENABLED = true;

--- a/internal-api/src/test/groovy/datadog/trace/api/debugger/DebuggerConfigBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/debugger/DebuggerConfigBridgeTest.groovy
@@ -15,7 +15,7 @@ class DebuggerConfigBridgeTest extends Specification {
     then:
     !DebuggerConfigBridge.isDynamicInstrumentationEnabled()
     !DebuggerConfigBridge.isExceptionReplayEnabled()
-    DebuggerConfigBridge.isCodeOriginEnabled()
+    !DebuggerConfigBridge.isCodeOriginEnabled()
     !DebuggerConfigBridge.isDistributedDebuggerEnabled()
 
     when:


### PR DESCRIPTION
# What Does This Do

# Motivation
it seems to lead to crashes on JDK8

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4768]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4768]: https://datadoghq.atlassian.net/browse/DEBUG-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ