### PR TITLE
Fix system tests check step

### DIFF
--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -84,4 +84,15 @@ jobs:
     if: ${{ always() }}
     needs: [build, main]
     steps:
-    - run: exit 0
+      - name: Fail if build failed
+        if: ${{ needs.build.result != 'success' }}
+        run: |
+          echo "❌ Build job did not succeed: ${{ needs.build.result }}"
+          exit 1
+      - name: Fail if main failed or is skipped
+        if: ${{ needs.main.result != 'success' }}
+        run: |
+          echo "❌ Main job did not succeed: ${{ needs.main.result }}"
+          exit 1    
+      - name: Success
+        run: echo "✅ All required jobs succeeded."


### PR DESCRIPTION
# What Does This Do

This PR makes sure the system tests run.

# Motivation

Even if build is failing and main is skipped, check is run (which was not with the last update) but check does not faill.
Check will now verify the status of both build (can fail) and main (can be skipped or fail).

Here is a case where system tests failed but the PR is ready to merge:

<img width="958" height="763" alt="image" src="https://github.com/user-attachments/assets/afd56c02-2669-4e10-ab7d-3eecd4940fd6" />

Here is the workflow status showing the check step is not verifying properly the build and main step despite being run when main is skipped:

<img width="956" height="658" alt="image" src="https://github.com/user-attachments/assets/5b124ec4-94d1-4fee-8708-c0ae70e22954" />



# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
