### PR TITLE
Marked test `tracer generates flare with profiling enabled (default)`as flaky.

### DIFF
--- a/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
+++ b/dd-smoke-tests/tracer-flare/src/test/groovy/datadog/smoketest/TracerFlareSmokeTest.groovy
@@ -1,5 +1,6 @@
 package datadog.smoketest
 
+import datadog.trace.test.util.Flaky
 import spock.lang.Shared
 
 import java.nio.file.FileSystems
@@ -153,6 +154,7 @@ class TracerFlareSmokeTest extends AbstractSmokeTest {
     fileName.startsWith(FLARE_FILE_PREFIX) && fileName.endsWith(FLARE_FILE_EXTENSION)
   }
 
+  @Flaky("No flare file created in 30 seconds under various JDKs: oracle8, ibm8, zulu8")
   def "tracer generates flare with profiling enabled (default)"() {
     when:
     // Wait for flare file to be created using filesystem watcher


### PR DESCRIPTION
# What Does This Do
Marked test as flaky.

# Motivation
Green CI.

# Additional Notes
```
java.lang.AssertionError: No flare file created in /tmp/flare-test-profiling-enabled-5120059025803481254 within 30 seconds

java.lang.AssertionError: No flare file created in /tmp/flare-test-profiling-enabled-5120059025803481254 within 30 seconds
	at datadog.smoketest.TracerFlareSmokeTest.waitForFlareFile(TracerFlareSmokeTest.groovy:301)
	at datadog.smoketest.TracerFlareSmokeTest.waitForFlareFile(TracerFlareSmokeTest.groovy:253)
	at datadog.smoketest.TracerFlareSmokeTest.tracer generates flare with profiling enabled (default)(TracerFlareSmokeTest.groovy:160)
```
