### PR TITLE
Store some crashtracking options on initialisation

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/ConfigManager.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/ConfigManager.java
@@ -33,6 +33,8 @@ public class ConfigManager {
     final String processTags;
     final String runtimeId;
     final String reportUUID;
+    final boolean agentless;
+    final boolean sendToErrorTracking;
 
     StoredConfig(
         String reportUUID,
@@ -41,7 +43,9 @@ public class ConfigManager {
         String version,
         String tags,
         String processTags,
-        String runtimeId) {
+        String runtimeId,
+        boolean agentless,
+        boolean sendToErrorTracking) {
       this.service = service;
       this.env = env;
       this.version = version;
@@ -49,6 +53,8 @@ public class ConfigManager {
       this.processTags = processTags;
       this.runtimeId = runtimeId;
       this.reportUUID = reportUUID;
+      this.agentless = agentless;
+      this.sendToErrorTracking = sendToErrorTracking;
     }
 
     public static class Builder {
@@ -59,6 +65,8 @@ public class ConfigManager {
       String processTags;
       String runtimeId;
       String reportUUID;
+      boolean agentless;
+      boolean sendToErrorTracking;
 
       public Builder(Config config) {
         // get sane defaults
@@ -67,6 +75,8 @@ public class ConfigManager {
         this.version = config.getVersion();
         this.runtimeId = config.getRuntimeId();
         this.reportUUID = RandomUtils.randomUUID().toString();
+        this.agentless = config.isCrashTrackingAgentless();
+        this.sendToErrorTracking = config.isCrashTrackingErrorsIntakeEnabled();
       }
 
       public Builder service(String service) {
@@ -99,6 +109,16 @@ public class ConfigManager {
         return this;
       }
 
+      public Builder sendToErrorTracking(boolean sendToErrorTracking) {
+        this.sendToErrorTracking = sendToErrorTracking;
+        return this;
+      }
+
+      public Builder agentless(boolean agentless) {
+        this.agentless = agentless;
+        return this;
+      }
+
       // @VisibleForTesting
       Builder reportUUID(String reportUUID) {
         this.reportUUID = reportUUID;
@@ -106,7 +126,16 @@ public class ConfigManager {
       }
 
       public StoredConfig build() {
-        return new StoredConfig(reportUUID, service, env, version, tags, processTags, runtimeId);
+        return new StoredConfig(
+            reportUUID,
+            service,
+            env,
+            version,
+            tags,
+            processTags,
+            runtimeId,
+            agentless,
+            sendToErrorTracking);
       }
     }
   }
@@ -163,6 +192,8 @@ public class ConfigManager {
       writeEntry(bw, "process_tags", ProcessTags.getTagsForSerialization());
       writeEntry(bw, "runtime_id", wellKnownTags.getRuntimeId());
       writeEntry(bw, "java_home", SystemProperties.get("java.home"));
+      writeEntry(bw, "agentless", Boolean.toString(config.isCrashTrackingAgentless()));
+      writeEntry(bw, "upload_to_et", Boolean.toString(config.isCrashTrackingErrorsIntakeEnabled()));
 
       Runtime.getRuntime()
           .addShutdownHook(
@@ -219,6 +250,12 @@ public class ConfigManager {
             break;
           case "runtime_id":
             cfgBuilder.runtimeId(value);
+            break;
+          case "agentless":
+            cfgBuilder.agentless(Boolean.parseBoolean(value));
+            break;
+          case "upload_to_et":
+            cfgBuilder.sendToErrorTracking(Boolean.parseBoolean(value));
             break;
           default:
             // ignore

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/ConfigManagerTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/ConfigManagerTest.java
@@ -1,6 +1,8 @@
 package datadog.crashtracking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +22,8 @@ public class ConfigManagerTest {
     Config config = mock(Config.class);
     when(config.getWellKnownTags())
         .thenReturn(new WellKnownTags("1234", "", "env", "service", "version", ""));
+    when(config.isCrashTrackingAgentless()).thenReturn(false);
+    when(config.isCrashTrackingErrorsIntakeEnabled()).thenReturn(true);
     when(config.getMergedCrashTrackingTags()).thenReturn(Collections.singletonMap("key", "value"));
     File tmpFile = File.createTempFile("ConfigManagerTest", null);
     tmpFile.deleteOnExit();
@@ -35,6 +39,8 @@ public class ConfigManagerTest {
     assertEquals(
         Objects.requireNonNull(ProcessTags.getTagsForSerialization()).toString(),
         deserialized.processTags);
+    assertFalse(deserialized.agentless);
+    assertTrue(deserialized.sendToErrorTracking);
   }
 
   @Test
@@ -48,5 +54,7 @@ public class ConfigManagerTest {
     assertEquals("service", storedConfig.service);
     assertEquals("version", storedConfig.version);
     assertEquals("env", storedConfig.env);
+    assertFalse(storedConfig.agentless);
+    assertFalse(storedConfig.sendToErrorTracking);
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR persists the crashtracking configuration for agentless and dual shipping into error tracking at main process startup. Without doing so, those values would be unavailable in the crashtracking child process when it forks, since system-property–based settings are not inherited automatically.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
