### PR TITLE
Properly fix the osgi smoke test bnd task setup

### DIFF
--- a/dd-smoke-tests/osgi/build.gradle
+++ b/dd-smoke-tests/osgi/build.gradle
@@ -70,7 +70,6 @@ def clientBundle = tasks.register('clientBundle', Bundle) {
     attributes('Bundle-Activator': 'datadog.smoketest.osgi.client.Activator')
   }
 }
-clientBundle.get()
 
 def messagingBundle = tasks.register('messagingBundle', Bundle) {
   archiveClassifier = 'messaging'
@@ -97,6 +96,10 @@ def subscribingBundle = tasks.register('subscribingBundle', Bundle) {
   manifest {
     attributes('Bundle-Activator': 'datadog.smoketest.osgi.subscribing.Activator')
   }
+}
+
+tasks.named("check") {
+  dependsOn commonBundle, clientBundle, messagingBundle, publishingBundle, subscribingBundle, jarTask
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
# What Does This Do

#9817 removed an eager tasks realization, while ensuring no tasks with a given name exist, however it forced to fix some behavior with the bnd gradle plugin.

In #9817 I made a mistake. This PR should provide a correct fix for this smoke test project.
The previous fix assumed it was related to the plugin update only. But actually, the missing piece was that custom bundle tasks also need to be depended on by the `check` lifecycle task.

Otherwise, it bnd failed the build as it was touching the configurations after Gradle made them immutable.

```
org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':dd-smoke-tests:osgi:forkedTest'.
    ...
Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$TaskCreationException: Could 
    ...
Caused by: org.gradle.api.tasks.TaskInstantiationException: Could not create task of type 'Bundle'.
    ...
Caused by: org.gradle.api.reflect.ObjectInstantiationException: Could not create an instance of type aQute.bnd.gradle.BundleTaskExtension.
    ...
Caused by: java.lang.IllegalStateException: Cannot change attributes of configuration ':dd-smoke-tests:osgi:compileClasspath' after it has been locked for mutation
    at org.gradle.api.internal.attributes.FreezableAttributeContainer.assertMutable(FreezableAttributeContainer.java:103)
    at org.gradle.api.internal.attributes.FreezableAttributeContainer.attribute(FreezableAttributeContainer.java:70)
    at aQute.bnd.gradle.BndUtils.jarLibraryElements(BndUtils.java:167)
    at aQute.bnd.gradle.BundleTaskExtension.setSourceSet(BundleTaskExtension.java:317)
    at aQute.bnd.gradle.BundleTaskExtension.<init>(BundleTaskExtension.java:204)
    at aQute.bnd.gradle.BundleTaskExtension_Decorated.<init>(Unknown Source)
    at org.gradle.internal.instantiation.generator.AsmBackedClassGenerator$InvokeConstructorStrategy.newInstance(AsmBackedClassGenerator.java:2138)
    at org.gradle.internal.instantiation.generator.AbstractClassGenerator$GeneratedClassImpl$GeneratedConstructorImpl.newInstance(AbstractClassGenerator.java:546)
    at org.gradle.internal.instantiation.generator.DependencyInjectingInstantiator.doCreate(DependencyInjectingInstantiator.java:62)
    ... 180 more
```


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
