### PR TITLE
Fix crash tracking initialization on Windows

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploaderScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploaderScriptInitializer.java
@@ -11,6 +11,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static java.util.Locale.ROOT;
 
+import datadog.environment.OperatingSystem;
 import datadog.environment.SystemProperties;
 import datadog.trace.util.PidHelper;
 import datadog.trace.util.Strings;
@@ -63,7 +64,11 @@ public final class CrashUploaderScriptInitializer {
       Path scriptPath, String onErrorFile, String agentJar) {
     Path scriptDirectory = scriptPath.getParent();
     try {
-      Files.createDirectories(scriptDirectory, asFileAttribute(fromString(RWXRWXRWX)));
+      if (OperatingSystem.isWindows()) {
+        Files.createDirectories(scriptDirectory);
+      } else {
+        Files.createDirectories(scriptDirectory, asFileAttribute(fromString(RWXRWXRWX)));
+      }
     } catch (UnsupportedOperationException e) {
       LOG.warn(
           SEND_TELEMETRY,
@@ -109,7 +114,9 @@ public final class CrashUploaderScriptInitializer {
           bw.newLine();
         }
       }
-      Files.setPosixFilePermissions(scriptPath, fromString(R_XR_XR_X));
+      if (!OperatingSystem.isWindows()) {
+        Files.setPosixFilePermissions(scriptPath, fromString(R_XR_XR_X));
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

This commit addresses UnsupportedOperationException errors when initializing crash tracking on Windows systems.

# Motivation

Instrumenting a java app on Windows currently logs the following warnings:

```
[dd.trace 2025-11-27 09:52:09:269 +0000] [dd-task-scheduler] SEND_TELEMETRY datadog.crashtracking.Initializer - Unsupported permissions 'rwxrwxrwx' for C:\Users\Administrator\AppData\Local\Temp\ddprof_administrator\pid_488. Crash tracking will not work properly.
[dd.trace 2025-11-27 09:52:09:284 +0000] [dd-task-scheduler] SEND_TELEMETRY datadog.crashtracking.Initializer - Unexpected exception while initializing OOME notifier. OOMEs will not be tracked. [null] (Change the logging level to debug to see the full stacktrace)
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
