### PR TITLE
Temporary fix to update project latest dependencies.

### DIFF
--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -49,7 +49,9 @@ dependencies {
 
   latestDepTestImplementation group: 'org.wildfly.core', name: 'wildfly-embedded', version: '+'
   latestDepTestImplementation group: 'org.wildfly.core', name: 'wildfly-server', version: '+'
-  wildflyLatestDepTest "org.wildfly:wildfly-dist:+@zip"
+  // FIXME: Latest wildfly-dist is broken, due to missing dependency on Maven Central
+  // see: https://github.com/wildfly/mvc-krazo-feature-pack/issues/142
+  wildflyLatestDepTest "org.wildfly:wildfly-dist:38.0.0.Final@zip"
 
   latestDepTestRuntimeOnly project(':dd-java-agent:instrumentation:servlet:jakarta-servlet-5.0')
 }


### PR DESCRIPTION
# What Does This Do
Applies a temporary workaround to pin the latest dependency for `wildfly-9.0`, ensuring that the job responsible for updating project-wide latest dependencies can proceed without interruption.

# Motivation
The current wildfly-dist release is broken due to a missing dependency on Maven Central.
For details, see the related [issue](https://github.com/wildfly/mvc-krazo-feature-pack/issues/142)

# Additional Notes
This change is intended as a temporary measure and must be reverted once the missing dependency in `wildfly-dist` is resolved.

