### PR TITLE
Workaround for Oracle 1.8 `MalformedParametersException`

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -20,6 +20,7 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.PROFILER_RECORDI
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.api.profiling.RecordingDataListener;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
@@ -87,6 +89,12 @@ public class ProfilingSystemTest {
   @SuppressWarnings("unchecked")
   @BeforeEach
   public void setup() throws Exception {
+    assumeFalse(
+        JavaVirtualMachine.isOracleJDK8(),
+        "Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly "
+            + "extract method parameters without args, when the code is compiled on a later JDK (targeting 8). "
+            + "This can manifest when creating mocks.");
+
     when(controller.createRecording(ProfilingSystem.RECORDING_NAME, context)).thenReturn(recording);
     when(threadLocalRandom.nextInt(eq(1), anyInt())).thenReturn(1);
     when(recordingData.getEnd()).thenAnswer(mockInvocation -> Instant.now());

--- a/dd-java-agent/instrumentation/junit/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -1,5 +1,6 @@
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
+import datadog.environment.JavaVirtualMachine
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.api.civisibility.config.TestFQN
 import datadog.trace.api.civisibility.config.TestIdentifier
@@ -48,7 +49,15 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.core.LauncherConfig
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
 import org.junit.platform.launcher.core.LauncherFactory
+import spock.lang.IgnoreIf
 
+@IgnoreIf(reason = """
+Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly 
+extract method parameters without args, when the code is compiled on a later JDK (targeting 8). 
+This can manifest when creating mocks.
+""", value = {
+  JavaVirtualMachine.isOracleJDK8()
+})
 @DisableTestTrace(reason = "avoid self-tracing")
 class JUnit5Test extends CiVisibilityInstrumentationTest {
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.core
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.communication.ddagent.SharedCommunicationObjects
+import datadog.environment.JavaVirtualMachine
 import datadog.trace.api.Config
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.sampling.PrioritySampling
@@ -10,7 +11,15 @@ import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
 
 import java.util.concurrent.TimeUnit
+import spock.lang.IgnoreIf
 
+@IgnoreIf(reason = """
+Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly 
+extract method parameters without args, when the code is compiled on a later JDK (targeting 8). 
+This can manifest when creating mocks.
+""", value = {
+  JavaVirtualMachine.isOracleJDK8()
+})
 class LongRunningTracesTrackerTest extends DDSpecification {
   Config config = Mock(Config)
   int maxTrackedTraces = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.core
 
+import datadog.environment.JavaVirtualMachine
 import datadog.trace.api.Config
 import datadog.communication.monitor.Monitoring
 import datadog.trace.SamplingPriorityMetadataChecker
@@ -14,6 +15,7 @@ import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
 import groovy.json.JsonSlurper
+import spock.lang.IgnoreIf
 import spock.lang.Subject
 import spock.lang.Timeout
 import spock.util.concurrent.PollingConditions
@@ -28,6 +30,13 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 import static datadog.trace.core.PendingTraceBuffer.BUFFER_SIZE
 import static java.nio.charset.StandardCharsets.UTF_8
 
+@IgnoreIf(reason = """
+Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly 
+extract method parameters without args, when the code is compiled on a later JDK (targeting 8). 
+This can manifest when creating mocks.
+""", value = {
+  JavaVirtualMachine.isOracleJDK8()
+})
 @Timeout(5)
 class PendingTraceBufferTest extends DDSpecification {
   @Subject

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -1,15 +1,24 @@
 package datadog.trace.core
 
+import datadog.environment.JavaVirtualMachine
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.time.TimeSource
 import datadog.trace.api.datastreams.NoopPathwayContext
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.propagation.PropagationTags
+import spock.lang.IgnoreIf
 import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
+@IgnoreIf(reason = """
+Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly 
+extract method parameters without args, when the code is compiled on a later JDK (targeting 8). 
+This can manifest when creating mocks.
+""", value = {
+  JavaVirtualMachine.isOracleJDK8()
+})
 class PendingTraceTest extends PendingTraceTestBase {
 
   @Override

--- a/internal-api/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
@@ -5,13 +5,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import datadog.environment.JavaVirtualMachine;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class DefaultStackWalkerTest {
 
   private final StackWalker stackWalker = new DefaultStackWalker();
+
+  @BeforeEach
+  void setUp() {
+    assumeFalse(
+        JavaVirtualMachine.isOracleJDK8(),
+        "Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly "
+            + "extract method parameters without args, when the code is compiled on a later JDK (targeting 8). "
+            + "This can manifest when creating mocks.");
+  }
 
   @Test
   public void defaultStackWalker_must_be_enabled() {

--- a/internal-api/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import datadog.environment.JavaVirtualMachine;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +29,11 @@ public class HotSpotStackWalkerTest {
   @BeforeAll
   public static void setUp() {
     assumeTrue(isRunningJDK8WithHotSpot());
+    assumeFalse(
+        JavaVirtualMachine.isOracleJDK8(),
+        "Oracle JDK 1.8 did not merge the fix in JDK-8058322, leading to the JVM failing to correctly "
+            + "extract method parameters without args, when the code is compiled on a later JDK (targeting 8). "
+            + "This can manifest when creating mocks.");
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Ignores test failing on Oracle JDK 1.8 due to patch apparently not merged on Oracle JDK.

Fixes test for 

* #10065 that was reverted for this reason
* #10074 for reapplying this Gradle JDK bump to 21 alongside a spotbugs bump

# Motivation

Oracle JDK 1.8u471 – the latest to this day – do not have the fix for [JDK-8058322](https://bugs.openjdk.org/browse/JDK-8058322) that landed last year in jdk8u, while other OpenJDK 8 distribution have it.

This prevents test to work correctly when the code is compiled to Java 8 from a JDK21+ compiler. In this version the HotSpot JVM on Oracle 8 misread the parameter names and raises a `MalformedParametersException` when invoking the method `Executable::getParameters`.

Full description here: https://github.com/bric3/malformed-parameters-oracle-8

```
java.lang.reflect.MalformedParametersException: Invalid parameter name ""
	at java.lang.reflect.Executable.verifyParameters(Executable.java:386)
	at java.lang.reflect.Executable.privateGetParameters(Executable.java:416)
	at java.lang.reflect.Executable.getParameters(Executable.java:357)
	...
```

Actual bug (fixed on OpenJDK not on Oracle JDK) : https://bugs.openjdk.org/browse/JDK-8058322

This to primarily impacts mocks (regardless of the test library), but it is not limited to that.

**Possible workarounds**
* **Ignore failing tests** (selected option)
* Use `-parameters` everywhere, this however increases the size by 44 KiB, without added benefit for the customers.
* Use a different compiler, this defeats the purpose of reducing the number of subprocess by using the Daemon JDK to compile to Java 8.


# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
