### PR TITLE
Avoid getTag overhead in ConflatingMetricsAggregator

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.jctools.queues.MpscCompoundQueue;
 import org.jctools.queues.SpmcArrayQueue;
 import org.slf4j.Logger;
@@ -276,7 +277,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     if (features.supportsMetrics()) {
       for (CoreSpan<?> span : trace) {
         boolean isTopLevel = span.isTopLevel();
-        if (shouldComputeMetric(span)) {
+        final CharSequence spanKind = span.unsafeGetTag(SPAN_KIND, "");
+        if (shouldComputeMetric(span, spanKind)) {
           final CharSequence resourceName = span.getResourceName();
           if (resourceName != null && ignoredResources.contains(resourceName.toString())) {
             // skip publishing all children
@@ -284,7 +286,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             break;
           }
           counted++;
-          forceKeep |= publish(span, isTopLevel);
+          forceKeep |= publish(span, isTopLevel, spanKind);
         }
       }
       healthMetrics.onClientStatTraceComputed(
@@ -293,21 +295,19 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     return forceKeep;
   }
 
-  private boolean shouldComputeMetric(CoreSpan<?> span) {
-    return (span.isMeasured() || span.isTopLevel() || spanKindEligible(span))
+  private boolean shouldComputeMetric(CoreSpan<?> span, @Nonnull CharSequence spanKind) {
+    return (span.isMeasured() || span.isTopLevel() || spanKindEligible(spanKind))
         && span.getLongRunningVersion()
             <= 0 // either not long-running or unpublished long-running span
         && span.getDurationNano() > 0;
   }
 
-  private boolean spanKindEligible(CoreSpan<?> span) {
-    final Object spanKind = span.getTag(SPAN_KIND);
+  private boolean spanKindEligible(@Nonnull CharSequence spanKind) {
     // use toString since it could be a CharSequence...
-    return spanKind != null && ELIGIBLE_SPAN_KINDS_FOR_METRICS.contains(spanKind.toString());
+    return ELIGIBLE_SPAN_KINDS_FOR_METRICS.contains(spanKind.toString());
   }
 
-  private boolean publish(CoreSpan<?> span, boolean isTopLevel) {
-    final CharSequence spanKind = span.getTag(SPAN_KIND, "");
+  private boolean publish(CoreSpan<?> span, boolean isTopLevel, CharSequence spanKind) {
     MetricKey newKey =
         new MetricKey(
             span.getResourceName(),
@@ -353,9 +353,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   private List<UTF8BytesString> getPeerTags(CoreSpan<?> span, String spanKind) {
     if (ELIGIBLE_SPAN_KINDS_FOR_PEER_AGGREGATION.contains(spanKind)) {
-      List<UTF8BytesString> peerTags = new ArrayList<>();
-      for (String peerTag : features.peerTags()) {
-        Object value = span.getTag(peerTag);
+      final Set<String> eligiblePeerTags = features.peerTags();
+      List<UTF8BytesString> peerTags = new ArrayList<>(eligiblePeerTags.size());
+      for (String peerTag : eligiblePeerTags) {
+        Object value = span.unsafeGetTag(peerTag);
         if (value != null) {
           final Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>
               cacheAndCreator = PEER_TAGS_CACHE.computeIfAbsent(peerTag, PEER_TAGS_CACHE_ADDER);
@@ -368,7 +369,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       return peerTags;
     } else if (SPAN_KIND_INTERNAL.equals(spanKind)) {
       // in this case only the base service should be aggregated if present
-      final Object baseService = span.getTag(BASE_SERVICE);
+      final Object baseService = span.unsafeGetTag(BASE_SERVICE);
       if (baseService != null) {
         final Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>
             cacheAndCreator = PEER_TAGS_CACHE.computeIfAbsent(BASE_SERVICE, PEER_TAGS_CACHE_ADDER);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -57,6 +57,14 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   <U> U getTag(CharSequence name);
 
+  default <U> U unsafeGetTag(CharSequence name, U defaultValue) {
+    return getTag(name, defaultValue);
+  }
+
+  default <U> U unsafeGetTag(CharSequence name) {
+    return getTag(name);
+  }
+
   boolean hasSamplingPriority();
 
   boolean isMeasured();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -506,6 +506,19 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
+  public <U> U unsafeGetTag(CharSequence name, U defaultValue) {
+    Object tag = unsafeGetTag(name);
+    return null == tag ? defaultValue : (U) tag;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <U> U unsafeGetTag(CharSequence name) {
+    return (U) context.unsafeGetTag(String.valueOf(name));
+  }
+
+  @Override
   @Nonnull
   public final DDSpanContext context() {
     return context;


### PR DESCRIPTION
# What Does This Do

Looking at some profiles (cannot attach), I noticed that getPeerTags() in ConflatingMetricsAggregator ends up invoking multiple times getTag on DDSpan. The problem is that getSpan introduces several indirections to retrieve some additional fields treated as tags (e.g., HTTP status code), which we don’t actually use here. Moreover, tag access is synchronized, adding extra barriers, even though at this stage such synchronization isn’t necessary.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
