### PR TITLE
Kotlin version already applied in the root `build.gradle.kts`.

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id 'com.gradleup.shadow'
-  id 'org.jetbrains.kotlin.jvm' version libs.versions.kotlin.plugin
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id 'java-test-fixtures'
-  id 'org.jetbrains.kotlin.jvm' version libs.versions.kotlin.plugin
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 muzzle {

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 plugins {
   id 'com.gradleup.shadow'
   id 'java'
-  id 'org.jetbrains.kotlin.jvm' version libs.versions.kotlin.plugin
+  id 'org.jetbrains.kotlin.jvm'
   id 'scala'
   id 'groovy'
 }


### PR DESCRIPTION
# What Does This Do
Minor build cleanup.
As Kotlin version applied in root `build.gradle.kts` there no need to apply it in sub-modules.

# Motivation
Clean build.

