### PR TITLE
Bump `codenarc` Groovy linter to v.3.7.0.

### DIFF
--- a/gradle/codenarc.gradle
+++ b/gradle/codenarc.gradle
@@ -1,9 +1,7 @@
 apply plugin: "codenarc"
 
 dependencies {
-  codenarc('org.codenarc:CodeNarc:3.6.0')
-  // if the groovy transitive dependencies are upgraded, this may not be pulled
-  codenarc('org.codehaus.groovy:groovy-templates')
+  codenarc('org.codenarc:CodeNarc:3.7.0')
 }
 
 codenarc {


### PR DESCRIPTION
# What Does This Do
Bump `codenarc` Groovy linter to v.3.7.0.

# Motivation
Latest tools provide more value.

# Additional Notes


