### PR TITLE
Remove native libraries for unsupported environment

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -104,6 +104,31 @@ def generalShadowJarConfig(ShadowJar shadowJarTask) {
     exclude '**/io/airlift/compress/snappy/**'
     relocate 'io.airlift', 'datadog.io.airlift'
 
+    // Minimize JNA, removing native libraries for unsupported environments
+    exclude '**/com/sun/jna/aix-*/**'
+    exclude '**/com/sun/jna/freebsd-*/**'
+    exclude '**/com/sun/jna/linux-armel/**'
+    exclude '**/com/sun/jna/linux-mips64el/**'
+    exclude '**/com/sun/jna/linux-ppc/**'
+    exclude '**/com/sun/jna/linux-ppc64le/**'
+    exclude '**/com/sun/jna/linux-riscv64/**'
+    exclude '**/com/sun/jna/linux-s390x/**'
+    exclude '**/com/sun/jna/openbsd-*/**'
+    exclude '**/com/sun/jna/sunos-*/**'
+
+    // Minimize JFFI, removing native libraries for unsupported environments
+    exclude '**/jni/*-AIX/**'
+    exclude '**/jni/*-DragonFlyBSD/**'
+    exclude '**/jni/*-FreeBSD/**'
+    exclude '**/jni/loongarch64-Linux/**'
+    exclude '**/jni/mips64el-Linux/**'
+    exclude '**/jni/ppc64-Linux/**'
+    exclude '**/jni/ppc64le-Linux/**'
+    exclude '**/jni/s390x-Linux/**'
+    exclude '**/jni/sparcv9-Linux/**'
+    exclude '**/jni/*-OpenBSD/**'
+    exclude '**/jni/*-SunOS/**'
+
     final String projectName = "${project.name}"
 
     // Prevents conflict with other instances, but doesn't relocate instrumentation


### PR DESCRIPTION
# What Does This Do

This PR removes the JNA and JFFI native libraries dependencies for unsupported environment. 

Here are size difference:

* **1.56.1 size**: 33503806
* **patch size**: 31891608
* **saving**: 1612198 (5%)

# Motivation

This should decrease the size of the artifact and for faster deployment and startup.

# Additional Notes

Expected native usage listed under "Native Library Usage" on the (private) Confluence page.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
