### PR TITLE
Move stray instrumentation switches to `InstrumenterConfig`

### DIFF
--- a/dd-java-agent/instrumentation/log4j/log4j-2.0/src/main/java/datadog/trace/instrumentation/log4j2/LoggerConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j/log4j-2.0/src/main/java/datadog/trace/instrumentation/log4j2/LoggerConfigInstrumentation.java
@@ -6,6 +6,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import java.util.Map;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
@@ -23,7 +24,8 @@ public class LoggerConfigInstrumentation extends InstrumenterModule.Tracing
 
   @Override
   public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-    return super.isApplicable(enabledSystems) && Config.get().isAgentlessLogSubmissionEnabled();
+    return super.isApplicable(enabledSystems)
+        && InstrumenterConfig.get().isAgentlessLogSubmissionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkExitInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkExitInstrumentation.java
@@ -6,7 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 
 @AutoService(InstrumenterModule.class)
 public class SparkExitInstrumentation extends InstrumenterModule.Tracing
@@ -18,7 +18,7 @@ public class SparkExitInstrumentation extends InstrumenterModule.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isDataJobsEnabled();
+    return InstrumenterConfig.get().isDataJobsEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletInstrumentation.java
@@ -11,7 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.telemetry.EndpointCollector;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,7 +65,7 @@ public class AppSecDispatcherServletInstrumentation extends InstrumenterModule.A
 
   @Override
   public boolean isEnabled() {
-    return super.isEnabled() && Config.get().isApiSecurityEndpointCollectionEnabled();
+    return super.isEnabled() && InstrumenterConfig.get().isApiSecurityEndpointCollectionEnabled();
   }
 
   public static class AppSecHandlerMappingAdvice {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/AppSecDispatcherServletWithPathPatternsInstrumentation.java
@@ -10,7 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.telemetry.EndpointCollector;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,7 +60,7 @@ public class AppSecDispatcherServletWithPathPatternsInstrumentation
 
   @Override
   public boolean isEnabled() {
-    return super.isEnabled() && Config.get().isApiSecurityEndpointCollectionEnabled();
+    return super.isEnabled() && InstrumenterConfig.get().isApiSecurityEndpointCollectionEnabled();
   }
 
   public static class AppSecHandlerMappingAdvice {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -9,7 +9,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_DOWNSTREAM_REQUEST_BODY_ANALYSIS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_MAX_DOWNSTREAM_REQUEST_BODY_ANALYSIS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_SAMPLE_DELAY;
@@ -47,7 +46,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_CODE_ORIGIN_MAX_USER_FRAM
 import static datadog.trace.api.ConfigDefaults.DEFAULT_COUCHBASE_INTERNAL_SPANS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_EXPERIMENTAL_FEATURES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_OPENLINEAGE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_OPENLINEAGE_TIMEOUT_ENABLED;
@@ -209,7 +207,6 @@ import static datadog.trace.api.config.AppSecConfig.API_SECURITY_DOWNSTREAM_REQU
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_DOWNSTREAM_REQUEST_BODY_ANALYSIS_SAMPLE_RATE;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENABLED_EXPERIMENTAL;
-import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENDPOINT_COLLECTION_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_MAX_DOWNSTREAM_REQUEST_BODY_ANALYSIS;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_SAMPLE_DELAY;
@@ -345,7 +342,6 @@ import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_DETECTION_INCL
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_EXCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_INCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_SHADING_IDENTIFIERS;
-import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_URL;
@@ -355,7 +351,6 @@ import static datadog.trace.api.config.GeneralConfig.APPLICATION_KEY;
 import static datadog.trace.api.config.GeneralConfig.APPLICATION_KEY_FILE;
 import static datadog.trace.api.config.GeneralConfig.APP_KEY;
 import static datadog.trace.api.config.GeneralConfig.AZURE_APP_SERVICES;
-import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_EXPERIMENTAL_FEATURES_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_OPENLINEAGE_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_OPENLINEAGE_TIMEOUT_ENABLED;
@@ -1004,7 +999,6 @@ public class Config {
   private final int appSecBodyParsingSizeLimit;
   private final boolean apiSecurityEnabled;
   private final float apiSecuritySampleDelay;
-  private final boolean apiSecurityEndpointCollectionEnabled;
   private final int apiSecurityEndpointCollectionMessageLimit;
   private final int apiSecurityMaxDownstreamRequestBodyAnalysis;
   private final double apiSecurityDownstreamRequestBodyAnalysisSampleRate;
@@ -1227,7 +1221,6 @@ public class Config {
   private final boolean cwsEnabled;
   private final int cwsTlsRefresh;
 
-  private final boolean dataJobsEnabled;
   private final boolean dataJobsOpenLineageEnabled;
   private final boolean dataJobsOpenLineageTimeoutEnabled;
   private final boolean dataJobsParseSparkPlanEnabled;
@@ -1288,7 +1281,6 @@ public class Config {
 
   private final boolean telemetryDebugRequestsEnabled;
 
-  private final boolean agentlessLogSubmissionEnabled;
   private final int agentlessLogSubmissionQueueSize;
   private final String agentlessLogSubmissionLevel;
   private final String agentlessLogSubmissionUrl;
@@ -2245,10 +2237,6 @@ public class Config {
             API_SECURITY_ENABLED, DEFAULT_API_SECURITY_ENABLED, API_SECURITY_ENABLED_EXPERIMENTAL);
     apiSecuritySampleDelay =
         configProvider.getFloat(API_SECURITY_SAMPLE_DELAY, DEFAULT_API_SECURITY_SAMPLE_DELAY);
-    apiSecurityEndpointCollectionEnabled =
-        configProvider.getBoolean(
-            API_SECURITY_ENDPOINT_COLLECTION_ENABLED,
-            DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED);
     apiSecurityEndpointCollectionMessageLimit =
         configProvider.getInteger(
             API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT,
@@ -2742,7 +2730,6 @@ public class Config {
     cwsEnabled = configProvider.getBoolean(CWS_ENABLED, DEFAULT_CWS_ENABLED);
     cwsTlsRefresh = configProvider.getInteger(CWS_TLS_REFRESH, DEFAULT_CWS_TLS_REFRESH);
 
-    dataJobsEnabled = configProvider.getBoolean(DATA_JOBS_ENABLED, DEFAULT_DATA_JOBS_ENABLED);
     dataJobsOpenLineageEnabled =
         configProvider.getBoolean(
             DATA_JOBS_OPENLINEAGE_ENABLED, DEFAULT_DATA_JOBS_OPENLINEAGE_ENABLED);
@@ -2887,8 +2874,6 @@ public class Config {
         configProvider.getBoolean(
             TELEMETRY_DEBUG_REQUESTS_ENABLED, DEFAULT_TELEMETRY_DEBUG_REQUESTS_ENABLED);
 
-    this.agentlessLogSubmissionEnabled =
-        configProvider.getBoolean(AGENTLESS_LOG_SUBMISSION_ENABLED, false);
     this.agentlessLogSubmissionQueueSize =
         configProvider.getInteger(AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE, 1024);
     this.agentlessLogSubmissionLevel =
@@ -3835,7 +3820,7 @@ public class Config {
   }
 
   public boolean isApiSecurityEndpointCollectionEnabled() {
-    return apiSecurityEndpointCollectionEnabled;
+    return instrumenterConfig.isApiSecurityEndpointCollectionEnabled();
   }
 
   public ProductActivation getIastActivation() {
@@ -4720,7 +4705,7 @@ public class Config {
   }
 
   public boolean isDataJobsEnabled() {
-    return dataJobsEnabled;
+    return instrumenterConfig.isDataJobsEnabled();
   }
 
   public boolean isDataJobsOpenLineageEnabled() {
@@ -5383,7 +5368,7 @@ public class Config {
   }
 
   public boolean isAgentlessLogSubmissionEnabled() {
-    return agentlessLogSubmissionEnabled;
+    return instrumenterConfig.isAgentlessLogSubmissionEnabled();
   }
 
   public int getAgentlessLogSubmissionQueueSize() {
@@ -6111,8 +6096,6 @@ public class Config {
         + appSecHttpBlockedTemplateJson
         + ", apiSecurityEnabled="
         + apiSecurityEnabled
-        + ", apiSecurityEndpointCollectionEnabled="
-        + apiSecurityEndpointCollectionEnabled
         + ", apiSecurityEndpointCollectionMessageLimit="
         + apiSecurityEndpointCollectionMessageLimit
         + ", cwsEnabled="
@@ -6167,8 +6150,6 @@ public class Config {
         + appSecScaEnabled
         + ", appSecRaspEnabled="
         + appSecRaspEnabled
-        + ", dataJobsEnabled="
-        + dataJobsEnabled
         + ", dataJobsOpenLineageEnabled="
         + dataJobsOpenLineageEnabled
         + ", dataJobsOpenLineageTimeoutEnabled="

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -1,8 +1,10 @@
 package datadog.trace.api;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LLM_OBS_ENABLED;
@@ -20,8 +22,11 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_OTEL_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_USM_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_WEBSOCKET_MESSAGES_ENABLED;
+import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENDPOINT_COLLECTION_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
@@ -193,6 +198,10 @@ public class InstrumenterConfig {
   private final Collection<String> additionalJaxRsAnnotations;
 
   private final boolean rumEnabled;
+  private final boolean dataJobsEnabled;
+
+  private final boolean agentlessLogSubmissionEnabled;
+  private final boolean apiSecurityEndpointCollectionEnabled;
 
   static {
     // Bind telemetry collector to config module before initializing ConfigProvider
@@ -227,6 +236,8 @@ public class InstrumenterConfig {
         ProfilingEnablement.of(
             configProvider.getString(PROFILING_ENABLED, String.valueOf(PROFILING_ENABLED_DEFAULT)));
     rumEnabled = configProvider.getBoolean(RUM_ENABLED, DEFAULT_RUM_ENABLED);
+    dataJobsEnabled = configProvider.getBoolean(DATA_JOBS_ENABLED, DEFAULT_DATA_JOBS_ENABLED);
+
     if (!Platform.isNativeImageBuilder()) {
       ciVisibilityEnabled =
           configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -327,6 +338,14 @@ public class InstrumenterConfig {
         configProvider.getBoolean(
             TRACE_WEBSOCKET_MESSAGES_ENABLED, DEFAULT_WEBSOCKET_MESSAGES_ENABLED);
     this.pekkoSchedulerEnabled = configProvider.getBoolean(TRACE_PEKKO_SCHEDULER_ENABLED, false);
+
+    agentlessLogSubmissionEnabled =
+        configProvider.getBoolean(AGENTLESS_LOG_SUBMISSION_ENABLED, false);
+
+    apiSecurityEndpointCollectionEnabled =
+        configProvider.getBoolean(
+            API_SECURITY_ENDPOINT_COLLECTION_ENABLED,
+            DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED);
   }
 
   public boolean isCodeOriginEnabled() {
@@ -618,6 +637,18 @@ public class InstrumenterConfig {
     return rumEnabled;
   }
 
+  public boolean isDataJobsEnabled() {
+    return dataJobsEnabled;
+  }
+
+  public boolean isAgentlessLogSubmissionEnabled() {
+    return agentlessLogSubmissionEnabled;
+  }
+
+  public boolean isApiSecurityEndpointCollectionEnabled() {
+    return apiSecurityEndpointCollectionEnabled;
+  }
+
   // This has to be placed after all other static fields to give them a chance to initialize
   private static final InstrumenterConfig INSTANCE =
       new InstrumenterConfig(
@@ -723,6 +754,10 @@ public class InstrumenterConfig {
         + pekkoSchedulerEnabled
         + ", rumEnabled="
         + rumEnabled
+        + ", dataJobsEnabled="
+        + dataJobsEnabled
+        + ", apiSecurityEndpointCollectionEnabled="
+        + apiSecurityEndpointCollectionEnabled
         + '}';
   }
 }


### PR DESCRIPTION
# What Does This Do

Move stray instrumentation switches to `InstrumenterConfig`

# Motivation

Switches that directly control which instrumentations are applied belong in `InstrumenterConfig`

Having such switches in `Config` can lead to odd errors in GraalVM. It can also cause certain JDK classes to load before instrumentations are fully installed, which means we lose the chance to field-inject context into those classes and have to fallback to use a global weak map.

# Additional Notes

Without these changes `./gradlew :dd-smoke-tests:field-injection:test -PtestJvm=11` was failing consistently for me locally.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
