### PR TITLE
Disable process advice until after agent tracer is registered

### DIFF
--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeExecStringAdvice.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeExecStringAdvice.java
@@ -1,20 +1,23 @@
 package datadog.trace.instrumentation.java.lang;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.java.lang.ProcessImplInstrumentationHelpers;
-import java.io.IOException;
 import net.bytebuddy.asm.Advice;
 
 class RuntimeExecStringAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static void beforeExec(@Advice.Argument(0) final String command) throws IOException {
-    if (command == null) {
-      return;
+  public static boolean beforeExec(@Advice.Argument(0) final String command) {
+    if (command == null || !AgentTracer.isRegistered()) {
+      return false;
     }
     ProcessImplInstrumentationHelpers.shiRaspCheck(command);
+    return true;
   }
 
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  public static void afterExec() {
-    ProcessImplInstrumentationHelpers.resetCheckShi();
+  public static void afterExec(@Advice.Enter boolean checking) {
+    if (checking) {
+      ProcessImplInstrumentationHelpers.resetCheckShi();
+    }
   }
 }


### PR DESCRIPTION
# Motivation

This avoids a potential reentrant situation when tracer debug is enabled:
1. The full `Config` is logged during startup in its constructor
2. This includes any lazy config fields, such as the `hostname`
3. If the host is not available in the environment/host-files then `Config` calls the `hostname` command using `Runtime.exec(...)`
4. The `Runtime.exec(...)` call is intercepted by the process advice
5. The process advice calls `Config.get()` to see if RASP is enabled
6. `Config.get()` returns `null` as the config is still being built

The resulting NPE is caught before it escapes to the application, but it still results in log-spam that could confuse investigations.

The APPSEC feature will only be marked as ready (and active) after `Config` has been initialized, at which point it is safe to enable the RASP process advice.

# Additional Notes

Example stack trace:
```
[dd.trace 2025-12-05 11:47:22:698 +0000] [main] DEBUG datadog.telemetry.dependency.LocationsCollectingTransformer - New pro[dd.trace 2025-12-05 11:47:22:475 +0000] [main] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for java.lang.Runtime
java.lang.NullPointerException: Cannot invoke "datadog.trace.api.Config.isAppSecRaspEnabled()" because the return value of "datadog.trace.api.Config.get()" is null
        at datadog.trace.bootstrap.instrumentation.api.java.lang.ProcessImplInstrumentationHelpers.shiRaspCheck(ProcessImplInstrumentationHelpers.java:271)
        at java.base/java.lang.Runtime.exec(Runtime.java:411)
        at java.base/java.lang.Runtime.exec(Runtime.java:315)
        at datadog.trace.api.Config.initHostName(Config.java:5619)
        at datadog.trace.api.Config$HostNameHolder.<clinit>(Config.java:788)
        at datadog.trace.api.Config.getHostName(Config.java:3066)
        at datadog.trace.api.Config.toString(Config.java:5727)
        at datadog.slf4j.helpers.MessageFormatter.safeObjectAppend(MessageFormatter.java:277)
        at datadog.slf4j.helpers.MessageFormatter.deeplyAppendParameter(MessageFormatter.java:249)
        at datadog.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:211)
        at datadog.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:161)
        at datadog.slf4j.helpers.MessageFormatter.format(MessageFormatter.java:124)
        at datadog.trace.logging.ddlogger.DDLogger.formatLog(DDLogger.java:331)
        at datadog.trace.logging.ddlogger.DDTelemetryLogger.formatLog(DDTelemetryLogger.java:18)
        at datadog.trace.logging.ddlogger.DDLogger.debug(DDLogger.java:98)
        at datadog.trace.api.Config.<init>(Config.java:2980)
        at datadog.trace.api.Config.<clinit>(Config.java:5683)
        at datadog.trace.bootstrap.Agent.createProfilingContextIntegration(Agent.java:1312)
        at datadog.trace.bootstrap.Agent.installDatadogTracer(Agent.java:811)
        at datadog.trace.bootstrap.Agent.access$300(Agent.java:86)
        at datadog.trace.bootstrap.Agent$InstallDatadogTracerCallback.<init>(Agent.java:662)
        at datadog.trace.bootstrap.Agent.start(Agent.java:387)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:159)
        at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:73)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at datadog.trace.bootstrap.AgentPreCheck.continueBootstrap(AgentPreCheck.java:169)
        at datadog.trace.bootstrap.AgentPreCheck.agentmain(AgentPreCheck.java:24)
        at datadog.trace.bootstrap.AgentPreCheck.premain(AgentPreCheck.java:17)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:491)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:503)
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
