### PR TITLE
Fix Kafka consumer instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfoInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfoInstrumentation.java
@@ -69,6 +69,7 @@ public final class KafkaConsumerInfoInstrumentation extends InstrumenterModule.T
     return new String[] {
       packageName + ".KafkaDecorator",
       packageName + ".KafkaConsumerInfo",
+      packageName + ".KafkaConsumerInstrumentationHelper",
       "datadog.trace.instrumentation.kafka_common.ClusterIdHolder",
     };
   }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/LegacyKafkaConsumerInfoInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/LegacyKafkaConsumerInfoInstrumentation.java
@@ -69,6 +69,7 @@ public final class LegacyKafkaConsumerInfoInstrumentation extends InstrumenterMo
     return new String[] {
       packageName + ".KafkaDecorator",
       packageName + ".KafkaConsumerInfo",
+      packageName + ".KafkaConsumerInstrumentationHelper",
       "datadog.trace.instrumentation.kafka_common.ClusterIdHolder",
     };
   }


### PR DESCRIPTION
# What Does This Do

https://github.com/DataDog/dd-trace-java/pull/9974/files introduced an issue:
```
[dd.trace 2025-12-05 14:09:42:608 +0000] [zio-default-blocking-10] DEBUG datadog.trace.agent.tooling.InstrumenterState - Instrumentation blocked - instrumentation.names=[kafka,kafka-3.8] instrumentation.class=datadog.trace.instrumentation.kafka_clients38.LegacyKafkaConsumerInfoInstrumentation instrumentation.target.classloader=jdk.internal.loader.ClassLoaders$AppClassLoader@4b960b5b
[dd.trace 2025-12-05 14:09:42:609 +0000] [zio-default-blocking-10] DEBUG datadog.trace.agent.tooling.muzzle.MuzzleCheck - Muzzled - instrumentation.names=[kafka,kafka-3.8] instrumentation.class=datadog.trace.instrumentation.kafka_clients38.LegacyKafkaConsumerInfoInstrumentation instrumentation.target.classloader=jdk.internal.loader.ClassLoaders$AppClassLoader@4b960b5b
[dd.trace 2025-12-05 14:09:42:609 +0000] [zio-default-blocking-10] DEBUG datadog.trace.agent.tooling.muzzle.MuzzleCheck - Muzzled mismatch - instrumentation.names=[kafka,kafka-3.8] instrumentation.class=datadog.trace.instrumentation.kafka_clients38.LegacyKafkaConsumerInfoInstrumentation instrumentation.target.classloader=jdk.internal.loader.ClassLoaders$AppClassLoader@4b960b5b muzzle.mismatch="datadog.trace.instrumentation.kafka_clients38.RecordsAdvice:32 Missing class datadog.trace.instrumentation.kafka_clients38.KafkaConsumerInstrumentationHelper"
```

This is due to a missing helper class in `KafkaConsumerInstrumentation.java`

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
