### PR TITLE
Changed order of clients and server shutdown to prevent freeze on GitLab CI.

### DIFF
--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/test/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/test/groovy/RedissonClientTest.groovy
@@ -48,9 +48,9 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
   }
 
   def cleanupSpec() {
-    redisServer.stop()
-    lowLevelRedisClient.shutdown()
     redissonClient.shutdown()
+    lowLevelRedisClient.shutdown()
+    redisServer.stop()
   }
 
   def setup() {


### PR DESCRIPTION
# What Does This Do
Refactored test to follow the proper cleanup pattern: resources should be released in reverse order of their creation, and dependencies (clients) should be cleaned up before the things they depend on (the server).

# Motivation
Test is freezing from time to time (not too often, but still) on GitLab CI with thread dump like:
```
"Test worker" #1 [48480] prio=5 os_prio=0 cpu=6671.20ms elapsed=1145.91s tid=0x00007f48f8032b90 nid=48480 in 
Object.wait()  [0x00007f48fedb4000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait0(java.base@21.0.9/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@21.0.9/Object.java:366)
	at java.lang.Object.wait(java.base@21.0.9/Object.java:339)
	at io.netty.util.concurrent.DefaultPromise.awaitUninterruptibly(DefaultPromise.java:286)
	- locked <0x00000000c38034f8> (a io.netty.util.concurrent.DefaultPromise)
	at io.netty.util.concurrent.DefaultPromise.syncUninterruptibly(DefaultPromise.java:225)
	at io.netty.util.concurrent.DefaultPromise.syncUninterruptibly(DefaultPromise.java:32)
	at org.redisson.connection.MasterSlaveConnectionManager.shutdown(MasterSlaveConnectionManager.java:472)
	at org.redisson.Redisson.shutdown(Redisson.java:301)
	at org.redisson.RedissonClient$shutdown$7.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:130)
	at RedissonClientTest.cleanupSpec(RedissonClientTest.groovy:53)
```

# Additional Notes

