### PR TITLE
Fix muzzle for HikariConcurrentBagHandoffQueueInstrumentation

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariBlockedTrackingSynchronousQueue.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariBlockedTrackingSynchronousQueue.java
@@ -1,0 +1,17 @@
+package datadog.trace.instrumentation.jdbc;
+
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+public class HikariBlockedTrackingSynchronousQueue<T> extends SynchronousQueue<T> {
+  public HikariBlockedTrackingSynchronousQueue() {
+    // This assumes the initialization of the SynchronousQueue in ConcurrentBag doesn't change
+    super(true);
+  }
+
+  @Override
+  public T poll(long timeout, TimeUnit unit) throws InterruptedException {
+    HikariBlockedTracker.setBlocked();
+    return super.poll(timeout, unit);
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagHandoffQueueInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagHandoffQueueInstrumentation.java
@@ -9,7 +9,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.InstrumenterConfig;
 import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.TimeUnit;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -46,9 +45,7 @@ public final class HikariConcurrentBagHandoffQueueInstrumentation extends Instru
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".HikariBlockedTracker",
-      packageName
-          + ".HikariConcurrentBagHandoffQueueInstrumentation$BlockedTrackingSynchronousQueue",
+      packageName + ".HikariBlockedTracker", packageName + ".HikariBlockedTrackingSynchronousQueue",
     };
   }
 
@@ -64,20 +61,7 @@ public final class HikariConcurrentBagHandoffQueueInstrumentation extends Instru
     static void after(
         @Advice.FieldValue(value = "handoffQueue", readOnly = false)
             SynchronousQueue handoffQueue) {
-      handoffQueue = new BlockedTrackingSynchronousQueue<>();
-    }
-  }
-
-  public static class BlockedTrackingSynchronousQueue<T> extends SynchronousQueue<T> {
-    public BlockedTrackingSynchronousQueue() {
-      // This assumes the initialization of the SynchronousQueue in ConcurrentBag doesn't change
-      super(true);
-    }
-
-    @Override
-    public T poll(long timeout, TimeUnit unit) throws InterruptedException {
-      HikariBlockedTracker.setBlocked();
-      return super.poll(timeout, unit);
+      handoffQueue = new HikariBlockedTrackingSynchronousQueue<>();
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Fixes the following error:
```
./gradlew :dd-java-agent:instrumentation:jdbc:muzzle

> Task :dd-java-agent:instrumentation:jdbc:muzzle-AssertPass-core-jdk FAILED
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
FAILED HELPER INJECTION. Are Helpers being injected in the correct order?
Nested helper datadog.trace.instrumentation.jdbc.HikariConcurrentBagHandoffQueueInstrumentation$BlockedTrackingSynchronousQueue must have the parent class datadog.trace.instrumentation.jdbc.HikariConcurrentBagHandoffQueueInstrumentation also defined as a helper
```

Note this instrumentation is not enabled by default.

# Motivation

avoid defining helper classes as inner classes of instrumentations

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
