### PR TITLE
Make spring-webflux instrumentation compatible with 7.0.0

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -73,8 +74,11 @@ public class RouteOnSuccessOrError implements Consumer<HandlerFunction<?>> {
       final AgentSpan parentSpan =
           (AgentSpan) serverRequest.attributes().get(AdviceUtils.PARENT_SPAN_ATTRIBUTE);
       if (parentSpan != null) {
-        HTTP_RESOURCE_DECORATOR.withRoute(
-            parentSpan, serverRequest.methodName(), parseRoute(predicateString));
+        final HttpMethod httpMethod = serverRequest.method();
+        if (httpMethod != null) {
+          HTTP_RESOURCE_DECORATOR.withRoute(
+              parentSpan, httpMethod.name(), parseRoute(predicateString));
+        }
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Spring WebFlux 7 removed several deprecated methods from the ServerRequest interface. Because of this, the instrumentation in this PR now obtains the HTTP method name from the httpMethod object rather than calling the removed method directly, which previously caused muzzle to disable the instrumentation.

Note: this also means that tracer version 1.56.x did not support WebFlux 7. Fortunately, WebFlux 7 was only released in November.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
