### PR TITLE
Test latest jersey-2.0 module

### DIFF
--- a/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
@@ -2,7 +2,7 @@ muzzle {
   pass {
     group = 'org.glassfish.jersey.core'
     module = 'jersey-common'
-    versions = '[2,4)'
+    versions = '[2,)'
     assertInverse = true
   }
 }
@@ -16,6 +16,7 @@ testJvmConstraints {
 // there are tests with jersey2 and grizzly on the grizzly-http-2.3.20 module
 addTestSuiteForDir('jersey2JettyTest', 'jersey2JettyTest')
 addTestSuiteForDir('jersey3JettyTest', 'jersey3JettyTest')
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileJersey3JettyTestGroovy", GroovyCompile) {
   configureCompiler(it, 11)
@@ -40,6 +41,9 @@ dependencies {
 
   testImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.0'
   testImplementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version: jersey3Version
+
+  latestDepTestImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '+'
+  latestDepTestImplementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version:'+'
 
   jersey2JettyTestImplementation project(':dd-java-agent:instrumentation-testing'), {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'

--- a/dd-java-agent/instrumentation/jersey/jersey-2.0/src/test/java/foo/bar/TestSuite.java
+++ b/dd-java-agent/instrumentation/jersey/jersey-2.0/src/test/java/foo/bar/TestSuite.java
@@ -1,9 +1,0 @@
-package foo.bar;
-
-import org.glassfish.jersey.internal.inject.ParamConverters.StringConstructor;
-
-public class TestSuite {
-  public static String convertString(String s) {
-    return new StringConstructor().getConverter(String.class, null, null).fromString(s);
-  }
-}


### PR DESCRIPTION
# What Does This Do

Muzzle passes on 4.0 unwards. I fixed the declaration and also added latestDep for those. Curiously there was one unused class that I wiped out since it contained incompatible code with latest

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
