### PR TITLE
Skip 1.2.0.Final for `jboss-logmanager-embedded` module

### DIFF
--- a/dd-java-agent/instrumentation/jboss/jboss-logmanager-1.1/build.gradle
+++ b/dd-java-agent/instrumentation/jboss/jboss-logmanager-1.1/build.gradle
@@ -9,6 +9,7 @@ muzzle {
     group = 'org.jboss.logmanager'
     module = 'jboss-logmanager-embedded'
     versions = '[1.0.0,]'
+    skipVersions += '1.2.0.Final' // TODO: missing jar in Maven Central (https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.2.0.Final/)
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Skip 1.2.0.Final version for `jboss-logmanager-embedded` module

# Motivation

Jar file is missing.

1.2.0.Final (missing jar):
https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.2.0.Final/

1.0.11 (expected):
https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.11/

# Additional Notes

To reproduce the failure: `./gradlew :dd-java-agent:instrumentation:jboss:jboss-logmanager-1.1:muzzle`

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
