### PR TITLE
MuzzleVersionScanPlugin needs reflective access on ClassLoader

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleTask.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleTask.kt
@@ -98,6 +98,10 @@ abstract class MuzzleTask @Inject constructor(
       // See https://github.com/gradle/gradle/issues/33987
       workerExecutor.processIsolation {
         forkOptions {
+          // datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin needs reflective access to ClassLoader.findLoadedClass
+          if(javaLauncher.metadata.languageVersion > JavaLanguageVersion.of(9)) {
+            jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+          }
           executable(javaLauncher.executablePath)
         }
       }


### PR DESCRIPTION
# What Does This Do

When the Gradle daemon is not a JDK 8, `MuzzleVersionScanPlugin` needs reflective access to `ClassLoader`. This should fix some muzzle failures where e.g. jakarta-jms instrumentation.

# Motivation

# Additional Notes

Follow-up to 
* #10114

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
