### PR TITLE
Update jersey-appsec-2.0 muzzle

### DIFF
--- a/dd-java-agent/instrumentation/jersey/jersey-appsec/jersey-appsec-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey-appsec/jersey-appsec-2.0/build.gradle
@@ -17,7 +17,7 @@ muzzle {
     name = 'jersey_2+3'
     group = 'org.glassfish.jersey.core'
     module = 'jersey-common'
-    versions = '[2,4)'
+    versions = '[2,)'
     assertInverse = true
   }
   pass {


### PR DESCRIPTION
# What Does This Do

Extend Muzzle pass range for the `jersey-appsec-2.0` module. Apply the same fix from #10121 

# Motivation

Address job failure: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1280892840

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
