### PR TITLE
Confluent has its own version scheme for kafka-clients

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
@@ -10,7 +10,7 @@ muzzle {
     name = "before-3.8"
     group = "org.apache.kafka"
     module = "kafka-clients"
-    versions = "[0.11.0.0,3.8.0)"
+    versions = "[0.11.0.0,3.8.0),[5,7.8.0)"
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
@@ -2,7 +2,7 @@ muzzle {
   pass {
     group = "org.apache.kafka"
     module = "kafka-clients"
-    versions = "[3.8.0,)"
+    versions = "[3.8.0,5),[7.8.0,)"
     assertInverse = true
     javaVersion = "17"
   }


### PR DESCRIPTION
# Motivation

This version schema is 'offset' from the original version:

| Confluent   | Apache       |
| ----------- | ----------- |
| 7.6.x            |  3.6.x           |
| 7.0.x            |  3.0.x           |
| 6.2.x           |   2.8.x           |
| 6.0.x           |   2.6.x           |
| 5.5.x           |   2.5.x           |
| 5.3.x           |   2.3.x           |

This PR tweaks the expected muzzle ranges to match both schemes.

We may need to revisit this if Apache decides to make a 5+ release.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
