### PR TITLE
Add custom dependency resolution to JUnit5 avoiding prereleases

### DIFF
--- a/dd-java-agent/instrumentation/junit/junit-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/build.gradle
@@ -70,7 +70,7 @@ configurations.matching { it.name.startsWith('latest5Test') || it.name.startsWit
   it.resolutionStrategy.componentSelection.all { ComponentSelection selection ->
     def version = selection.candidate.version
     if ((selection.candidate.group == 'org.junit.platform' || selection.candidate.group == 'org.junit.jupiter') &&
-        (version.matches('.*-RC.*') || version.matches('.*-M\\d+.*'))) {
+      (version.matches('.*-RC.*') || version.matches('.*-M\\d+.*'))) {
       selection.reject("Skipping pre-release version: ${version}")
     }
   }

--- a/dd-java-agent/instrumentation/junit/junit-5.3/junit-5.8/build.gradle
+++ b/dd-java-agent/instrumentation/junit/junit-5.3/junit-5.8/build.gradle
@@ -62,7 +62,7 @@ configurations.matching { it.name.startsWith('latestDepTest') }.configureEach {
   it.resolutionStrategy.componentSelection.all { ComponentSelection selection ->
     def version = selection.candidate.version
     if ((selection.candidate.group == 'org.junit.platform' || selection.candidate.group == 'org.junit.jupiter') &&
-        (version.matches('.*-RC.*') || version.matches('.*-M\\d+.*'))) {
+      (version.matches('.*-RC.*') || version.matches('.*-M\\d+.*'))) {
       selection.reject("Skipping pre-release version: ${version}")
     }
   }


### PR DESCRIPTION
# What Does This Do

Adds a custom resolution strategy for dependency versions for the JUnit5 instrumentation to avoid using pre-releases as latest versions. The implementation is based on the logic already available for the `scalatest` instrumentation. 

Tested that the latest `M1` version is not used (and instead the latest stable one `6.0.1`) with the following command:

```
./gradlew :dd-java-agent:instrumentation:junit:junit-5.3:dependencies --configuration latestDepTestRuntimeClasspath 2>&1 | grep -E "org.junit.(platform|jupiter)"
```

# Motivation

This will avoid failing the dependency update jobs for non-release versions if they introduce breaking changes.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
