### PR TITLE
Disable virtual thread instrumentation by default

### DIFF
--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
@@ -60,6 +60,12 @@ public final class VirtualThreadInstrumentation extends InstrumenterModule.Traci
   }
 
   @Override
+  protected boolean defaultEnabled() {
+    // Disabled by default until non flaky
+    return false;
+  }
+
+  @Override
   public Map<String, String> contextStore() {
     Map<String, String> contextStore = new HashMap<>();
     contextStore.put(Runnable.class.getName(), State.class.getName());

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/test/groovy/VirtualThreadApiTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/test/groovy/VirtualThreadApiTest.groovy
@@ -6,6 +6,13 @@ import datadog.trace.test.util.Flaky
 // Note: test builder x2 + test factory can be refactored but are kept simple to ease with debugging.
 @Flaky("class loader deadlock on virtual thread clean up while Groovy do dynamic code generation - APMLP-782")
 class VirtualThreadApiTest extends InstrumentationSpecification {
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig('dd.trace.java.lang.21.enabled=true', 'true')
+  }
+
   def "test Thread.Builder.OfVirtual - start()"() {
     setup:
     def threadBuilder = Thread.ofVirtual().name("builder - started")

--- a/dd-smoke-tests/concurrent/java-21/src/test/groovy/datadog/smoketest/concurrent/AbstractConcurrentTest.groovy
+++ b/dd-smoke-tests/concurrent/java-21/src/test/groovy/datadog/smoketest/concurrent/AbstractConcurrentTest.groovy
@@ -18,6 +18,7 @@ abstract class AbstractConcurrentTest extends AbstractSmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.add("-Ddd.trace.otel.enabled=true")
+    command.add("-Ddd.trace.java.lang.21.enabled=true")
     command.addAll(["-jar", jarPath])
     command.addAll(getTestArguments())
 


### PR DESCRIPTION
# What Does This Do

There is a deadlock with groovy testing making them flaky.
I need time to properly test it and before activating the feature by default.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
