### PR TITLE
Add pin system tests workflow

### DIFF
--- a/.github/chainguard/self.pin-system-tests.create-pr.sts.yaml
+++ b/.github/chainguard/self.pin-system-tests.create-pr.sts.yaml
@@ -1,11 +1,11 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/dd-trace-java:ref:refs/heads/.+
+subject_pattern: repo:DataDog/dd-trace-java:ref:refs/heads/(master|test/v.+)
 
 claim_pattern:
-  event_name: (push|workflow_dispatch)
-  ref: refs/heads/.+
-  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/pin-system-tests\.yaml@refs/heads/.+
+  event_name: (create|workflow_dispatch)
+  ref: refs/heads/(master|test/v.+)
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/pin-system-tests\.yaml@refs/heads/(master|test/v.+)
 
 permissions:
   contents: write

--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   pin-system-tests:
     name: "Pin system tests"
+    # CHANGE BACK TO release/v*
     if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/test/v')
     runs-on: ubuntu-latest
     permissions:
@@ -95,7 +96,7 @@ jobs:
         if: steps.check-changes.outputs.commit_changes == 'true' && steps.check-branch.outputs.creating_new_branch == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        # base may need to be `release/v*`
+        # REMOVE DRAFT
         run: |
           gh pr create --title "Pin system tests for release branch" \
             --base ${{ steps.define-base-branch.outputs.base_branch }} \


### PR DESCRIPTION
# What Does This Do

Add workflow that pins system tests

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
