### PR TITLE
Fix pattern matching in dd-octo-sts policy

### DIFF
--- a/.github/chainguard/self.pin-system-tests.create-pr.sts.yaml
+++ b/.github/chainguard/self.pin-system-tests.create-pr.sts.yaml
@@ -1,11 +1,11 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/dd-trace-java:ref:refs/heads/**
+subject_pattern: ^repo:DataDog/dd-trace-java:ref:refs/heads/.+$
 
 claim_pattern:
   event_name: (push|workflow_dispatch)
   ref: refs/heads/.+
-  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/pin-system-tests\.yaml@refs/heads/master
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/pin-system-tests\.yaml@refs/heads/.+
 
 permissions:
   contents: write


### PR DESCRIPTION
# What Does This Do

Fix `dd-octo-sts` trust policy's pattern-matching

# Motivation

Address the failure [here](https://github.com/DataDog/dd-trace-java/actions/runs/20143266074). I confirmed with the following local output:

```
sarah.chen@COMP-GHXRH1QQ7F dd-trace-java % DDOCTOSTS_ID_TOKEN='{"actor":"sarahchen6","actor_id":"68485867","aud":"dd-octo-sts","base_ref":"","check_run_id":"57816563539","enterprise":"datadog-inc","enterprise_id":"42","event_name":"push","exp":1765477852,"head_ref":"","iat":1765477552,"iss":"https://token.actions.githubusercontent.com","job_workflow_ref":"DataDog/dd-trace-java/.github/workflows/pin-system-tests.yaml@refs/heads/sarahchen6/pin-system-tests-workflow","job_workflow_sha":"c4421ba5a6647bbd8615a995babea998c4c7f5b6","jti":"954e5dda-a50f-4183-9ccb-a7cb8c44e3fe","nbf":1765477252,"ref":"refs/heads/sarahchen6/pin-system-tests-workflow","ref_protected":"false","ref_type":"branch","repository":"DataDog/dd-trace-java","repository_id":"89221572","repository_owner":"DataDog","repository_owner_id":"365230","repository_visibility":"public","run_attempt":"1","run_id":"20143266074","run_number":"2","runner_environment":"github-hosted","sha":"c4421ba5a6647bbd8615a995babea998c4c7f5b6","sub":"repo:DataDog/dd-trace-java:ref:refs/heads/sarahchen6/pin-system-tests-workflow","workflow":"Pin system tests","workflow_ref":"DataDog/dd-trace-java/.github/workflows/pin-system-tests.yaml@refs/heads/sarahchen6/pin-system-tests-workflow","workflow_sha":"c4421ba5a6647bbd8615a995babea998c4c7f5b6"}' \
dd-octo-sts check -s DataDog/dd-trace-java -p self.pin-system-tests.create-pr
🔍 Checking repository and policy location...
Assuming repository path "/Users/sarah.chen/Source/github.com/DataDog/dd-trace-java"
  Tip: Use --repo/-r to override.
✅ Policy is in a valid location.
   Location: .github/chainguard/self.pin-system-tests.create-pr.sts.yaml

🔍 Checking policy file...
✅ Policy is valid
   Permissions:
   - pull_requests: write
✅ Policy is valid
   Permissions:
   - contents: write

🔍 Checking token...
⚠️ Fabricating a token out of claims.
   This token will not work in production, but is suitable for testing.
⚠️ Token is invalid: oidc: token is expired (Token Expiry: 2025-12-11 13:30:52 -0500 EST)
   Note that in real usage, this token would not be useable.
✅ Supplied token is valid for policy
   Matching claims:
   - job_workflow_ref: DataDog/dd-trace-java/.github/workflows/pin-system-tests.yaml@refs/heads/sarahchen6/pin-system-tests-workflow
   - ref: refs/heads/sarahchen6/pin-system-tests-workflow
   - event_name: push
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
