### PR TITLE
Fixed flaky muzzle test for jersy-client-2.0 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/jersey/jersey-client-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey-client-2.0/build.gradle
@@ -3,6 +3,9 @@ muzzle {
     group = "org.glassfish.jersey.core"
     module = "jersey-client"
     versions = "[2.0,3.0.0)"
+    // There is no such file `jakarta.annotation-api-1.3.4.redhat-00002.jar`
+    // in the Maven repository: https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/jakarta/annotation/jakarta.annotation-api/1.3.4.redhat-00002/
+    excludeDependency "jakarta.annotation:jakarta.annotation-api:1.3.4.redhat-00002"
   }
 }
 
@@ -10,10 +13,8 @@ apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
   compileOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.0'
-
   compileOnly project(':dd-java-agent:instrumentation:rs:jax-rs:jax-rs-client:jax-rs-client-2.0')
 
   testImplementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.0'
-
   testImplementation project(':dd-java-agent:instrumentation:rs:jax-rs:jax-rs-client:jax-rs-client-2.0')
 }


### PR DESCRIPTION
# What Does This Do
Fix the flaky muzzle test for the jersey-client-2.0 instrumentation by excluding problematic external dependencies.

# Motivation
The muzzle test has been intermittently failing due to missing artifacts in external repositories. For example, builds sometimes fail with errors such as:
```
Execution failed for task ':dd-java-agent:instrumentation:jersey:jersey-client-2.0:muzzle-AssertPass-org.glassfish.jersey.core-jersey-client-2.28.0.redhat-00001'.
> Could not resolve all files for configuration ':dd-java-agent:instrumentation:jersey:jersey-client-2.0:muzzle-AssertPass-org.glassfish.jersey.core-jersey-client-2.28.0.redhat-00001'.
   > Could not find jakarta.annotation-api-1.3.4.redhat-00002.jar (jakarta.annotation:jakarta.annotation-api:1.3.4.redhat-00002).
     Searched in the following locations:
         https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/jakarta/annotation/jakarta.annotation-api/1.3.4.redhat-00002/jakarta.annotation-api-1.3.4.redhat-00002.jar
```

Verification shows that the Red Hat Maven repository does not contain this artifact [see](https://maven.repository.redhat.com/ga/jakarta/annotation/jakarta.annotation-api/1.3.4.redhat-00002/)

# Additional Notes
To fix such failures the only way is to explicitly exclude known bad releases and/or their missing/broken transitive dependencies..

