### PR TITLE
Avoid NPE when setting resource with null path

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/normalize/HttpResourceNames.java
+++ b/internal-api/src/main/java/datadog/trace/api/normalize/HttpResourceNames.java
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 
 public class HttpResourceNames {
   public static final UTF8BytesString DEFAULT_RESOURCE_NAME = UTF8BytesString.create("/");
@@ -71,6 +72,9 @@ public class HttpResourceNames {
 
   public static AgentSpan setForServer(
       AgentSpan span, CharSequence method, CharSequence path, boolean encoded) {
+    if (path == null) {
+      return span;
+    }
     Pair<CharSequence, Byte> result = computeForServer(method, path, encoded);
     if (result.hasLeft()) {
       span.setResourceName(result.getLeft(), result.getRight());
@@ -80,7 +84,7 @@ public class HttpResourceNames {
   }
 
   public static Pair<CharSequence, Byte> computeForServer(
-      CharSequence method, CharSequence path, boolean encoded) {
+      CharSequence method, @Nonnull CharSequence path, boolean encoded) {
     byte priority;
 
     String resourcePath =
@@ -96,7 +100,7 @@ public class HttpResourceNames {
   }
 
   public static Pair<CharSequence, Byte> computeForClient(
-      CharSequence method, CharSequence path, boolean encoded) {
+      CharSequence method, @Nonnull CharSequence path, boolean encoded) {
     byte priority;
 
     String resourcePath =
@@ -112,6 +116,9 @@ public class HttpResourceNames {
 
   public static AgentSpan setForClient(
       AgentSpan span, CharSequence method, CharSequence path, boolean encoded) {
+    if (path == null) {
+      return span;
+    }
     Pair<CharSequence, Byte> result = computeForClient(method, path, encoded);
     if (result.hasLeft()) {
       span.setResourceName(result.getLeft(), result.getRight());


### PR DESCRIPTION
# What Does This Do

When setting client/server resource name from the path, the path must not be null. This was already checked on the tag interceptor but not from the calls coming from instrumentations. This PR enforces this check

Avoids:

```
java.lang.NullPointerException
  at datadog.trace.api.normalize.HttpResourceNames.computeForServer(HttpResourceNames.java:87)
  at datadog.trace.api.normalize.HttpResourceNames.setForServer(HttpResourceNames.java:74)
  at datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.withServerPath(HttpResourceDecorator.java:31)
  at datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.onRequest(HttpServerDecorator.java:266)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
