### PR TITLE
Avoid NPE on QuartzDecorator

### DIFF
--- a/dd-java-agent/instrumentation/quartz-2.0/src/main/java/datadog/trace/instrumentation/quartz/QuartzDecorator.java
+++ b/dd-java-agent/instrumentation/quartz-2.0/src/main/java/datadog/trace/instrumentation/quartz/QuartzDecorator.java
@@ -10,6 +10,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.TriggerKey;
 
 public class QuartzDecorator extends BaseDecorator {
   public static final CharSequence SCHEDULED_CALL = UTF8BytesString.create("scheduled.call");
@@ -34,11 +36,21 @@ public class QuartzDecorator extends BaseDecorator {
 
   public AgentSpan onExecute(final AgentSpan span, JobExecutionContext context) {
     if (context != null) {
-      span.setTag(DDTags.RESOURCE_NAME, context.getJobInstance().getClass()).toString();
-      span.setTag(QUARTZ_TRIGGER_NAME, context.getTrigger().getKey().getName());
-      span.setTag(QUARTZ_TRIGGER_GROUP, context.getTrigger().getKey().getGroup());
-      span.setTag(QUARTZ_JOB_NAME, context.getTrigger().getJobKey().getName());
-      span.setTag(QUARTZ_JOB_GROUP, context.getTrigger().getJobKey().getGroup());
+      if (context.getJobInstance() != null) {
+        span.setTag(DDTags.RESOURCE_NAME, context.getJobInstance().getClass()).toString();
+      }
+      if (context.getTrigger() != null) {
+        final TriggerKey key = context.getTrigger().getKey();
+        if (key != null) {
+          span.setTag(QUARTZ_TRIGGER_NAME, key.getName());
+          span.setTag(QUARTZ_TRIGGER_GROUP, key.getGroup());
+        }
+        final JobKey jobKey = context.getJobDetail().getKey();
+        if (jobKey != null) {
+          span.setTag(QUARTZ_JOB_NAME, jobKey.getName());
+          span.setTag(QUARTZ_JOB_GROUP, jobKey.getGroup());
+        }
+      }
     }
     return span;
   }


### PR DESCRIPTION
# What Does This Do

Correctly protects from null access variables used on QuartzDecorator.

Solves:

```
java.lang.NullPointerException
  at datadog.trace.instrumentation.quartz.QuartzDecorator.onExecute(QuartzDecorator.java:37)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
