### PR TITLE
Replace in spotless `greclipse` by `prettier`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import com.diffplug.spotless.npm.PrettierFormatterStep
 import datadog.gradle.plugin.ci.testAggregate
 
 plugins {
@@ -39,10 +40,10 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     googleJavaFormat("1.32.0")
   }
   groovyGradle {
-    greclipse()
+    prettier(mapOf("prettier" to "3.7.4", "prettier-plugin-groovy" to "0.2.1"))
   }
   groovy {
-    greclipse()
+    prettier(mapOf("prettier" to "3.7.4", "prettier-plugin-groovy" to "0.2.1"))
   }
   kotlinGradle {
     ktlint("1.8.0")

--- a/gradle/enforcement/prettier-groovy.toml
+++ b/gradle/enforcement/prettier-groovy.toml
@@ -1,0 +1,10 @@
+# prettier-groovy.toml
+# Reads the .editorconfig file in the project root for base settings
+
+plugins = [
+  "prettier-plugin-groovy", # https://www.npmjs.com/package/prettier-plugin-groovy
+]
+
+[[overrides]]
+files = ["*.groovy"]
+options = { parser = "groovy" }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,6 +9,7 @@ def buildDirectoryFiles = project.layout.buildDirectory.asFileTree
 
 spotless {
   if (rootProject.hasProperty('skipSpotless')) {
+    logger.warn("This property is going away, use standard Gradle options: '-x spotlessCheck' or '-x spotlessApply' to exclude spotless tasks")
     // Spotless in JDK 8 uses an older eclipse formatter, and it has a (flaky) bug crashing check_profiling.
     // We disable it in CI, since we have a job dedicated to spotless anyway.
     enforceCheck false
@@ -37,7 +38,7 @@ spotless {
     } else {
       target '*.gradle'
     }
-    greclipse().configFile(configPath + '/enforcement/spotless-groovy.properties')
+    prettier(["prettier" : "3.7.4", "prettier-plugin-groovy" : "0.2.1"]).configFile(configPath + '/enforcement/prettier-groovy.toml')
   }
 
   kotlinGradle {
@@ -54,13 +55,9 @@ spotless {
   project.pluginManager.withPlugin('groovy') {
     groovy {
       toggleOffOn()
-      if (!groovySkipJavaExclude) {
-        excludeJava() // excludes all Java sources within the Groovy source dirs from formatting
-        // the Groovy Eclipse formatter extends the Java Eclipse formatter,
-        // so it formats Java files by default (unless `excludeJava` is used).
-      }
+      target("**/*.groovy")
       targetExclude(buildDirectoryFiles)
-      greclipse().configFile(configPath + '/enforcement/spotless-groovy.properties')
+      prettier(["prettier" : "3.7.4", "prettier-plugin-groovy" : "0.2.1"]).configFile(configPath + '/enforcement/prettier-groovy.toml')
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Replaces `greclipse` to format Groovy files, by `prettier` and the `prettier-plugin-groovy` (that uses `beautify-groovy`).

# Motivation

Avoid slow and memory hungry spotless. See https://github.com/diffplug/spotless/issues/2788

# Additional Notes

> [!CAUTION]
> An issue with that approach is that the underlying formatter is too zealous and is not super configurable. Thus making files barely readable.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
