### PR TITLE
Fixed flaky muzzle test for apache-httpclient-4.0 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/build.gradle
@@ -10,6 +10,7 @@ muzzle {
     group = "org.apache.httpcomponents"
     module = "httpclient"
     versions = "[4.0,5)"
+    skipVersions += "4.3.6" // missing httpcore-4.3.3.redhat-3.jar at https://maven.repository.redhat.com/ga/org/apache/httpcomponents/httpcore/4.3.3.redhat-3/
     assertInverse = true
   }
   pass {


### PR DESCRIPTION
# What Does This Do
Fix the flaky muzzle test for the `apache-httpclient-4.0` instrumentation by excluding problematic version.

# Motivation
The muzzle test has been intermittently failing due to missing artifacts in external repositories. For example, builds sometimes fail with errors such as:
```
EExecution failed for task ':dd-java-agent:instrumentation:apache-httpclient:apache-httpclient-4.0:muzzle-AssertPass-org.apache.httpcomponents-httpclient-4.3.6.redhat-3'.
> Could not resolve all files for configuration ':dd-java-agent:instrumentation:apache-httpclient:apache-httpclient-4.0:muzzle-AssertPass-org.apache.httpcomponents-httpclient-4.3.6.redhat-3'.
   > Could not find httpcore-4.3.3.redhat-3.jar (org.apache.httpcomponents:httpcore:4.3.3.redhat-3).
     Searched in the following locations:
         https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/org/apache/httpcomponents/httpcore/4.3.3.redhat-3/httpcore-4.3.3.redhat-3.jar
```

Verification shows that the Red Hat Maven repository does not contain this artifact [see](https://maven.repository.redhat.com/ga/org/apache/httpcomponents/httpcore/4.3.3.redhat-3/)

# Additional Notes
To fix such failures the only way is to explicitly exclude known bad releases and/or their missing/broken transitive dependencies..

