### PR TITLE
Refine pin-system-tests workflow

### DIFF
--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -52,7 +52,6 @@ jobs:
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
             echo "creating_new_branch=false" >> "$GITHUB_OUTPUT"
             echo "Branch $BRANCH already exists - please delete it and re-run the workflow."
-            exit 0 # REMOVE THIS
           else
             echo "creating_new_branch=true" >> "$GITHUB_OUTPUT"
             echo "Branch $BRANCH does not exist - creating it now"
@@ -67,7 +66,6 @@ jobs:
           if [[ -z "$(git status -s)" ]]; then
             echo "No changes to commit, exiting."
             echo "commit_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0 # REMOVE THIS
           else
             echo "commit_changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes to commit:"


### PR DESCRIPTION
# What Does This Do

Refine `pin-system-tests` workflow

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
