### PR TITLE
Revert workaround. Maven Central issue with missing dependency was resolved

### DIFF
--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -49,9 +49,7 @@ dependencies {
 
   latestDepTestImplementation group: 'org.wildfly.core', name: 'wildfly-embedded', version: '+'
   latestDepTestImplementation group: 'org.wildfly.core', name: 'wildfly-server', version: '+'
-  // FIXME: Latest wildfly-dist is broken, due to missing dependency on Maven Central
-  // see: https://github.com/wildfly/mvc-krazo-feature-pack/issues/142
-  wildflyLatestDepTest "org.wildfly:wildfly-dist:38.0.0.Final@zip"
+  wildflyLatestDepTest "org.wildfly:wildfly-dist:+@zip"
 
   latestDepTestRuntimeOnly project(':dd-java-agent:instrumentation:servlet:jakarta-servlet-5.0')
 }


### PR DESCRIPTION
# What Does This Do
Revert of #10053

# Motivation
Green CI

# Additional Notes
See [here](https://github.com/wildfly/mvc-krazo-feature-pack/issues/142#issuecomment-3648205497)

