### PR TITLE
Avoid NPE on BaseDecorator

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -91,7 +91,9 @@ public abstract class BaseDecorator {
   }
 
   public AgentScope onError(final AgentScope scope, final Throwable throwable) {
-    onError(scope.span(), throwable);
+    if (scope != null) {
+      onError(scope.span(), throwable);
+    }
     return scope;
   }
 
@@ -100,7 +102,7 @@ public abstract class BaseDecorator {
   }
 
   public AgentSpan onError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
-    if (throwable != null) {
+    if (throwable != null && span != null) {
       span.addThrowable(
           throwable instanceof ExecutionException ? throwable.getCause() : throwable,
           errorPriority);
@@ -109,7 +111,9 @@ public abstract class BaseDecorator {
   }
 
   public ContextScope onError(final ContextScope scope, final Throwable throwable) {
-    onError(AgentSpan.fromContext(scope.context()), throwable);
+    if (scope != null) {
+      onError(AgentSpan.fromContext(scope.context()), throwable);
+    }
     return scope;
   }
 


### PR DESCRIPTION
# What Does This Do

Some instrumentations seems willing to decorate null scopes/spans

```
java.lang.NullPointerException
  at decorator.BaseDecorator.onError(BaseDecorator.java:89)
```

This PR just protect the scope.span() and span itself from null accesses


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
