### PR TITLE
Avoid NPE when enumerating servlet headers

### DIFF
--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletExtractAdapter.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletExtractAdapter.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.servlet3;
 
+import static java.util.Collections.emptyEnumeration;
+import static java.util.Collections.enumeration;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,7 +44,8 @@ public abstract class HttpServletExtractAdapter<T> implements AgentPropagation.C
 
     @Override
     Enumeration<String> getHeaderNames(HttpServletResponse response) {
-      return Collections.enumeration(response.getHeaderNames());
+      final Collection<String> headerNames = response.getHeaderNames();
+      return headerNames != null ? enumeration(headerNames) : emptyEnumeration();
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

ServletRequest.getHeaderNames() can return null.

Fixes:

```
java.lang.NullPointerException
  at (redacted: 6 frames)
  at datadog.trace.instrumentation.servlet3.HttpServletExtractAdapter$Response.getHeaderNames(HttpServletExtractAdapter.java:44)
  at 
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
