### PR TITLE
Log injection issues in JDBC only once + promote to WARN

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -9,6 +9,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -425,6 +426,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     if (!loggedInjectionError) {
       loggedInjectionError = true;
       log.warn(
+          LogCollector.EXCLUDE_TELEMETRY, // nothing we can do on our side about this
           "Failed to set extra DBM data in {}. "
               + "To disable this behavior, set trace_prepared_statements to 'false'. "
               + "See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm/ for more info. "


### PR DESCRIPTION
# What Does This Do

Make sure we only log injection errors once.
We have that info on the span anyway.
I also raised the severity to WARN because there is a clear call to action in the log to make it disappear, so if customers are bothered by it, it shouldn't raise any tickets.

# Motivation

Since debug logs send telemetry even when debug is disabled, this reduces the number of telemetry events we receive, and the performance overhead of the instrumentation.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
