### PR TITLE
Bump Groovy and Kotlin plugin versions.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,11 @@ okhttp = "3.12.15" # Datadog fork to support Java 7
 
 # Languages
 ## Groovy
-groovy = "3.0.24"
+groovy = "3.0.25"
 
 ## Kotlin
 kotlin = "1.6.21"
-kotlin-plugin = "1.9.24"
+kotlin-plugin = "2.0.21"
 kotlinx-coroutines = "1.3.0"
 
 ## Scala


### PR DESCRIPTION
# What Does This Do
- Bump Groovy `3.0.24` - > `3.0.25`
- Bump Kotlin plugin `1.9.24` -> `2.0.21`

# Motivation
- Since `Spock` has been updated to the `final 2.4` release, it is reasonable to update `Groovy` to `3.0.25` so both stay aligned and compatible.
- The project was still using an older version of the Gradle Kotlin plugin. Gradle `8.14.3` ships with Kotlin `2.0.21` by default, so updating ensures consistency with Gradle’s toolchain.

# Additional Notes
- These upgrades are minor but help keep dependencies aligned with upstream versions.
- No functional changes are expected; builds should remain stable.
