### PR TITLE
Adjusted check for akka token to validate that it is not blank.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -636,7 +636,6 @@ if (providers.gradleProperty("akkaRepositoryToken").getOrElse("").isNotBlank()) 
   logger.quiet("Omitting :dd-java-agent:instrumentation:akka:akka-http:akka-http-10.6: 'akkaRepositoryToken' not configured")
 }
 
-
 // benchmark
 include(
   ":dd-java-agent:benchmark",


### PR DESCRIPTION
# What Does This Do
Updates the check for the `Akka` token to ensure it is not blank before use.

# Motivation
GitHub Actions may encounter permission issues when reading tokens from secrets.
In such cases, the token may be initialized as an empty value, causing the build to fail.
Since `Akka` instrumentation is not required for GitHub jobs, an empty token can safely be ignored..

# Additional Notes
It would be better to investigate and resolve the underlying issue preventing GitHub Actions from correctly reading the secret token.

