### PR TITLE
Temporary fix to unblock GitLab CI.

### DIFF
--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
@@ -5,6 +5,7 @@ muzzle {
     module = "redisson"
     versions = "[3.10.3,)"
     skipVersions += "0.9.0"
+    skipVersions += "4.0.0" // FIXME: Temporary skip `4.0.0` as we need more time to support it.
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -16,6 +16,7 @@ muzzle {
     group = "org.apache.spark"
     module = "spark-sql_$scalaVersion"
     versions = "[4.0.0,)"
+    skipVersions += "4.1.0" // FIXME: Temporary skip `4.1.0` as we need more time to support it.
     javaVersion = 17
   }
 }


### PR DESCRIPTION
# What Does This Do
Implements a temporary workaround for a muzzle compatibility issue.
A proper fix will be delivered in follow-up PRs by the code owners.

# Motivation
Unblock CI for other developers and keep development moving while the underlying issue is being addressed.

# Additional Notes
Two external dependencies were recently released — `redison-4.0.0` and `spark-4.1.0` — and they are no longer compatible with dd-trace-java. This incompatibility was detected by the muzzle plugin.

We will need some time to add full support for these new versions. In the meantime, we are temporarily skipping them to restore CI stability.
