### PR TITLE
muzzle fix for redisson

### DIFF
--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/build.gradle
@@ -5,7 +5,6 @@ muzzle {
     module = "redisson"
     versions = "[3.10.3,)"
     skipVersions += "0.9.0"
-    skipVersions += "4.0.0" // FIXME: Temporary skip `4.0.0` as we need more time to support it.
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import net.bytebuddy.asm.Advice;
-import org.redisson.api.RFuture;
+import org.redisson.api.RTransaction;
 import org.redisson.client.RedisConnection;
 import org.redisson.client.protocol.CommandData;
 import org.redisson.client.protocol.CommandsData;
@@ -86,9 +86,9 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
     }
 
-    public static void muzzleCheck(final RFuture<?> future) {
+    public static void muzzleCheck(final RTransaction b) {
       // added on 3.10.3
-      future.onComplete(null);
+      b.getBuckets();
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Change the method used for the muzzlecheck for redison advice.
The method we used to "restrict" versions older than 3.10.3 got remove in 4.0.0, so I found a different one that was added in 3.10.3 and was still in v4.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
