### PR TITLE
Mitigate user prefs lock

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -565,7 +565,7 @@ muzzle-dep-report:
       export PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/${CI_JOB_NAME_SLUG}.jfr,dumponexit=true";
       fi
     - *prepare_test_env
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEM -Xmx$GRADLE_MEM $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=1024M -Ddatadog.forkedMinHeapSize=128M"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEM -Xmx$GRADLE_MEM $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.util.prefs.userRoot=/tmp/.java/.userPrefs-${CI_JOB_ID}' -Ddatadog.forkedMaxHeapSize=1024M -Ddatadog.forkedMinHeapSize=128M"
     - ./gradlew --version
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PtestJvm=$testJvm -Pslot=$CI_NODE_INDEX/$CI_NODE_TOTAL $GRADLE_ARGS --continue || $CONTINUE_ON_FAILURE
   after_script:


### PR DESCRIPTION
# What Does This Do

Move the Gradle daemon user prefs location to a different location.

# Motivation

Filing steps, due to user preferences locking contention.

Symptom:
```
Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock.
```

User preferences are still a bottleneck for some steps, in particular the `5/6` slot for instrumentation tests.


**Analysis**
This is still happening, the reason is that on Linux, the `Preferences` backend is a [`FileSystemPreferences`](https://github.com/openjdk/jdk8u/blob/6a3f7bb9a01114a01628e49792caf1a6c3f071e4/jdk/src/solaris/classes/java/util/prefs/FileSystemPreferences.java). 

Whoever request the user preferences, trigger the following [automatic flush mechanism](https://github.com/openjdk/jdk8u/blob/6a3f7bb9a01114a01628e49792caf1a6c3f071e4/jdk/src/solaris/classes/java/util/prefs/FileSystemPreferences.java#L440-L460), that will happen

* Every 30 seconds via a timer (`java.util.prefs.syncInterval` property, default 30s)
* On shutdown

Gradle is configured to have 4 active parallel workers via the `--max-workers` flag (otherwise the default would be [10, the number of requested CPU](https://github.com/DataDog/dd-trace-java/blob/f2184f4bf5e27c3d730873772a8b2fba7d2faec0/.gitlab-ci.yml#L544)). Possibly they are started around the same time and contend on this lock.


**Who is writing there**
Groovy !

```
~/.java/.userPrefs
├── .user.lock.non-root-user
├── .userRootModFile.non-root-user
└── org
    ├── codehaus
    │   ├── groovy
    │   │   ├── tools
    │   │   │   └── shell
    │   │   │   │   └── prefs.xml
    │   │   │   └── prefs.xml
    │   │   └── prefs.xml
    │   └── prefs.xml
    └── prefs.xml
```

This is a follow-up of the mitigations in
* #10083


# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
