### PR TITLE
Show container, processes dashboard links

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ default:
       TIME_PARAMS=""
     fi
 
-    echo -e "${TEXT_BOLD}${TEXT_YELLOW}Runner dashboard, these are live (expire after 1 hour)${TEXT_CLEAR}"
+    echo -e "${TEXT_BOLD}${TEXT_YELLOW}Runner dashboard, these are live (limited to a 1-hour window, and expire after 36 hours)${TEXT_CLEAR}"
     echo -e "${TEXT_BOLD}${TEXT_YELLOW}   Containers:${TEXT_CLEAR} https://app.datadoghq.com/containers?${TIME_PARAMS}query=image_name%3A%2A%2Fdatadog%2Fdd-trace-java-docker-build%20AND%20pod_name%3A${POD_NAME}&live=false"
     echo -e "${TEXT_BOLD}${TEXT_YELLOW}   Processes:${TEXT_CLEAR} https://app.datadoghq.com/process?${TIME_PARAMS}query=image_name%3A%2A%2Fdatadog%2Fdd-trace-java-docker-build%20AND%20pod_name%3A${POD_NAME}&live=false"
 


### PR DESCRIPTION
# What Does This Do

Simple PR to show a link to container dashboards.

<img width="877" height="109" alt="image" src="https://github.com/user-attachments/assets/95bb4ae3-32ae-4347-8d93-a0214ffea39c" />

> [!NOTE]
> The data is **Live**, only allow a 1-hour window and expire after 36-hours.

> [!NOTE]
> At this time, the processes are not shown when the runner allows `docker-in-docker`, which are all jobs extending `.test_job` because they are tagged with `tags: [ "docker-in-docker:amd64" ]`. Those are currently ran in MicroVMs (hence the cgroup v2). Currently the jobs running on these micro vms don't report everything (RSS or processes).

I don't believe this is a blocker for this improvement though.

_Possibly the query for in the explorer could use the job name tag, e.g. : `ci-job-name:test-base---11--1-4`._

# Motivation

Quick way to explore what's happening inside our runners.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
