### PR TITLE
Enable Code Origin by default for JDK25+

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
@@ -1,0 +1,43 @@
+package com.datadog.debugger.origin;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+public class CodeOriginConfigTest {
+
+  @EnabledForJreRange(min = JRE.JAVA_25)
+  @Test
+  public void defaultConfigJDK25() {
+    assertTrue(Config.get().isDebuggerCodeOriginEnabled());
+  }
+
+  @EnabledOnJre(JRE.JAVA_21)
+  @Test
+  public void defaultConfigJDK21() {
+    assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+  }
+
+  @EnabledOnJre(JRE.JAVA_17)
+  @Test
+  public void defaultConfigJDK17() {
+    assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+  }
+
+  @EnabledOnJre(JRE.JAVA_11)
+  @Test
+  public void defaultConfigJDK11() {
+    assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+  }
+
+  @EnabledOnJre(JRE.JAVA_8)
+  @Test
+  public void defaultConfigJDK8() {
+    assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -40,7 +40,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_SIGNAL_SERVE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_SOURCE_DATA_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CLIENT_IP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SYNC_PERIOD;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_COUCHBASE_INTERNAL_SPANS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
@@ -2597,7 +2596,7 @@ public class Config {
             EXCEPTION_REPLAY_ENABLED);
     debuggerCodeOriginEnabled =
         configProvider.getBoolean(
-            CODE_ORIGIN_FOR_SPANS_ENABLED, DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED);
+            CODE_ORIGIN_FOR_SPANS_ENABLED, getDefaultCodeOriginForSpanEnabled());
     debuggerCodeOriginMaxUserFrames =
         configProvider.getInteger(CODE_ORIGIN_MAX_USER_FRAMES, DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES);
     debuggerMaxExceptionPerSecond =
@@ -2976,6 +2975,14 @@ public class Config {
             AI_GUARD_MAX_MESSAGES_LENGTH, DEFAULT_AI_GUARD_MAX_MESSAGES_LENGTH);
 
     log.debug("New instance: {}", this);
+  }
+
+  private boolean getDefaultCodeOriginForSpanEnabled() {
+    if (JavaVirtualMachine.isJavaVersionAtLeast(25)) {
+      // activate by default Code Origin only for JDK25+
+      return true;
+    }
+    return false;
   }
 
   private static boolean isValidUrl(String url) {


### PR DESCRIPTION
# What Does This Do
Add tests for ensuring enablement by JDK version

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4173]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4173]: https://datadoghq.atlassian.net/browse/DEBUG-4173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ