### PR TITLE
Add support for Agrona collections

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -193,7 +193,8 @@ public class WellKnownClasses {
           "java.", // JDK base module
           "com.google.protobuf.", // Google ProtoBuf
           "com.google.common.collect.", // Google Guava
-          "it.unimi.dsi.fastutil." // fastutil
+          "it.unimi.dsi.fastutil.", // fastutil
+          "org.agrona.collections." // Agrona
           );
 
   private static final List<String> SAFE_MAP_PACKAGES =
@@ -201,7 +202,8 @@ public class WellKnownClasses {
           "java.", // JDK base module
           "com.google.protobuf.", // Google ProtoBuf
           "com.google.common.collect.", // Google Guava
-          "it.unimi.dsi.fastutil." // fastutil
+          "it.unimi.dsi.fastutil.", // fastutil
+          "org.agrona.collections." // Agrona
           );
 
   /**


### PR DESCRIPTION
# What Does This Do
Consider Agrona collections and maps as safe so they can be treated as regular collections and maps and use in expression and captured as well

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4662]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4662]: https://datadoghq.atlassian.net/browse/DEBUG-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ