### PR TITLE
Fix InstrumenterConfig for Code Origin default

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnJre;
@@ -15,29 +16,34 @@ public class CodeOriginConfigTest {
   @Test
   public void defaultConfigJDK25() {
     assertTrue(Config.get().isDebuggerCodeOriginEnabled());
+    assertTrue(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 
   @EnabledOnJre(JRE.JAVA_21)
   @Test
   public void defaultConfigJDK21() {
     assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+    assertFalse(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 
   @EnabledOnJre(JRE.JAVA_17)
   @Test
   public void defaultConfigJDK17() {
     assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+    assertFalse(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 
   @EnabledOnJre(JRE.JAVA_11)
   @Test
   public void defaultConfigJDK11() {
     assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+    assertFalse(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 
   @EnabledOnJre(JRE.JAVA_8)
   @Test
   public void defaultConfigJDK8() {
     assertFalse(Config.get().isDebuggerCodeOriginEnabled());
+    assertFalse(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2596,7 +2596,7 @@ public class Config {
             EXCEPTION_REPLAY_ENABLED);
     debuggerCodeOriginEnabled =
         configProvider.getBoolean(
-            CODE_ORIGIN_FOR_SPANS_ENABLED, getDefaultCodeOriginForSpanEnabled());
+            CODE_ORIGIN_FOR_SPANS_ENABLED, InstrumenterConfig.getDefaultCodeOriginForSpanEnabled());
     debuggerCodeOriginMaxUserFrames =
         configProvider.getInteger(CODE_ORIGIN_MAX_USER_FRAMES, DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES);
     debuggerMaxExceptionPerSecond =
@@ -2975,14 +2975,6 @@ public class Config {
             AI_GUARD_MAX_MESSAGES_LENGTH, DEFAULT_AI_GUARD_MAX_MESSAGES_LENGTH);
 
     log.debug("New instance: {}", this);
-  }
-
-  private boolean getDefaultCodeOriginForSpanEnabled() {
-    if (JavaVirtualMachine.isJavaVersionAtLeast(25)) {
-      // activate by default Code Origin only for JDK25+
-      return true;
-    }
-    return false;
   }
 
   private static boolean isValidUrl(String url) {

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -3,7 +3,6 @@ package datadog.trace.api;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENDPOINT_COLLECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_JOBS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
@@ -86,6 +85,7 @@ import static datadog.trace.api.config.UsmConfig.USM_ENABLED;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
 
+import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.profiling.ProfilingEnablement;
 import datadog.trace.api.telemetry.ConfigInversionMetricCollectorImpl;
 import datadog.trace.api.telemetry.ConfigInversionMetricCollectorProvider;
@@ -231,7 +231,7 @@ public class InstrumenterConfig {
 
     codeOriginEnabled =
         configProvider.getBoolean(
-            CODE_ORIGIN_FOR_SPANS_ENABLED, DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED);
+            CODE_ORIGIN_FOR_SPANS_ENABLED, getDefaultCodeOriginForSpanEnabled());
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     traceOtelEnabled = configProvider.getBoolean(TRACE_OTEL_ENABLED, DEFAULT_TRACE_OTEL_ENABLED);
     metricsOtelEnabled =
@@ -664,6 +664,14 @@ public class InstrumenterConfig {
           Platform.isNativeImageBuilder()
               ? ConfigProvider.withoutCollector()
               : ConfigProvider.getInstance());
+
+  static boolean getDefaultCodeOriginForSpanEnabled() {
+    if (JavaVirtualMachine.isJavaVersionAtLeast(25)) {
+      // activate by default Code Origin only for JDK25+
+      return true;
+    }
+    return false;
+  }
 
   public static InstrumenterConfig get() {
     return INSTANCE;


### PR DESCRIPTION
# What Does This Do
Missed that Code Origin is also defined in InstrumenterConfig so need to share the default based on JDK version between InstrumenterConfig and Config

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
