### PR TITLE
Clean up `forbiddenApi` configurations; after updating to the latest version, many entries are no longer relevant.

### DIFF
--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -52,10 +52,6 @@ tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-tasks.named("forbiddenApisMain_java11", CheckForbiddenApis) {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-builder/build.gradle
+++ b/dd-java-agent/agent-builder/build.gradle
@@ -33,10 +33,6 @@ tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-tasks.named("forbiddenApisMain_java11") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/build.gradle
@@ -49,10 +49,6 @@ tasks.withType(AbstractCompile).configureEach {
   options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -38,10 +38,6 @@ tasks.named("compileTestJava", JavaCompile) {
   options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
 }
 
-tasks.named("forbiddenApisMain", CheckForbiddenApis) {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/build.gradle
@@ -44,10 +44,6 @@ tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-tasks.named("forbiddenApisMain", CheckForbiddenApis) {
-  it.failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/build.gradle
@@ -48,10 +48,6 @@ dependencies {
   }
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -55,10 +55,6 @@ configurations.configureEach {
   }
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -77,13 +77,6 @@ tasks.named("forbiddenApisJmh") {
   ignoreFailures = true
 }
 
-tasks.named("forbiddenApisTest_java11") {
-  // it will fail due to missing JDK >= 9 classes
-  // java.lang.ClassNotFoundException: java.lang.invoke.StringConcatFactory
-  failOnMissingClasses = false
-  ignoreFailures = true
-}
-
 tasks.named("compileTestJava") {
   dependsOn('generateTestClassNameTries')
 }

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/UnknownArityExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/UnknownArityExample.java
@@ -1,13 +1,13 @@
 package datadog.trace.agent.tooling.csi;
 
-import java.util.UUID;
+import datadog.trace.util.RandomUtils;
 import java.util.function.Supplier;
 
 public class UnknownArityExample implements Supplier<String> {
 
   @Override
   public String get() {
-    final String name = UUID.randomUUID().toString();
+    final String name = RandomUtils.randomUUID().toString();
     final long height = Math.round(Math.random() * 200);
     final double weight = Math.random() * 100;
     final int age = (int) Math.round(Math.random() * 100);

--- a/dd-java-agent/instrumentation/exception-profiling/build.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/build.gradle
@@ -31,10 +31,6 @@ dependencies {
   }
 }
 
-tasks.named("forbiddenApisMain_java11") {
-  failOnMissingClasses = false
-}
-
 tasks.named("test", Test) {
   useJUnitPlatform()
 }

--- a/dd-java-agent/instrumentation/gradle-testing-5.1/build.gradle
+++ b/dd-java-agent/instrumentation/gradle-testing-5.1/build.gradle
@@ -11,7 +11,3 @@ dependencies {
   compileOnly gradleApi()
   compileOnly project(":dd-java-agent:instrumentation:junit:junit-4.10")
 }
-
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/dd-java-agent/instrumentation/gradle/gradle-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/gradle/gradle-3.0/build.gradle
@@ -9,7 +9,3 @@ repositories {
 dependencies {
   compileOnly gradleApi()
 }
-
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/dd-java-agent/instrumentation/gradle/gradle-8.3/build.gradle
+++ b/dd-java-agent/instrumentation/gradle/gradle-8.3/build.gradle
@@ -9,7 +9,3 @@ repositories {
 dependencies {
   compileOnly gradleApi()
 }
-
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/build.gradle
@@ -19,10 +19,6 @@ tasks.named("compileTestGroovy", GroovyCompile) {
   configureCompiler(it, 11)
 }
 
-tasks.named("forbiddenApisMain_java11") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/instrumentation/java/java-nio-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-nio-1.8/build.gradle
@@ -24,10 +24,6 @@ testJvmConstraints {
   }
 }
 
-tasks.named("forbiddenApisMain_java11") {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = '11'

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/build.gradle
@@ -44,10 +44,6 @@ addTestSuiteExtendingForDir('ee10LatestDepForkedTest', 'ee10LatestDepTest', 'tes
   }
 }
 
-tasks.named("forbiddenApisMain_java17") {
-  failOnMissingClasses = false
-}
-
 tasks.withType(GroovyCompile).configureEach {
   configureCompiler(it, 17)
 }

--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -102,10 +102,6 @@ tasks.named("jar", Jar) {
   from sourceSets.main_java11.output
 }
 
-tasks.named("forbiddenApisMain_java11") {
-  failOnMissingClasses = false
-}
-
 tasks.named("forkedTest", Test) {
   testJvmConstraints {
     maxJavaVersion = JavaVersion.VERSION_11

--- a/dd-smoke-tests/appsec/springboot-security/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-security/build.gradle
@@ -16,10 +16,6 @@ tasks.named("jar", Jar) {
   }
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 // Use Java 17 to build application
 tasks.withType(JavaCompile).configureEach {
   configureCompiler(delegate, 17)

--- a/dd-smoke-tests/iast-util/iast-util-11/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-11/build.gradle
@@ -27,7 +27,3 @@ dependencies {
 tasks.named("compileJava", JavaCompile) {
   configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
-
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/dd-smoke-tests/iast-util/iast-util-17/build.gradle
+++ b/dd-smoke-tests/iast-util/iast-util-17/build.gradle
@@ -28,7 +28,3 @@ dependencies {
 tasks.named("compileJava", JavaCompile) {
   configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
-
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -30,10 +30,6 @@ tasks.named("compileJava", JavaCompile) {
   configureCompiler(it, 11, JavaVersion.VERSION_11)
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 tasks.withType(Test).configureEach {
   dependsOn "bootJar"
   def bootJarTask = tasks.named('bootJar', BootJar)

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -30,10 +30,6 @@ tasks.named("compileJava", JavaCompile) {
   configureCompiler(it, 17, JavaVersion.VERSION_17)
 }
 
-tasks.named("forbiddenApisMain") {
-  failOnMissingClasses = false
-}
-
 tasks.withType(Test).configureEach {
   dependsOn "bootJar"
   def bootJarTask = tasks.named('bootJar', BootJar)

--- a/internal-api/internal-api-9/build.gradle.kts
+++ b/internal-api/internal-api-9/build.gradle.kts
@@ -44,10 +44,6 @@ dependencies {
   testImplementation(libs.slf4j)
 }
 
-tasks.forbiddenApisMain {
-  failOnMissingClasses = false
-}
-
 idea {
   module {
     jdkName = "11"

--- a/products/feature-flagging/api/build.gradle.kts
+++ b/products/feature-flagging/api/build.gradle.kts
@@ -73,7 +73,3 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.withType<Javadoc>().configureEach {
   javadocTool = javaToolchains.javadocToolFor(java.toolchain)
 }
-
-tasks.named<CheckForbiddenApis>("forbiddenApisMain") {
-  failOnMissingClasses = false
-}

--- a/utils/socket-utils/build.gradle.kts
+++ b/utils/socket-utils/build.gradle.kts
@@ -21,10 +21,6 @@ dependencies {
   testImplementation(files(sourceSets["main_java17"].output))
 }
 
-tasks.named<CheckForbiddenApis>("forbiddenApisMain_java17") {
-  failOnMissingClasses = false
-}
-
 fun AbstractCompile.configureCompiler(javaVersionInteger: Int, compatibilityVersion: JavaVersion? = null, unsetReleaseFlagReason: String? = null) {
   (project.extra["configureCompiler"] as Closure<*>).call(this, javaVersionInteger, compatibilityVersion, unsetReleaseFlagReason)
 }


### PR DESCRIPTION
# What Does This Do
Clean up `forbiddenApi` configurations; after updating to the latest version, many entries are no longer relevant.

# Motivation
Simplify and tidy up the Gradle scripts. Unnecessary suppressions may mask real issues in the future, so removing them improves maintainability and safety.
