### PR TITLE
Bump `com.gradleup.shadow` Gradle plugin version from `8.3.6` to `8.3.9`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
   id("com.github.spotbugs") version "6.4.8"
   id("de.thetaphi.forbiddenapis") version "3.10"
   id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-  id("com.gradleup.shadow") version "8.3.6" apply false
+  id("com.gradleup.shadow") version "8.3.9" apply false
   id("me.champeau.jmh") version "0.7.3" apply false
   id("org.gradle.playframework") version "0.13" apply false
 }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   java
   groovy
   id("com.diffplug.spotless") version "8.1.0"
-  id("com.gradleup.shadow") version "8.3.6"
+  id("com.gradleup.shadow") version "8.3.9"
 }
 
 java {

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
   id 'application'
   id 'java'
-  id 'com.gradleup.shadow' version '8.3.6'
+  id 'com.gradleup.shadow' version '8.3.9'
   id 'com.google.protobuf' version '0.9.3'
 }
 


### PR DESCRIPTION
# What Does This Do
Bump `com.gradleup.shadow` Gradle plugin version from `8.3.6` to `8.3.9`.

# Motivation
Latest tools.

# Additional Notes
Technically we can migrate to `9.2.x` but there a lot of breaking changes, need more time to find how to migrate.
