### PR TITLE
Add CapturedContext interface implementation

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.CapturedContextProbe;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.MethodLocation;
@@ -28,11 +29,26 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SpanDecorationProbe extends ProbeDefinition {
+public class SpanDecorationProbe extends ProbeDefinition implements CapturedContextProbe {
   private static final Logger LOGGER = LoggerFactory.getLogger(SpanDecorationProbe.class);
   private static final String PROBEID_DD_TAGS_FORMAT = "_dd.di.%s.probe_id";
   private static final String EVALERROR_DD_TAGS_FORMAT = "_dd.di.%s.evaluation_error";
   private static final Limits LIMITS = new Limits(1, 3, 255, 5);
+
+  @Override
+  public boolean isCaptureSnapshot() {
+    return false;
+  }
+
+  @Override
+  public boolean hasCondition() {
+    return false;
+  }
+
+  @Override
+  public boolean isReadyToCapture() {
+    return true;
+  }
 
   public enum TargetSpan {
     ACTIVE,


### PR DESCRIPTION
# What Does This Do
SpanDecorationProbe use also the CaptureContext instrumentation so need to implement the interface.
this fixes the class cast exception.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
