### PR TITLE
Protect jsp decorator from NPE

### DIFF
--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -67,8 +67,10 @@ public class JSPDecorator extends BaseDecorator {
     try {
       // note: getRequestURL is supposed to always be nonnull - however servlet wrapping can happen
       // and we never know if ever this can happen
-      span.setTag(
-          "jsp.requestURL", (new URI(req.getRequestURL().toString())).normalize().toString());
+      final StringBuffer requestURL = req.getRequestURL();
+      if (requestURL != null && requestURL.length() > 0) {
+        span.setTag("jsp.requestURL", (new URI(requestURL.toString())).normalize().toString());
+      }
     } catch (final Throwable ignored) {
       // logging here will be too verbose
     }


### PR DESCRIPTION
# What Does This Do

BaseDecorator fails here:

```
Error : Failed to handle exception in instrumentation for org.apache.jsp.view_jsp
java.lang.NullPointerException
  at datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator.beforeFinish(BaseDecorator.java:81)
  at (redacted: 2 frames)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:596)
  at (redacted: 3 frames)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:596)
  at (redacted: 13 frames)
  at javax.portlet.GenericPortlet.render(GenericPortlet.java:291)
  at (redacted: 6 frames)
```

Correlating than with other similar telemetry signals - this happens because there is another issue in the JSP decorator:

```
  java.lang.NullPointerException
  at datadog.trace.instrumentation.jsp.JSPDecorator.onRender(JSPDecorator.java:72)
  at (redacted: 2 frames)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:623)
  at (redacted: 3 frames)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:623)
  at (redacted: 13 frames)
  at javax.portlet.GenericPortlet.render(GenericPortlet.java:291)
  at (redacted: 7 frames)
```

This happens because getRequestURL seems to be null. This PR also avoid this by widening the catch to Throwable. The logging is also removed for two reasons:
1. We do not pollute the customer logs (it was in the servlet application logging)
2. Logging each failure will be too verbose 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
