### PR TITLE
Avoid NPE when inspecting spring messaging headers

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageExtractAdapter.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 
 public final class SpringMessageExtractAdapter
     implements AgentPropagation.ContextVisitor<Message<?>> {
@@ -33,7 +34,12 @@ public final class SpringMessageExtractAdapter
 
   @Override
   public void forEachKey(Message<?> carrier, AgentPropagation.KeyClassifier classifier) {
-    for (Map.Entry<String, ?> header : carrier.getHeaders().entrySet()) {
+    final MessageHeaders messageHeaders = carrier.getHeaders();
+    if (messageHeaders == null || messageHeaders.isEmpty()) {
+      return;
+    }
+
+    for (Map.Entry<String, ?> header : messageHeaders.entrySet()) {
       Object headerValue = header.getValue();
       if ("_datadog".equals(header.getKey())) {
         if (headerValue instanceof String) {


### PR DESCRIPTION
# What Does This Do

Solves:

```
java.lang.NullPointerException
  at datadog.trace.instrumentation.springmessaging.SpringMessageExtractAdapter.forEachKey(SpringMessageExtractAdapter.java:36)
  at datadog.trace.instrumentation.springmessaging.SpringMessageExtractAdapter.forEachKey(SpringMessageExtractAdapter.java:14)
  at datadog.trace.bootstrap.instrumentation.api.AgentPropagation$ContextVisitor.forEachKeyValue(AgentPropagation.java:47)
  at datadog.context.propagation.CompositePropagator.extract(CompositePropagator.java:26)
  at datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extractContextAndGetSpanContext(AgentPropagation.java:32)
  at (redacted: 10 frames)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
