### PR TITLE
Avoid NPE in tomcat classloading instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/tomcat/tomcat-9.0/src/main/java/datadog/trace/instrumentation/tomcat9/WebappClassLoaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-9.0/src/main/java/datadog/trace/instrumentation/tomcat9/WebappClassLoaderInstrumentation.java
@@ -41,7 +41,7 @@ public class WebappClassLoaderInstrumentation extends InstrumenterModule.Tracing
         @Advice.This final WebappClassLoaderBase classLoader,
         @Advice.Argument(0) final WebResourceRoot webResourceRoot) {
       // at this moment we have the context set in this classloader, hence its name
-      final Context context = webResourceRoot.getContext();
+      final Context context = webResourceRoot != null ? webResourceRoot.getContext() : null;
       if (context == null) {
         return;
       }


### PR DESCRIPTION
# What Does This Do

It does not cause functional issue - however it produces annoying telemetry signals.
Should solve:

```
Error : Failed to handle exception in instrumentation for org.apache.catalina.loader.WebappClassLoaderBase
java.lang.NullPointerException
  at (redacted: 9 frames)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:569)
  at (redacted: 10 frames)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:529)
  at (redacted)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:623)
  at (redacted: 60 frames)
  at datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal(HandlerMappingResourceNameFilter.java:51)
  at (redacted: 32 frames)
  at java.base/java.lang.Thread.run(Thread.java:840)
```

Note: the code is inlined reason why there is no direct relationship

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
