### PR TITLE
Silence non-critical PayloadTagsProcessor parsing exception alert

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PayloadTagsProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PayloadTagsProcessor.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.tagprocessor;
 
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 import static datadog.trace.util.json.JsonPathParser.parseJsonPaths;
 
 import datadog.trace.api.Config;
@@ -262,7 +263,8 @@ public final class PayloadTagsProcessor extends TagsPostProcessor {
 
     @Override
     public void expandValueFailed(PathCursor path, Exception exception) {
-      log.debug("Failed to expand value at path '{}'", path.toString(""), exception);
+      log.debug(
+          EXCLUDE_TELEMETRY, "Failed to expand value at path '{}'", path.toString(""), exception);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Silence non-critical PayloadTagsProcessor parsing exception alert.

# Motivation

Disable reporting of JSON parsing exceptions to the error tracking telemetry.

# Additional Notes

[Alert](https://app.datadoghq.com/error-tracking/unified?query=source%3Ajvm+service%3Ainstrumentation-telemetry-data+-%28%40tags.severity%3Acrash+OR+severity%3Acrash+OR+signum%3A%2A+OR+%40error.is_crash%3Atrue%29+%40library_version.major%3A1+%40library_version.minor%3A57+-%28%40error.stack%3A%2Adatadog.trace.instrumentation%2A+OR+%22Failed+to+handle+exception+in+instrumentation%22+OR+%40error.stack%3A%2AOutOfMemoryError%2A+OR+%40error.stack%3A%2AAccessControlException%2A%29&issueId=a926c4d4-c6b5-11f0-b89a-da7ad0900002&from_ts=1766053245000&to_ts=1766139645000&live=false&monitor_id=227934645&monitor_sub_type=.new%28%29&link_source=monitor_notif)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
