### PR TITLE
Ensure the class name is valid when enhancing with SerialVersionUIDAdder

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/asm/SerialVersionUIDAdder.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/asm/SerialVersionUIDAdder.java
@@ -182,7 +182,7 @@ public class SerialVersionUIDAdder extends ClassVisitor {
       final String[] interfaces) {
     // Get the class name, access flags, and interfaces information (step 1, 2 and 3) for SVUID
     // computation.
-    computeSvuid = (access & Opcodes.ACC_ENUM) == 0;
+    computeSvuid = name != null && (access & Opcodes.ACC_ENUM) == 0;
 
     if (computeSvuid) {
       this.name = name;


### PR DESCRIPTION
# What Does This Do

According to that telemetry issue it seems that the class name can be null while visiting it:

```
java.lang.NullPointerException
  at datadog.trace.agent.tooling.context.asm.SerialVersionUIDAdder.computeSVUID(SerialVersionUIDAdder.java:349)
  at datadog.trace.agent.tooling.context.FieldBackedContextInjector$SerialVersionUIDInjector.injectSerialVersionUID(FieldBackedContextInjector.java:529)
  at datadog.trace.agent.tooling.context.FieldBackedContextInjector$1.visitEnd(FieldBackedContextInjector.java:233)
  at (redacted: 12 frames)
```

This PR avoid trigger a computation when the required meta are missing

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
