### PR TITLE
Add a limit to the number of elements we process in a mongo document

### DIFF
--- a/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/Context.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/Context.java
@@ -2,13 +2,19 @@ package datadog.trace.instrumentation.mongo;
 
 final class Context {
 
+  private static final int MAX_DEPTH = 64;
+  private static final int MAX_SEQUENCE_LENGTH = 256;
+
   private final StringBuilder buffer = new StringBuilder();
 
   // specifies the depth below which everything must be discarded,
   // e.g. because we're inside an $in clause we want to collapse
-  private int discardDepth = 64;
-  private int keepDepth = 64;
+  private int discardDepth = MAX_DEPTH;
+  private int keepDepth = MAX_DEPTH;
   private int depth;
+
+  // tracks sequence element counts at each depth level to limit long arrays
+  private final int[] sequenceCounts = new int[MAX_DEPTH];
 
   public void discardSubTree() {
     if (depth < discardDepth) {
@@ -29,11 +35,32 @@ final class Context {
   public void endDocument() {
     --depth;
     if (discardDepth == depth) {
-      discardDepth = 64;
+      discardDepth = MAX_DEPTH;
     }
     if (keepDepth == depth) {
-      keepDepth = 64;
+      keepDepth = MAX_DEPTH;
     }
+  }
+
+  public void startArray() {
+    if (depth < MAX_DEPTH) {
+      sequenceCounts[depth] = 0;
+    }
+    // note: nothing to do at the end of the array
+  }
+
+  /**
+   * Signals that a new element is being processed in the current array. Returns true if this
+   * element should be written, false if the sequence limit has been reached.
+   */
+  public boolean nextSequenceElement() {
+    // checking depth just to make sure we don't access the array out of bounds, but it should never
+    // be the case since we stop processing the document before reaching this code.
+    if (depth < MAX_DEPTH) {
+      sequenceCounts[depth]++;
+      return sequenceCounts[depth] <= MAX_SEQUENCE_LENGTH;
+    }
+    return false; // theoretically unreachable
   }
 
   public boolean disableObfuscation() {
@@ -48,7 +75,7 @@ final class Context {
     // this means we are parsing a huge document, which we will truncate anyway
     // note that MongoDB sets a default max nested depth of 100, and MongoDB users
     // are generally advised to avoid deep nesting for the sake of database performance
-    return depth >= 64;
+    return depth >= MAX_DEPTH;
   }
 
   private boolean shouldWrite() {
@@ -82,6 +109,8 @@ final class Context {
   public void clear() {
     buffer.setLength(0);
     depth = 0;
+    discardDepth = MAX_DEPTH;
+    keepDepth = MAX_DEPTH;
   }
 
   public String asString() {

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber31.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber31.java
@@ -270,6 +270,7 @@ public final class BsonScrubber31 implements BsonWriter, BsonScrubber {
 
   @Override
   public void writeStartArray() {
+    context.startArray();
     context.write('[');
   }
 
@@ -455,7 +456,11 @@ public final class BsonScrubber31 implements BsonWriter, BsonScrubber {
     writeStartArray(attribute);
     BsonType type = reader.readBsonType();
     while (type != BsonType.END_OF_DOCUMENT) {
-      pipeValue(null, reader);
+      if (context.nextSequenceElement()) {
+        pipeValue(null, reader);
+      } else {
+        reader.skipValue();
+      }
       type = reader.readBsonType();
       nextValue(type);
     }
@@ -466,6 +471,9 @@ public final class BsonScrubber31 implements BsonWriter, BsonScrubber {
   private void pipeArray(String attribute, final BsonArray array) {
     writeStartArray(attribute);
     for (BsonValue cur : array) {
+      if (!context.nextSequenceElement()) {
+        break;
+      }
       pipeValue(null, cur);
     }
     writeEndArray();

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.1/src/test/groovy/BsonScrubber31Test.groovy
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.1/src/test/groovy/BsonScrubber31Test.groovy
@@ -27,4 +27,28 @@ class BsonScrubber31Test extends InstrumentationSpecification {
     "{\"update\" : \"orders\", \"ordered\" : false, \"writeConcern\" : { \"w\" : \"majority\" }, \"updates\": [{ \"q\" : { \"_id\" : 1 }, \"u\" : { \"orderId\" : \"Account1\", \"qty\" : 10 } } ]}"                                                                                 | "{\"update\": \"orders\", \"ordered\": false, \"writeConcern\": {\"w\": \"majority\"}, \"updates\": []}"
     "{\"insert\" : \"stuff\", \"ordered\" : true, \"writeConcern\" : { \"w\" : 10 }, \"documents\": [{ \"_id\" : { \"s\" : 0, \"i\": \"DEADBEEF\" }, \"array\" : [0, \"foo\", {\"foo\": 10}], \"qty\" : 10 } ]}"                                                                      | "{\"insert\": \"stuff\", \"ordered\": true, \"writeConcern\": {\"w\": 10}, \"documents\": []}"
   }
+
+  def "test BSON scrubber truncates long sequences"() {
+    setup:
+    // Create a document with an array containing 300 elements (more than the limit)
+    def elements = (1..300).collect { "\"item$it\"" }.join(", ")
+    def input = "{\"find\": \"collection\", \"filter\": {\"\$or\": [$elements]}}"
+    BsonDocument doc = BsonDocument.parse(input)
+
+    when:
+    BsonScrubber31 scrubber = new BsonScrubber31()
+    scrubber.pipe(new BsonDocumentReader(doc))
+    String resourceName = scrubber.getResourceName()
+
+    then:
+    // The output should contain exactly 256 "?" elements (the first 256 get obfuscated)
+    // and should still be valid JSON with a closing bracket
+    resourceName.startsWith("{\"find\": \"collection\", \"filter\": {\"\$or\": [")
+    resourceName.endsWith("]}}")
+    // Count the number of obfuscated values - should be exactly 256
+    resourceName.count("\"?\"") == 256
+
+    cleanup:
+    scrubber.close()
+  }
 }

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber34.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber34.java
@@ -279,6 +279,7 @@ public class BsonScrubber34 implements BsonWriter, BsonScrubber {
 
   @Override
   public void writeStartArray() {
+    context.startArray();
     context.write('[');
   }
 
@@ -467,7 +468,11 @@ public class BsonScrubber34 implements BsonWriter, BsonScrubber {
     writeStartArray(attribute);
     BsonType type = reader.readBsonType();
     while (type != BsonType.END_OF_DOCUMENT) {
-      pipeValue(null, reader);
+      if (context.nextSequenceElement()) {
+        pipeValue(null, reader);
+      } else {
+        reader.skipValue();
+      }
       type = reader.readBsonType();
       nextValue(type);
     }
@@ -478,6 +483,9 @@ public class BsonScrubber34 implements BsonWriter, BsonScrubber {
   private void pipeArray(String attribute, final BsonArray array) {
     writeStartArray(attribute);
     for (BsonValue cur : array) {
+      if (!context.nextSequenceElement()) {
+        break;
+      }
       pipeValue(null, cur);
     }
     writeEndArray();

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.4/src/test/groovy/BsonScrubber34Test.groovy
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.4/src/test/groovy/BsonScrubber34Test.groovy
@@ -27,4 +27,28 @@ class BsonScrubber34Test extends InstrumentationSpecification {
     "{\"update\" : \"orders\", \"ordered\" : false, \"writeConcern\" : { \"w\" : \"majority\" }, \"updates\": [{ \"q\" : { \"_id\" : 1 }, \"u\" : { \"orderId\" : \"Account1\", \"qty\" : 10 } } ]}"                                                                                 | "{\"update\": \"orders\", \"ordered\": false, \"writeConcern\": {\"w\": \"majority\"}, \"updates\": []}"
     "{\"insert\" : \"stuff\", \"ordered\" : true, \"writeConcern\" : { \"w\" : 10 }, \"documents\": [{ \"_id\" : { \"s\" : 0, \"i\": \"DEADBEEF\" }, \"array\" : [0, \"foo\", {\"foo\": 10}], \"qty\" : 10 } ]}"                                                                      | "{\"insert\": \"stuff\", \"ordered\": true, \"writeConcern\": {\"w\": 10}, \"documents\": []}"
   }
+
+  def "test BSON scrubber truncates long sequences"() {
+    setup:
+    // Create a document with an array containing 300 elements (more than the limit)
+    def elements = (1..300).collect { "\"item$it\"" }.join(", ")
+    def input = "{\"find\": \"collection\", \"filter\": {\"\$or\": [$elements]}}"
+    BsonDocument doc = BsonDocument.parse(input)
+
+    when:
+    BsonScrubber34 scrubber = new BsonScrubber34()
+    scrubber.pipe(new BsonDocumentReader(doc))
+    String resourceName = scrubber.getResourceName()
+
+    then:
+    // The output should contain exactly 256 "?" elements (the first 256 get obfuscated)
+    // and should still be valid JSON with a closing bracket
+    resourceName.startsWith("{\"find\": \"collection\", \"filter\": {\"\$or\": [")
+    resourceName.endsWith("]}}")
+    // Count the number of obfuscated values - should be exactly 256
+    resourceName.count("\"?\"") == 256
+
+    cleanup:
+    scrubber.close()
+  }
 }


### PR DESCRIPTION
# What Does This Do

stop adding elements to the internal string we build for Bson documents once we have reached a certain number.
This has been shown to create memory issues for customers (see linked escalation tickets in the task)

# Motivation

customer escalation

# Additional Notes

This is potentially a breaking change, because the resource name would change in some cases, but I think in the cases where this would happen, the resource name would be super long and unusable by humans, so it's very unlikely customers would rely on its value.
(tbh, it's still be super long and unusable after that change, since the limit is pretty high, at 256, but at least it wouldn't cause memory issues - hopefully)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-267]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-267]: https://datadoghq.atlassian.net/browse/AIDM-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ