### PR TITLE
Batch re-transformations when there are a high number of inner classes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -225,6 +225,28 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
   }
 
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {
+    int classCount = classesToBeTransformed.size();
+    if (classCount <= 10) {
+      retransformIndividualClasses(classesToBeTransformed);
+    } else if (classCount <= 1000) {
+      retransformClassesAtOnce(classesToBeTransformed);
+    } else {
+      throw new IllegalStateException("Too many classes to retransform: " + classCount);
+    }
+  }
+
+  private void retransformClassesAtOnce(List<Class<?>> classesToBeTransformed) {
+    LOGGER.debug("Re-transforming classes: {}", classesToBeTransformed);
+    try {
+      instrumentation.retransformClasses(classesToBeTransformed.toArray(new Class[0]));
+    } catch (Exception ex) {
+      ExceptionHelper.logException(LOGGER, ex, "Re-transform error:");
+    } catch (Throwable ex) {
+      ExceptionHelper.logException(LOGGER, ex, "Re-transform throwable:");
+    }
+  }
+
+  private void retransformIndividualClasses(List<Class<?>> classesToBeTransformed) {
     for (Class<?> clazz : classesToBeTransformed) {
       try {
         LOGGER.debug("Re-transforming class: {}", clazz.getTypeName());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -9,6 +9,7 @@ import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -405,6 +406,22 @@ class ConfigurationComparerTest {
         probe, sourceFileMapping, TopLevelHelper.class, false, TopLevelHelper.class);
     doAllLoadedChangedClasses(
         probe, sourceFileMapping, MyTopLevelClass.class, false, MyTopLevelClass.class);
+  }
+
+  @Test
+  public void allLoadedChangedClassesLargeInnerClasses() {
+    final String CLASS_FILENAME = "LargeInnerClasses.java";
+    Map<String, List<String>> sourceFileMapping = new HashMap<>();
+    List<String> classNames = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      classNames.add(
+          String.format("com.datadog.debugger.agent.LargeInnerClasses$MyInnerClass%02d", i));
+    }
+    sourceFileMapping.put(CLASS_FILENAME, classNames);
+    LogProbe probe =
+        LogProbe.builder().probeId(PROBE_ID).where(null, null, null, 6, CLASS_FILENAME).build();
+    doAllLoadedChangedClasses(
+        probe, sourceFileMapping, LargeInnerClasses.class, false, LargeInnerClasses.class);
   }
 
   private void doAllLoadedChangedClasses(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LargeInnerClasses.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LargeInnerClasses.java
@@ -1,0 +1,208 @@
+package com.datadog.debugger.agent;
+
+public class LargeInnerClasses {
+
+  public static int main(String arg) {
+    return 42; // beae1817-f3b0-4ea8-a74f-000000000001
+  }
+
+  static class MyInnerClass00 {}
+
+  static class MyInnerClass01 {}
+
+  static class MyInnerClass02 {}
+
+  static class MyInnerClass03 {}
+
+  static class MyInnerClass04 {}
+
+  static class MyInnerClass05 {}
+
+  static class MyInnerClass06 {}
+
+  static class MyInnerClass07 {}
+
+  static class MyInnerClass08 {}
+
+  static class MyInnerClass09 {}
+
+  static class MyInnerClass10 {}
+
+  static class MyInnerClass11 {}
+
+  static class MyInnerClass12 {}
+
+  static class MyInnerClass13 {}
+
+  static class MyInnerClass14 {}
+
+  static class MyInnerClass15 {}
+
+  static class MyInnerClass16 {}
+
+  static class MyInnerClass17 {}
+
+  static class MyInnerClass18 {}
+
+  static class MyInnerClass19 {}
+
+  static class MyInnerClass20 {}
+
+  static class MyInnerClass21 {}
+
+  static class MyInnerClass22 {}
+
+  static class MyInnerClass23 {}
+
+  static class MyInnerClass24 {}
+
+  static class MyInnerClass25 {}
+
+  static class MyInnerClass26 {}
+
+  static class MyInnerClass27 {}
+
+  static class MyInnerClass28 {}
+
+  static class MyInnerClass29 {}
+
+  static class MyInnerClass30 {}
+
+  static class MyInnerClass31 {}
+
+  static class MyInnerClass32 {}
+
+  static class MyInnerClass33 {}
+
+  static class MyInnerClass34 {}
+
+  static class MyInnerClass35 {}
+
+  static class MyInnerClass36 {}
+
+  static class MyInnerClass37 {}
+
+  static class MyInnerClass38 {}
+
+  static class MyInnerClass39 {}
+
+  static class MyInnerClass40 {}
+
+  static class MyInnerClass41 {}
+
+  static class MyInnerClass42 {}
+
+  static class MyInnerClass43 {}
+
+  static class MyInnerClass44 {}
+
+  static class MyInnerClass45 {}
+
+  static class MyInnerClass46 {}
+
+  static class MyInnerClass47 {}
+
+  static class MyInnerClass48 {}
+
+  static class MyInnerClass49 {}
+
+  static class MyInnerClass50 {}
+
+  static class MyInnerClass51 {}
+
+  static class MyInnerClass52 {}
+
+  static class MyInnerClass53 {}
+
+  static class MyInnerClass54 {}
+
+  static class MyInnerClass55 {}
+
+  static class MyInnerClass56 {}
+
+  static class MyInnerClass57 {}
+
+  static class MyInnerClass58 {}
+
+  static class MyInnerClass59 {}
+
+  static class MyInnerClass60 {}
+
+  static class MyInnerClass61 {}
+
+  static class MyInnerClass62 {}
+
+  static class MyInnerClass63 {}
+
+  static class MyInnerClass64 {}
+
+  static class MyInnerClass65 {}
+
+  static class MyInnerClass66 {}
+
+  static class MyInnerClass67 {}
+
+  static class MyInnerClass68 {}
+
+  static class MyInnerClass69 {}
+
+  static class MyInnerClass70 {}
+
+  static class MyInnerClass71 {}
+
+  static class MyInnerClass72 {}
+
+  static class MyInnerClass73 {}
+
+  static class MyInnerClass74 {}
+
+  static class MyInnerClass75 {}
+
+  static class MyInnerClass76 {}
+
+  static class MyInnerClass77 {}
+
+  static class MyInnerClass78 {}
+
+  static class MyInnerClass79 {}
+
+  static class MyInnerClass80 {}
+
+  static class MyInnerClass81 {}
+
+  static class MyInnerClass82 {}
+
+  static class MyInnerClass83 {}
+
+  static class MyInnerClass84 {}
+
+  static class MyInnerClass85 {}
+
+  static class MyInnerClass86 {}
+
+  static class MyInnerClass87 {}
+
+  static class MyInnerClass88 {}
+
+  static class MyInnerClass89 {}
+
+  static class MyInnerClass90 {}
+
+  static class MyInnerClass91 {}
+
+  static class MyInnerClass92 {}
+
+  static class MyInnerClass93 {}
+
+  static class MyInnerClass94 {}
+
+  static class MyInnerClass95 {}
+
+  static class MyInnerClass96 {}
+
+  static class MyInnerClass97 {}
+
+  static class MyInnerClass98 {}
+
+  static class MyInnerClass99 {}
+}

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/HugeInnerClasses.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/HugeInnerClasses.java
@@ -1,0 +1,3020 @@
+package datadog.smoketest.debugger;
+
+public class HugeInnerClasses {
+
+  public static int main(String arg) {
+    return 42; // beae1817-f3b0-4ea8-a74f-000000000001
+  }
+
+  static {
+    new MyInnerClass000();
+    new MyInnerClass001();
+    new MyInnerClass002();
+    new MyInnerClass003();
+    new MyInnerClass004();
+    new MyInnerClass005();
+    new MyInnerClass006();
+    new MyInnerClass007();
+    new MyInnerClass008();
+    new MyInnerClass009();
+    new MyInnerClass010();
+    new MyInnerClass011();
+    new MyInnerClass012();
+    new MyInnerClass013();
+    new MyInnerClass014();
+    new MyInnerClass015();
+    new MyInnerClass016();
+    new MyInnerClass017();
+    new MyInnerClass018();
+    new MyInnerClass019();
+    new MyInnerClass020();
+    new MyInnerClass021();
+    new MyInnerClass022();
+    new MyInnerClass023();
+    new MyInnerClass024();
+    new MyInnerClass025();
+    new MyInnerClass026();
+    new MyInnerClass027();
+    new MyInnerClass028();
+    new MyInnerClass029();
+    new MyInnerClass030();
+    new MyInnerClass031();
+    new MyInnerClass032();
+    new MyInnerClass033();
+    new MyInnerClass034();
+    new MyInnerClass035();
+    new MyInnerClass036();
+    new MyInnerClass037();
+    new MyInnerClass038();
+    new MyInnerClass039();
+    new MyInnerClass040();
+    new MyInnerClass041();
+    new MyInnerClass042();
+    new MyInnerClass043();
+    new MyInnerClass044();
+    new MyInnerClass045();
+    new MyInnerClass046();
+    new MyInnerClass047();
+    new MyInnerClass048();
+    new MyInnerClass049();
+    new MyInnerClass050();
+    new MyInnerClass051();
+    new MyInnerClass052();
+    new MyInnerClass053();
+    new MyInnerClass054();
+    new MyInnerClass055();
+    new MyInnerClass056();
+    new MyInnerClass057();
+    new MyInnerClass058();
+    new MyInnerClass059();
+    new MyInnerClass060();
+    new MyInnerClass061();
+    new MyInnerClass062();
+    new MyInnerClass063();
+    new MyInnerClass064();
+    new MyInnerClass065();
+    new MyInnerClass066();
+    new MyInnerClass067();
+    new MyInnerClass068();
+    new MyInnerClass069();
+    new MyInnerClass070();
+    new MyInnerClass071();
+    new MyInnerClass072();
+    new MyInnerClass073();
+    new MyInnerClass074();
+    new MyInnerClass075();
+    new MyInnerClass076();
+    new MyInnerClass077();
+    new MyInnerClass078();
+    new MyInnerClass079();
+    new MyInnerClass080();
+    new MyInnerClass081();
+    new MyInnerClass082();
+    new MyInnerClass083();
+    new MyInnerClass084();
+    new MyInnerClass085();
+    new MyInnerClass086();
+    new MyInnerClass087();
+    new MyInnerClass088();
+    new MyInnerClass089();
+    new MyInnerClass090();
+    new MyInnerClass091();
+    new MyInnerClass092();
+    new MyInnerClass093();
+    new MyInnerClass094();
+    new MyInnerClass095();
+    new MyInnerClass096();
+    new MyInnerClass097();
+    new MyInnerClass098();
+    new MyInnerClass099();
+
+    new MyInnerClass100();
+    new MyInnerClass101();
+    new MyInnerClass102();
+    new MyInnerClass103();
+    new MyInnerClass104();
+    new MyInnerClass105();
+    new MyInnerClass106();
+    new MyInnerClass107();
+    new MyInnerClass108();
+    new MyInnerClass109();
+    new MyInnerClass110();
+    new MyInnerClass111();
+    new MyInnerClass112();
+    new MyInnerClass113();
+    new MyInnerClass114();
+    new MyInnerClass115();
+    new MyInnerClass116();
+    new MyInnerClass117();
+    new MyInnerClass118();
+    new MyInnerClass119();
+    new MyInnerClass120();
+    new MyInnerClass121();
+    new MyInnerClass122();
+    new MyInnerClass123();
+    new MyInnerClass124();
+    new MyInnerClass125();
+    new MyInnerClass126();
+    new MyInnerClass127();
+    new MyInnerClass128();
+    new MyInnerClass129();
+    new MyInnerClass130();
+    new MyInnerClass131();
+    new MyInnerClass132();
+    new MyInnerClass133();
+    new MyInnerClass134();
+    new MyInnerClass135();
+    new MyInnerClass136();
+    new MyInnerClass137();
+    new MyInnerClass138();
+    new MyInnerClass139();
+    new MyInnerClass140();
+    new MyInnerClass141();
+    new MyInnerClass142();
+    new MyInnerClass143();
+    new MyInnerClass144();
+    new MyInnerClass145();
+    new MyInnerClass146();
+    new MyInnerClass147();
+    new MyInnerClass148();
+    new MyInnerClass149();
+    new MyInnerClass150();
+    new MyInnerClass151();
+    new MyInnerClass152();
+    new MyInnerClass153();
+    new MyInnerClass154();
+    new MyInnerClass155();
+    new MyInnerClass156();
+    new MyInnerClass157();
+    new MyInnerClass158();
+    new MyInnerClass159();
+    new MyInnerClass160();
+    new MyInnerClass161();
+    new MyInnerClass162();
+    new MyInnerClass163();
+    new MyInnerClass164();
+    new MyInnerClass165();
+    new MyInnerClass166();
+    new MyInnerClass167();
+    new MyInnerClass168();
+    new MyInnerClass169();
+    new MyInnerClass170();
+    new MyInnerClass171();
+    new MyInnerClass172();
+    new MyInnerClass173();
+    new MyInnerClass174();
+    new MyInnerClass175();
+    new MyInnerClass176();
+    new MyInnerClass177();
+    new MyInnerClass178();
+    new MyInnerClass179();
+    new MyInnerClass180();
+    new MyInnerClass181();
+    new MyInnerClass182();
+    new MyInnerClass183();
+    new MyInnerClass184();
+    new MyInnerClass185();
+    new MyInnerClass186();
+    new MyInnerClass187();
+    new MyInnerClass188();
+    new MyInnerClass189();
+    new MyInnerClass190();
+    new MyInnerClass191();
+    new MyInnerClass192();
+    new MyInnerClass193();
+    new MyInnerClass194();
+    new MyInnerClass195();
+    new MyInnerClass196();
+    new MyInnerClass197();
+    new MyInnerClass198();
+    new MyInnerClass199();
+
+    new MyInnerClass200();
+    new MyInnerClass201();
+    new MyInnerClass202();
+    new MyInnerClass203();
+    new MyInnerClass204();
+    new MyInnerClass205();
+    new MyInnerClass206();
+    new MyInnerClass207();
+    new MyInnerClass208();
+    new MyInnerClass209();
+    new MyInnerClass210();
+    new MyInnerClass211();
+    new MyInnerClass212();
+    new MyInnerClass213();
+    new MyInnerClass214();
+    new MyInnerClass215();
+    new MyInnerClass216();
+    new MyInnerClass217();
+    new MyInnerClass218();
+    new MyInnerClass219();
+    new MyInnerClass220();
+    new MyInnerClass221();
+    new MyInnerClass222();
+    new MyInnerClass223();
+    new MyInnerClass224();
+    new MyInnerClass225();
+    new MyInnerClass226();
+    new MyInnerClass227();
+    new MyInnerClass228();
+    new MyInnerClass229();
+    new MyInnerClass230();
+    new MyInnerClass231();
+    new MyInnerClass232();
+    new MyInnerClass233();
+    new MyInnerClass234();
+    new MyInnerClass235();
+    new MyInnerClass236();
+    new MyInnerClass237();
+    new MyInnerClass238();
+    new MyInnerClass239();
+    new MyInnerClass240();
+    new MyInnerClass241();
+    new MyInnerClass242();
+    new MyInnerClass243();
+    new MyInnerClass244();
+    new MyInnerClass245();
+    new MyInnerClass246();
+    new MyInnerClass247();
+    new MyInnerClass248();
+    new MyInnerClass249();
+    new MyInnerClass250();
+    new MyInnerClass251();
+    new MyInnerClass252();
+    new MyInnerClass253();
+    new MyInnerClass254();
+    new MyInnerClass255();
+    new MyInnerClass256();
+    new MyInnerClass257();
+    new MyInnerClass258();
+    new MyInnerClass259();
+    new MyInnerClass260();
+    new MyInnerClass261();
+    new MyInnerClass262();
+    new MyInnerClass263();
+    new MyInnerClass264();
+    new MyInnerClass265();
+    new MyInnerClass266();
+    new MyInnerClass267();
+    new MyInnerClass268();
+    new MyInnerClass269();
+    new MyInnerClass270();
+    new MyInnerClass271();
+    new MyInnerClass272();
+    new MyInnerClass273();
+    new MyInnerClass274();
+    new MyInnerClass275();
+    new MyInnerClass276();
+    new MyInnerClass277();
+    new MyInnerClass278();
+    new MyInnerClass279();
+    new MyInnerClass280();
+    new MyInnerClass281();
+    new MyInnerClass282();
+    new MyInnerClass283();
+    new MyInnerClass284();
+    new MyInnerClass285();
+    new MyInnerClass286();
+    new MyInnerClass287();
+    new MyInnerClass288();
+    new MyInnerClass289();
+    new MyInnerClass290();
+    new MyInnerClass291();
+    new MyInnerClass292();
+    new MyInnerClass293();
+    new MyInnerClass294();
+    new MyInnerClass295();
+    new MyInnerClass296();
+    new MyInnerClass297();
+    new MyInnerClass298();
+    new MyInnerClass299();
+
+    new MyInnerClass300();
+    new MyInnerClass301();
+    new MyInnerClass302();
+    new MyInnerClass303();
+    new MyInnerClass304();
+    new MyInnerClass305();
+    new MyInnerClass306();
+    new MyInnerClass307();
+    new MyInnerClass308();
+    new MyInnerClass309();
+    new MyInnerClass310();
+    new MyInnerClass311();
+    new MyInnerClass312();
+    new MyInnerClass313();
+    new MyInnerClass314();
+    new MyInnerClass315();
+    new MyInnerClass316();
+    new MyInnerClass317();
+    new MyInnerClass318();
+    new MyInnerClass319();
+    new MyInnerClass320();
+    new MyInnerClass321();
+    new MyInnerClass322();
+    new MyInnerClass323();
+    new MyInnerClass324();
+    new MyInnerClass325();
+    new MyInnerClass326();
+    new MyInnerClass327();
+    new MyInnerClass328();
+    new MyInnerClass329();
+    new MyInnerClass330();
+    new MyInnerClass331();
+    new MyInnerClass332();
+    new MyInnerClass333();
+    new MyInnerClass334();
+    new MyInnerClass335();
+    new MyInnerClass336();
+    new MyInnerClass337();
+    new MyInnerClass338();
+    new MyInnerClass339();
+    new MyInnerClass340();
+    new MyInnerClass341();
+    new MyInnerClass342();
+    new MyInnerClass343();
+    new MyInnerClass344();
+    new MyInnerClass345();
+    new MyInnerClass346();
+    new MyInnerClass347();
+    new MyInnerClass348();
+    new MyInnerClass349();
+    new MyInnerClass350();
+    new MyInnerClass351();
+    new MyInnerClass352();
+    new MyInnerClass353();
+    new MyInnerClass354();
+    new MyInnerClass355();
+    new MyInnerClass356();
+    new MyInnerClass357();
+    new MyInnerClass358();
+    new MyInnerClass359();
+    new MyInnerClass360();
+    new MyInnerClass361();
+    new MyInnerClass362();
+    new MyInnerClass363();
+    new MyInnerClass364();
+    new MyInnerClass365();
+    new MyInnerClass366();
+    new MyInnerClass367();
+    new MyInnerClass368();
+    new MyInnerClass369();
+    new MyInnerClass370();
+    new MyInnerClass371();
+    new MyInnerClass372();
+    new MyInnerClass373();
+    new MyInnerClass374();
+    new MyInnerClass375();
+    new MyInnerClass376();
+    new MyInnerClass377();
+    new MyInnerClass378();
+    new MyInnerClass379();
+    new MyInnerClass380();
+    new MyInnerClass381();
+    new MyInnerClass382();
+    new MyInnerClass383();
+    new MyInnerClass384();
+    new MyInnerClass385();
+    new MyInnerClass386();
+    new MyInnerClass387();
+    new MyInnerClass388();
+    new MyInnerClass389();
+    new MyInnerClass390();
+    new MyInnerClass391();
+    new MyInnerClass392();
+    new MyInnerClass393();
+    new MyInnerClass394();
+    new MyInnerClass395();
+    new MyInnerClass396();
+    new MyInnerClass397();
+    new MyInnerClass398();
+    new MyInnerClass399();
+
+    new MyInnerClass400();
+    new MyInnerClass401();
+    new MyInnerClass402();
+    new MyInnerClass403();
+    new MyInnerClass404();
+    new MyInnerClass405();
+    new MyInnerClass406();
+    new MyInnerClass407();
+    new MyInnerClass408();
+    new MyInnerClass409();
+    new MyInnerClass410();
+    new MyInnerClass411();
+    new MyInnerClass412();
+    new MyInnerClass413();
+    new MyInnerClass414();
+    new MyInnerClass415();
+    new MyInnerClass416();
+    new MyInnerClass417();
+    new MyInnerClass418();
+    new MyInnerClass419();
+    new MyInnerClass420();
+    new MyInnerClass421();
+    new MyInnerClass422();
+    new MyInnerClass423();
+    new MyInnerClass424();
+    new MyInnerClass425();
+    new MyInnerClass426();
+    new MyInnerClass427();
+    new MyInnerClass428();
+    new MyInnerClass429();
+    new MyInnerClass430();
+    new MyInnerClass431();
+    new MyInnerClass432();
+    new MyInnerClass433();
+    new MyInnerClass434();
+    new MyInnerClass435();
+    new MyInnerClass436();
+    new MyInnerClass437();
+    new MyInnerClass438();
+    new MyInnerClass439();
+    new MyInnerClass440();
+    new MyInnerClass441();
+    new MyInnerClass442();
+    new MyInnerClass443();
+    new MyInnerClass444();
+    new MyInnerClass445();
+    new MyInnerClass446();
+    new MyInnerClass447();
+    new MyInnerClass448();
+    new MyInnerClass449();
+    new MyInnerClass450();
+    new MyInnerClass451();
+    new MyInnerClass452();
+    new MyInnerClass453();
+    new MyInnerClass454();
+    new MyInnerClass455();
+    new MyInnerClass456();
+    new MyInnerClass457();
+    new MyInnerClass458();
+    new MyInnerClass459();
+    new MyInnerClass460();
+    new MyInnerClass461();
+    new MyInnerClass462();
+    new MyInnerClass463();
+    new MyInnerClass464();
+    new MyInnerClass465();
+    new MyInnerClass466();
+    new MyInnerClass467();
+    new MyInnerClass468();
+    new MyInnerClass469();
+    new MyInnerClass470();
+    new MyInnerClass471();
+    new MyInnerClass472();
+    new MyInnerClass473();
+    new MyInnerClass474();
+    new MyInnerClass475();
+    new MyInnerClass476();
+    new MyInnerClass477();
+    new MyInnerClass478();
+    new MyInnerClass479();
+    new MyInnerClass480();
+    new MyInnerClass481();
+    new MyInnerClass482();
+    new MyInnerClass483();
+    new MyInnerClass484();
+    new MyInnerClass485();
+    new MyInnerClass486();
+    new MyInnerClass487();
+    new MyInnerClass488();
+    new MyInnerClass489();
+    new MyInnerClass490();
+    new MyInnerClass491();
+    new MyInnerClass492();
+    new MyInnerClass493();
+    new MyInnerClass494();
+    new MyInnerClass495();
+    new MyInnerClass496();
+    new MyInnerClass497();
+    new MyInnerClass498();
+    new MyInnerClass499();
+
+    new MyInnerClass500();
+    new MyInnerClass501();
+    new MyInnerClass502();
+    new MyInnerClass503();
+    new MyInnerClass504();
+    new MyInnerClass505();
+    new MyInnerClass506();
+    new MyInnerClass507();
+    new MyInnerClass508();
+    new MyInnerClass509();
+    new MyInnerClass510();
+    new MyInnerClass511();
+    new MyInnerClass512();
+    new MyInnerClass513();
+    new MyInnerClass514();
+    new MyInnerClass515();
+    new MyInnerClass516();
+    new MyInnerClass517();
+    new MyInnerClass518();
+    new MyInnerClass519();
+    new MyInnerClass520();
+    new MyInnerClass521();
+    new MyInnerClass522();
+    new MyInnerClass523();
+    new MyInnerClass524();
+    new MyInnerClass525();
+    new MyInnerClass526();
+    new MyInnerClass527();
+    new MyInnerClass528();
+    new MyInnerClass529();
+    new MyInnerClass530();
+    new MyInnerClass531();
+    new MyInnerClass532();
+    new MyInnerClass533();
+    new MyInnerClass534();
+    new MyInnerClass535();
+    new MyInnerClass536();
+    new MyInnerClass537();
+    new MyInnerClass538();
+    new MyInnerClass539();
+    new MyInnerClass540();
+    new MyInnerClass541();
+    new MyInnerClass542();
+    new MyInnerClass543();
+    new MyInnerClass544();
+    new MyInnerClass545();
+    new MyInnerClass546();
+    new MyInnerClass547();
+    new MyInnerClass548();
+    new MyInnerClass549();
+    new MyInnerClass550();
+    new MyInnerClass551();
+    new MyInnerClass552();
+    new MyInnerClass553();
+    new MyInnerClass554();
+    new MyInnerClass555();
+    new MyInnerClass556();
+    new MyInnerClass557();
+    new MyInnerClass558();
+    new MyInnerClass559();
+    new MyInnerClass560();
+    new MyInnerClass561();
+    new MyInnerClass562();
+    new MyInnerClass563();
+    new MyInnerClass564();
+    new MyInnerClass565();
+    new MyInnerClass566();
+    new MyInnerClass567();
+    new MyInnerClass568();
+    new MyInnerClass569();
+    new MyInnerClass570();
+    new MyInnerClass571();
+    new MyInnerClass572();
+    new MyInnerClass573();
+    new MyInnerClass574();
+    new MyInnerClass575();
+    new MyInnerClass576();
+    new MyInnerClass577();
+    new MyInnerClass578();
+    new MyInnerClass579();
+    new MyInnerClass580();
+    new MyInnerClass581();
+    new MyInnerClass582();
+    new MyInnerClass583();
+    new MyInnerClass584();
+    new MyInnerClass585();
+    new MyInnerClass586();
+    new MyInnerClass587();
+    new MyInnerClass588();
+    new MyInnerClass589();
+    new MyInnerClass590();
+    new MyInnerClass591();
+    new MyInnerClass592();
+    new MyInnerClass593();
+    new MyInnerClass594();
+    new MyInnerClass595();
+    new MyInnerClass596();
+    new MyInnerClass597();
+    new MyInnerClass598();
+    new MyInnerClass599();
+
+    new MyInnerClass600();
+    new MyInnerClass601();
+    new MyInnerClass602();
+    new MyInnerClass603();
+    new MyInnerClass604();
+    new MyInnerClass605();
+    new MyInnerClass606();
+    new MyInnerClass607();
+    new MyInnerClass608();
+    new MyInnerClass609();
+    new MyInnerClass610();
+    new MyInnerClass611();
+    new MyInnerClass612();
+    new MyInnerClass613();
+    new MyInnerClass614();
+    new MyInnerClass615();
+    new MyInnerClass616();
+    new MyInnerClass617();
+    new MyInnerClass618();
+    new MyInnerClass619();
+    new MyInnerClass620();
+    new MyInnerClass621();
+    new MyInnerClass622();
+    new MyInnerClass623();
+    new MyInnerClass624();
+    new MyInnerClass625();
+    new MyInnerClass626();
+    new MyInnerClass627();
+    new MyInnerClass628();
+    new MyInnerClass629();
+    new MyInnerClass630();
+    new MyInnerClass631();
+    new MyInnerClass632();
+    new MyInnerClass633();
+    new MyInnerClass634();
+    new MyInnerClass635();
+    new MyInnerClass636();
+    new MyInnerClass637();
+    new MyInnerClass638();
+    new MyInnerClass639();
+    new MyInnerClass640();
+    new MyInnerClass641();
+    new MyInnerClass642();
+    new MyInnerClass643();
+    new MyInnerClass644();
+    new MyInnerClass645();
+    new MyInnerClass646();
+    new MyInnerClass647();
+    new MyInnerClass648();
+    new MyInnerClass649();
+    new MyInnerClass650();
+    new MyInnerClass651();
+    new MyInnerClass652();
+    new MyInnerClass653();
+    new MyInnerClass654();
+    new MyInnerClass655();
+    new MyInnerClass656();
+    new MyInnerClass657();
+    new MyInnerClass658();
+    new MyInnerClass659();
+    new MyInnerClass660();
+    new MyInnerClass661();
+    new MyInnerClass662();
+    new MyInnerClass663();
+    new MyInnerClass664();
+    new MyInnerClass665();
+    new MyInnerClass666();
+    new MyInnerClass667();
+    new MyInnerClass668();
+    new MyInnerClass669();
+    new MyInnerClass670();
+    new MyInnerClass671();
+    new MyInnerClass672();
+    new MyInnerClass673();
+    new MyInnerClass674();
+    new MyInnerClass675();
+    new MyInnerClass676();
+    new MyInnerClass677();
+    new MyInnerClass678();
+    new MyInnerClass679();
+    new MyInnerClass680();
+    new MyInnerClass681();
+    new MyInnerClass682();
+    new MyInnerClass683();
+    new MyInnerClass684();
+    new MyInnerClass685();
+    new MyInnerClass686();
+    new MyInnerClass687();
+    new MyInnerClass688();
+    new MyInnerClass689();
+    new MyInnerClass690();
+    new MyInnerClass691();
+    new MyInnerClass692();
+    new MyInnerClass693();
+    new MyInnerClass694();
+    new MyInnerClass695();
+    new MyInnerClass696();
+    new MyInnerClass697();
+    new MyInnerClass698();
+    new MyInnerClass699();
+
+    new MyInnerClass700();
+    new MyInnerClass701();
+    new MyInnerClass702();
+    new MyInnerClass703();
+    new MyInnerClass704();
+    new MyInnerClass705();
+    new MyInnerClass706();
+    new MyInnerClass707();
+    new MyInnerClass708();
+    new MyInnerClass709();
+    new MyInnerClass710();
+    new MyInnerClass711();
+    new MyInnerClass712();
+    new MyInnerClass713();
+    new MyInnerClass714();
+    new MyInnerClass715();
+    new MyInnerClass716();
+    new MyInnerClass717();
+    new MyInnerClass718();
+    new MyInnerClass719();
+    new MyInnerClass720();
+    new MyInnerClass721();
+    new MyInnerClass722();
+    new MyInnerClass723();
+    new MyInnerClass724();
+    new MyInnerClass725();
+    new MyInnerClass726();
+    new MyInnerClass727();
+    new MyInnerClass728();
+    new MyInnerClass729();
+    new MyInnerClass730();
+    new MyInnerClass731();
+    new MyInnerClass732();
+    new MyInnerClass733();
+    new MyInnerClass734();
+    new MyInnerClass735();
+    new MyInnerClass736();
+    new MyInnerClass737();
+    new MyInnerClass738();
+    new MyInnerClass739();
+    new MyInnerClass740();
+    new MyInnerClass741();
+    new MyInnerClass742();
+    new MyInnerClass743();
+    new MyInnerClass744();
+    new MyInnerClass745();
+    new MyInnerClass746();
+    new MyInnerClass747();
+    new MyInnerClass748();
+    new MyInnerClass749();
+    new MyInnerClass750();
+    new MyInnerClass751();
+    new MyInnerClass752();
+    new MyInnerClass753();
+    new MyInnerClass754();
+    new MyInnerClass755();
+    new MyInnerClass756();
+    new MyInnerClass757();
+    new MyInnerClass758();
+    new MyInnerClass759();
+    new MyInnerClass760();
+    new MyInnerClass761();
+    new MyInnerClass762();
+    new MyInnerClass763();
+    new MyInnerClass764();
+    new MyInnerClass765();
+    new MyInnerClass766();
+    new MyInnerClass767();
+    new MyInnerClass768();
+    new MyInnerClass769();
+    new MyInnerClass770();
+    new MyInnerClass771();
+    new MyInnerClass772();
+    new MyInnerClass773();
+    new MyInnerClass774();
+    new MyInnerClass775();
+    new MyInnerClass776();
+    new MyInnerClass777();
+    new MyInnerClass778();
+    new MyInnerClass779();
+    new MyInnerClass780();
+    new MyInnerClass781();
+    new MyInnerClass782();
+    new MyInnerClass783();
+    new MyInnerClass784();
+    new MyInnerClass785();
+    new MyInnerClass786();
+    new MyInnerClass787();
+    new MyInnerClass788();
+    new MyInnerClass789();
+    new MyInnerClass790();
+    new MyInnerClass791();
+    new MyInnerClass792();
+    new MyInnerClass793();
+    new MyInnerClass794();
+    new MyInnerClass795();
+    new MyInnerClass796();
+    new MyInnerClass797();
+    new MyInnerClass798();
+    new MyInnerClass799();
+
+    new MyInnerClass800();
+    new MyInnerClass801();
+    new MyInnerClass802();
+    new MyInnerClass803();
+    new MyInnerClass804();
+    new MyInnerClass805();
+    new MyInnerClass806();
+    new MyInnerClass807();
+    new MyInnerClass808();
+    new MyInnerClass809();
+    new MyInnerClass810();
+    new MyInnerClass811();
+    new MyInnerClass812();
+    new MyInnerClass813();
+    new MyInnerClass814();
+    new MyInnerClass815();
+    new MyInnerClass816();
+    new MyInnerClass817();
+    new MyInnerClass818();
+    new MyInnerClass819();
+    new MyInnerClass820();
+    new MyInnerClass821();
+    new MyInnerClass822();
+    new MyInnerClass823();
+    new MyInnerClass824();
+    new MyInnerClass825();
+    new MyInnerClass826();
+    new MyInnerClass827();
+    new MyInnerClass828();
+    new MyInnerClass829();
+    new MyInnerClass830();
+    new MyInnerClass831();
+    new MyInnerClass832();
+    new MyInnerClass833();
+    new MyInnerClass834();
+    new MyInnerClass835();
+    new MyInnerClass836();
+    new MyInnerClass837();
+    new MyInnerClass838();
+    new MyInnerClass839();
+    new MyInnerClass840();
+    new MyInnerClass841();
+    new MyInnerClass842();
+    new MyInnerClass843();
+    new MyInnerClass844();
+    new MyInnerClass845();
+    new MyInnerClass846();
+    new MyInnerClass847();
+    new MyInnerClass848();
+    new MyInnerClass849();
+    new MyInnerClass850();
+    new MyInnerClass851();
+    new MyInnerClass852();
+    new MyInnerClass853();
+    new MyInnerClass854();
+    new MyInnerClass855();
+    new MyInnerClass856();
+    new MyInnerClass857();
+    new MyInnerClass858();
+    new MyInnerClass859();
+    new MyInnerClass860();
+    new MyInnerClass861();
+    new MyInnerClass862();
+    new MyInnerClass863();
+    new MyInnerClass864();
+    new MyInnerClass865();
+    new MyInnerClass866();
+    new MyInnerClass867();
+    new MyInnerClass868();
+    new MyInnerClass869();
+    new MyInnerClass870();
+    new MyInnerClass871();
+    new MyInnerClass872();
+    new MyInnerClass873();
+    new MyInnerClass874();
+    new MyInnerClass875();
+    new MyInnerClass876();
+    new MyInnerClass877();
+    new MyInnerClass878();
+    new MyInnerClass879();
+    new MyInnerClass880();
+    new MyInnerClass881();
+    new MyInnerClass882();
+    new MyInnerClass883();
+    new MyInnerClass884();
+    new MyInnerClass885();
+    new MyInnerClass886();
+    new MyInnerClass887();
+    new MyInnerClass888();
+    new MyInnerClass889();
+    new MyInnerClass890();
+    new MyInnerClass891();
+    new MyInnerClass892();
+    new MyInnerClass893();
+    new MyInnerClass894();
+    new MyInnerClass895();
+    new MyInnerClass896();
+    new MyInnerClass897();
+    new MyInnerClass898();
+    new MyInnerClass899();
+
+    new MyInnerClass900();
+    new MyInnerClass901();
+    new MyInnerClass902();
+    new MyInnerClass903();
+    new MyInnerClass904();
+    new MyInnerClass905();
+    new MyInnerClass906();
+    new MyInnerClass907();
+    new MyInnerClass908();
+    new MyInnerClass909();
+    new MyInnerClass910();
+    new MyInnerClass911();
+    new MyInnerClass912();
+    new MyInnerClass913();
+    new MyInnerClass914();
+    new MyInnerClass915();
+    new MyInnerClass916();
+    new MyInnerClass917();
+    new MyInnerClass918();
+    new MyInnerClass919();
+    new MyInnerClass920();
+    new MyInnerClass921();
+    new MyInnerClass922();
+    new MyInnerClass923();
+    new MyInnerClass924();
+    new MyInnerClass925();
+    new MyInnerClass926();
+    new MyInnerClass927();
+    new MyInnerClass928();
+    new MyInnerClass929();
+    new MyInnerClass930();
+    new MyInnerClass931();
+    new MyInnerClass932();
+    new MyInnerClass933();
+    new MyInnerClass934();
+    new MyInnerClass935();
+    new MyInnerClass936();
+    new MyInnerClass937();
+    new MyInnerClass938();
+    new MyInnerClass939();
+    new MyInnerClass940();
+    new MyInnerClass941();
+    new MyInnerClass942();
+    new MyInnerClass943();
+    new MyInnerClass944();
+    new MyInnerClass945();
+    new MyInnerClass946();
+    new MyInnerClass947();
+    new MyInnerClass948();
+    new MyInnerClass949();
+    new MyInnerClass950();
+    new MyInnerClass951();
+    new MyInnerClass952();
+    new MyInnerClass953();
+    new MyInnerClass954();
+    new MyInnerClass955();
+    new MyInnerClass956();
+    new MyInnerClass957();
+    new MyInnerClass958();
+    new MyInnerClass959();
+    new MyInnerClass960();
+    new MyInnerClass961();
+    new MyInnerClass962();
+    new MyInnerClass963();
+    new MyInnerClass964();
+    new MyInnerClass965();
+    new MyInnerClass966();
+    new MyInnerClass967();
+    new MyInnerClass968();
+    new MyInnerClass969();
+    new MyInnerClass970();
+    new MyInnerClass971();
+    new MyInnerClass972();
+    new MyInnerClass973();
+    new MyInnerClass974();
+    new MyInnerClass975();
+    new MyInnerClass976();
+    new MyInnerClass977();
+    new MyInnerClass978();
+    new MyInnerClass979();
+    new MyInnerClass980();
+    new MyInnerClass981();
+    new MyInnerClass982();
+    new MyInnerClass983();
+    new MyInnerClass984();
+    new MyInnerClass985();
+    new MyInnerClass986();
+    new MyInnerClass987();
+    new MyInnerClass988();
+    new MyInnerClass989();
+    new MyInnerClass990();
+    new MyInnerClass991();
+    new MyInnerClass992();
+    new MyInnerClass993();
+    new MyInnerClass994();
+    new MyInnerClass995();
+    new MyInnerClass996();
+    new MyInnerClass997();
+    new MyInnerClass998();
+    new MyInnerClass999();
+  }
+
+  static class MyInnerClass000 {}
+
+  static class MyInnerClass001 {}
+
+  static class MyInnerClass002 {}
+
+  static class MyInnerClass003 {}
+
+  static class MyInnerClass004 {}
+
+  static class MyInnerClass005 {}
+
+  static class MyInnerClass006 {}
+
+  static class MyInnerClass007 {}
+
+  static class MyInnerClass008 {}
+
+  static class MyInnerClass009 {}
+
+  static class MyInnerClass010 {}
+
+  static class MyInnerClass011 {}
+
+  static class MyInnerClass012 {}
+
+  static class MyInnerClass013 {}
+
+  static class MyInnerClass014 {}
+
+  static class MyInnerClass015 {}
+
+  static class MyInnerClass016 {}
+
+  static class MyInnerClass017 {}
+
+  static class MyInnerClass018 {}
+
+  static class MyInnerClass019 {}
+
+  static class MyInnerClass020 {}
+
+  static class MyInnerClass021 {}
+
+  static class MyInnerClass022 {}
+
+  static class MyInnerClass023 {}
+
+  static class MyInnerClass024 {}
+
+  static class MyInnerClass025 {}
+
+  static class MyInnerClass026 {}
+
+  static class MyInnerClass027 {}
+
+  static class MyInnerClass028 {}
+
+  static class MyInnerClass029 {}
+
+  static class MyInnerClass030 {}
+
+  static class MyInnerClass031 {}
+
+  static class MyInnerClass032 {}
+
+  static class MyInnerClass033 {}
+
+  static class MyInnerClass034 {}
+
+  static class MyInnerClass035 {}
+
+  static class MyInnerClass036 {}
+
+  static class MyInnerClass037 {}
+
+  static class MyInnerClass038 {}
+
+  static class MyInnerClass039 {}
+
+  static class MyInnerClass040 {}
+
+  static class MyInnerClass041 {}
+
+  static class MyInnerClass042 {}
+
+  static class MyInnerClass043 {}
+
+  static class MyInnerClass044 {}
+
+  static class MyInnerClass045 {}
+
+  static class MyInnerClass046 {}
+
+  static class MyInnerClass047 {}
+
+  static class MyInnerClass048 {}
+
+  static class MyInnerClass049 {}
+
+  static class MyInnerClass050 {}
+
+  static class MyInnerClass051 {}
+
+  static class MyInnerClass052 {}
+
+  static class MyInnerClass053 {}
+
+  static class MyInnerClass054 {}
+
+  static class MyInnerClass055 {}
+
+  static class MyInnerClass056 {}
+
+  static class MyInnerClass057 {}
+
+  static class MyInnerClass058 {}
+
+  static class MyInnerClass059 {}
+
+  static class MyInnerClass060 {}
+
+  static class MyInnerClass061 {}
+
+  static class MyInnerClass062 {}
+
+  static class MyInnerClass063 {}
+
+  static class MyInnerClass064 {}
+
+  static class MyInnerClass065 {}
+
+  static class MyInnerClass066 {}
+
+  static class MyInnerClass067 {}
+
+  static class MyInnerClass068 {}
+
+  static class MyInnerClass069 {}
+
+  static class MyInnerClass070 {}
+
+  static class MyInnerClass071 {}
+
+  static class MyInnerClass072 {}
+
+  static class MyInnerClass073 {}
+
+  static class MyInnerClass074 {}
+
+  static class MyInnerClass075 {}
+
+  static class MyInnerClass076 {}
+
+  static class MyInnerClass077 {}
+
+  static class MyInnerClass078 {}
+
+  static class MyInnerClass079 {}
+
+  static class MyInnerClass080 {}
+
+  static class MyInnerClass081 {}
+
+  static class MyInnerClass082 {}
+
+  static class MyInnerClass083 {}
+
+  static class MyInnerClass084 {}
+
+  static class MyInnerClass085 {}
+
+  static class MyInnerClass086 {}
+
+  static class MyInnerClass087 {}
+
+  static class MyInnerClass088 {}
+
+  static class MyInnerClass089 {}
+
+  static class MyInnerClass090 {}
+
+  static class MyInnerClass091 {}
+
+  static class MyInnerClass092 {}
+
+  static class MyInnerClass093 {}
+
+  static class MyInnerClass094 {}
+
+  static class MyInnerClass095 {}
+
+  static class MyInnerClass096 {}
+
+  static class MyInnerClass097 {}
+
+  static class MyInnerClass098 {}
+
+  static class MyInnerClass099 {}
+
+  static class MyInnerClass100 {}
+
+  static class MyInnerClass101 {}
+
+  static class MyInnerClass102 {}
+
+  static class MyInnerClass103 {}
+
+  static class MyInnerClass104 {}
+
+  static class MyInnerClass105 {}
+
+  static class MyInnerClass106 {}
+
+  static class MyInnerClass107 {}
+
+  static class MyInnerClass108 {}
+
+  static class MyInnerClass109 {}
+
+  static class MyInnerClass110 {}
+
+  static class MyInnerClass111 {}
+
+  static class MyInnerClass112 {}
+
+  static class MyInnerClass113 {}
+
+  static class MyInnerClass114 {}
+
+  static class MyInnerClass115 {}
+
+  static class MyInnerClass116 {}
+
+  static class MyInnerClass117 {}
+
+  static class MyInnerClass118 {}
+
+  static class MyInnerClass119 {}
+
+  static class MyInnerClass120 {}
+
+  static class MyInnerClass121 {}
+
+  static class MyInnerClass122 {}
+
+  static class MyInnerClass123 {}
+
+  static class MyInnerClass124 {}
+
+  static class MyInnerClass125 {}
+
+  static class MyInnerClass126 {}
+
+  static class MyInnerClass127 {}
+
+  static class MyInnerClass128 {}
+
+  static class MyInnerClass129 {}
+
+  static class MyInnerClass130 {}
+
+  static class MyInnerClass131 {}
+
+  static class MyInnerClass132 {}
+
+  static class MyInnerClass133 {}
+
+  static class MyInnerClass134 {}
+
+  static class MyInnerClass135 {}
+
+  static class MyInnerClass136 {}
+
+  static class MyInnerClass137 {}
+
+  static class MyInnerClass138 {}
+
+  static class MyInnerClass139 {}
+
+  static class MyInnerClass140 {}
+
+  static class MyInnerClass141 {}
+
+  static class MyInnerClass142 {}
+
+  static class MyInnerClass143 {}
+
+  static class MyInnerClass144 {}
+
+  static class MyInnerClass145 {}
+
+  static class MyInnerClass146 {}
+
+  static class MyInnerClass147 {}
+
+  static class MyInnerClass148 {}
+
+  static class MyInnerClass149 {}
+
+  static class MyInnerClass150 {}
+
+  static class MyInnerClass151 {}
+
+  static class MyInnerClass152 {}
+
+  static class MyInnerClass153 {}
+
+  static class MyInnerClass154 {}
+
+  static class MyInnerClass155 {}
+
+  static class MyInnerClass156 {}
+
+  static class MyInnerClass157 {}
+
+  static class MyInnerClass158 {}
+
+  static class MyInnerClass159 {}
+
+  static class MyInnerClass160 {}
+
+  static class MyInnerClass161 {}
+
+  static class MyInnerClass162 {}
+
+  static class MyInnerClass163 {}
+
+  static class MyInnerClass164 {}
+
+  static class MyInnerClass165 {}
+
+  static class MyInnerClass166 {}
+
+  static class MyInnerClass167 {}
+
+  static class MyInnerClass168 {}
+
+  static class MyInnerClass169 {}
+
+  static class MyInnerClass170 {}
+
+  static class MyInnerClass171 {}
+
+  static class MyInnerClass172 {}
+
+  static class MyInnerClass173 {}
+
+  static class MyInnerClass174 {}
+
+  static class MyInnerClass175 {}
+
+  static class MyInnerClass176 {}
+
+  static class MyInnerClass177 {}
+
+  static class MyInnerClass178 {}
+
+  static class MyInnerClass179 {}
+
+  static class MyInnerClass180 {}
+
+  static class MyInnerClass181 {}
+
+  static class MyInnerClass182 {}
+
+  static class MyInnerClass183 {}
+
+  static class MyInnerClass184 {}
+
+  static class MyInnerClass185 {}
+
+  static class MyInnerClass186 {}
+
+  static class MyInnerClass187 {}
+
+  static class MyInnerClass188 {}
+
+  static class MyInnerClass189 {}
+
+  static class MyInnerClass190 {}
+
+  static class MyInnerClass191 {}
+
+  static class MyInnerClass192 {}
+
+  static class MyInnerClass193 {}
+
+  static class MyInnerClass194 {}
+
+  static class MyInnerClass195 {}
+
+  static class MyInnerClass196 {}
+
+  static class MyInnerClass197 {}
+
+  static class MyInnerClass198 {}
+
+  static class MyInnerClass199 {}
+
+  static class MyInnerClass200 {}
+
+  static class MyInnerClass201 {}
+
+  static class MyInnerClass202 {}
+
+  static class MyInnerClass203 {}
+
+  static class MyInnerClass204 {}
+
+  static class MyInnerClass205 {}
+
+  static class MyInnerClass206 {}
+
+  static class MyInnerClass207 {}
+
+  static class MyInnerClass208 {}
+
+  static class MyInnerClass209 {}
+
+  static class MyInnerClass210 {}
+
+  static class MyInnerClass211 {}
+
+  static class MyInnerClass212 {}
+
+  static class MyInnerClass213 {}
+
+  static class MyInnerClass214 {}
+
+  static class MyInnerClass215 {}
+
+  static class MyInnerClass216 {}
+
+  static class MyInnerClass217 {}
+
+  static class MyInnerClass218 {}
+
+  static class MyInnerClass219 {}
+
+  static class MyInnerClass220 {}
+
+  static class MyInnerClass221 {}
+
+  static class MyInnerClass222 {}
+
+  static class MyInnerClass223 {}
+
+  static class MyInnerClass224 {}
+
+  static class MyInnerClass225 {}
+
+  static class MyInnerClass226 {}
+
+  static class MyInnerClass227 {}
+
+  static class MyInnerClass228 {}
+
+  static class MyInnerClass229 {}
+
+  static class MyInnerClass230 {}
+
+  static class MyInnerClass231 {}
+
+  static class MyInnerClass232 {}
+
+  static class MyInnerClass233 {}
+
+  static class MyInnerClass234 {}
+
+  static class MyInnerClass235 {}
+
+  static class MyInnerClass236 {}
+
+  static class MyInnerClass237 {}
+
+  static class MyInnerClass238 {}
+
+  static class MyInnerClass239 {}
+
+  static class MyInnerClass240 {}
+
+  static class MyInnerClass241 {}
+
+  static class MyInnerClass242 {}
+
+  static class MyInnerClass243 {}
+
+  static class MyInnerClass244 {}
+
+  static class MyInnerClass245 {}
+
+  static class MyInnerClass246 {}
+
+  static class MyInnerClass247 {}
+
+  static class MyInnerClass248 {}
+
+  static class MyInnerClass249 {}
+
+  static class MyInnerClass250 {}
+
+  static class MyInnerClass251 {}
+
+  static class MyInnerClass252 {}
+
+  static class MyInnerClass253 {}
+
+  static class MyInnerClass254 {}
+
+  static class MyInnerClass255 {}
+
+  static class MyInnerClass256 {}
+
+  static class MyInnerClass257 {}
+
+  static class MyInnerClass258 {}
+
+  static class MyInnerClass259 {}
+
+  static class MyInnerClass260 {}
+
+  static class MyInnerClass261 {}
+
+  static class MyInnerClass262 {}
+
+  static class MyInnerClass263 {}
+
+  static class MyInnerClass264 {}
+
+  static class MyInnerClass265 {}
+
+  static class MyInnerClass266 {}
+
+  static class MyInnerClass267 {}
+
+  static class MyInnerClass268 {}
+
+  static class MyInnerClass269 {}
+
+  static class MyInnerClass270 {}
+
+  static class MyInnerClass271 {}
+
+  static class MyInnerClass272 {}
+
+  static class MyInnerClass273 {}
+
+  static class MyInnerClass274 {}
+
+  static class MyInnerClass275 {}
+
+  static class MyInnerClass276 {}
+
+  static class MyInnerClass277 {}
+
+  static class MyInnerClass278 {}
+
+  static class MyInnerClass279 {}
+
+  static class MyInnerClass280 {}
+
+  static class MyInnerClass281 {}
+
+  static class MyInnerClass282 {}
+
+  static class MyInnerClass283 {}
+
+  static class MyInnerClass284 {}
+
+  static class MyInnerClass285 {}
+
+  static class MyInnerClass286 {}
+
+  static class MyInnerClass287 {}
+
+  static class MyInnerClass288 {}
+
+  static class MyInnerClass289 {}
+
+  static class MyInnerClass290 {}
+
+  static class MyInnerClass291 {}
+
+  static class MyInnerClass292 {}
+
+  static class MyInnerClass293 {}
+
+  static class MyInnerClass294 {}
+
+  static class MyInnerClass295 {}
+
+  static class MyInnerClass296 {}
+
+  static class MyInnerClass297 {}
+
+  static class MyInnerClass298 {}
+
+  static class MyInnerClass299 {}
+
+  static class MyInnerClass300 {}
+
+  static class MyInnerClass301 {}
+
+  static class MyInnerClass302 {}
+
+  static class MyInnerClass303 {}
+
+  static class MyInnerClass304 {}
+
+  static class MyInnerClass305 {}
+
+  static class MyInnerClass306 {}
+
+  static class MyInnerClass307 {}
+
+  static class MyInnerClass308 {}
+
+  static class MyInnerClass309 {}
+
+  static class MyInnerClass310 {}
+
+  static class MyInnerClass311 {}
+
+  static class MyInnerClass312 {}
+
+  static class MyInnerClass313 {}
+
+  static class MyInnerClass314 {}
+
+  static class MyInnerClass315 {}
+
+  static class MyInnerClass316 {}
+
+  static class MyInnerClass317 {}
+
+  static class MyInnerClass318 {}
+
+  static class MyInnerClass319 {}
+
+  static class MyInnerClass320 {}
+
+  static class MyInnerClass321 {}
+
+  static class MyInnerClass322 {}
+
+  static class MyInnerClass323 {}
+
+  static class MyInnerClass324 {}
+
+  static class MyInnerClass325 {}
+
+  static class MyInnerClass326 {}
+
+  static class MyInnerClass327 {}
+
+  static class MyInnerClass328 {}
+
+  static class MyInnerClass329 {}
+
+  static class MyInnerClass330 {}
+
+  static class MyInnerClass331 {}
+
+  static class MyInnerClass332 {}
+
+  static class MyInnerClass333 {}
+
+  static class MyInnerClass334 {}
+
+  static class MyInnerClass335 {}
+
+  static class MyInnerClass336 {}
+
+  static class MyInnerClass337 {}
+
+  static class MyInnerClass338 {}
+
+  static class MyInnerClass339 {}
+
+  static class MyInnerClass340 {}
+
+  static class MyInnerClass341 {}
+
+  static class MyInnerClass342 {}
+
+  static class MyInnerClass343 {}
+
+  static class MyInnerClass344 {}
+
+  static class MyInnerClass345 {}
+
+  static class MyInnerClass346 {}
+
+  static class MyInnerClass347 {}
+
+  static class MyInnerClass348 {}
+
+  static class MyInnerClass349 {}
+
+  static class MyInnerClass350 {}
+
+  static class MyInnerClass351 {}
+
+  static class MyInnerClass352 {}
+
+  static class MyInnerClass353 {}
+
+  static class MyInnerClass354 {}
+
+  static class MyInnerClass355 {}
+
+  static class MyInnerClass356 {}
+
+  static class MyInnerClass357 {}
+
+  static class MyInnerClass358 {}
+
+  static class MyInnerClass359 {}
+
+  static class MyInnerClass360 {}
+
+  static class MyInnerClass361 {}
+
+  static class MyInnerClass362 {}
+
+  static class MyInnerClass363 {}
+
+  static class MyInnerClass364 {}
+
+  static class MyInnerClass365 {}
+
+  static class MyInnerClass366 {}
+
+  static class MyInnerClass367 {}
+
+  static class MyInnerClass368 {}
+
+  static class MyInnerClass369 {}
+
+  static class MyInnerClass370 {}
+
+  static class MyInnerClass371 {}
+
+  static class MyInnerClass372 {}
+
+  static class MyInnerClass373 {}
+
+  static class MyInnerClass374 {}
+
+  static class MyInnerClass375 {}
+
+  static class MyInnerClass376 {}
+
+  static class MyInnerClass377 {}
+
+  static class MyInnerClass378 {}
+
+  static class MyInnerClass379 {}
+
+  static class MyInnerClass380 {}
+
+  static class MyInnerClass381 {}
+
+  static class MyInnerClass382 {}
+
+  static class MyInnerClass383 {}
+
+  static class MyInnerClass384 {}
+
+  static class MyInnerClass385 {}
+
+  static class MyInnerClass386 {}
+
+  static class MyInnerClass387 {}
+
+  static class MyInnerClass388 {}
+
+  static class MyInnerClass389 {}
+
+  static class MyInnerClass390 {}
+
+  static class MyInnerClass391 {}
+
+  static class MyInnerClass392 {}
+
+  static class MyInnerClass393 {}
+
+  static class MyInnerClass394 {}
+
+  static class MyInnerClass395 {}
+
+  static class MyInnerClass396 {}
+
+  static class MyInnerClass397 {}
+
+  static class MyInnerClass398 {}
+
+  static class MyInnerClass399 {}
+
+  static class MyInnerClass400 {}
+
+  static class MyInnerClass401 {}
+
+  static class MyInnerClass402 {}
+
+  static class MyInnerClass403 {}
+
+  static class MyInnerClass404 {}
+
+  static class MyInnerClass405 {}
+
+  static class MyInnerClass406 {}
+
+  static class MyInnerClass407 {}
+
+  static class MyInnerClass408 {}
+
+  static class MyInnerClass409 {}
+
+  static class MyInnerClass410 {}
+
+  static class MyInnerClass411 {}
+
+  static class MyInnerClass412 {}
+
+  static class MyInnerClass413 {}
+
+  static class MyInnerClass414 {}
+
+  static class MyInnerClass415 {}
+
+  static class MyInnerClass416 {}
+
+  static class MyInnerClass417 {}
+
+  static class MyInnerClass418 {}
+
+  static class MyInnerClass419 {}
+
+  static class MyInnerClass420 {}
+
+  static class MyInnerClass421 {}
+
+  static class MyInnerClass422 {}
+
+  static class MyInnerClass423 {}
+
+  static class MyInnerClass424 {}
+
+  static class MyInnerClass425 {}
+
+  static class MyInnerClass426 {}
+
+  static class MyInnerClass427 {}
+
+  static class MyInnerClass428 {}
+
+  static class MyInnerClass429 {}
+
+  static class MyInnerClass430 {}
+
+  static class MyInnerClass431 {}
+
+  static class MyInnerClass432 {}
+
+  static class MyInnerClass433 {}
+
+  static class MyInnerClass434 {}
+
+  static class MyInnerClass435 {}
+
+  static class MyInnerClass436 {}
+
+  static class MyInnerClass437 {}
+
+  static class MyInnerClass438 {}
+
+  static class MyInnerClass439 {}
+
+  static class MyInnerClass440 {}
+
+  static class MyInnerClass441 {}
+
+  static class MyInnerClass442 {}
+
+  static class MyInnerClass443 {}
+
+  static class MyInnerClass444 {}
+
+  static class MyInnerClass445 {}
+
+  static class MyInnerClass446 {}
+
+  static class MyInnerClass447 {}
+
+  static class MyInnerClass448 {}
+
+  static class MyInnerClass449 {}
+
+  static class MyInnerClass450 {}
+
+  static class MyInnerClass451 {}
+
+  static class MyInnerClass452 {}
+
+  static class MyInnerClass453 {}
+
+  static class MyInnerClass454 {}
+
+  static class MyInnerClass455 {}
+
+  static class MyInnerClass456 {}
+
+  static class MyInnerClass457 {}
+
+  static class MyInnerClass458 {}
+
+  static class MyInnerClass459 {}
+
+  static class MyInnerClass460 {}
+
+  static class MyInnerClass461 {}
+
+  static class MyInnerClass462 {}
+
+  static class MyInnerClass463 {}
+
+  static class MyInnerClass464 {}
+
+  static class MyInnerClass465 {}
+
+  static class MyInnerClass466 {}
+
+  static class MyInnerClass467 {}
+
+  static class MyInnerClass468 {}
+
+  static class MyInnerClass469 {}
+
+  static class MyInnerClass470 {}
+
+  static class MyInnerClass471 {}
+
+  static class MyInnerClass472 {}
+
+  static class MyInnerClass473 {}
+
+  static class MyInnerClass474 {}
+
+  static class MyInnerClass475 {}
+
+  static class MyInnerClass476 {}
+
+  static class MyInnerClass477 {}
+
+  static class MyInnerClass478 {}
+
+  static class MyInnerClass479 {}
+
+  static class MyInnerClass480 {}
+
+  static class MyInnerClass481 {}
+
+  static class MyInnerClass482 {}
+
+  static class MyInnerClass483 {}
+
+  static class MyInnerClass484 {}
+
+  static class MyInnerClass485 {}
+
+  static class MyInnerClass486 {}
+
+  static class MyInnerClass487 {}
+
+  static class MyInnerClass488 {}
+
+  static class MyInnerClass489 {}
+
+  static class MyInnerClass490 {}
+
+  static class MyInnerClass491 {}
+
+  static class MyInnerClass492 {}
+
+  static class MyInnerClass493 {}
+
+  static class MyInnerClass494 {}
+
+  static class MyInnerClass495 {}
+
+  static class MyInnerClass496 {}
+
+  static class MyInnerClass497 {}
+
+  static class MyInnerClass498 {}
+
+  static class MyInnerClass499 {}
+
+  static class MyInnerClass500 {}
+
+  static class MyInnerClass501 {}
+
+  static class MyInnerClass502 {}
+
+  static class MyInnerClass503 {}
+
+  static class MyInnerClass504 {}
+
+  static class MyInnerClass505 {}
+
+  static class MyInnerClass506 {}
+
+  static class MyInnerClass507 {}
+
+  static class MyInnerClass508 {}
+
+  static class MyInnerClass509 {}
+
+  static class MyInnerClass510 {}
+
+  static class MyInnerClass511 {}
+
+  static class MyInnerClass512 {}
+
+  static class MyInnerClass513 {}
+
+  static class MyInnerClass514 {}
+
+  static class MyInnerClass515 {}
+
+  static class MyInnerClass516 {}
+
+  static class MyInnerClass517 {}
+
+  static class MyInnerClass518 {}
+
+  static class MyInnerClass519 {}
+
+  static class MyInnerClass520 {}
+
+  static class MyInnerClass521 {}
+
+  static class MyInnerClass522 {}
+
+  static class MyInnerClass523 {}
+
+  static class MyInnerClass524 {}
+
+  static class MyInnerClass525 {}
+
+  static class MyInnerClass526 {}
+
+  static class MyInnerClass527 {}
+
+  static class MyInnerClass528 {}
+
+  static class MyInnerClass529 {}
+
+  static class MyInnerClass530 {}
+
+  static class MyInnerClass531 {}
+
+  static class MyInnerClass532 {}
+
+  static class MyInnerClass533 {}
+
+  static class MyInnerClass534 {}
+
+  static class MyInnerClass535 {}
+
+  static class MyInnerClass536 {}
+
+  static class MyInnerClass537 {}
+
+  static class MyInnerClass538 {}
+
+  static class MyInnerClass539 {}
+
+  static class MyInnerClass540 {}
+
+  static class MyInnerClass541 {}
+
+  static class MyInnerClass542 {}
+
+  static class MyInnerClass543 {}
+
+  static class MyInnerClass544 {}
+
+  static class MyInnerClass545 {}
+
+  static class MyInnerClass546 {}
+
+  static class MyInnerClass547 {}
+
+  static class MyInnerClass548 {}
+
+  static class MyInnerClass549 {}
+
+  static class MyInnerClass550 {}
+
+  static class MyInnerClass551 {}
+
+  static class MyInnerClass552 {}
+
+  static class MyInnerClass553 {}
+
+  static class MyInnerClass554 {}
+
+  static class MyInnerClass555 {}
+
+  static class MyInnerClass556 {}
+
+  static class MyInnerClass557 {}
+
+  static class MyInnerClass558 {}
+
+  static class MyInnerClass559 {}
+
+  static class MyInnerClass560 {}
+
+  static class MyInnerClass561 {}
+
+  static class MyInnerClass562 {}
+
+  static class MyInnerClass563 {}
+
+  static class MyInnerClass564 {}
+
+  static class MyInnerClass565 {}
+
+  static class MyInnerClass566 {}
+
+  static class MyInnerClass567 {}
+
+  static class MyInnerClass568 {}
+
+  static class MyInnerClass569 {}
+
+  static class MyInnerClass570 {}
+
+  static class MyInnerClass571 {}
+
+  static class MyInnerClass572 {}
+
+  static class MyInnerClass573 {}
+
+  static class MyInnerClass574 {}
+
+  static class MyInnerClass575 {}
+
+  static class MyInnerClass576 {}
+
+  static class MyInnerClass577 {}
+
+  static class MyInnerClass578 {}
+
+  static class MyInnerClass579 {}
+
+  static class MyInnerClass580 {}
+
+  static class MyInnerClass581 {}
+
+  static class MyInnerClass582 {}
+
+  static class MyInnerClass583 {}
+
+  static class MyInnerClass584 {}
+
+  static class MyInnerClass585 {}
+
+  static class MyInnerClass586 {}
+
+  static class MyInnerClass587 {}
+
+  static class MyInnerClass588 {}
+
+  static class MyInnerClass589 {}
+
+  static class MyInnerClass590 {}
+
+  static class MyInnerClass591 {}
+
+  static class MyInnerClass592 {}
+
+  static class MyInnerClass593 {}
+
+  static class MyInnerClass594 {}
+
+  static class MyInnerClass595 {}
+
+  static class MyInnerClass596 {}
+
+  static class MyInnerClass597 {}
+
+  static class MyInnerClass598 {}
+
+  static class MyInnerClass599 {}
+
+  static class MyInnerClass600 {}
+
+  static class MyInnerClass601 {}
+
+  static class MyInnerClass602 {}
+
+  static class MyInnerClass603 {}
+
+  static class MyInnerClass604 {}
+
+  static class MyInnerClass605 {}
+
+  static class MyInnerClass606 {}
+
+  static class MyInnerClass607 {}
+
+  static class MyInnerClass608 {}
+
+  static class MyInnerClass609 {}
+
+  static class MyInnerClass610 {}
+
+  static class MyInnerClass611 {}
+
+  static class MyInnerClass612 {}
+
+  static class MyInnerClass613 {}
+
+  static class MyInnerClass614 {}
+
+  static class MyInnerClass615 {}
+
+  static class MyInnerClass616 {}
+
+  static class MyInnerClass617 {}
+
+  static class MyInnerClass618 {}
+
+  static class MyInnerClass619 {}
+
+  static class MyInnerClass620 {}
+
+  static class MyInnerClass621 {}
+
+  static class MyInnerClass622 {}
+
+  static class MyInnerClass623 {}
+
+  static class MyInnerClass624 {}
+
+  static class MyInnerClass625 {}
+
+  static class MyInnerClass626 {}
+
+  static class MyInnerClass627 {}
+
+  static class MyInnerClass628 {}
+
+  static class MyInnerClass629 {}
+
+  static class MyInnerClass630 {}
+
+  static class MyInnerClass631 {}
+
+  static class MyInnerClass632 {}
+
+  static class MyInnerClass633 {}
+
+  static class MyInnerClass634 {}
+
+  static class MyInnerClass635 {}
+
+  static class MyInnerClass636 {}
+
+  static class MyInnerClass637 {}
+
+  static class MyInnerClass638 {}
+
+  static class MyInnerClass639 {}
+
+  static class MyInnerClass640 {}
+
+  static class MyInnerClass641 {}
+
+  static class MyInnerClass642 {}
+
+  static class MyInnerClass643 {}
+
+  static class MyInnerClass644 {}
+
+  static class MyInnerClass645 {}
+
+  static class MyInnerClass646 {}
+
+  static class MyInnerClass647 {}
+
+  static class MyInnerClass648 {}
+
+  static class MyInnerClass649 {}
+
+  static class MyInnerClass650 {}
+
+  static class MyInnerClass651 {}
+
+  static class MyInnerClass652 {}
+
+  static class MyInnerClass653 {}
+
+  static class MyInnerClass654 {}
+
+  static class MyInnerClass655 {}
+
+  static class MyInnerClass656 {}
+
+  static class MyInnerClass657 {}
+
+  static class MyInnerClass658 {}
+
+  static class MyInnerClass659 {}
+
+  static class MyInnerClass660 {}
+
+  static class MyInnerClass661 {}
+
+  static class MyInnerClass662 {}
+
+  static class MyInnerClass663 {}
+
+  static class MyInnerClass664 {}
+
+  static class MyInnerClass665 {}
+
+  static class MyInnerClass666 {}
+
+  static class MyInnerClass667 {}
+
+  static class MyInnerClass668 {}
+
+  static class MyInnerClass669 {}
+
+  static class MyInnerClass670 {}
+
+  static class MyInnerClass671 {}
+
+  static class MyInnerClass672 {}
+
+  static class MyInnerClass673 {}
+
+  static class MyInnerClass674 {}
+
+  static class MyInnerClass675 {}
+
+  static class MyInnerClass676 {}
+
+  static class MyInnerClass677 {}
+
+  static class MyInnerClass678 {}
+
+  static class MyInnerClass679 {}
+
+  static class MyInnerClass680 {}
+
+  static class MyInnerClass681 {}
+
+  static class MyInnerClass682 {}
+
+  static class MyInnerClass683 {}
+
+  static class MyInnerClass684 {}
+
+  static class MyInnerClass685 {}
+
+  static class MyInnerClass686 {}
+
+  static class MyInnerClass687 {}
+
+  static class MyInnerClass688 {}
+
+  static class MyInnerClass689 {}
+
+  static class MyInnerClass690 {}
+
+  static class MyInnerClass691 {}
+
+  static class MyInnerClass692 {}
+
+  static class MyInnerClass693 {}
+
+  static class MyInnerClass694 {}
+
+  static class MyInnerClass695 {}
+
+  static class MyInnerClass696 {}
+
+  static class MyInnerClass697 {}
+
+  static class MyInnerClass698 {}
+
+  static class MyInnerClass699 {}
+
+  static class MyInnerClass700 {}
+
+  static class MyInnerClass701 {}
+
+  static class MyInnerClass702 {}
+
+  static class MyInnerClass703 {}
+
+  static class MyInnerClass704 {}
+
+  static class MyInnerClass705 {}
+
+  static class MyInnerClass706 {}
+
+  static class MyInnerClass707 {}
+
+  static class MyInnerClass708 {}
+
+  static class MyInnerClass709 {}
+
+  static class MyInnerClass710 {}
+
+  static class MyInnerClass711 {}
+
+  static class MyInnerClass712 {}
+
+  static class MyInnerClass713 {}
+
+  static class MyInnerClass714 {}
+
+  static class MyInnerClass715 {}
+
+  static class MyInnerClass716 {}
+
+  static class MyInnerClass717 {}
+
+  static class MyInnerClass718 {}
+
+  static class MyInnerClass719 {}
+
+  static class MyInnerClass720 {}
+
+  static class MyInnerClass721 {}
+
+  static class MyInnerClass722 {}
+
+  static class MyInnerClass723 {}
+
+  static class MyInnerClass724 {}
+
+  static class MyInnerClass725 {}
+
+  static class MyInnerClass726 {}
+
+  static class MyInnerClass727 {}
+
+  static class MyInnerClass728 {}
+
+  static class MyInnerClass729 {}
+
+  static class MyInnerClass730 {}
+
+  static class MyInnerClass731 {}
+
+  static class MyInnerClass732 {}
+
+  static class MyInnerClass733 {}
+
+  static class MyInnerClass734 {}
+
+  static class MyInnerClass735 {}
+
+  static class MyInnerClass736 {}
+
+  static class MyInnerClass737 {}
+
+  static class MyInnerClass738 {}
+
+  static class MyInnerClass739 {}
+
+  static class MyInnerClass740 {}
+
+  static class MyInnerClass741 {}
+
+  static class MyInnerClass742 {}
+
+  static class MyInnerClass743 {}
+
+  static class MyInnerClass744 {}
+
+  static class MyInnerClass745 {}
+
+  static class MyInnerClass746 {}
+
+  static class MyInnerClass747 {}
+
+  static class MyInnerClass748 {}
+
+  static class MyInnerClass749 {}
+
+  static class MyInnerClass750 {}
+
+  static class MyInnerClass751 {}
+
+  static class MyInnerClass752 {}
+
+  static class MyInnerClass753 {}
+
+  static class MyInnerClass754 {}
+
+  static class MyInnerClass755 {}
+
+  static class MyInnerClass756 {}
+
+  static class MyInnerClass757 {}
+
+  static class MyInnerClass758 {}
+
+  static class MyInnerClass759 {}
+
+  static class MyInnerClass760 {}
+
+  static class MyInnerClass761 {}
+
+  static class MyInnerClass762 {}
+
+  static class MyInnerClass763 {}
+
+  static class MyInnerClass764 {}
+
+  static class MyInnerClass765 {}
+
+  static class MyInnerClass766 {}
+
+  static class MyInnerClass767 {}
+
+  static class MyInnerClass768 {}
+
+  static class MyInnerClass769 {}
+
+  static class MyInnerClass770 {}
+
+  static class MyInnerClass771 {}
+
+  static class MyInnerClass772 {}
+
+  static class MyInnerClass773 {}
+
+  static class MyInnerClass774 {}
+
+  static class MyInnerClass775 {}
+
+  static class MyInnerClass776 {}
+
+  static class MyInnerClass777 {}
+
+  static class MyInnerClass778 {}
+
+  static class MyInnerClass779 {}
+
+  static class MyInnerClass780 {}
+
+  static class MyInnerClass781 {}
+
+  static class MyInnerClass782 {}
+
+  static class MyInnerClass783 {}
+
+  static class MyInnerClass784 {}
+
+  static class MyInnerClass785 {}
+
+  static class MyInnerClass786 {}
+
+  static class MyInnerClass787 {}
+
+  static class MyInnerClass788 {}
+
+  static class MyInnerClass789 {}
+
+  static class MyInnerClass790 {}
+
+  static class MyInnerClass791 {}
+
+  static class MyInnerClass792 {}
+
+  static class MyInnerClass793 {}
+
+  static class MyInnerClass794 {}
+
+  static class MyInnerClass795 {}
+
+  static class MyInnerClass796 {}
+
+  static class MyInnerClass797 {}
+
+  static class MyInnerClass798 {}
+
+  static class MyInnerClass799 {}
+
+  static class MyInnerClass800 {}
+
+  static class MyInnerClass801 {}
+
+  static class MyInnerClass802 {}
+
+  static class MyInnerClass803 {}
+
+  static class MyInnerClass804 {}
+
+  static class MyInnerClass805 {}
+
+  static class MyInnerClass806 {}
+
+  static class MyInnerClass807 {}
+
+  static class MyInnerClass808 {}
+
+  static class MyInnerClass809 {}
+
+  static class MyInnerClass810 {}
+
+  static class MyInnerClass811 {}
+
+  static class MyInnerClass812 {}
+
+  static class MyInnerClass813 {}
+
+  static class MyInnerClass814 {}
+
+  static class MyInnerClass815 {}
+
+  static class MyInnerClass816 {}
+
+  static class MyInnerClass817 {}
+
+  static class MyInnerClass818 {}
+
+  static class MyInnerClass819 {}
+
+  static class MyInnerClass820 {}
+
+  static class MyInnerClass821 {}
+
+  static class MyInnerClass822 {}
+
+  static class MyInnerClass823 {}
+
+  static class MyInnerClass824 {}
+
+  static class MyInnerClass825 {}
+
+  static class MyInnerClass826 {}
+
+  static class MyInnerClass827 {}
+
+  static class MyInnerClass828 {}
+
+  static class MyInnerClass829 {}
+
+  static class MyInnerClass830 {}
+
+  static class MyInnerClass831 {}
+
+  static class MyInnerClass832 {}
+
+  static class MyInnerClass833 {}
+
+  static class MyInnerClass834 {}
+
+  static class MyInnerClass835 {}
+
+  static class MyInnerClass836 {}
+
+  static class MyInnerClass837 {}
+
+  static class MyInnerClass838 {}
+
+  static class MyInnerClass839 {}
+
+  static class MyInnerClass840 {}
+
+  static class MyInnerClass841 {}
+
+  static class MyInnerClass842 {}
+
+  static class MyInnerClass843 {}
+
+  static class MyInnerClass844 {}
+
+  static class MyInnerClass845 {}
+
+  static class MyInnerClass846 {}
+
+  static class MyInnerClass847 {}
+
+  static class MyInnerClass848 {}
+
+  static class MyInnerClass849 {}
+
+  static class MyInnerClass850 {}
+
+  static class MyInnerClass851 {}
+
+  static class MyInnerClass852 {}
+
+  static class MyInnerClass853 {}
+
+  static class MyInnerClass854 {}
+
+  static class MyInnerClass855 {}
+
+  static class MyInnerClass856 {}
+
+  static class MyInnerClass857 {}
+
+  static class MyInnerClass858 {}
+
+  static class MyInnerClass859 {}
+
+  static class MyInnerClass860 {}
+
+  static class MyInnerClass861 {}
+
+  static class MyInnerClass862 {}
+
+  static class MyInnerClass863 {}
+
+  static class MyInnerClass864 {}
+
+  static class MyInnerClass865 {}
+
+  static class MyInnerClass866 {}
+
+  static class MyInnerClass867 {}
+
+  static class MyInnerClass868 {}
+
+  static class MyInnerClass869 {}
+
+  static class MyInnerClass870 {}
+
+  static class MyInnerClass871 {}
+
+  static class MyInnerClass872 {}
+
+  static class MyInnerClass873 {}
+
+  static class MyInnerClass874 {}
+
+  static class MyInnerClass875 {}
+
+  static class MyInnerClass876 {}
+
+  static class MyInnerClass877 {}
+
+  static class MyInnerClass878 {}
+
+  static class MyInnerClass879 {}
+
+  static class MyInnerClass880 {}
+
+  static class MyInnerClass881 {}
+
+  static class MyInnerClass882 {}
+
+  static class MyInnerClass883 {}
+
+  static class MyInnerClass884 {}
+
+  static class MyInnerClass885 {}
+
+  static class MyInnerClass886 {}
+
+  static class MyInnerClass887 {}
+
+  static class MyInnerClass888 {}
+
+  static class MyInnerClass889 {}
+
+  static class MyInnerClass890 {}
+
+  static class MyInnerClass891 {}
+
+  static class MyInnerClass892 {}
+
+  static class MyInnerClass893 {}
+
+  static class MyInnerClass894 {}
+
+  static class MyInnerClass895 {}
+
+  static class MyInnerClass896 {}
+
+  static class MyInnerClass897 {}
+
+  static class MyInnerClass898 {}
+
+  static class MyInnerClass899 {}
+
+  static class MyInnerClass900 {}
+
+  static class MyInnerClass901 {}
+
+  static class MyInnerClass902 {}
+
+  static class MyInnerClass903 {}
+
+  static class MyInnerClass904 {}
+
+  static class MyInnerClass905 {}
+
+  static class MyInnerClass906 {}
+
+  static class MyInnerClass907 {}
+
+  static class MyInnerClass908 {}
+
+  static class MyInnerClass909 {}
+
+  static class MyInnerClass910 {}
+
+  static class MyInnerClass911 {}
+
+  static class MyInnerClass912 {}
+
+  static class MyInnerClass913 {}
+
+  static class MyInnerClass914 {}
+
+  static class MyInnerClass915 {}
+
+  static class MyInnerClass916 {}
+
+  static class MyInnerClass917 {}
+
+  static class MyInnerClass918 {}
+
+  static class MyInnerClass919 {}
+
+  static class MyInnerClass920 {}
+
+  static class MyInnerClass921 {}
+
+  static class MyInnerClass922 {}
+
+  static class MyInnerClass923 {}
+
+  static class MyInnerClass924 {}
+
+  static class MyInnerClass925 {}
+
+  static class MyInnerClass926 {}
+
+  static class MyInnerClass927 {}
+
+  static class MyInnerClass928 {}
+
+  static class MyInnerClass929 {}
+
+  static class MyInnerClass930 {}
+
+  static class MyInnerClass931 {}
+
+  static class MyInnerClass932 {}
+
+  static class MyInnerClass933 {}
+
+  static class MyInnerClass934 {}
+
+  static class MyInnerClass935 {}
+
+  static class MyInnerClass936 {}
+
+  static class MyInnerClass937 {}
+
+  static class MyInnerClass938 {}
+
+  static class MyInnerClass939 {}
+
+  static class MyInnerClass940 {}
+
+  static class MyInnerClass941 {}
+
+  static class MyInnerClass942 {}
+
+  static class MyInnerClass943 {}
+
+  static class MyInnerClass944 {}
+
+  static class MyInnerClass945 {}
+
+  static class MyInnerClass946 {}
+
+  static class MyInnerClass947 {}
+
+  static class MyInnerClass948 {}
+
+  static class MyInnerClass949 {}
+
+  static class MyInnerClass950 {}
+
+  static class MyInnerClass951 {}
+
+  static class MyInnerClass952 {}
+
+  static class MyInnerClass953 {}
+
+  static class MyInnerClass954 {}
+
+  static class MyInnerClass955 {}
+
+  static class MyInnerClass956 {}
+
+  static class MyInnerClass957 {}
+
+  static class MyInnerClass958 {}
+
+  static class MyInnerClass959 {}
+
+  static class MyInnerClass960 {}
+
+  static class MyInnerClass961 {}
+
+  static class MyInnerClass962 {}
+
+  static class MyInnerClass963 {}
+
+  static class MyInnerClass964 {}
+
+  static class MyInnerClass965 {}
+
+  static class MyInnerClass966 {}
+
+  static class MyInnerClass967 {}
+
+  static class MyInnerClass968 {}
+
+  static class MyInnerClass969 {}
+
+  static class MyInnerClass970 {}
+
+  static class MyInnerClass971 {}
+
+  static class MyInnerClass972 {}
+
+  static class MyInnerClass973 {}
+
+  static class MyInnerClass974 {}
+
+  static class MyInnerClass975 {}
+
+  static class MyInnerClass976 {}
+
+  static class MyInnerClass977 {}
+
+  static class MyInnerClass978 {}
+
+  static class MyInnerClass979 {}
+
+  static class MyInnerClass980 {}
+
+  static class MyInnerClass981 {}
+
+  static class MyInnerClass982 {}
+
+  static class MyInnerClass983 {}
+
+  static class MyInnerClass984 {}
+
+  static class MyInnerClass985 {}
+
+  static class MyInnerClass986 {}
+
+  static class MyInnerClass987 {}
+
+  static class MyInnerClass988 {}
+
+  static class MyInnerClass989 {}
+
+  static class MyInnerClass990 {}
+
+  static class MyInnerClass991 {}
+
+  static class MyInnerClass992 {}
+
+  static class MyInnerClass993 {}
+
+  static class MyInnerClass994 {}
+
+  static class MyInnerClass995 {}
+
+  static class MyInnerClass996 {}
+
+  static class MyInnerClass997 {}
+
+  static class MyInnerClass998 {}
+
+  static class MyInnerClass999 {}
+}

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/LargeInnerClasses.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/LargeInnerClasses.java
@@ -1,0 +1,311 @@
+package datadog.smoketest.debugger;
+
+public class LargeInnerClasses {
+
+  public static int main(String arg) {
+    return 42; // beae1817-f3b0-4ea8-a74f-000000000001
+  }
+
+  static {
+    new MyInnerClass00();
+    new MyInnerClass01();
+    new MyInnerClass02();
+    new MyInnerClass03();
+    new MyInnerClass04();
+    new MyInnerClass05();
+    new MyInnerClass06();
+    new MyInnerClass07();
+    new MyInnerClass08();
+    new MyInnerClass09();
+    new MyInnerClass10();
+    new MyInnerClass11();
+    new MyInnerClass12();
+    new MyInnerClass13();
+    new MyInnerClass14();
+    new MyInnerClass15();
+    new MyInnerClass16();
+    new MyInnerClass17();
+    new MyInnerClass18();
+    new MyInnerClass19();
+    new MyInnerClass20();
+    new MyInnerClass21();
+    new MyInnerClass22();
+    new MyInnerClass23();
+    new MyInnerClass24();
+    new MyInnerClass25();
+    new MyInnerClass26();
+    new MyInnerClass27();
+    new MyInnerClass28();
+    new MyInnerClass29();
+    new MyInnerClass30();
+    new MyInnerClass31();
+    new MyInnerClass32();
+    new MyInnerClass33();
+    new MyInnerClass34();
+    new MyInnerClass35();
+    new MyInnerClass36();
+    new MyInnerClass37();
+    new MyInnerClass38();
+    new MyInnerClass39();
+    new MyInnerClass40();
+    new MyInnerClass41();
+    new MyInnerClass42();
+    new MyInnerClass43();
+    new MyInnerClass44();
+    new MyInnerClass45();
+    new MyInnerClass46();
+    new MyInnerClass47();
+    new MyInnerClass48();
+    new MyInnerClass49();
+    new MyInnerClass50();
+    new MyInnerClass51();
+    new MyInnerClass52();
+    new MyInnerClass53();
+    new MyInnerClass54();
+    new MyInnerClass55();
+    new MyInnerClass56();
+    new MyInnerClass57();
+    new MyInnerClass58();
+    new MyInnerClass59();
+    new MyInnerClass60();
+    new MyInnerClass61();
+    new MyInnerClass62();
+    new MyInnerClass63();
+    new MyInnerClass64();
+    new MyInnerClass65();
+    new MyInnerClass66();
+    new MyInnerClass67();
+    new MyInnerClass68();
+    new MyInnerClass69();
+    new MyInnerClass70();
+    new MyInnerClass71();
+    new MyInnerClass72();
+    new MyInnerClass73();
+    new MyInnerClass74();
+    new MyInnerClass75();
+    new MyInnerClass76();
+    new MyInnerClass77();
+    new MyInnerClass78();
+    new MyInnerClass79();
+    new MyInnerClass80();
+    new MyInnerClass81();
+    new MyInnerClass82();
+    new MyInnerClass83();
+    new MyInnerClass84();
+    new MyInnerClass85();
+    new MyInnerClass86();
+    new MyInnerClass87();
+    new MyInnerClass88();
+    new MyInnerClass89();
+    new MyInnerClass90();
+    new MyInnerClass91();
+    new MyInnerClass92();
+    new MyInnerClass93();
+    new MyInnerClass94();
+    new MyInnerClass95();
+    new MyInnerClass96();
+    new MyInnerClass97();
+    new MyInnerClass98();
+    new MyInnerClass99();
+  }
+
+  static class MyInnerClass00 {}
+
+  static class MyInnerClass01 {}
+
+  static class MyInnerClass02 {}
+
+  static class MyInnerClass03 {}
+
+  static class MyInnerClass04 {}
+
+  static class MyInnerClass05 {}
+
+  static class MyInnerClass06 {}
+
+  static class MyInnerClass07 {}
+
+  static class MyInnerClass08 {}
+
+  static class MyInnerClass09 {}
+
+  static class MyInnerClass10 {}
+
+  static class MyInnerClass11 {}
+
+  static class MyInnerClass12 {}
+
+  static class MyInnerClass13 {}
+
+  static class MyInnerClass14 {}
+
+  static class MyInnerClass15 {}
+
+  static class MyInnerClass16 {}
+
+  static class MyInnerClass17 {}
+
+  static class MyInnerClass18 {}
+
+  static class MyInnerClass19 {}
+
+  static class MyInnerClass20 {}
+
+  static class MyInnerClass21 {}
+
+  static class MyInnerClass22 {}
+
+  static class MyInnerClass23 {}
+
+  static class MyInnerClass24 {}
+
+  static class MyInnerClass25 {}
+
+  static class MyInnerClass26 {}
+
+  static class MyInnerClass27 {}
+
+  static class MyInnerClass28 {}
+
+  static class MyInnerClass29 {}
+
+  static class MyInnerClass30 {}
+
+  static class MyInnerClass31 {}
+
+  static class MyInnerClass32 {}
+
+  static class MyInnerClass33 {}
+
+  static class MyInnerClass34 {}
+
+  static class MyInnerClass35 {}
+
+  static class MyInnerClass36 {}
+
+  static class MyInnerClass37 {}
+
+  static class MyInnerClass38 {}
+
+  static class MyInnerClass39 {}
+
+  static class MyInnerClass40 {}
+
+  static class MyInnerClass41 {}
+
+  static class MyInnerClass42 {}
+
+  static class MyInnerClass43 {}
+
+  static class MyInnerClass44 {}
+
+  static class MyInnerClass45 {}
+
+  static class MyInnerClass46 {}
+
+  static class MyInnerClass47 {}
+
+  static class MyInnerClass48 {}
+
+  static class MyInnerClass49 {}
+
+  static class MyInnerClass50 {}
+
+  static class MyInnerClass51 {}
+
+  static class MyInnerClass52 {}
+
+  static class MyInnerClass53 {}
+
+  static class MyInnerClass54 {}
+
+  static class MyInnerClass55 {}
+
+  static class MyInnerClass56 {}
+
+  static class MyInnerClass57 {}
+
+  static class MyInnerClass58 {}
+
+  static class MyInnerClass59 {}
+
+  static class MyInnerClass60 {}
+
+  static class MyInnerClass61 {}
+
+  static class MyInnerClass62 {}
+
+  static class MyInnerClass63 {}
+
+  static class MyInnerClass64 {}
+
+  static class MyInnerClass65 {}
+
+  static class MyInnerClass66 {}
+
+  static class MyInnerClass67 {}
+
+  static class MyInnerClass68 {}
+
+  static class MyInnerClass69 {}
+
+  static class MyInnerClass70 {}
+
+  static class MyInnerClass71 {}
+
+  static class MyInnerClass72 {}
+
+  static class MyInnerClass73 {}
+
+  static class MyInnerClass74 {}
+
+  static class MyInnerClass75 {}
+
+  static class MyInnerClass76 {}
+
+  static class MyInnerClass77 {}
+
+  static class MyInnerClass78 {}
+
+  static class MyInnerClass79 {}
+
+  static class MyInnerClass80 {}
+
+  static class MyInnerClass81 {}
+
+  static class MyInnerClass82 {}
+
+  static class MyInnerClass83 {}
+
+  static class MyInnerClass84 {}
+
+  static class MyInnerClass85 {}
+
+  static class MyInnerClass86 {}
+
+  static class MyInnerClass87 {}
+
+  static class MyInnerClass88 {}
+
+  static class MyInnerClass89 {}
+
+  static class MyInnerClass90 {}
+
+  static class MyInnerClass91 {}
+
+  static class MyInnerClass92 {}
+
+  static class MyInnerClass93 {}
+
+  static class MyInnerClass94 {}
+
+  static class MyInnerClass95 {}
+
+  static class MyInnerClass96 {}
+
+  static class MyInnerClass97 {}
+
+  static class MyInnerClass98 {}
+
+  static class MyInnerClass99 {}
+}

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -29,6 +29,8 @@ public class ServerDebuggerTestApplication {
   public static void main(String[] args) throws Exception {
     System.out.println(ServerDebuggerTestApplication.class.getName());
     try {
+      new LargeInnerClasses();
+      new HugeInnerClasses();
       registerMethods();
       ServerDebuggerTestApplication serverTestApplication =
           new ServerDebuggerTestApplication(args[0]);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/CodeOriginIntegrationTest.java
@@ -47,7 +47,7 @@ public class CodeOriginIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 assertEquals("runTracedMethod", span.getMeta().get(DD_CODE_ORIGIN_FRAME_METHOD));
                 assertEquals(
                     "(java.lang.String)", span.getMeta().get(DD_CODE_ORIGIN_FRAME_SIGNATURE));
-                assertEquals("156", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
+                assertEquals("158", span.getMeta().get(DD_CODE_ORIGIN_FRAME_LINE));
                 codeOrigin.set(true);
               }
             }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -102,11 +102,6 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
     LOG.info("feature {} stopped", feature);
   }
 
-  private void waitForSpecificLine(String appUrl, String line) throws IOException {
-    String url = String.format(appUrl + "/waitForSpecificLine?line=%s", line);
-    sendRequest(url);
-  }
-
   private static ConfigOverrides createConfigOverrides(
       boolean dynamicInstrumentationEnabled, boolean exceptionReplayEnabled) {
     ConfigOverrides config = new ConfigOverrides();

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
@@ -9,6 +9,7 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.test.util.NonRetryable;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -25,6 +26,13 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
   void setup(TestInfo testInfo) throws Exception {
     super.setup(testInfo);
     appUrl = startAppAndAndGetUrl();
+  }
+
+  @Override
+  protected List<String> getDebuggerCommandParams() {
+    List<String> args = super.getDebuggerCommandParams();
+    args.add("-Ddd.third.party.excludes=datadog.smoketest");
+    return args;
   }
 
   @Test
@@ -47,6 +55,39 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
     execute(appUrl, FULL_METHOD_NAME);
     snapshot = waitForOneSnapshot();
     assertEquals(FULL_METHOD_NAME, snapshot.getProbe().getLocation().getMethod());
+  }
+
+  @Test
+  @DisplayName("testAddSourceFileProbeLargeInnerClasses")
+  @DisabledIf(
+      value = "datadog.environment.JavaVirtualMachine#isJ9",
+      disabledReason = "Flaky on J9 JVMs")
+  void testAddSourceFileProbeLargeInnerClasses() throws Exception {
+    LogProbe logProbe =
+        LogProbe.builder()
+            .probeId(PROBE_ID)
+            .where("LargeInnerClasses.java", 6)
+            .captureSnapshot(true)
+            .build();
+    addProbe(logProbe);
+    waitForInstrumentation(appUrl, "datadog.smoketest.debugger.LargeInnerClasses", true);
+  }
+
+  @Test
+  @DisplayName("testAddSourceFileProbeHugeInnerClasses")
+  @DisabledIf(
+      value = "datadog.environment.JavaVirtualMachine#isJ9",
+      disabledReason = "Flaky on J9 JVMs")
+  void testAddSourceFileProbeHugeInnerClasses() throws Exception {
+    LogProbe logProbe =
+        LogProbe.builder()
+            .probeId(PROBE_ID)
+            .where("HugeInnerClasses.java", 6)
+            .captureSnapshot(true)
+            .build();
+    addProbe(logProbe);
+    waitForSpecificLine(
+        appUrl, "java.lang.IllegalStateException: Too many classes to retransform: 1001");
   }
 
   @Test

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
@@ -155,6 +155,11 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
     LOG.info("re-transformation done");
   }
 
+  protected void waitForSpecificLine(String appUrl, String line) throws IOException {
+    String url = String.format(appUrl + "/waitForSpecificLine?line=%s", line);
+    sendRequest(url);
+  }
+
   protected String startAppAndAndGetUrl() throws InterruptedException, IOException {
     controlServer.enqueue(EMPTY_200_RESPONSE); // ack response
     targetProcess = createProcessBuilder(logFilePath, controlUrl.toString()).start();


### PR DESCRIPTION
# What Does This Do
if a source file has a large number of inner classes, putting a line probe will trigger the retransformation of all inner classes individually which can lead to significant overhead (retransformation is Stop-The-World event). The api instrumentation::retransformClasses can take a list of classes that are retransformed in a single STW event which armortized the cost. However we put a hard limit of number of inner classes to avoid long STW event in case of generated code.

# Motivation

# Additional Notes
Did some tests about the overhead of retransformClasses:

for 100 inner classes
individually: 600ms
batch: 34ms

for 1000 inner classes
individually: 5500ms
batch: 260ms

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4890]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4890]: https://datadoghq.atlassian.net/browse/DEBUG-4890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ