### PR TITLE
Avoid null store put on Ignite instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/IgniteInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/IgniteInstrumentation.java
@@ -78,8 +78,9 @@ public class IgniteInstrumentation extends InstrumenterModule.Tracing
         @Advice.This Ignite that,
         @Advice.Thrown final Throwable throwable,
         @Advice.Return final IgniteCache<?, ?> cache) {
-
-      InstrumentationContext.get(IgniteCache.class, Ignite.class).put(cache, that);
+      if (cache != null) {
+        InstrumentationContext.get(IgniteCache.class, Ignite.class).put(cache, that);
+      }
     }
   }
 
@@ -91,8 +92,10 @@ public class IgniteInstrumentation extends InstrumenterModule.Tracing
         @Advice.Thrown final Throwable throwable,
         @Advice.Return final Collection<IgniteCache<?, ?>> caches) {
 
-      for (IgniteCache<?, ?> cache : caches) {
-        InstrumentationContext.get(IgniteCache.class, Ignite.class).put(cache, that);
+      if (caches != null) {
+        for (IgniteCache<?, ?> cache : caches) {
+          InstrumentationContext.get(IgniteCache.class, Ignite.class).put(cache, that);
+        }
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

The exitValue oft this advice might be null if an exception is thrown. This PR avoid having a NPE because we try to store a null value. 

Fixes:

```
Error : Failed to handle exception in instrumentation for org.apache.ignite.internal.IgniteKernal
java.lang.NullPointerException
  at (redacted)
  at datadog.trace.agent.tooling.WeakMaps$Adapter.put(WeakMaps.java:75)
  at datadog.trace.bootstrap.WeakMapContextStore.put(WeakMapContextStore.java:31)
  at datadog.trace.bootstrap.FieldBackedContextStore.put(FieldBackedContextStore.java:28)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
