### PR TITLE
Loosen pin-system-tests restriction

### DIFF
--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           scope: DataDog/dd-trace-java
           policy: self.pin-system-tests.create-pr
+
+      # temporary
+      - name: Print github.ref
+        run: echo "github.ref: ${{ github.ref }}"
       
       - name: Define base branch
         id: define-base-branch


### PR DESCRIPTION
# What Does This Do

This PR loosens the `if:` statement restriction such that branches that include the `release/v` keyword trigger the workflow.

It also includes a step that prints out `github.ref` such that we can refine the `if:` statement back to `startsWith` if possible.

# Motivation

For the recent `1.58.0` release, the `pin-system-tests` workflow was skipped: https://github.com/DataDog/dd-trace-java/actions/runs/20744801688. This is likely because the `create` event uses the branch / tag name as the `GITHUB_REF` ([doc](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#create)), instead of the `GITHUB_REF` starting with `refs/heads/` as is currently expected.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
