### PR TITLE
Print github ref in a separate job in pin-system-tests workflow

### DIFF
--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -11,7 +11,7 @@ on:
   create:
 
 jobs:
-  # temporary
+  # TODO: Remove this job after confirming the github.ref when a release branch is created
   print-github-ref:
     name: "Print github.ref"
     runs-on: ubuntu-latest
@@ -22,7 +22,6 @@ jobs:
 
   pin-system-tests:
     name: "Pin system tests"
-    # temporary
     needs:
       - print-github-ref
     if: github.event_name != 'create' || contains(github.ref, 'release/v')


### PR DESCRIPTION
# What Does This Do

Add a separate job before `dd-octo-sts` that prints the github ref. This should allow us to see the full github ref and properly refine the workflow's `if:` statement filter.

# Motivation

Unfortunately I failed to take into account `dd-octo-sts` restrictions in #10293 ([failure](https://github.com/DataDog/dd-trace-java/actions/runs/20756446019)). It was not sufficient to only loosen the trigger branch restrictions in the workflow. 

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
