### PR TITLE
🪞 9947 - Fix GitClientTest.test git diff when diff.noprefix=true is used

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 public class GitDiffParser {
 
   private static final Pattern CHANGED_FILE_PATTERN =
-      Pattern.compile("^diff --git a/(?<oldfilename>.+) b/(?<newfilename>.+)$");
+      Pattern.compile("^diff --git (?<oldfilename>.+) (?<newfilename>.+)$");
   private static final Pattern CHANGED_LINES_PATTERN =
       Pattern.compile("^@@ -\\d+(,\\d+)? \\+(?<startline>\\d+)(,(?<count>\\d+))? @@");
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/ShellGitClient.java
@@ -929,6 +929,7 @@ public class ShellGitClient implements GitClient {
                   "diff",
                   "-U0",
                   "--word-diff=porcelain",
+                  "--no-prefix",
                   baseCommit,
                   targetCommit));
     } else {
@@ -936,7 +937,13 @@ public class ShellGitClient implements GitClient {
           Command.DIFF,
           () ->
               commandExecutor.executeCommand(
-                  GitDiffParser::parse, "git", "diff", "-U0", "--word-diff=porcelain", baseCommit));
+                  GitDiffParser::parse,
+                  "git",
+                  "diff",
+                  "-U0",
+                  "--word-diff=porcelain",
+                  "--no-prefix",
+                  baseCommit));
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/git-diff.txt
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/git-diff.txt
@@ -1,16 +1,16 @@
-diff --git a/java/maven-junit4/pom.xml b/java/maven-junit4/pom.xml
+diff --git java/maven-junit4/pom.xml java/maven-junit4/pom.xml
 index 6d73cda..2a1f220 100644
---- a/java/maven-junit4/pom.xml
-+++ b/java/maven-junit4/pom.xml
+--- java/maven-junit4/pom.xml
++++ java/maven-junit4/pom.xml
 @@ -10 +10 @@
 
 -<name>java-maven-junit4</name>
 +<name>java-maven-junit4-test-project</name>
 ~
-diff --git a/java/maven-junit5/pom.xml b/java/maven-junit5/pom.xml
+diff --git java/maven-junit5/pom.xml java/maven-junit5/pom.xml
 index 7b92d64..834a61c 100644
---- a/java/maven-junit5/pom.xml
-+++ b/java/maven-junit5/pom.xml
+--- java/maven-junit5/pom.xml
++++ java/maven-junit5/pom.xml
 @@ -14 +14 @@
 
 -<module>module-b</module>

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/larger-git-diff.txt
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/datadog/trace/civisibility/git/tree/larger-git-diff.txt
@@ -1,16 +1,16 @@
-diff --git a/java/maven-junit4/pom.xml b/java/maven-junit4/pom.xml
+diff --git java/maven-junit4/pom.xml java/maven-junit4/pom.xml
 index 6d73cda..2a1f220 100644
---- a/java/maven-junit4/pom.xml
-+++ b/java/maven-junit4/pom.xml
+--- java/maven-junit4/pom.xml
++++ java/maven-junit4/pom.xml
 @@ -10 +10 @@
      
 -<name>java-maven-junit4</name>
 +<name>java-maven-junit4-test-project</name>
 ~
-diff --git a/java/maven-junit5/module-a/pom.xml b/java/maven-junit5/module-a/pom.xml
+diff --git java/maven-junit5/module-a/pom.xml java/maven-junit5/module-a/pom.xml
 index 29a3a73..4567037 100644
---- a/java/maven-junit5/module-a/pom.xml
-+++ b/java/maven-junit5/module-a/pom.xml
+--- java/maven-junit5/module-a/pom.xml
++++ java/maven-junit5/module-a/pom.xml
 @@ -8,3 +8,3 @@
          
 -<groupId>com.datadog.ci.test</groupId>
@@ -53,10 +53,10 @@ index 29a3a73..4567037 100644
 @@ -34 +40 @@
  </project>
 ~
-diff --git a/java/maven-junit5/module-b/pom.xml b/java/maven-junit5/module-b/pom.xml
+diff --git java/maven-junit5/module-b/pom.xml java/maven-junit5/module-b/pom.xml
 deleted file mode 100644
 index f18dd09..0000000
---- a/java/maven-junit5/module-b/pom.xml
+--- java/maven-junit5/module-b/pom.xml
 +++ /dev/null
 @@ -1,17 +0,0 @@
 -<?xml version="1.0"?>
@@ -91,10 +91,10 @@ index f18dd09..0000000
 ~
 -</project>
 ~
-diff --git a/java/maven-junit5/pom.xml b/java/maven-junit5/pom.xml
+diff --git java/maven-junit5/pom.xml java/maven-junit5/pom.xml
 index 7b92d64..834a61c 100644
---- a/java/maven-junit5/pom.xml
-+++ b/java/maven-junit5/pom.xml
+--- java/maven-junit5/pom.xml
++++ java/maven-junit5/pom.xml
 @@ -14 +14 @@
          
 -<module>module-b</module>


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/9947
**Original Author:** @deejgregor
**Original Branch:** deejgregor/dd-trace-java:fix-git-client-test-with-diff-noprefix

Closes #9947

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*