### PR TITLE
Mute JNA initialisation when creating ForeignMemoryWriters

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/servicediscovery/ForeignMemoryWriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/servicediscovery/ForeignMemoryWriterFactory.java
@@ -5,9 +5,6 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import datadog.environment.JavaVirtualMachine;
 import datadog.environment.OperatingSystem;
 import datadog.environment.SystemProperties;
-import datadog.trace.api.GlobalTracer;
-import datadog.trace.api.Tracer;
-import datadog.trace.context.TraceScope;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -28,9 +25,7 @@ public final class ForeignMemoryWriterFactory implements Supplier<ForeignMemoryW
 
   @SuppressForbidden // intentional Class.forName to force loading
   private ForeignMemoryWriter createForLinux() {
-    final Tracer tracer = GlobalTracer.get();
-    // JNA initialisation can do ldconfig and other commands. Those are hidden since internal.
-    try (TraceScope closeme = tracer != null ? tracer.muteTracing() : null) {
+    try {
       // first check if the arch is supported
       if (OperatingSystem.architecture() == OperatingSystem.Architecture.UNKNOWN) {
         log.debug(


### PR DESCRIPTION
# What Does This Do

JNA initialisation usually trigger unix command executions that creates  process execution spans. This causes the smoke test to count more spans hence it made it failing.

This PR move the blackhole that was hiding the spans from the write to the initialisation of writer instances (since now the JNA is initialised here)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
