### PR TITLE
Lazy init JNA on service discovery

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/servicediscovery/MemFDUnixWriterJNA.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/servicediscovery/MemFDUnixWriterJNA.java
@@ -7,7 +7,9 @@ import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 
 public final class MemFDUnixWriterJNA extends MemFDUnixWriter {
-  private final LibC libc = Native.load("c", LibC.class);
+  private static final class Lazy {
+    static final LibC LIBC = Native.load("c", LibC.class);
+  }
 
   private interface LibC extends Library {
     long syscall(long number, Object... args);
@@ -19,19 +21,19 @@ public final class MemFDUnixWriterJNA extends MemFDUnixWriter {
 
   @Override
   protected long syscall(long number, String name, int flags) {
-    return libc.syscall(number, name, flags);
+    return Lazy.LIBC.syscall(number, name, flags);
   }
 
   @Override
   protected long write(int fd, byte[] payload) {
     Memory buf = new Memory(payload.length);
     buf.write(0, payload, 0, payload.length);
-    return libc.write(fd, buf, new NativeLong(payload.length)).longValue();
+    return Lazy.LIBC.write(fd, buf, new NativeLong(payload.length)).longValue();
   }
 
   @Override
   protected int fcntl(int fd, int cmd, int arg) {
-    return libc.fcntl(fd, cmd, arg);
+    return Lazy.LIBC.fcntl(fd, cmd, arg);
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

JNA initialisation usually trigger unix command executions that creates process execution spans. This causes the smoke test to count more spans hence it made it failing.

This PR lazy init the JNA subsystem on the first usage (happening at write - compatible with the current place where the tracing is muted)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
