### PR TITLE
Always record force keep decisions for future distributed trace propagation

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -530,10 +530,9 @@ public class DDSpanContext
   private void forceKeepThisSpan(byte samplingMechanism) {
     // if the user really wants to keep this trace chunk, we will let them,
     // even if the old sampling priority and mechanism have already propagated
-    if (SAMPLING_PRIORITY_UPDATER.getAndSet(this, PrioritySampling.USER_KEEP)
-        == PrioritySampling.UNSET) {
-      propagationTags.updateTraceSamplingPriority(PrioritySampling.USER_KEEP, samplingMechanism);
-    }
+    SAMPLING_PRIORITY_UPDATER.set(this, PrioritySampling.USER_KEEP);
+    // record force keep decision for future distributed trace propagation
+    propagationTags.forceKeep(samplingMechanism);
   }
 
   public void addPropagatedTraceSource(final int value) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -57,6 +57,8 @@ public abstract class PropagationTags {
    */
   public abstract void updateTraceSamplingPriority(int samplingPriority, int samplingMechanism);
 
+  public abstract void forceKeep(int samplingMechanism);
+
   public abstract int getSamplingPriority();
 
   public abstract void updateTraceOrigin(CharSequence origin);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -99,11 +99,10 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     dd.createTagMap() == tagMap
 
     where:
-    priority     | header                                | newHeader                             | tagMap
-    UNSET        | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123"           | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
-    // decision has already been made, propagate as-is
-    SAMPLER_KEEP | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | ["_dd.p.dm": "9bf3439f2f-1", "_dd.p.usr": "123"]
-    SAMPLER_KEEP | "_dd.p.usr=123"                       | "_dd.p.usr=123"                       | ["_dd.p.usr": "123"]
+    priority     | header                                | newHeader                   | tagMap
+    UNSET        | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
+    SAMPLER_KEEP | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
+    SAMPLER_KEEP | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
   }
 
   def "forceKeep trace PropagationTags #priority #header"() {
@@ -127,10 +126,9 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     ddRoot.createTagMap() == rootTagMap
 
     where:
-    priority     | header                                | rootHeader                            | rootTagMap
-    UNSET        | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123"           | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
-    // decision has already been made, propagate as-is
-    SAMPLER_KEEP | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | ["_dd.p.dm": "9bf3439f2f-1", "_dd.p.usr": "123"]
-    SAMPLER_KEEP | "_dd.p.usr=123"                       | "_dd.p.usr=123"                       | ["_dd.p.usr": "123"]
+    priority     | header                                | rootHeader                  | rootTagMap
+    UNSET        | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
+    SAMPLER_KEEP | "_dd.p.dm=9bf3439f2f-1,_dd.p.usr=123" | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
+    SAMPLER_KEEP | "_dd.p.usr=123"                       | "_dd.p.dm=-4,_dd.p.usr=123" | ["_dd.p.dm": "-4", "_dd.p.usr": "123"]
   }
 }


### PR DESCRIPTION
# Motivation

Fixes an issue uncovered by https://github.com/DataDog/system-tests/pull/5617

While manually overriding the sampling decision was correctly updating the sampling priority in the local root span, it wasn't overriding the decision maker tag for future distributed trace propagation if a sampling priority had already been propagated.

# Additional Notes

This change in behaviour should be called out in the release notes.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-1721]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-1721]: https://datadoghq.atlassian.net/browse/APMAPI-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ