### PR TITLE
Add long running traces to flare report

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceDumpJsonExporter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceDumpJsonExporter.java
@@ -3,12 +3,9 @@ package datadog.trace.common.writer;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
-import datadog.trace.api.flare.TracerFlare;
 import datadog.trace.core.DDSpan;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.zip.ZipOutputStream;
 
 public class TraceDumpJsonExporter implements Writer {
 
@@ -17,11 +14,9 @@ public class TraceDumpJsonExporter implements Writer {
           .add(DDSpanJsonAdapter.buildFactory(false))
           .build()
           .adapter(Types.newParameterizedType(Collection.class, DDSpan.class));
-  private StringBuilder dumpText;
-  private ZipOutputStream zip;
+  private final StringBuilder dumpText;
 
-  public TraceDumpJsonExporter(ZipOutputStream zip) {
-    this.zip = zip;
+  public TraceDumpJsonExporter() {
     dumpText = new StringBuilder();
   }
 
@@ -32,7 +27,8 @@ public class TraceDumpJsonExporter implements Writer {
 
   @Override
   public void write(List<DDSpan> trace) {
-    // Do nothing
+    Collection<DDSpan> collectionTrace = trace;
+    write(collectionTrace);
   }
 
   @Override
@@ -42,12 +38,12 @@ public class TraceDumpJsonExporter implements Writer {
 
   @Override
   public boolean flush() {
-    try {
-      TracerFlare.addText(zip, "pending_traces.txt", dumpText.toString());
-    } catch (IOException e) {
-      // do nothing
-    }
+    // do nothing
     return true;
+  }
+
+  public String getDumpJson() {
+    return dumpText.toString();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -71,6 +71,23 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
     private final LongRunningTracesTracker runningTracesTracker;
 
+    private void dumpTraces() {
+      if (worker.isAlive()) {
+        int count = dumpCounter.get();
+        int loop = 1;
+        boolean signaled = queue.offer(DUMP_ELEMENT);
+        while (!closed && !signaled) {
+          yieldOrSleep(loop++);
+          signaled = queue.offer(DUMP_ELEMENT);
+        }
+        int newCount = dumpCounter.get();
+        while (!closed && count >= newCount) {
+          yieldOrSleep(loop++);
+          newCount = dumpCounter.get();
+        }
+      }
+    }
+
     public boolean longRunningSpansEnabled() {
       return runningTracesTracker != null;
     }
@@ -133,6 +150,18 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
           yieldOrSleep(loop++);
           newCount = flushCounter.get();
         }
+      }
+    }
+
+    private String getDumpJson() {
+      try (TraceDumpJsonExporter writer = new TraceDumpJsonExporter()) {
+        for (Element e : DumpDrain.DUMP_DRAIN.collectTraces()) {
+          if (e instanceof PendingTrace) {
+            PendingTrace trace = (PendingTrace) e;
+            writer.write(trace.getSpans());
+          }
+        }
+        return writer.getDumpJson();
       }
     }
 
@@ -354,32 +383,12 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
     @Override
     public void prepareForFlare() {
-      if (buffer.worker.isAlive()) {
-        int count = buffer.dumpCounter.get();
-        int loop = 1;
-        boolean signaled = buffer.queue.offer(DelayingPendingTraceBuffer.DUMP_ELEMENT);
-        while (!buffer.closed && !signaled) {
-          buffer.yieldOrSleep(loop++);
-          signaled = buffer.queue.offer(DelayingPendingTraceBuffer.DUMP_ELEMENT);
-        }
-        int newCount = buffer.dumpCounter.get();
-        while (!buffer.closed && count >= newCount) {
-          buffer.yieldOrSleep(loop++);
-          newCount = buffer.dumpCounter.get();
-        }
-      }
+      buffer.dumpTraces();
     }
 
     @Override
     public void addReportToFlare(ZipOutputStream zip) throws IOException {
-      TraceDumpJsonExporter writer = new TraceDumpJsonExporter(zip);
-      for (Element e : DelayingPendingTraceBuffer.DumpDrain.DUMP_DRAIN.collectTraces()) {
-        if (e instanceof PendingTrace) {
-          PendingTrace trace = (PendingTrace) e;
-          writer.write(trace.getSpans());
-        }
-      }
-      writer.flush();
+      TracerFlare.addText(zip, "pending_traces.txt", buffer.getDumpJson());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -71,6 +71,8 @@ public abstract class HealthMetrics implements AutoCloseable {
   public void onFailedSend(
       final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}
 
+  public void onPendingWriteAround() {}
+
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {}
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -85,6 +85,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final LongAdder scopeCloseErrors = new LongAdder();
   private final LongAdder userScopeCloseErrors = new LongAdder();
 
+  private final LongAdder pendingWriteAround = new LongAdder();
+
   private final LongAdder longRunningTracesWrite = new LongAdder();
   private final LongAdder longRunningTracesDropped = new LongAdder();
   private final LongAdder longRunningTracesExpired = new LongAdder();
@@ -296,6 +298,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
+  public void onPendingWriteAround() {
+    pendingWriteAround.increment();
+  }
+
+  @Override
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {
     longRunningTracesWrite.add(write);
     longRunningTracesDropped.add(dropped);
@@ -473,6 +480,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(
             target.statsd, "scope.user.close.error", target.userScopeCloseErrors, NO_TAGS);
 
+        reportIfChanged(target.statsd, "pending.write_around", target.pendingWriteAround, NO_TAGS);
+
         reportIfChanged(
             target.statsd, "long-running.write", target.longRunningTracesWrite, NO_TAGS);
         reportIfChanged(
@@ -601,6 +610,9 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         + scopeCloseErrors.sum()
         + "\nuserScopeCloseErrors="
         + userScopeCloseErrors.sum()
+        + "\n"
+        + "\npendingWriteAround="
+        + pendingWriteAround.sum()
         + "\n"
         + "\nlongRunningTracesWrite="
         + longRunningTracesWrite.sum()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
@@ -201,4 +201,43 @@ class LongRunningTracesTrackerTest extends DDSpecification {
     PrioritySampling.USER_KEEP | 1 | LongRunningTracesTracker.WRITE_RUNNING_SPANS
     PrioritySampling.SAMPLER_KEEP | 1 | LongRunningTracesTracker.WRITE_RUNNING_SPANS
   }
+
+  def "getTracesAsJson with no traces"() {
+    when:
+    def json = tracker.getTracesAsJson()
+
+    then:
+    json == ""
+  }
+
+  def "getTracesAsJson with traces"() {
+    given:
+    def trace = newTraceToTrack()
+    tracker.add(trace)
+
+    when:
+    def json = tracker.getTracesAsJson()
+
+    then:
+    json != null
+    !json.isEmpty()
+    json.contains('"service"')
+    json.contains('"name"')
+  }
+
+  def "testing tracer flare dump with trace"() {
+    given:
+    def trace = newTraceToTrack()
+    tracker.add(trace)
+
+    when:
+    def entries = PendingTraceBufferTest.buildAndExtractZip()
+
+    then:
+    entries.containsKey("long_running_traces.txt")
+
+    def jsonContent = entries["long_running_traces.txt"] as String
+    jsonContent.contains('"service"')
+    jsonContent.contains('"name"')
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -605,7 +605,7 @@ class PendingTraceBufferTest extends DDSpecification {
     return DDSpan.create("test", 0, context, null)
   }
 
-  def buildAndExtractZip() {
+  static buildAndExtractZip() {
     TracerFlare.prepareForFlare()
     def out = new ByteArrayOutputStream()
     try (ZipOutputStream zip = new ZipOutputStream(out)) {


### PR DESCRIPTION
# What Does This Do

Adds long running traces to the flare report.

Also keeps track of how often we write around the pending trace buffer.

# Motivation

While adding custom instrumentation to a complex, asynchronous application we found it was challenging to validate if all spans were end()ed during tests. dd.trace.debug=true and dd.trace.experimental.long-running.enabled=true could be used with some post-processing of debug logs, however this didn't work for our needs because the application breaks with that level of logging. When dd.trace.experimental.long-running.enabled=true is used, the long running traces are sent to Datadog's backend, however they are not searchable until they are finished, so we didn't have a good way to find them. This change adds the long running traces list to the flare report.

# Additional Notes

This was originally part of #9874, which is being broken out into a few individual PRs.

Some highlights in the different commits:

- [Trace dump refactor in preparation for adding long running traces](https://github.com/DataDog/dd-trace-java/pull/10309/commits/a04c75d7b566a453ca860cc2e3c4f761d821d525) -- This doesn't need to be kept in its own commit. I kept it separate for now to make review a little easier.
- [Add long_running_traces.json to flare report](https://github.com/DataDog/dd-trace-java/pull/10309/commits/248c7de863d0d3842f99aebeaf0686910089ddfd) -- Note: this adds synchronized to a few methods (see commit comment for details).
- [PendingTraceBuffer: Keep track of how often we write around the buffer](https://github.com/DataDog/dd-trace-java/pull/10309/commits/743dd899228434ff0c01d19282d6d05b2eed6783) -- This seems like a valuable metric to track but could be removed or moved to a separate PR.

This also limits the number of long running traces added to the flare report, [like is already done for the pending trace buffer](https://github.com/DataDog/dd-trace-java/blob/33bbc70b2912f75b37913174745b0be6a6d003ee/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java#L152) ( MAX_DUMPED_TRACES = 50).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
