### PR TITLE
Add JMX MBean for getting tracer flare files

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -116,6 +116,7 @@ public class JMXFetch {
             .refreshBeansPeriod(refreshBeansPeriod)
             .globalTags(globalTags)
             .reporter(reporter)
+            .jmxfetchTelemetry(config.isTelemetryJmxEnabled())
             .connectionFactory(new AgentConnectionFactory());
 
     if (config.isJmxFetchMultipleRuntimeServicesEnabled()) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -101,6 +101,7 @@ public final class GeneralConfig {
   public static final String TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE =
       "telemetry.dependency-resolution.queue.size";
   public static final String TELEMETRY_DEBUG_REQUESTS_ENABLED = "telemetry.debug.requests.enabled";
+  public static final String TELEMETRY_JMX_ENABLED = "telemetry.jmx.enabled";
   public static final String AGENTLESS_LOG_SUBMISSION_ENABLED = "agentless.log.submission.enabled";
   public static final String AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE =
       "agentless.log.submission.queue.size";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -393,6 +393,7 @@ import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_COLLEC
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_JMX_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_LOG_COLLECTION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_METRICS_INTERVAL;
@@ -1243,6 +1244,7 @@ public class Config {
   private final boolean isTelemetryDependencyServiceEnabled;
   private final boolean telemetryMetricsEnabled;
   private final boolean isTelemetryLogCollectionEnabled;
+  private final boolean isTelemetryJmxEnabled;
   private final int telemetryDependencyResolutionQueueSize;
 
   private final boolean azureAppServices;
@@ -2175,6 +2177,8 @@ public class Config {
         instrumenterConfig.isTelemetryEnabled()
             && configProvider.getBoolean(
                 TELEMETRY_LOG_COLLECTION_ENABLED, DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED);
+
+    isTelemetryJmxEnabled = configProvider.getBoolean(TELEMETRY_JMX_ENABLED, false);
 
     isTelemetryDependencyServiceEnabled =
         configProvider.getBoolean(
@@ -3746,6 +3750,10 @@ public class Config {
 
   public boolean isTelemetryLogCollectionEnabled() {
     return isTelemetryLogCollectionEnabled;
+  }
+
+  public boolean isTelemetryJmxEnabled() {
+    return isTelemetryJmxEnabled;
   }
 
   public int getTelemetryDependencyResolutionQueueSize() {

--- a/internal-api/src/main/java/datadog/trace/api/flare/TracerFlare.java
+++ b/internal-api/src/main/java/datadog/trace/api/flare/TracerFlare.java
@@ -4,6 +4,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,6 +67,19 @@ public final class TracerFlare {
 
   public static void addReporter(Reporter reporter) {
     reporters.put(reporter.getClass(), reporter);
+  }
+
+  public static Collection<Reporter> getReporters() {
+    return Collections.unmodifiableCollection(reporters.values());
+  }
+
+  public static Reporter getReporter(String className) {
+    for (Reporter reporter : getReporters()) {
+      if (reporter.getClass().getName().equals(className)) {
+        return reporter;
+      }
+    }
+    return null;
   }
 
   public static void addText(ZipOutputStream zip, String section, String text) throws IOException {

--- a/internal-api/src/test/groovy/datadog/trace/api/flare/TracerFlareTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/flare/TracerFlareTest.groovy
@@ -51,6 +51,34 @@ class TracerFlareTest extends DDSpecification {
       /^(java.lang.IllegalStateException: (bin|txt) \(expected\)\n){2}$/
   }
 
+  def "test getReporter finds reporter by class name"() {
+    setup:
+    def reporter1 = Mock(Reporter1)
+    def reporter2 = Mock(Reporter2)
+    TracerFlare.addReporter(reporter1)
+    TracerFlare.addReporter(reporter2)
+
+    when:
+    def found1 = TracerFlare.getReporter(reporter1.getClass().getName())
+    def found2 = TracerFlare.getReporter(reporter2.getClass().getName())
+
+    then:
+    found1 == reporter1
+    found2 == reporter2
+  }
+
+  def "test getReporter returns null for non-existent reporter"() {
+    setup:
+    def reporter = Mock(Reporter1)
+    TracerFlare.addReporter(reporter)
+
+    when:
+    def found = TracerFlare.getReporter("com.example.NonExistentReporter")
+
+    then:
+    found == null
+  }
+
   def buildAndExtractZip() {
     TracerFlare.prepareForFlare()
     def out = new ByteArrayOutputStream()

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -3737,6 +3737,14 @@
         "aliases": []
       }
     ],
+    "DD_TELEMETRY_JMX_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_TELEMETRY_LOG_COLLECTION_ENABLED": [
       {
         "version": "A",

--- a/utils/flare-utils/build.gradle.kts
+++ b/utils/flare-utils/build.gradle.kts
@@ -12,4 +12,7 @@ dependencies {
   implementation(project(":utils:version-utils"))
   implementation(project(":internal-api"))
   implementation(libs.slf4j)
+
+  testImplementation(project(":utils:test-utils"))
+  testImplementation(project(":dd-trace-api"))
 }

--- a/utils/flare-utils/src/main/java/datadog/flare/TracerFlareManager.java
+++ b/utils/flare-utils/src/main/java/datadog/flare/TracerFlareManager.java
@@ -1,0 +1,200 @@
+package datadog.flare;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.flare.TracerFlare;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MBean implementation for managing and accessing tracer flare data.
+ *
+ * <p>This class provides JMX operations to list flare data sources and retrieve flare data either
+ * for individual sources or a complete flare archive. See {@link TracerFlareManagerMBean} for
+ * documentation on the exposed operations.
+ */
+public class TracerFlareManager implements TracerFlareManagerMBean {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TracerFlareManager.class);
+
+  private final TracerFlareService flareService;
+  protected ObjectName mbeanName;
+
+  public TracerFlareManager(TracerFlareService flareService) {
+    this.flareService = flareService;
+  }
+
+  @Override
+  public String generateFullFlareZip() throws IOException {
+    TracerFlare.prepareForFlare();
+
+    long currentMillis = System.currentTimeMillis();
+    boolean dumpThreads = Config.get().isTriageEnabled() || LOGGER.isDebugEnabled();
+    byte[] zipBytes = flareService.buildFlareZip(currentMillis, currentMillis, dumpThreads);
+    return Base64.getEncoder().encodeToString(zipBytes);
+  }
+
+  @Override
+  public String listFlareFiles() throws IOException {
+    TracerFlare.prepareForFlare();
+
+    StringBuilder result = new StringBuilder();
+
+    for (Map.Entry<String, String[]> entry : TracerFlareService.BUILT_IN_SOURCES.entrySet()) {
+      String sourceName = entry.getKey();
+      String[] files = entry.getValue();
+
+      for (String filename : files) {
+        result.append(sourceName).append(" ").append(filename).append("\n");
+      }
+    }
+
+    for (TracerFlare.Reporter reporter : TracerFlare.getReporters()) {
+      try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+          ZipOutputStream zip = new ZipOutputStream(bytes)) {
+        reporter.addReportToFlare(zip);
+        zip.finish();
+
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes.toByteArray());
+            ZipInputStream zis = new ZipInputStream(bais)) {
+          ZipEntry entry;
+          while ((entry = zis.getNextEntry()) != null) {
+            result
+                .append(reporter.getClass().getName())
+                .append(" ")
+                .append(entry.getName())
+                .append("\n");
+            zis.closeEntry();
+          }
+        }
+      } catch (IOException e) {
+        LOGGER.debug("Failed to inspect reporter {}", reporter.getClass().getName(), e);
+      }
+    }
+
+    return result.toString();
+  }
+
+  @Override
+  public String getFlareFile(String sourceName, String filename) throws IOException {
+    final byte[] zipBytes;
+    if (isBuiltInSource(sourceName)) {
+      zipBytes = flareService.getBuiltInSourceZip(sourceName);
+    } else {
+      zipBytes = getReporterFile(sourceName);
+    }
+    return extractFileFromZip(zipBytes, filename);
+  }
+
+  private boolean isBuiltInSource(String sourceName) {
+    return TracerFlareService.BUILT_IN_SOURCES.containsKey(sourceName);
+  }
+
+  /**
+   * Generates flare data for a specific reporter.
+   *
+   * <p>The reporter's data is generated as a ZIP file, and the specified filename is extracted. If
+   * the file is text, it is returned as plain text; if binary, it is returned base64-encoded.
+   *
+   * @param reporterClassName the fully qualified class name of the reporter
+   * @return the zip file containing the reporter's content
+   * @throws IOException if an error occurs while generating the flare
+   */
+  private byte[] getReporterFile(String reporterClassName) throws IOException {
+    TracerFlare.Reporter reporter = TracerFlare.getReporter(reporterClassName);
+    if (reporter == null) {
+      throw new IOException("Error: Reporter not found: " + reporterClassName);
+    }
+
+    reporter.prepareForFlare();
+
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ZipOutputStream zip = new ZipOutputStream(bytes)) {
+      reporter.addReportToFlare(zip);
+      zip.finish();
+      return bytes.toByteArray();
+    }
+  }
+
+  /**
+   * Extracts a specific file from a ZIP archive.
+   *
+   * <p>Searches through the ZIP entries for the specified filename and returns its content. If the
+   * file name ends in ".txt", it is returned as plain text; if binary, it is returned
+   * base64-encoded.
+   *
+   * @param zipBytes the ZIP file bytes
+   * @param filename the name of the file to extract
+   * @return the file content (plain text or base64-encoded binary)
+   * @throws IOException if an error occurs while reading the ZIP
+   */
+  private String extractFileFromZip(byte[] zipBytes, String filename) throws IOException {
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(zipBytes);
+        ZipInputStream zis = new ZipInputStream(bais)) {
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+        if (entry.getName().equals(filename)) {
+          ByteArrayOutputStream content = new ByteArrayOutputStream();
+          byte[] buffer = new byte[8192];
+          int bytesRead;
+          while ((bytesRead = zis.read(buffer)) != -1) {
+            content.write(buffer, 0, bytesRead);
+          }
+          zis.closeEntry();
+
+          byte[] contentBytes = content.toByteArray();
+          if (entry.getName().endsWith(".txt")) {
+            return new String(contentBytes, StandardCharsets.UTF_8);
+          } else {
+            return Base64.getEncoder().encodeToString(contentBytes);
+          }
+        }
+        zis.closeEntry();
+      }
+
+      throw new IOException("Failed to extract file: " + filename);
+    }
+  }
+
+  void registerMBean() {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+
+    try {
+      mbeanName = new ObjectName("datadog.flare:type=TracerFlare");
+      mbs.registerMBean(this, mbeanName);
+      LOGGER.info("Registered TracerFlare MBean at {}", mbeanName);
+    } catch (MalformedObjectNameException
+        | InstanceAlreadyExistsException
+        | MBeanRegistrationException
+        | NotCompliantMBeanException e) {
+      LOGGER.warn("Failed to register TracerFlare MBean", e);
+      mbeanName = null;
+    }
+  }
+
+  void unregisterMBean() {
+    if (mbeanName != null) {
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      try {
+        mbs.unregisterMBean(mbeanName);
+        LOGGER.debug("Unregistered TracerFlare MBean");
+      } catch (Exception e) {
+        LOGGER.warn("Failed to unregister TracerFlare MBean", e);
+      }
+    }
+  }
+}

--- a/utils/flare-utils/src/main/java/datadog/flare/TracerFlareManagerMBean.java
+++ b/utils/flare-utils/src/main/java/datadog/flare/TracerFlareManagerMBean.java
@@ -1,0 +1,53 @@
+package datadog.flare;
+
+import java.io.IOException;
+
+/**
+ * MBean interface for managing and accessing tracer flare data.
+ *
+ * <p>This interface provides JMX operations to inspect flare data sources and generate flare data
+ * either for individual sources or as a complete ZIP archive. Sources include both registered
+ * reporters and built-in data (config, runtime, flare prelude, etc.).
+ */
+public interface TracerFlareManagerMBean {
+  /**
+   * Lists all available flare files from all sources.
+   *
+   * <p>Returns a newline-separated string where each line is formatted as "&lt;source&gt;
+   * &lt;file&gt;". This format makes it easy to pass the source and filename to {@link
+   * #getFlareFile(String, String)}.
+   *
+   * <p>Example output:
+   *
+   * <pre>
+   * config initial_config.txt
+   * ...
+   * datadog.trace.agent.core.CoreTracer tracer_health.txt
+   * ...
+   * </pre>
+   *
+   * @return newline-separated string listing all available files and their source name
+   * @throws IOException if an error occurs
+   */
+  String listFlareFiles() throws IOException;
+
+  /**
+   * Returns a specific flare file by source name and filename.
+   *
+   * <p>If the file is text, it is returned as plain text; if binary, it is returned base64-encoded.
+   *
+   * @param sourceName the name of the source (reporter class name or built-in source name)
+   * @param filename the name of the file to retrieve
+   * @return the file content (plain text or base64-encoded binary)
+   * @throws IOException if an error occurs while generating or extracting the data
+   */
+  String getFlareFile(String sourceName, String filename) throws IOException;
+
+  /**
+   * Generates a complete tracer flare as a ZIP file.
+   *
+   * @return base64-encoded ZIP file containing the complete flare data
+   * @throws IOException if an error occurs while generating the flare ZIP
+   */
+  String generateFullFlareZip() throws IOException;
+}

--- a/utils/flare-utils/src/main/java/datadog/flare/TracerFlarePoller.java
+++ b/utils/flare-utils/src/main/java/datadog/flare/TracerFlarePoller.java
@@ -54,6 +54,9 @@ public final class TracerFlarePoller {
     if (null != stopSubmitter) {
       stopSubmitter.run();
     }
+    if (null != tracerFlareService) {
+      tracerFlareService.close();
+    }
   }
 
   final class Preparer implements ProductListener {

--- a/utils/flare-utils/src/test/groovy/datadog/flare/TracerFlareJmxTest.groovy
+++ b/utils/flare-utils/src/test/groovy/datadog/flare/TracerFlareJmxTest.groovy
@@ -1,0 +1,73 @@
+package datadog.flare
+
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_JMX_ENABLED
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+import okhttp3.HttpUrl
+import spock.lang.Timeout
+
+import javax.management.MBeanServer
+import javax.management.ObjectName
+import java.lang.management.ManagementFactory
+
+@Timeout(1)
+class TracerFlareJmxTest extends DDSpecification {
+  static final ObjectName MBEAN_NAME = new ObjectName("datadog.flare:type=TracerFlare")
+
+  final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer()
+
+  TracerFlareService tracerFlareService
+
+  def cleanup() {
+    if (tracerFlareService != null) {
+      tracerFlareService.close()
+    }
+  }
+
+  private void createTracerFlareService() {
+    tracerFlareService = new TracerFlareService(
+      Config.get(),
+      null, // okHttpClient - not needed for JMX test
+      HttpUrl.get("http://localhost:8126")
+      )
+  }
+
+  def "TracerFlare MBean is registered when telemetry JMX is enabled"() {
+    given:
+    injectSysConfig(TELEMETRY_JMX_ENABLED, "true")
+
+    when:
+    createTracerFlareService()
+
+    then:
+    mbs.isRegistered(MBEAN_NAME)
+  }
+
+  def "TracerFlare MBean is not registered when telemetry JMX is disabled"() {
+    given:
+    injectSysConfig(TELEMETRY_JMX_ENABLED, "false")
+
+    when:
+    createTracerFlareService()
+
+    then:
+    !mbs.isRegistered(MBEAN_NAME)
+  }
+
+  def "TracerFlare MBean operations work when JMX is enabled"() {
+    given:
+    injectSysConfig(TELEMETRY_JMX_ENABLED, "true")
+    createTracerFlareService()
+
+    when:
+    def fileList = mbs.invoke(MBEAN_NAME, "listFlareFiles", null, null) as String
+
+    then:
+    mbs.isRegistered(MBEAN_NAME)
+    fileList != null
+    fileList.contains("flare_info.txt")
+    fileList.contains("tracer_version.txt")
+    fileList.contains("initial_config.txt")
+  }
+}


### PR DESCRIPTION
# What Does This Do

Allow flare dumps and individual files from flares to be downloaded with JMX.

# Motivation

This work was originally paired with adding a way to get the long-running traces queue in #10309.  I initially started by adding JMX MBeans to retrieve just the pending and long running traces and counters. Once I added the long running traces to the flare report to parity with pending traces, I realized that a more generic mechanism to allow getting flare details over JMX might be useful. After adding a TracerFlare MBean, this seemed like a far more valuable route and I removed the code I had added for pending/long running trace MBeans.

# Additional Notes

This was originally part of #9874, which is being broken out into a few individual PRs.

Commit notes:

- [Add JMX MBean for getting tracer flare files](https://github.com/DataDog/dd-trace-java/pull/10310/commits/bda047a9f354bfd0ba7bc784e1adf7cad6a14348) -- Note: see if the JMX MBean ObjectName and operation names sound good. I kept the existing `add*` methods as-is, but this could be simplified by refactoring the `add*` methods into `Reporter` instances (with a new signature that passes a few more parameters to `addReportToFlare`). I think this refactoring would be a good change to make--let me know and I'll happily do that. I also considered not making the zip file an intermediary, and if you like, I could look at what that change might be, as well.

The JMX telemetry feature is controlled by `dd.telemetry.jmx.enabled` and is disabled by default. This option enables both JMXFetch telemetry (when JMXFetch is enabled, which it is by default) and the new tracer flare MBean at `datadog.flare:type=TracerFlare`. This new MBean exposes three operations:

`java.lang.String listFlareFiles()`

- Returns a list of sources and files available from each source.

`java.lang.String getFlareFile(java.lang.String p1, java.lang.String p2)`

- Returns a single file from a specific reporter (or flare source).
- If the file ends in ".txt", it is returned as-is, otherwise it is base64 encoded.

`java.lang.String generateFullFlareZip()`

- Returns a full flare dump, base64 encoded.

An easy way to enable this for testing is to add these arguments:

```
    -Ddd.telemetry.jmx.enabled=true
    -Dcom.sun.management.jmxremote
    -Dcom.sun.management.jmxremote.host=127.0.0.1
    -Dcom.sun.management.jmxremote.port=9010
    -Dcom.sun.management.jmxremote.authenticate=false
    -Dcom.sun.management.jmxremote.ssl=false
```

To test, you can use jmxterm (https://github.com/jiaqi/jmxterm) like this:

```
echo "run -b datadog.flare:type=TracerFlare listFlareFiles" | \
    java --add-exports jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED \
        -jar jmxterm-1.0.4-uber.jar -l localhost:9010 -n -v silent

echo "run -b datadog.flare:type=TracerFlare getFlareFile datadog.trace.agent.core.LongRunningTracesTracker long_running_traces.txt" | \
    java --add-exports jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED \
        -jar jmxterm-1.0.4-uber.jar -l localhost:9010 -n -v silent | \
    jq .

echo "run -b datadog.flare:type=TracerFlare generateFullFlareZip" | \
    java --add-exports jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED \
        -jar jmxterm-1.0.4-uber.jar -l localhost:9010 -n -v silent | \
    base64 -d > /tmp/flare.zip && \
    unzip -v /tmp/flare.zip
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
