### PR TITLE
Always track long running traces when feature is enabled, regardless of agent support 

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
@@ -26,6 +26,7 @@ public class LongRunningTracesTracker {
   private int dropped = 0;
   private int write = 0;
   private int expired = 0;
+  private int droppedSampling = 0;
 
   public static final int NOT_TRACKED = -1;
   public static final int UNDEFINED = 0;
@@ -107,6 +108,7 @@ public class LongRunningTracesTracker {
       if (shouldFlush(nowMilli, trace)) {
         if (negativeOrNullPriority(trace)) {
           trace.compareAndSetLongRunningState(TRACKED, NOT_TRACKED);
+          droppedSampling++;
           cleanSlot(i);
           continue;
         }
@@ -151,9 +153,10 @@ public class LongRunningTracesTracker {
   }
 
   private void flushStats() {
-    healthMetrics.onLongRunningUpdate(dropped, write, expired);
+    healthMetrics.onLongRunningUpdate(dropped, write, expired, droppedSampling);
     dropped = 0;
     write = 0;
     expired = 0;
+    droppedSampling = 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -71,7 +71,8 @@ public abstract class HealthMetrics implements AutoCloseable {
   public void onFailedSend(
       final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}
 
-  public void onLongRunningUpdate(final int dropped, final int write, final int expired) {}
+  public void onLongRunningUpdate(
+      final int dropped, final int write, final int expired, final int droppedSampling) {}
 
   /**
    * Report that a trace has been used to compute client stats.

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -88,6 +88,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final LongAdder longRunningTracesWrite = new LongAdder();
   private final LongAdder longRunningTracesDropped = new LongAdder();
   private final LongAdder longRunningTracesExpired = new LongAdder();
+  private final LongAdder longRunningTracesDroppedSampling = new LongAdder();
 
   private final LongAdder clientStatsProcessedSpans = new LongAdder();
   private final LongAdder clientStatsProcessedTraces = new LongAdder();
@@ -296,10 +297,12 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
-  public void onLongRunningUpdate(final int dropped, final int write, final int expired) {
+  public void onLongRunningUpdate(
+      final int dropped, final int write, final int expired, final int droppedSampling) {
     longRunningTracesWrite.add(write);
     longRunningTracesDropped.add(dropped);
     longRunningTracesExpired.add(expired);
+    longRunningTracesDroppedSampling.add(droppedSampling);
   }
 
   private void onSendAttempt(
@@ -479,6 +482,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             target.statsd, "long-running.dropped", target.longRunningTracesDropped, NO_TAGS);
         reportIfChanged(
             target.statsd, "long-running.expired", target.longRunningTracesExpired, NO_TAGS);
+        reportIfChanged(
+            target.statsd,
+            "long-running.dropped_sampling",
+            target.longRunningTracesDroppedSampling,
+            NO_TAGS);
 
         reportIfChanged(
             target.statsd, "stats.traces_in", target.clientStatsProcessedTraces, NO_TAGS);
@@ -608,6 +616,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         + longRunningTracesDropped.sum()
         + "\nlongRunningTracesExpired="
         + longRunningTracesExpired.sum()
+        + "\nlongRunningTracesDroppedSampling="
+        + longRunningTracesDroppedSampling.sum()
         + "\n"
         + "\nclientStatsRequests="
         + clientStatsRequests.sum()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
@@ -123,7 +123,7 @@ class LongRunningTracesTrackerTest extends DDSpecification {
     trace.longRunningTrackedState == LongRunningTracesTracker.EXPIRED
   }
 
-  def "agent disabled feature"() {
+  def "trace remains tracked but not written when agent long running feature not available"() {
     given:
     def trace = newTraceToTrack()
     tracker.add(trace)
@@ -133,7 +133,9 @@ class LongRunningTracesTrackerTest extends DDSpecification {
 
     then:
     1 * features.supportsLongRunning() >> false
-    tracker.traceArray.size() == 0
+    tracker.traceArray.size() == 1
+    tracker.traceArray[0].longRunningTrackedState == LongRunningTracesTracker.TRACKED
+    tracker.traceArray[0].getLastWriteTime() == 0
   }
 
   def flushAt(long timeMilli) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -40,7 +40,7 @@ This can manifest when creating mocks.
 @Timeout(5)
 class PendingTraceBufferTest extends DDSpecification {
   @Subject
-  def buffer = PendingTraceBuffer.delaying(SystemTimeSource.INSTANCE, Mock(Config), null, null)
+  def buffer = PendingTraceBuffer.delaying(SystemTimeSource.INSTANCE, Mock(Config), null, HealthMetrics.NO_OP)
   def bufferSpy = Spy(buffer)
 
   def tracer = Mock(CoreTracer)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -400,12 +400,13 @@ class HealthMetricsTest extends Specification {
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
     healthMetrics.start()
     when:
-    healthMetrics.onLongRunningUpdate(3,10,1)
+    healthMetrics.onLongRunningUpdate(3,10,1,5)
     latch.await(10, TimeUnit.SECONDS)
     then:
     1 * statsD.count("long-running.write", 10, _)
     1 * statsD.count("long-running.dropped", 3, _)
     1 * statsD.count("long-running.expired", 1, _)
+    1 * statsD.count("long-running.dropped_sampling", 5, _)
     cleanup:
     healthMetrics.close()
   }


### PR DESCRIPTION
# What Does This Do

Currently, the tracer will silently drop long running traces--even if the feature is enabled--when it can't connect to an agent or when the agent doesn't support the long running traces feature.

# Motivation

Previously the long running traces buffer would always be empty, even though the feature was enabled with `dd.trace.experimental.long-running.enabled=true`. This led to a good amount of confusion when I was initially developing a feature to dump long running traces without a local Datadog Agent running.

# Additional Notes

This was originally part of #9874, which is being broken out into a few individual PRs.

Commit notes:

- [Warn when long running trace feature is enabled but not supported](https://github.com/DataDog/dd-trace-java/pull/10311/commits/ee61d42dc3b0422a3dfe918d4e958e08ac6ce45c) -- 
- [Always track long running traces when feature is enabled](https://github.com/DataDog/dd-trace-java/pull/10311/commits/eb0d36d1b67a8dc67df3beaf51e3f50cfbb797b0) -- This could be dropped, but if so, I'd highly suggest keeping the previous commit that adds the warning message. If kept, this should probably be squashed with the previous commit. Note: if `features.supportsLongRunning()` is false, the traces are kept in the `TRACKED` state, compared to the `NOT_TRACKED` state and then immediately removed with `cleanSlot`, previously.
- [Add long-running traces metric for drops due to sampling priority](https://github.com/DataDog/dd-trace-java/pull/10311/commits/8be81a393c29774feb1d11553ee9bc9ea3254c88) -- This could be dropped. I'm not sure if this is an important metric to track.

Assuming #10309 is merged, the only remaining case where a metric isn't tracked is when an entry is removed from the tracker is when the trace list is empty:

```
      if (trace.empty()) {
        trace.compareAndSetLongRunningState(WRITE_RUNNING_SPANS, NOT_TRACKED);
        cleanSlot(i);
        continue;
      }
```

If this case is desired to have a metric, let me know, and I'll add it (`long-running.completed`??). That would cover every single case where a trace is removed from the tracker.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
