### PR TITLE
Use component as framework tag in manual API

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestModule;
@@ -56,30 +57,36 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
   }
 
   @Override
-  public TestSuiteImpl testSuiteStart(
+  public ManualApiTestSuite testSuiteStart(
       String testSuiteName,
       @Nullable Class<?> testClass,
       @Nullable Long startTime,
       boolean parallelized) {
-    return new TestSuiteImpl(
-        span.context(),
-        moduleName,
-        testSuiteName,
-        null,
-        testClass,
-        startTime,
-        parallelized,
-        InstrumentationType.MANUAL_API,
-        TestFrameworkInstrumentation.OTHER,
-        config,
-        metricCollector,
-        testDecorator,
-        sourcePathResolver,
-        codeowners,
-        linesResolver,
-        coverageStoreFactory,
-        executionResults,
-        Collections.emptyList(),
-        tagsPropagator::propagateCiVisibilityTags);
+    TestSuiteImpl suite =
+        new TestSuiteImpl(
+            span.context(),
+            moduleName,
+            testSuiteName,
+            null,
+            testClass,
+            startTime,
+            parallelized,
+            InstrumentationType.MANUAL_API,
+            TestFrameworkInstrumentation.OTHER, // for metric purposes, framework is OTHER
+            config,
+            metricCollector,
+            testDecorator,
+            sourcePathResolver,
+            codeowners,
+            linesResolver,
+            coverageStoreFactory,
+            executionResults,
+            Collections.emptyList(),
+            tagsPropagator::propagateCiVisibilityTags);
+
+    String frameworkName = testDecorator.component().toString();
+    suite.setTag(Tags.TEST_FRAMEWORK, frameworkName);
+
+    return new ManualApiTestSuite(suite, frameworkName);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSuite.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSuite.java
@@ -1,0 +1,51 @@
+package datadog.trace.civisibility.domain.manualapi;
+
+import datadog.trace.api.civisibility.DDTest;
+import datadog.trace.api.civisibility.DDTestSuite;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.civisibility.domain.TestImpl;
+import datadog.trace.civisibility.domain.TestSuiteImpl;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+
+/**
+ * Test suite that was created using manual API ({@link
+ * datadog.trace.api.civisibility.CIVisibility}).
+ */
+public class ManualApiTestSuite implements DDTestSuite {
+
+  private final TestSuiteImpl delegate;
+  private final String frameworkName;
+
+  public ManualApiTestSuite(TestSuiteImpl delegate, String frameworkName) {
+    this.delegate = delegate;
+    this.frameworkName = frameworkName;
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    delegate.setTag(key, value);
+  }
+
+  @Override
+  public void setErrorInfo(Throwable error) {
+    delegate.setErrorInfo(error);
+  }
+
+  @Override
+  public void setSkipReason(String skipReason) {
+    delegate.setSkipReason(skipReason);
+  }
+
+  @Override
+  public void end(@Nullable Long endTime) {
+    delegate.end(endTime);
+  }
+
+  @Override
+  public DDTest testStart(String testName, @Nullable Method testMethod, @Nullable Long startTime) {
+    TestImpl test = delegate.testStart(testName, testMethod, startTime);
+    test.setTag(Tags.TEST_FRAMEWORK, frameworkName);
+    return test;
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/manualapi/ManualApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/manualapi/ManualApiTest.groovy
@@ -1,0 +1,66 @@
+package datadog.trace.civisibility.domain.manualapi
+
+import datadog.trace.api.Config
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.civisibility.coverage.CoverageStore
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
+import datadog.trace.api.civisibility.telemetry.tag.Provider
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.civisibility.codeowners.Codeowners
+import datadog.trace.civisibility.decorator.TestDecoratorImpl
+import datadog.trace.civisibility.domain.SpanWriterTest
+import datadog.trace.civisibility.source.LinesResolver
+import datadog.trace.civisibility.source.SourcePathResolver
+
+class ManualApiTest extends SpanWriterTest {
+
+  def "test framework tag is set on suite, test, module and session with component info"() {
+    setup:
+    def component = "my-custom-framework"
+    def session = givenAManualApiSession(component)
+    def module = session.testModuleStart("module-name", null)
+    def suite = module.testSuiteStart("suite-name", null, null, false)
+    def test = suite.testStart("test-name", null, null)
+
+    when:
+    test.end(null)
+    suite.end(null)
+    module.end(null)
+    session.end(null)
+
+    then:
+    def traces = TEST_WRITER.toList()
+    traces.size() == 2
+
+    def allSpans = traces.flatten()
+    def sessionSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_SESSION_END }
+    def moduleSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_MODULE_END }
+    def suiteSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_SUITE_END }
+    def testSpan = allSpans.find { it.spanType == DDSpanTypes.TEST }
+
+    sessionSpan != null
+    moduleSpan != null
+    suiteSpan != null
+    testSpan != null
+
+    sessionSpan.tags[Tags.TEST_FRAMEWORK] == component
+    moduleSpan.tags[Tags.TEST_FRAMEWORK] == component
+    suiteSpan.tags[Tags.TEST_FRAMEWORK] == component
+    testSpan.tags[Tags.TEST_FRAMEWORK] == component
+  }
+
+  private ManualApiTestSession givenAManualApiSession(String component) {
+    new ManualApiTestSession(
+      "project-name",
+      null,
+      Provider.UNSUPPORTED,
+      Stub(Config),
+      Stub(CiVisibilityMetricCollector),
+      new TestDecoratorImpl(component, "session-name", "test-command", [:]),
+      Stub(SourcePathResolver),
+      Stub(Codeowners),
+      Stub(LinesResolver),
+      Stub(CoverageStore.Factory)
+      )
+  }
+}


### PR DESCRIPTION
# What Does This Do
- Updates the manual API to use the `component` value as framework to tag suite and test events. 
- For metrics, the framework will still be considered `OTHER`.

# Motivation

This change comes from a customer request where they noticed the framework value provided when creating a manual API test session wasn't correctly propagated.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
