### PR TITLE
Convert downstream requests header keys to lower case

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -989,7 +989,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     bundle.size() == (sampled ? 4 : 3)
     bundle.get(KnownAddresses.IO_NET_URL) == url
     bundle.get(KnownAddresses.IO_NET_REQUEST_METHOD) == method
-    bundle.get(KnownAddresses.IO_NET_REQUEST_HEADERS) == headers
+    bundle.get(KnownAddresses.IO_NET_REQUEST_HEADERS) == toLowerCaseHeaders(headers)
     if (sampled) {
       bundle.get(KnownAddresses.IO_NET_REQUEST_BODY) == ['Hello': 'World!']
     }
@@ -1029,7 +1029,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     }
     bundle.size() == (sampled ? 3 : 2)
     bundle.get(KnownAddresses.IO_NET_RESPONSE_STATUS) == Integer.toString(status)
-    bundle.get(KnownAddresses.IO_NET_RESPONSE_HEADERS) == headers
+    bundle.get(KnownAddresses.IO_NET_RESPONSE_HEADERS) == toLowerCaseHeaders(headers)
     if (sampled) {
       bundle.get(KnownAddresses.IO_NET_RESPONSE_BODY) == ['Hello': 'World!']
     }
@@ -1613,6 +1613,12 @@ class GatewayBridgeSpecification extends DDSpecification {
       final bundle = it[2] as DataBundle
       final body = bundle.get(KnownAddresses.RESPONSE_BODY_OBJECT)
       assert body['test'] == 'this is a test'
+    }
+  }
+
+  static toLowerCaseHeaders(final Map<String, List<String>> headers) {
+    return headers.collectEntries {
+      [(it.key.toLowerCase(Locale.ROOT)): it.value]
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Convert header keys to lower case before being set to the WAF

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-60515]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-60515]: https://datadoghq.atlassian.net/browse/APPSEC-60515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ