### PR TITLE
Fix exceptions raised from Collection values

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
@@ -39,8 +39,8 @@ public final class HasAnyExpression extends MatchingExpression {
         // always return FALSE for empty collection
         return Boolean.FALSE;
       }
-      int len = collection.count();
       try {
+        int len = collection.count();
         for (int i = 0; i < len; i++) {
           valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, collection.get(i));
           if (filterPredicateExpression.evaluate(valueRefResolver)) {
@@ -48,6 +48,9 @@ public final class HasAnyExpression extends MatchingExpression {
           }
         }
         return Boolean.FALSE;
+
+      } catch (IllegalArgumentException | UnsupportedOperationException ex) {
+        throw new EvaluationException(ex.getMessage(), print(this));
       } finally {
         valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
       }
@@ -55,10 +58,10 @@ public final class HasAnyExpression extends MatchingExpression {
     if (value instanceof MapValue) {
       MapValue map = (MapValue) value;
       checkSupportedMap(map, this);
-      if (map.isEmpty()) {
-        return Boolean.FALSE;
-      }
       try {
+        if (map.isEmpty()) {
+          return Boolean.FALSE;
+        }
         for (Value<?> key : map.getKeys()) {
           Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
           valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, key);
@@ -70,6 +73,8 @@ public final class HasAnyExpression extends MatchingExpression {
           }
         }
         return Boolean.FALSE;
+      } catch (IllegalArgumentException | UnsupportedOperationException ex) {
+        throw new EvaluationException(ex.getMessage(), print(this));
       } finally {
         valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
         valueRefResolver.removeExtension(ValueReferences.KEY_EXTENSION_NAME);
@@ -79,10 +84,10 @@ public final class HasAnyExpression extends MatchingExpression {
     if (value instanceof SetValue) {
       SetValue set = (SetValue) value;
       Set<?> setHolder = checkSupportedSet(set, this);
-      if (set.isEmpty()) {
-        return Boolean.FALSE;
-      }
       try {
+        if (set.isEmpty()) {
+          return Boolean.FALSE;
+        }
         for (Object val : setHolder) {
           valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, Value.of(val));
           if (filterPredicateExpression.evaluate(valueRefResolver)) {
@@ -90,6 +95,8 @@ public final class HasAnyExpression extends MatchingExpression {
           }
         }
         return Boolean.FALSE;
+      } catch (IllegalArgumentException | UnsupportedOperationException ex) {
+        throw new EvaluationException(ex.getMessage(), print(this));
       } finally {
         valueRefResolver.removeExtension(ValueReferences.ITERATOR_EXTENSION_NAME);
       }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -1,5 +1,8 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.expressions.CollectionExpressionHelper.checkSupportedList;
+import static com.datadog.debugger.el.expressions.CollectionExpressionHelper.checkSupportedMap;
+
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
@@ -41,17 +44,21 @@ public class IndexExpression implements ValueExpression<Value<?>> {
         if (objKey instanceof String && Redaction.isRedactedKeyword((String) objKey)) {
           ExpressionHelper.throwRedactedException(this);
         } else {
-          result = ((MapValue) targetValue).get(objKey);
+          MapValue mapValue = (MapValue) targetValue;
+          checkSupportedMap(mapValue, this);
+          result = mapValue.get(objKey);
         }
       } else if (targetValue instanceof ListValue) {
-        result = ((ListValue) targetValue).get(keyValue.getValue());
+        ListValue listValue = (ListValue) targetValue;
+        checkSupportedList(listValue, this);
+        result = listValue.get(keyValue.getValue());
       } else {
         throw new EvaluationException(
             "Cannot evaluate the expression for unsupported type: "
                 + targetValue.getClass().getTypeName(),
             PrettyPrintVisitor.print(this));
       }
-    } catch (IllegalArgumentException ex) {
+    } catch (IllegalArgumentException | UnsupportedOperationException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }
     Object obj = result.getValue();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -72,7 +72,7 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
       if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
         return ((Collection<?>) listHolder).size();
       } else {
-        throw new RuntimeException(
+        throw new UnsupportedOperationException(
             "Unsupported Collection class: " + listHolder.getClass().getTypeName());
       }
     } else if (listHolder == Value.nullValue()) {
@@ -136,14 +136,14 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
       if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
         return ((Collection<?>) listHolder).contains(val.isNull() ? null : val.getValue());
       }
-      throw new RuntimeException(
+      throw new UnsupportedOperationException(
           "Unsupported Collection class: " + listHolder.getClass().getTypeName());
     }
     if (arrayHolder != null) {
       int count = Array.getLength(arrayHolder);
       if (arrayType.isPrimitive()) {
         if (val.getValue() == null || val.isNull()) {
-          throw new RuntimeException("Cannot compare null with primitive array");
+          throw new IllegalArgumentException("Cannot compare null with primitive array");
         }
         if (arrayType == byte.class) {
           byte byteValue = (Byte) val.getValue();
@@ -224,7 +224,8 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
           }
         }
       }
-      throw new RuntimeException("Unsupported value class: " + objValue.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported value class: " + objValue.getClass().getTypeName());
     }
     return false;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -47,7 +47,8 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
       if (WellKnownClasses.isSafe((Map<?, ?>) mapHolder)) {
         return ((Map<?, ?>) mapHolder).isEmpty();
       }
-      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Map class: " + mapHolder.getClass().getTypeName());
     } else if (mapHolder instanceof Value) {
       Value<?> val = (Value<?>) mapHolder;
       return val.isNull() || val.isUndefined();
@@ -60,7 +61,8 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
       if (WellKnownClasses.isSafe((Map<?, ?>) mapHolder)) {
         return ((Map<?, ?>) mapHolder).size();
       }
-      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Map class: " + mapHolder.getClass().getTypeName());
     } else if (mapHolder == Value.nullValue()) {
       return 0;
     }
@@ -73,7 +75,8 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
         Map<?, ?> map = (Map<?, ?>) mapHolder;
         return map.keySet().stream().map(Value::of).collect(Collectors.toSet());
       }
-      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Map class: " + mapHolder.getClass().getTypeName());
     }
     log.warn("{} is not a map", mapHolder);
     return Collections.singleton(Value.undefinedValue());
@@ -94,7 +97,8 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
         Object value = map.get(key);
         return value != null ? Value.of(value) : Value.nullValue();
       }
-      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Map class: " + mapHolder.getClass().getTypeName());
     }
     // the result will be either Value.nullValue() or Value.undefinedValue() depending on the holder
     // value
@@ -112,10 +116,11 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
         if (WellKnownClasses.isEqualsSafe(val.getValue().getClass())) {
           return map.containsKey(val.getValue());
         }
-        throw new RuntimeException(
+        throw new UnsupportedOperationException(
             "Unsupported key class: " + val.getValue().getClass().getTypeName());
       }
-      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Map class: " + mapHolder.getClass().getTypeName());
     }
     return false;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
@@ -39,7 +39,8 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
       if (WellKnownClasses.isSafe((Collection<?>) setHolder)) {
         return ((Set<?>) setHolder).isEmpty();
       }
-      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Set class: " + setHolder.getClass().getTypeName());
     } else if (setHolder instanceof Value) {
       Value<?> val = (Value<?>) setHolder;
       return val.isNull() || val.isUndefined();
@@ -53,7 +54,8 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
       if (WellKnownClasses.isSafe((Collection<?>) setHolder)) {
         return ((Set<?>) setHolder).size();
       }
-      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Set class: " + setHolder.getClass().getTypeName());
     } else if (setHolder == Value.nullValue()) {
       return 0;
     }
@@ -75,7 +77,8 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
         key = key instanceof Value ? ((Value<?>) key).getValue() : key;
         return Value.of(set.contains(key));
       }
-      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Set class: " + setHolder.getClass().getTypeName());
     }
     // the result will be either Value.nullValue() or Value.undefinedValue() depending on the holder
     // value
@@ -92,10 +95,11 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
         if (WellKnownClasses.isEqualsSafe(val.getValue().getClass())) {
           return ((Set<?>) setHolder).contains(val.getValue());
         }
-        throw new RuntimeException(
+        throw new UnsupportedOperationException(
             "Unsupported value class: " + val.getValue().getClass().getTypeName());
       }
-      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+      throw new UnsupportedOperationException(
+          "Unsupported Set class: " + setHolder.getClass().getTypeName());
     }
     return false;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
@@ -8,6 +8,8 @@ import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RedactedException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.values.ListValue;
+import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
@@ -77,7 +79,7 @@ class IndexExpressionTest {
   }
 
   @Test
-  void testUnsupported() {
+  void testUnsupportedSet() {
     IndexExpression expr =
         new IndexExpression(new SetValue(new HashSet<>()), new StringValue("foo"));
     EvaluationException evaluationException =
@@ -85,6 +87,40 @@ class IndexExpressionTest {
             EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
     assertEquals(
         "Cannot evaluate the expression for unsupported type: com.datadog.debugger.el.values.SetValue",
+        evaluationException.getMessage());
+  }
+
+  @Test
+  void testUnsupportedList() {
+    IndexExpression expr =
+        new IndexExpression(new ListValue(new ArrayList<String>() {}), new NumericValue(0));
+    EvaluationException evaluationException =
+        assertThrows(
+            EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals(
+        "Unsupported List class: com.datadog.debugger.el.expressions.IndexExpressionTest$1",
+        evaluationException.getMessage());
+  }
+
+  @Test
+  void testOutOfBoundsList() {
+    IndexExpression expr =
+        new IndexExpression(new ListValue(new ArrayList<String>()), new NumericValue(42));
+    EvaluationException evaluationException =
+        assertThrows(
+            EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals("index[42] out of bounds: [0-0]", evaluationException.getMessage());
+  }
+
+  @Test
+  void testUnsupportedMap() {
+    IndexExpression expr =
+        new IndexExpression(new MapValue(new HashMap<String, String>() {}), new StringValue("foo"));
+    EvaluationException evaluationException =
+        assertThrows(
+            EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals(
+        "Unsupported Map class: com.datadog.debugger.el.expressions.IndexExpressionTest$2",
         evaluationException.getMessage());
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
@@ -54,10 +54,10 @@ public class StringTemplateBuilder {
                   sb, segment.getParsedExpr().getDsl(), result.getValue(), status, limits);
             }
           } catch (EvaluationException ex) {
-            status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
-            String msg =
-                ex instanceof RedactedException ? Redaction.REDACTED_VALUE : ex.getMessage();
-            sb.append('{').append(msg).append('}');
+            handleException(status, ex, ex.getExpr(), sb);
+          } catch (Exception ex) {
+            // catch all for unexpected exceptions
+            handleException(status, ex, segment.getExpr(), sb);
           }
           if (!status.getErrors().isEmpty()) {
             status.setLogTemplateErrors(true);
@@ -66,5 +66,12 @@ public class StringTemplateBuilder {
       }
     }
     return sb.toString();
+  }
+
+  private static void handleException(
+      LogProbe.LogStatus status, Exception ex, String expr, StringBuilder sb) {
+    status.addError(new EvaluationError(expr, ex.getMessage()));
+    String msg = ex instanceof RedactedException ? Redaction.REDACTED_VALUE : ex.getMessage();
+    sb.append('{').append(msg).append('}');
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -577,6 +577,11 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
       status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
       status.setConditionErrors(true);
       return false;
+    } catch (Exception ex) {
+      // catch all for unexpected exceptions
+      status.addError(new EvaluationError(probeCondition.getDslExpression(), ex.getMessage()));
+      status.setConditionErrors(true);
+      return false;
     }
     return true;
   }
@@ -684,6 +689,11 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
         }
       } catch (EvaluationException ex) {
         logStatus.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
+        logStatus.setLogTemplateErrors(true);
+      } catch (Exception ex) {
+        // catch all for unexpected exceptions
+        logStatus.addError(
+            new EvaluationError(captureExpression.getExpr().getDsl(), ex.getMessage()));
         logStatus.setLogTemplateErrors(true);
       }
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -201,6 +201,10 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
         } catch (EvaluationException ex) {
           status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
           continue;
+        } catch (Exception ex) {
+          // catch all for unexpected exceptions
+          status.addError(new EvaluationError(decoration.when.getDslExpression(), ex.getMessage()));
+          continue;
         }
       }
       if (!(status instanceof SpanDecorationStatus)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -4,7 +4,6 @@ import static java.lang.String.format;
 
 import com.datadog.debugger.agent.DebuggerAgent;
 import com.datadog.debugger.agent.Generated;
-import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.instrumentation.CapturedContextInstrumenter;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
@@ -122,7 +121,7 @@ public class TriggerProbe extends ProbeDefinition implements Sampled, CapturedCo
     long start = System.nanoTime();
     try {
       return probeCondition.execute(capture);
-    } catch (EvaluationException ex) {
+    } catch (Exception ex) {
       DebuggerAgent.getSink().getProbeStatusSink().addError(probeId, ex);
       return false;
     } finally {


### PR DESCRIPTION
# What Does This Do
Some RuntimeException thrown by collection values (ListValue, MapValue
 or SetValue) may not be caught correctly and handled as
EvaluationError leading to exception bubbling up to catches into instrumented code but lost and only reported as telemetry logs. All exceptions in collection values are now either IllegalArgumentException or UnsupportedOperationException and handled as such in collection expressions and index expression.
As a a safety net, all expression evaluations are wrapped with a catch
 all exceptions to be wrapped as an EvaluationError with the full expression string.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4938]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4938]: https://datadoghq.atlassian.net/browse/DEBUG-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ