### PR TITLE
Socket.connect may throw other exceptions, such as SecurityException

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -162,15 +162,17 @@ public final class StatusLogger extends JsonAdapter<Config>
   }
 
   private static boolean agentServiceCheck(Config config) {
-    if (config.getAgentUrl().startsWith("unix:")) {
-      return new File(config.getAgentUnixDomainSocket()).exists();
-    } else {
-      try (Socket s = new Socket()) {
-        s.connect(new InetSocketAddress(config.getAgentHost(), config.getAgentPort()), 500);
-        return true;
-      } catch (IOException ex) {
-        return false;
+    try {
+      if (config.getAgentUrl().startsWith("unix:")) {
+        return new File(config.getAgentUnixDomainSocket()).exists();
+      } else {
+        try (Socket s = new Socket()) {
+          s.connect(new InetSocketAddress(config.getAgentHost(), config.getAgentPort()), 500);
+          return true;
+        }
       }
+    } catch (Throwable ex) {
+      return false;
     }
   }
 


### PR DESCRIPTION
# Motivation

Catch security exception in `StatusLogger` when running the tracer with security enabled and limited permissions:
```
java.lang.SecurityException
  at java.base/java.net.Socket.<init>(Socket.java:142)
  at datadog.trace.agent.core.StatusLogger.agentServiceCheck(StatusLogger.java:166)
  at datadog.trace.agent.core.StatusLogger.toJson(StatusLogger.java:90)
  at datadog.trace.agent.core.StatusLogger.toJson(StatusLogger.java:26)
  at (redacted: 2 frames)
  at datadog.trace.agent.core.StatusLogger.run(StatusLogger.java:39)
  at datadog.trace.agent.core.StatusLogger.run(StatusLogger.java:26)
  at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:329)
  at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:284)
  at java.base/java.lang.Thread.run(Unknown Source)
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
