### PR TITLE
Fixed logic of splitting tasks by slots on CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -490,7 +490,7 @@ check_base:
 
 check_inst:
   extends: .check_job
-  parallel: 5
+  parallel: 4
   variables:
     GRADLE_TARGET: ":instrumentationCheck"
     CACHE_TYPE: "inst"

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/ci/CIJobsExtensions.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/ci/CIJobsExtensions.kt
@@ -94,7 +94,7 @@ private fun Project.createRootTask(
   tasks.register(rootTaskName) {
     subprojects.forEach { subproject ->
       if (
-        isInSelectedSlot.get() &&
+        subproject.isInSelectedSlot.get() &&
         includePrefixes.any { subproject.path.startsWith(it) } &&
         !excludePrefixes.any { subproject.path.startsWith(it) }
       ) {


### PR DESCRIPTION
# What Does This Do
Fixed logic of splitting tasks by slots on CI.

# Motivation
Correct CI work.

# Additional Notes
Found that `check_inst 3/4` job executes all tasks and other jobs doing nothing. 
