### PR TITLE
Fix DebuggerConfigBridgeTest

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -676,7 +676,7 @@ public class InstrumenterConfig {
               ? ConfigProvider.withoutCollector()
               : ConfigProvider.getInstance());
 
-  static boolean getDefaultCodeOriginForSpanEnabled() {
+  public static boolean getDefaultCodeOriginForSpanEnabled() {
     if (JavaVirtualMachine.isJavaVersionAtLeast(25)) {
       // activate by default Code Origin only for JDK25+
       return true;

--- a/internal-api/src/test/groovy/datadog/trace/api/debugger/DebuggerConfigBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/debugger/DebuggerConfigBridgeTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.api.debugger
 
+import datadog.environment.JavaVirtualMachine
+import datadog.trace.api.InstrumenterConfig
 import spock.lang.Specification
 
 class DebuggerConfigBridgeTest extends Specification {
@@ -15,7 +17,7 @@ class DebuggerConfigBridgeTest extends Specification {
     then:
     !DebuggerConfigBridge.isDynamicInstrumentationEnabled()
     !DebuggerConfigBridge.isExceptionReplayEnabled()
-    !DebuggerConfigBridge.isCodeOriginEnabled()
+    DebuggerConfigBridge.isCodeOriginEnabled() == InstrumenterConfig.defaultCodeOriginForSpanEnabled
     !DebuggerConfigBridge.isDistributedDebuggerEnabled()
 
     when:


### PR DESCRIPTION
# What Does This Do
fix for JDK25, Code Origin is now enabled by default for JDK25+

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
