### PR TITLE
Fix Spock tests

### DIFF
--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-disabled-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-disabled-failed/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -67,116 +135,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_test_disabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_test_disabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -188,12 +146,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -208,7 +166,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -243,8 +201,118 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_test_disabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_test_disabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -254,7 +322,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -289,7 +357,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -301,7 +369,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -309,72 +377,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-disabled-succeeded/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-disabled-succeeded/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,120 +88,20 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
   },
   "type" : "test_suite_end",
   "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_2},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_test_disabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_test_disabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_4},
@@ -151,10 +119,8 @@
       "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test success()V",
       "test.status" : "pass",
@@ -176,12 +142,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -227,8 +193,110 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_test_disabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_test_disabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -238,7 +306,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -268,7 +336,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -280,7 +348,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -288,72 +356,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-failed/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "fail",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "fail",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -65,112 +133,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -182,12 +144,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -202,7 +164,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -235,8 +197,114 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -246,7 +314,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -279,7 +347,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -291,7 +359,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -299,72 +367,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "fail",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "fail",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-quarantined-failed/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -67,116 +135,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -188,12 +146,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -208,7 +166,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -243,8 +201,118 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -254,7 +322,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -289,7 +357,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -301,7 +369,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -309,72 +377,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-quarantined-succeeded/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-quarantined-succeeded/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,120 +88,20 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
   },
   "type" : "test_suite_end",
   "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_2},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_4},
@@ -151,10 +119,8 @@
       "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test success()V",
       "test.status" : "pass",
@@ -176,12 +142,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -227,8 +193,110 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -238,7 +306,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -268,7 +336,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -280,7 +348,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -288,72 +356,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-succeeded/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-attempt-to-fix-succeeded/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,118 +88,20 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
   },
   "type" : "test_suite_end",
   "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_2},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.is_attempt_to_fix" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_4},
@@ -149,10 +119,8 @@
       "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test success",
-      "test.retry_reason" : "attempt_to_fix",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test success()V",
       "test.status" : "pass",
@@ -173,12 +141,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -223,12 +191,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_4}
+    "trace_id" : ${content_trace_id_2}
   },
   "type" : "test",
   "version" : 2
@@ -257,7 +225,6 @@
       "test.source.method" : "test success()V",
       "test.status" : "pass",
       "test.suite" : "org.example.TestSucceedSpock",
-      "test.test_management.attempt_to_fix_passed" : "true",
       "test.test_management.is_attempt_to_fix" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
@@ -274,12 +241,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_5},
+    "span_id" : ${content_span_id_3},
     "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_5}
+    "trace_id" : ${content_trace_id_3}
   },
   "type" : "test",
   "version" : 2
@@ -288,7 +255,6 @@
     "duration" : ${content_duration_7},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
       "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
@@ -297,12 +263,19 @@
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
       "test.status" : "pass",
-      "test.test_management.enabled" : "true",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.is_attempt_to_fix" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
@@ -310,45 +283,72 @@
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
     "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_4}
   },
-  "type" : "test_session_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_8},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
+      "language" : "jvm",
       "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "attempt_to_fix",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
       "test.status" : "pass",
-      "test.test_management.enabled" : "true",
+      "test.suite" : "org.example.TestSucceedSpock",
+      "test.test_management.attempt_to_fix_passed" : "true",
+      "test.test_management.is_attempt_to_fix" : "true",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
     "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_5}
   },
-  "type" : "test_module_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-disabled-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-disabled-failed-parameterized/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +142,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +152,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -112,7 +180,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -124,7 +192,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -132,72 +200,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-disabled-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-disabled-failed/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "skip",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "skip",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -21,14 +89,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -37,7 +105,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -64,7 +132,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -76,7 +144,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,72 +152,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "skip",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "skip",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-faulty-session-threshold/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-faulty-session-threshold/events.ftl
@@ -4,6 +4,76 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.abort_reason" : "faulty",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.abort_reason" : "faulty",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +90,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedAndFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +106,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +132,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +144,7 @@
     "resource" : "org.example.TestSucceedAndFailedSpock.test another success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +154,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -113,7 +183,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -125,7 +195,7 @@
     "resource" : "org.example.TestSucceedAndFailedSpock.test failure",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -135,7 +205,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -166,7 +236,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -178,7 +248,7 @@
     "resource" : "org.example.TestSucceedAndFailedSpock.test failure",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -188,7 +258,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_5},
+    "duration" : ${content_duration_7},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -220,7 +290,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -232,109 +302,11 @@
     "resource" : "org.example.TestSucceedAndFailedSpock.test failure",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_4},
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_4}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedAndFailedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedAndFailedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_5}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.retry_reason" : "early_flake_detection",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedAndFailedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedAndFailedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_6},
     "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_6}
+    "trace_id" : ${content_trace_id_4}
   },
   "type" : "test",
   "version" : 2
@@ -356,10 +328,8 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.is_new" : "true",
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test success",
-      "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test success()V",
       "test.status" : "pass",
@@ -379,12 +349,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedAndFailedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_7},
+    "span_id" : ${content_span_id_5},
     "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_7}
+    "trace_id" : ${content_trace_id_5}
   },
   "type" : "test",
   "version" : 2
@@ -393,7 +363,6 @@
     "duration" : ${content_duration_9},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
       "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
@@ -402,13 +371,19 @@
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.abort_reason" : "faulty",
-      "test.early_flake.enabled" : "true",
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "fail",
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedAndFailedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
@@ -416,46 +391,71 @@
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_9},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedAndFailedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_6},
     "start" : ${content_start_9},
-    "test_session_id" : ${content_test_session_id}
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_6}
   },
-  "type" : "test_session_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_10},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
+      "language" : "jvm",
       "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.abort_reason" : "faulty",
-      "test.early_flake.enabled" : "true",
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
-      "test.status" : "fail",
+      "test.name" : "test success",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedAndFailedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_10}
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_10},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedAndFailedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_7},
     "start" : ${content_start_10},
     "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_7}
   },
-  "type" : "test_module_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-parameterized-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-parameterized-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +142,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +152,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -110,7 +178,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -122,7 +190,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -130,72 +198,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -61,7 +129,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -73,7 +141,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -81,72 +149,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-tests-and-new-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-known-tests-and-new-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,111 +142,11 @@
     "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
-      "test.retry_reason" : "early_flake_detection",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -200,11 +168,9 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.is_new" : "true",
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test add 4 and 4",
       "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
-      "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
       "test.status" : "pass",
@@ -224,12 +190,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_4}
+    "trace_id" : ${content_trace_id_2}
   },
   "type" : "test",
   "version" : 2
@@ -238,7 +204,6 @@
     "duration" : ${content_duration_6},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
       "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
@@ -247,12 +212,20 @@
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
       "test.status" : "pass",
+      "test.suite" : "org.example.TestParameterizedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
@@ -260,45 +233,72 @@
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
     "start" : ${content_start_6},
-    "test_session_id" : ${content_test_session_id}
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
   },
-  "type" : "test_session_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_7},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
+      "language" : "jvm",
       "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
       "test.status" : "pass",
+      "test.suite" : "org.example.TestParameterizedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7}
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
     "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_4}
   },
-  "type" : "test_module_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-parameterized-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-parameterized-test/events.ftl
@@ -4,6 +4,76 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.abort_reason" : "faulty",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.abort_reason" : "faulty",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,120 +90,20 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
   },
   "type" : "test_suite_end",
   "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_2},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 1 and 2",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 1 and 2\"}}",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 1 and 2",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 1 and 2\"}}",
-      "test.retry_reason" : "early_flake_detection",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_4},
@@ -152,11 +122,9 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.is_new" : "true",
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test add 1 and 2",
       "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 1 and 2\"}}",
-      "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
       "test.status" : "pass",
@@ -176,12 +144,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -203,9 +171,11 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.is_new" : "true",
+      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.name" : "test add 1 and 2",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 1 and 2\"}}",
+      "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
       "test.status" : "pass",
@@ -223,14 +193,14 @@
     },
     "name" : "spock.test",
     "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
+    "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_4}
+    "trace_id" : ${content_trace_id_2}
   },
   "type" : "test",
   "version" : 2
@@ -254,8 +224,8 @@
       "test.is_new" : "true",
       "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.name" : "test add 1 and 2",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 1 and 2\"}}",
       "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
@@ -274,20 +244,69 @@
     },
     "name" : "spock.test",
     "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
+    "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_5},
+    "span_id" : ${content_span_id_3},
     "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_5}
+    "trace_id" : ${content_trace_id_3}
   },
   "type" : "test",
   "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_7},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestParameterizedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_4}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_8},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -316,7 +335,58 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_5}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_9},
+    "error" : 0,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
+      "test.status" : "pass",
+      "test.suite" : "org.example.TestParameterizedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_9},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -328,7 +398,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_6},
-    "start" : ${content_start_7},
+    "start" : ${content_start_9},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -336,74 +406,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.abort_reason" : "faulty",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_9},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.abort_reason" : "faulty",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_9}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_9},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-slow-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-slow-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpockSlow",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +142,7 @@
     "resource" : "org.example.TestSucceedSpockSlow.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +152,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -112,7 +180,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -124,7 +192,7 @@
     "resource" : "org.example.TestSucceedSpockSlow.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -132,72 +200,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,118 +88,20 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
   },
   "type" : "test_suite_end",
   "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_2},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_new" : "true",
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test success",
-      "test.retry_reason" : "early_flake_detection",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test success()V",
-      "test.status" : "pass",
-      "test.suite" : "org.example.TestSucceedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestSucceedSpock.test success",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_4},
@@ -150,10 +120,8 @@
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
       "test.is_new" : "true",
-      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
       "test.name" : "test success",
-      "test.retry_reason" : "early_flake_detection",
       "test.source.file" : "dummy_source_path",
       "test.source.method" : "test success()V",
       "test.status" : "pass",
@@ -173,12 +141,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -187,7 +155,6 @@
     "duration" : ${content_duration_5},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
       "_dd.profiling.ctx" : "test",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
@@ -196,12 +163,19 @@
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
       "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
       "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
@@ -209,45 +183,71 @@
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
-    "test_session_id" : ${content_test_session_id}
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
   },
-  "type" : "test_session_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 }, {
   "content" : {
     "duration" : ${content_duration_6},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
+      "language" : "jvm",
       "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
       "test.framework" : "spock",
       "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_new" : "true",
+      "test.is_retry" : "true",
       "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test success",
+      "test.retry_reason" : "early_flake_detection",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test success()V",
       "test.status" : "pass",
+      "test.suite" : "org.example.TestSucceedSpock",
       "test.type" : "test",
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6}
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
     },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
     "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
   },
-  "type" : "test_module_end",
-  "version" : 1
+  "type" : "test",
+  "version" : 2
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-very-slow-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-new-very-slow-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpockVerySlow",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +142,7 @@
     "resource" : "org.example.TestSucceedSpockVerySlow.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -82,72 +150,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-skip-new-test/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-efd-skip-new-test/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpockSkipEfd",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -63,7 +131,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -75,7 +143,7 @@
     "resource" : "org.example.TestSucceedSpockSkipEfd.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -83,72 +151,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-failed-then-succeed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-failed-then-succeed/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedThenSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -65,7 +131,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +143,7 @@
     "resource" : "org.example.TestFailedThenSucceedSpock.test failed then succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -87,7 +153,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -118,7 +184,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -130,7 +196,7 @@
     "resource" : "org.example.TestFailedThenSucceedSpock.test failed then succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -140,7 +206,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -171,7 +237,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -183,7 +249,7 @@
     "resource" : "org.example.TestFailedThenSucceedSpock.test failed then succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -193,7 +259,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_5},
+    "duration" : ${content_duration_7},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -220,7 +286,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -232,7 +298,7 @@
     "resource" : "org.example.TestFailedThenSucceedSpock.test failed then succeed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_4},
-    "start" : ${content_start_5},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -240,70 +306,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_6},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-failed/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -64,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -76,7 +142,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,70 +150,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-not-skipping-parameterized-spec-setup/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-not-skipping-parameterized-spec-setup/events.ftl
@@ -3,7 +3,81 @@
     "duration" : ${content_duration},
     "error" : 0,
     "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +94,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSetupSpecSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +110,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +139,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +151,7 @@
     "resource" : "org.example.TestParameterizedSetupSpecSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -87,7 +161,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -114,7 +188,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -126,7 +200,7 @@
     "resource" : "org.example.TestParameterizedSetupSpecSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -136,10 +210,10 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_4},
       "env" : "none",
       "library_version" : ${content_meta_library_version}
     },
@@ -149,83 +223,9 @@
     "resource" : "spec_setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "trace_id" : ${content_test_session_id}
   },
   "type" : "span",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_6},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
   "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-not-skipping-spec-setup/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-not-skipping-spec-setup/events.ftl
@@ -3,7 +3,81 @@
     "duration" : ${content_duration},
     "error" : 0,
     "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +94,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSetupSpecSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +110,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -62,7 +136,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +148,7 @@
     "resource" : "org.example.TestSucceedSetupSpecSpock.test another success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +158,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -112,7 +186,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -124,7 +198,7 @@
     "resource" : "org.example.TestSucceedSetupSpecSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -134,10 +208,10 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_4},
       "env" : "none",
       "library_version" : ${content_meta_library_version}
     },
@@ -147,83 +221,9 @@
     "resource" : "spec_setup",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "trace_id" : ${content_test_session_id}
   },
   "type" : "span",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_4},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_6},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
   "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping-parameterized/events.ftl
@@ -3,7 +3,81 @@
     "duration" : ${content_duration},
     "error" : 0,
     "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +94,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +110,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +139,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +151,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -87,7 +161,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -114,7 +188,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -126,7 +200,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -134,78 +208,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping-spec-setup/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping-spec-setup/events.ftl
@@ -3,7 +3,81 @@
     "duration" : ${content_duration},
     "error" : 0,
     "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 2
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 2
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -21,14 +95,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSetupSpecSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -37,7 +111,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +139,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +151,7 @@
     "resource" : "org.example.TestSucceedSetupSpecSpock.test another success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -87,7 +161,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -115,7 +189,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -127,7 +201,7 @@
     "resource" : "org.example.TestSucceedSetupSpecSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -135,78 +209,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "skip",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 2
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "skip",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
-      "test.itr.tests_skipping.count" : 2
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-skipping/events.ftl
@@ -3,7 +3,81 @@
     "duration" : ${content_duration},
     "error" : 0,
     "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.ci.itr.tests_skipped" : "true",
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "skip",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 1
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -21,14 +95,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -37,7 +111,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +139,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +151,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -85,78 +159,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "skip",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.ci.itr.tests_skipped" : "true",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "skip",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.itr.tests_skipping.count" : 1
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-unskippable-suite/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-unskippable-suite/events.ftl
@@ -4,6 +4,78 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 0
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 0
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +92,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpockUnskippableSuite",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +108,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +137,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +149,7 @@
     "resource" : "org.example.TestSucceedSpockUnskippableSuite.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -85,76 +157,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 0
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.itr.tests_skipping.count" : 0
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-unskippable/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-itr-unskippable/events.ftl
@@ -4,6 +4,78 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.itr.tests_skipping.count" : 0
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.itr.tests_skipping.enabled" : "true",
+      "test.itr.tests_skipping.type" : "test",
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "test.itr.tests_skipping.count" : 0
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +92,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpockUnskippable",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +108,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "itr_correlation_id" : "itrCorrelationId",
     "meta" : {
@@ -65,7 +137,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -77,7 +149,7 @@
     "resource" : "org.example.TestSucceedSpockUnskippable.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -85,76 +157,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.itr.tests_skipping.count" : 0
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.itr.tests_skipping.enabled" : "true",
-      "test.itr.tests_skipping.type" : "test",
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "test.itr.tests_skipping.count" : 0
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-parameterized-failed-then-succeed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-parameterized-failed-then-succeed/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedThenSucceedParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -66,7 +132,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -78,7 +144,7 @@
     "resource" : "org.example.TestFailedThenSucceedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -88,7 +154,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -120,7 +186,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -132,7 +198,7 @@
     "resource" : "org.example.TestFailedThenSucceedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -142,7 +208,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -170,7 +236,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -182,7 +248,7 @@
     "resource" : "org.example.TestFailedThenSucceedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -192,7 +258,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_5},
+    "duration" : ${content_duration_7},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -218,7 +284,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -230,7 +296,7 @@
     "resource" : "org.example.TestFailedThenSucceedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_4},
-    "start" : ${content_start_5},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -238,70 +304,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_6},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-atr/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-atr/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -66,114 +134,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.test_management.is_quarantined" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -185,12 +145,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -205,7 +165,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -239,8 +199,116 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.test_management.is_quarantined" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -250,7 +318,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -283,7 +351,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -295,7 +363,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -303,72 +371,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-efd/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-efd/events.ftl
@@ -4,6 +4,76 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +90,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +106,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -67,7 +137,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -79,7 +149,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -89,7 +159,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -122,7 +192,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -134,7 +204,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -144,7 +214,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_4},
+    "duration" : ${content_duration_6},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -178,7 +248,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -190,7 +260,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
+    "start" : ${content_start_6},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -198,74 +268,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_6},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_6},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-known/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-known/events.ftl
@@ -4,6 +4,76 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.early_flake.enabled" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +90,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +106,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -66,7 +136,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -78,7 +148,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -86,74 +156,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.early_flake.enabled" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed-parameterized/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +130,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +142,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +152,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -115,7 +183,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -127,7 +195,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -135,72 +203,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-quarantined-failed/events.ftl
@@ -4,6 +4,74 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.test_management.enabled" : "true",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +88,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +104,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -66,7 +134,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -78,7 +146,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -86,72 +154,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.test_management.enabled" : "true",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-retry-failed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-retry-failed/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -65,112 +131,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedSpock.test failed",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test failed",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test failed()V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -182,12 +142,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
+    "trace_id" : ${content_trace_id}
   },
   "type" : "test",
   "version" : 2
@@ -202,7 +162,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -235,8 +195,114 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_2}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_6},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test failed",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test failed()V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedSpock.test failed",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -246,7 +312,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_6},
+    "duration" : ${content_duration_8},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -277,7 +343,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -289,7 +355,7 @@
     "resource" : "org.example.TestFailedSpock.test failed",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_5},
-    "start" : ${content_start_6},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -297,70 +363,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_7},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_7},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-retry-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-retry-parameterized/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "fail",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestFailedParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +128,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +140,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +150,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -114,114 +180,6 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_2}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_2},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id},
-      "test.source.end" : 18,
-      "test.source.start" : 12
-    },
-    "name" : "spock.test",
-    "parent_id" : ${content_parent_id},
-    "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_3},
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id},
-    "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_3}
-  },
-  "type" : "test",
-  "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 1,
-    "meta" : {
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_3},
-      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test",
-      "test.codeowners" : "[\"owner1\",\"owner2\"]",
-      "test.failure_suppressed" : "true",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.is_retry" : "true",
-      "test.module" : "junit-5-spock-2.0",
-      "test.name" : "test add 4 and 4",
-      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
-      "test.retry_reason" : "auto_test_retry",
-      "test.source.file" : "dummy_source_path",
-      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-      "test.status" : "fail",
-      "test.suite" : "org.example.TestFailedParameterizedSpock",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
       "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
@@ -233,12 +191,12 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_4},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
-    "trace_id" : ${content_trace_id_4}
+    "trace_id" : ${content_trace_id_2}
   },
   "type" : "test",
   "version" : 2
@@ -253,7 +211,7 @@
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
       "error.message" : ${content_meta_error_message},
-      "error.stack" : ${content_meta_error_stack_4},
+      "error.stack" : ${content_meta_error_stack_2},
       "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
       "language" : "jvm",
       "library_version" : ${content_meta_library_version},
@@ -287,8 +245,116 @@
     "parent_id" : ${content_parent_id},
     "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "span_id" : ${content_span_id_5},
+    "span_id" : ${content_span_id_3},
     "start" : ${content_start_6},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_3}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_3},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedParameterizedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "trace_id" : ${content_trace_id_4}
+  },
+  "type" : "test",
+  "version" : 2
+}, {
+  "content" : {
+    "duration" : ${content_duration_8},
+    "error" : 1,
+    "meta" : {
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "error.message" : ${content_meta_error_message},
+      "error.stack" : ${content_meta_error_stack_4},
+      "error.type" : "org.spockframework.runtime.SpockComparisonFailure",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test",
+      "test.codeowners" : "[\"owner1\",\"owner2\"]",
+      "test.failure_suppressed" : "true",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.is_retry" : "true",
+      "test.module" : "junit-5-spock-2.0",
+      "test.name" : "test add 4 and 4",
+      "test.parameters" : "{\"metadata\":{\"test_name\":\"test add 4 and 4\"}}",
+      "test.retry_reason" : "auto_test_retry",
+      "test.source.file" : "dummy_source_path",
+      "test.source.method" : "test add #a and #b(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
+      "test.status" : "fail",
+      "test.suite" : "org.example.TestFailedParameterizedSpock",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id},
+      "test.source.end" : 18,
+      "test.source.start" : 12
+    },
+    "name" : "spock.test",
+    "parent_id" : ${content_parent_id},
+    "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -298,7 +364,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_7},
+    "duration" : ${content_duration_9},
     "error" : 1,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -330,7 +396,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_9},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -342,7 +408,7 @@
     "resource" : "org.example.TestFailedParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_6},
-    "start" : ${content_start_7},
+    "start" : ${content_start_9},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -350,70 +416,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_8},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_8},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_8},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_9},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "fail",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_9}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_9},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed-impacted/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed-impacted/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +128,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +140,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -82,70 +148,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed-parameterized/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed-parameterized/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestParameterizedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -62,7 +128,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -74,7 +140,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 1 and 2",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -84,7 +150,7 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_3},
+    "duration" : ${content_duration_5},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -110,7 +176,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -122,7 +188,7 @@
     "resource" : "org.example.TestParameterizedSpock.test add 4 and 4",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id_2},
-    "start" : ${content_start_3},
+    "start" : ${content_start_5},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -130,70 +196,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_5},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_5},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed/events.ftl
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5-spock-2.0/src/test/resources/test-succeed/events.ftl
@@ -4,6 +4,72 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid},
+      "_dd.profiling.ctx" : "test",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "span.kind" : "test_session_end",
+      "test.command" : "junit-5-spock-2.0",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "spock.test_session",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
+      "component" : "spock",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "env" : "none",
+      "library_version" : ${content_meta_library_version},
+      "span.kind" : "test_module_end",
+      "test.framework" : "spock",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.module" : "junit-5-spock-2.0",
+      "test.status" : "pass",
+      "test.type" : "test",
+      "test_session.name" : "session-name"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2}
+    },
+    "name" : "spock.test_module",
+    "resource" : "junit-5-spock-2.0",
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "start" : ${content_start_2},
+    "test_module_id" : ${content_test_module_id},
+    "test_session_id" : ${content_test_session_id}
+  },
+  "type" : "test_module_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
       "component" : "spock",
       "dummy_ci_tag" : "dummy_ci_tag_value",
       "env" : "none",
@@ -20,14 +86,14 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.source.end" : 19,
       "test.source.start" : 11
     },
     "name" : "spock.test_suite",
     "resource" : "org.example.TestSucceedSpock",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -36,7 +102,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_2},
+    "duration" : ${content_duration_4},
     "error" : 0,
     "meta" : {
       "_dd.profiling.ctx" : "test",
@@ -61,7 +127,7 @@
       "test_session.name" : "session-name"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id},
@@ -73,7 +139,7 @@
     "resource" : "org.example.TestSucceedSpock.test success",
     "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
     "span_id" : ${content_span_id},
-    "start" : ${content_start_2},
+    "start" : ${content_start_4},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -81,70 +147,4 @@
   },
   "type" : "test",
   "version" : 2
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_2},
-      "_dd.profiling.ctx" : "test",
-      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "span.kind" : "test_session_end",
-      "test.command" : "junit-5-spock-2.0",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
-      "_dd.profiling.enabled" : 0,
-      "_dd.trace_span_attribute_schema" : 0,
-      "process_id" : ${content_metrics_process_id}
-    },
-    "name" : "spock.test_session",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_3},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_session_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_4},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "component" : "spock",
-      "dummy_ci_tag" : "dummy_ci_tag_value",
-      "env" : "none",
-      "library_version" : ${content_meta_library_version},
-      "span.kind" : "test_module_end",
-      "test.framework" : "spock",
-      "test.framework_version" : ${content_meta_test_framework_version},
-      "test.module" : "junit-5-spock-2.0",
-      "test.status" : "pass",
-      "test.type" : "test",
-      "test_session.name" : "session-name"
-    },
-    "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4}
-    },
-    "name" : "spock.test_module",
-    "resource" : "junit-5-spock-2.0",
-    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
-    "start" : ${content_start_4},
-    "test_module_id" : ${content_test_module_id},
-    "test_session_id" : ${content_test_session_id}
-  },
-  "type" : "test_module_end",
-  "version" : 1
 } ]


### PR DESCRIPTION
# What Does This Do

After module refactored the json objects were ordered differently, making our code which takes care of dynamic values (like `content.duration`) populate the wrong events.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
