### PR TITLE
Fix Servlet 3.x leaking to servlet 2.x instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/build.gradle
@@ -30,6 +30,14 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
+// Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure IastServlet2Instrumentation applies (requires no javax.servlet.AsyncEvent)
+configurations.testImplementation {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+configurations.testRuntimeOnly {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+
 dependencies {
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.2'
   implementation project(':dd-java-agent:instrumentation:servlet:javax-servlet:javax-servlet-iast')


### PR DESCRIPTION
# What Does This Do

Exclude Servlet 3.x dependency leaking to the Servlet 2.x instrumentation tests.

# Additional Notes

`IastJettyServlet2ForkedTest` was failing because `:dd-java-agent:testing` exports `javax.servlet-api:3.1.0` which includes `javax.servlet.AsyncEvent`. This caused `IastServlet2Instrumentation` to not apply.