### PR TITLE
Promote 'com.google.inject' from additional ignore to global ignore

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -104,6 +104,7 @@
 0 sun.security.ssl.*
 0 javax.net.ssl.SSLSocket
 1 org.mockito.codegen.*
+1 com.google.inject.*
 
 # Prevent IllegalAccessError in OpenJDK 17.0.4
 1 javax.management.*
@@ -209,7 +210,6 @@
 # Need for IAST: we instrument this class
 0 com.google.gson.Gson
 0 com.google.gson.stream.JsonReader
-2 com.google.inject.*
 # We instrument Runnable there
 0 com.google.inject.internal.AbstractBindingProcessor$*
 0 com.google.inject.internal.BytecodeGen$*


### PR DESCRIPTION
# Motivation

This fixes a warning in `maven-3.2.1-latestDepTest` because latest Maven pulls in `com.google.inject.internal.aop.ChildClassDefiner$ChildLoader`

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
