### PR TITLE
Exclude signed javax-servlet coming from jetty

### DIFF
--- a/dd-smoke-tests/jersey-2/build.gradle
+++ b/dd-smoke-tests/jersey-2/build.gradle
@@ -14,12 +14,24 @@ tasks.named("jar", Jar) {
   }
 }
 
+// Servlet API conflict resolution:
+// Two servlet JARs end up on the test classpath causing a SecurityException (signer mismatch):
+//   1. org.eclipse.jetty.orbit:javax.servlet (Servlet 3.0, signed) - from Jetty 9.0.4
+//   2. javax.servlet:javax.servlet-api (Servlet 3.1, unsigned) - from the testing module
+// The mock agent server in the test JVM uses repackaged Jetty which requires Servlet 3.1,
+// so we exclude the signed Servlet 3.0 and use the unsigned Servlet 3.1 everywhere
+// (including in the shadowJar for the smoke test app running in a separate process).
 dependencies {
-  implementation group: 'org.eclipse.jetty', name: 'jetty-server', version:'9.0.4.v20130625'
-  implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version:'9.0.4.v20130625'
+  implementation(group: 'org.eclipse.jetty', name: 'jetty-server', version:'9.0.4.v20130625') {
+    exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+  }
+  implementation(group: 'org.eclipse.jetty', name: 'jetty-servlet', version:'9.0.4.v20130625') {
+    exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+  }
   implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version:'2.0'
   implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version:'2.0'
   implementation group: 'javax.xml', name: 'jaxb-api', version:'2.1'
+  implementation group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
   testImplementation project(':dd-smoke-tests')
   testImplementation(testFixtures(project(":dd-smoke-tests:iast-util")))
   testImplementation project(':dd-smoke-tests:appsec')


### PR DESCRIPTION
# What Does This Do

Use only a single servlet-api to avoid conflict.

# Motivation

Jetty comes with a signed version of javax-servlet, this conflict with the standard servlet api which is not signed, and make the test throw `SecurityException` when the classes are loaded.

The mock agent server in the test JVM uses repackaged Jetty which requires Servlet 3.1, so we exclude the signed Servlet 3.0 and use the unsigned Servlet 3.1 everywhere (including in the shadowJar for the smoke test app running in a separate process).

# Additional Notes

Related to https://github.com/DataDog/dd-trace-java/pull/10365, but different due to jetty having a signed variant.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
