### PR TITLE
Fix Servlet 3.x leaking to jetty 7.x and 9.0 instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.0/build.gradle
@@ -12,6 +12,14 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepForkedTest', 'test')
 
+// Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure servlet 2.x instrumentation applies
+configurations.testImplementation {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+configurations.testRuntimeOnly {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'
   implementation project(':dd-java-agent:instrumentation:jetty:jetty-common')

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/build.gradle
@@ -12,6 +12,14 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepForkedTest', 'test')
 
+// Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure servlet 2.x instrumentation applies
+configurations.testImplementation {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+configurations.testRuntimeOnly {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.6.0.v20120127'
   implementation project(':dd-java-agent:instrumentation:jetty:jetty-common')

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/build.gradle
@@ -18,6 +18,14 @@ muzzle {
 apply plugin: 'java-test-fixtures'
 apply from: "$rootDir/gradle/java.gradle"
 
+// Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure servlet 2.x instrumentation applies
+configurations.testImplementation {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+configurations.testRuntimeOnly {
+  exclude group: 'javax.servlet', module: 'javax.servlet-api'
+}
+
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.0.v20130308'
 


### PR DESCRIPTION
# What Does This Do

Like #10355, servlet 3.x is leaking, this exclude the dependency

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
