### PR TITLE
Fix servlet 3.x leaking to jetty 9.0.4 instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0.4/build.gradle
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0.4/build.gradle
@@ -12,9 +12,9 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir("latestDepTest", "test")
 addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "test")
 
-// Exclude servlet 3.x API from test runtime to ensure servlet 2.x instrumentation applies.
-// Only exclude from testRuntimeClasspath (not testImplementation) to avoid propagating to latestDep* configs
-// which need servlet 3.1 API for Jetty 9.2.x.
+// Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure servlet 2.x instrumentation applies.
+// Using testRuntimeClasspath instead of testImplementation because exclusions on testImplementation
+// propagate to latestDep* configurations, which need servlet 3.1 API for Jetty 9.2.x.
 configurations.testRuntimeClasspath {
   exclude group: 'javax.servlet', module: 'javax.servlet-api'
 }
@@ -29,16 +29,9 @@ dependencies {
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.4.v20130625'
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.0.4.v20130625'
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.0.4.v20130625'
-  // Exclude servlet 3.x API (coming from dd-java-agent:testing) to ensure servlet 2.x instrumentation applies
-  testImplementation(project(':dd-java-agent:appsec:appsec-test-fixtures')) {
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
-  testImplementation(testFixtures(project(":dd-java-agent:instrumentation:jetty:jetty-server:jetty-server-9.0"))) {
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
-  testImplementation(testFixtures(project(':dd-java-agent:instrumentation:servlet:javax-servlet:javax-servlet-3.0'))) {
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  testImplementation project(':dd-java-agent:appsec:appsec-test-fixtures')
+  testImplementation testFixtures(project(":dd-java-agent:instrumentation:jetty:jetty-server:jetty-server-9.0"))
+  testImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:javax-servlet:javax-servlet-3.0'))
 
   // Include all jetty-server instrumentation modules for testing. Only the version-compatible module will apply at runtime.
   testRuntimeOnly project(":dd-java-agent:instrumentation:jetty:jetty-server:jetty-server-9.0")


### PR DESCRIPTION
# What Does This Do

Like #10355, #10365, servlet 3.x is leaking, this exclude the dependency. However this module's latest dependency is jersey 9.2, which supports servlet-api 3.

Given the rules of configurations, it's not possible to exclude on `testImplementation` (the exclusion would propagate). So instead, we need to apply on the exclusion on `testRuntimeClasspath`. And we explicitly add `latestDepTestImplementation` the servlet-api there.

# Motivation

# Additional Notes
