### PR TITLE
Fixed `ClassNotFoundException: jakarta.servlet.ServletInputStream` error for `jersey3JettyTest`.

### DIFF
--- a/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
@@ -63,6 +63,7 @@ dependencies {
   jersey3JettyTestImplementation project(':dd-java-agent:instrumentation-testing'), {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
+  jersey3JettyTestImplementation('jakarta.servlet:jakarta.servlet-api:6.0.0')
   jersey3JettyTestImplementation project(':dd-java-agent:appsec:appsec-test-fixtures')
   jersey3JettyTestImplementation project(':dd-java-agent:agent-iast:iast-test-fixtures')
   jersey3JettyTestImplementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-jetty-http', version : jersey3Version


### PR DESCRIPTION
# What Does This Do
Fixed `ClassNotFoundException: jakarta.servlet.ServletInputStream` error for `jersey3JettyTest`.

# Motivation
Green CI

# Additional Notes

