### PR TITLE
Avoid sending empty payloads to the LLMObs endpoint

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
+++ b/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
@@ -27,8 +27,12 @@ public final class FlushingBuffer implements StreamingBuffer {
 
   @Override
   public void mark() {
-    mark = buffer.position();
-    ++messageCount;
+    int current = buffer.position();
+    if (current != mark) {
+      // count only non-empty messages
+      ++messageCount;
+      mark = current;
+    }
   }
 
   @Override
@@ -100,5 +104,10 @@ public final class FlushingBuffer implements StreamingBuffer {
     buffer.position(0);
     buffer.limit(buffer.capacity());
     mark = 0;
+  }
+
+  // for tests only
+  int getMessageCount() {
+    return messageCount;
   }
 }

--- a/communication/src/test/groovy/datadog/communication/serialization/FlushingBufferTest.java
+++ b/communication/src/test/groovy/datadog/communication/serialization/FlushingBufferTest.java
@@ -10,4 +10,45 @@ public class FlushingBufferTest {
   public void testBufferCapacity() {
     assertEquals(5, new FlushingBuffer(5, (messageCount, buffer) -> {}).capacity());
   }
+
+  @Test
+  public void testMessageCount() {
+    FlushingBuffer fb = new FlushingBuffer(10, (messageCount, buffer) -> {});
+
+    // initial counter
+    assertEquals(0, fb.getMessageCount());
+
+    fb.mark();
+    fb.mark();
+
+    // counter doesn't change if no data pushed into the buffer
+    assertEquals(0, fb.getMessageCount());
+
+    fb.put((byte) 1);
+    // still zero because the message counter increases on mark
+    assertEquals(0, fb.getMessageCount());
+
+    fb.mark();
+    // expect increased message counter
+    assertEquals(1, fb.getMessageCount());
+
+    fb.mark();
+    fb.mark();
+    // no change to the counter expected for consecutive mark calls
+
+    fb.putChar('a');
+    fb.putChar('b');
+    fb.putChar('c');
+    // no change to the message counter expected before mark call
+    assertEquals(1, fb.getMessageCount());
+
+    fb.mark();
+    // expect increased message counter
+    assertEquals(2, fb.getMessageCount());
+
+    fb.mark();
+    fb.mark();
+    // no change to the counter expected for consecutive mark calls
+    assertEquals(2, fb.getMessageCount());
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
@@ -111,13 +111,20 @@ public class PayloadDispatcherImpl implements ByteBufferConsumer, PayloadDispatc
       mapper.reset();
       if (response.success()) {
         if (log.isDebugEnabled()) {
-          log.debug("Successfully sent {} traces to the API", messageCount);
+          log.debug(
+              "Successfully sent {} traces {} bytes to the API {}",
+              messageCount,
+              buffer.position(),
+              mapper.endpoint());
         }
         healthMetrics.onSend(messageCount, sizeInBytes, response);
       } else {
         if (log.isDebugEnabled()) {
           log.debug(
-              "Failed to send {} traces of size {} bytes to the API", messageCount, sizeInBytes);
+              "Failed to send {} traces of size {} bytes to the API {}",
+              messageCount,
+              sizeInBytes,
+              mapper.endpoint());
         }
         healthMetrics.onFailedSend(messageCount, sizeInBytes, response);
       }

--- a/dd-trace-core/src/main/java/datadog/trace/llmobs/writer/ddintake/LLMObsSpanMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/llmobs/writer/ddintake/LLMObsSpanMapper.java
@@ -93,6 +93,11 @@ public class LLMObsSpanMapper implements RemoteMapper {
     List<? extends CoreSpan<?>> llmobsSpans =
         trace.stream().filter(LLMObsSpanMapper::isLLMObsSpan).collect(Collectors.toList());
 
+    if (llmobsSpans.isEmpty()) {
+      // do nothing if no llmobs spans in the trace
+      return;
+    }
+
     writable.startMap(3);
 
     writable.writeUTF8(EVENT_TYPE);


### PR DESCRIPTION
# What Does This Do

Avoids sending payloads to the LLMObs endpoint when the trace does not contain any LLMObs spans.

# Motivation

# Additional Notes

Add the receiving endpoint and payload size to the debug logs.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
