### PR TITLE
🍒 10344 - Add InstrumenterModule.Tracing for Aerospike

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeModule.java
+++ b/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeModule.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @AutoService(InstrumenterModule.class)
-public final class AerospikeModule extends InstrumenterModule {
+public final class AerospikeModule extends InstrumenterModule.Tracing {
   public AerospikeModule() {
     super("aerospike");
   }


### PR DESCRIPTION
Backport #10344 to release/v1.58.x

Aerospike instrumentation missed the qualifier .Tracing meaning that the instrumentation was not applying