### PR TITLE
Add test case for OF.7: empty targeting key is valid

### DIFF
--- a/products/feature-flagging/api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -213,6 +213,11 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("simple-string")
             .result(new Result<>("default").reason(ERROR.name()).errorCode(TARGETING_KEY_MISSING)),
+        // OF.7: Empty string is a valid targeting key - evaluation should proceed as normal
+        new TestCase<>("default")
+            .flag("simple-string")
+            .targetingKey("")
+            .result(new Result<>("test-value").reason(TARGETING_MATCH.name()).variant("on")),
         new TestCase<>("default")
             .flag("non-existent-flag")
             .targetingKey("user-123")

--- a/products/feature-flagging/api/src/test/java/datadog/trace/api/openfeature/util/TestCase.java
+++ b/products/feature-flagging/api/src/test/java/datadog/trace/api/openfeature/util/TestCase.java
@@ -1,20 +1,52 @@
 package datadog.trace.api.openfeature.util;
 
 import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TestCase<E> {
 
   public Class<E> type;
   public String flag;
   public E defaultValue;
-  public final MutableContext context = new MutableContext();
+  private final MutableContext baseContext = new MutableContext();
+  private String targetingKeyOverride;
+  private boolean hasTargetingKeyOverride = false;
   public Result<E> result;
+
+  // Custom context wrapper that preserves empty targeting key (OF.7 compliance)
+  public final EvaluationContext context = new EvaluationContext() {
+    @Override
+    public String getTargetingKey() {
+      return hasTargetingKeyOverride ? targetingKeyOverride : baseContext.getTargetingKey();
+    }
+
+    @Override
+    public Value getValue(String key) {
+      return baseContext.getValue(key);
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return baseContext.keySet();
+    }
+
+    @Override
+    public Map<String, Value> asMap() {
+      return baseContext.asMap();
+    }
+
+    @Override
+    public Map<String, Object> asObjectMap() {
+      return baseContext.asObjectMap();
+    }
+  };
 
   @SuppressWarnings("unchecked")
   public TestCase(final E defaultValue) {
@@ -28,37 +60,39 @@ public class TestCase<E> {
   }
 
   public TestCase<E> targetingKey(final String targetingKey) {
-    context.setTargetingKey(targetingKey);
+    // Preserve the targeting key directly to support empty string (OF.7)
+    this.targetingKeyOverride = targetingKey;
+    this.hasTargetingKeyOverride = true;
     return this;
   }
 
   public TestCase<E> context(final String key, final String value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 
   public TestCase<E> context(final String key, final Integer value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 
   public TestCase<E> context(final String key, final Double value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 
   public TestCase<E> context(final String key, final Boolean value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 
   public TestCase<E> context(final String key, final Structure value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 
   public TestCase<E> context(final String key, final List<Value> value) {
-    context.add(key, value);
+    baseContext.add(key, value);
     return this;
   }
 


### PR DESCRIPTION
# What Does This Do

# Motivation

OF.7 specifies that empty string shall be accepted as a targeting key and evaluation should proceed as normal.

This test verifies that flag evaluation works correctly when the targeting key is an empty string.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
