### PR TITLE
Fix debugger start when endpoints aren't available

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -95,7 +95,7 @@ public abstract class BaseIntegrationTest {
   public static final String APM_TRACING_PRODUCT = "APM_TRACING";
 
   protected MockWebServer datadogAgentServer;
-  private MockDispatcher probeMockDispatcher;
+  protected MockDispatcher probeMockDispatcher;
   private StatsDServer statsDServer;
   private HttpUrl probeUrl;
   private HttpUrl snapshotUrl;
@@ -410,7 +410,7 @@ public abstract class BaseIntegrationTest {
     return statsDServer.waitForMessage(str);
   }
 
-  private MockResponse datadogAgentDispatch(RecordedRequest request) {
+  protected MockResponse datadogAgentDispatch(RecordedRequest request) {
     LOG.info("datadogAgentDispatch request path: {}", request.getPath());
     if (request.getPath().equals("/info")) {
       return AGENT_INFO_RESPONSE;
@@ -591,7 +591,7 @@ public abstract class BaseIntegrationTest {
     }
   }
 
-  private static class MockDispatcher extends okhttp3.mockwebserver.QueueDispatcher {
+  protected static class MockDispatcher extends okhttp3.mockwebserver.QueueDispatcher {
     private Function<RecordedRequest, MockResponse> dispatcher;
 
     @Override


### PR DESCRIPTION
# What Does This Do
catch exception throws during common init and keep the product stopped SymDB, Exception Replay and Code Origin requires CommonInit which may in some cases throw exception (endpoints are not available from Datadog Agent)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4985]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4985]: https://datadoghq.atlassian.net/browse/DEBUG-4985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ