### PR TITLE
WIP / DRAFT gradle 9.x

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/testJvmConstraints/TestJvmSpec.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/testJvmConstraints/TestJvmSpec.kt
@@ -138,7 +138,7 @@ class TestJvmSpec(val project: Project) {
     project.providers.zip(testJvmSpec, normalizedTestJvm) { jvmSpec, testJvm ->
       // Only change test JVM if it's not the one we are running the gradle build with
       if ((jvmSpec as? SpecificInstallationToolchainSpec)?.javaHome == currentJavaHomePath.get()) {
-        project.providers.provider<JavaLauncher?> { null }
+        project.objects.property(JavaLauncher::class.java) // Empty property - no value set
       } else {
         // The provider always says that a value is present so we need to wrap it for proper error messages
         project.javaToolchains.launcherFor(jvmSpec).orElse(project.providers.provider {

--- a/buildSrc/src/main/kotlin/dd-trace-java.dependency-locking.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.dependency-locking.gradle.kts
@@ -10,12 +10,16 @@
  * See https://docs.gradle.org/current/userguide/dependency_locking.html
  */
 
-project.dependencyLocking {
-  lockAllConfigurations()
-  // lockmode set to LENIENT because there are resolution
-  // errors in the build with an apiguardian dependency.
-  // See: https://docs.gradle.org/current/userguide/dependency_locking.html for more info
-  lockMode = LockMode.LENIENT
+// Configure dependency locking after java plugin is fully applied
+// to avoid conflicts with Gradle 9's test suite creation
+pluginManager.withPlugin("java") {
+  project.dependencyLocking {
+    lockAllConfigurations()
+    // lockmode set to LENIENT because there are resolution
+    // errors in the build with an apiguardian dependency.
+    // See: https://docs.gradle.org/current/userguide/dependency_locking.html for more info
+    lockMode = LockMode.LENIENT
+  }
 }
 
 tasks.register("resolveAndLockAll") {

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -4,7 +4,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 plugins {
   id 'com.gradleup.shadow'
   id 'me.champeau.jmh'
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.9.6'
   id 'net.ltgt.errorprone' version '3.1.0'
 }
 

--- a/dd-java-agent/benchmark-integration/build.gradle
+++ b/dd-java-agent/benchmark-integration/build.gradle
@@ -25,8 +25,10 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Integration Level Agent benchmarks.'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 subprojects { sub ->
   sub.apply plugin: 'com.gradleup.shadow'

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/protobuf-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/protobuf-3.0/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.9.4'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/apm-tracing-disabled/build.gradle
+++ b/dd-smoke-tests/apm-tracing-disabled/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.3'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.6'
   }
 }
 
@@ -8,7 +8,7 @@ plugins {
   id 'application'
   id 'java'
   id 'com.gradleup.shadow' version '8.3.9'
-  id 'com.google.protobuf' version '0.9.3'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/armeria-grpc/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.9.3'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
   id 'com.gradleup.shadow'
   id 'java'
-  id 'org.springframework.boot' version '2.6.3'
+  id 'org.springframework.boot' version '3.5.9'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/grpc-1.5/build.gradle
+++ b/dd-smoke-tests/grpc-1.5/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'application'
   id 'java'
   id 'java-test-fixtures'
-  id 'com.google.protobuf' version '0.9.4'
+  id 'com.google.protobuf' version '0.9.6'
   id 'com.gradleup.shadow'
 }
 

--- a/dd-smoke-tests/kafka-2/build.gradle
+++ b/dd-smoke-tests/kafka-2/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/kafka-3/application/build.gradle
+++ b/dd-smoke-tests/kafka-3/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.2.2'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/dd-smoke-tests/openfeature/build.gradle
+++ b/dd-smoke-tests/openfeature/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 

--- a/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.4'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 }
 

--- a/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.0.0'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id 'org.graalvm.buildtools.native' version '0.9.28'
 }

--- a/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.0.0'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 }
 

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.0.0'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 }
 

--- a/dd-smoke-tests/spring-boot-3.3-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.3-webmvc/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.5'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 }
 

--- a/dd-smoke-tests/springboot-freemarker/build.gradle
+++ b/dd-smoke-tests/springboot-freemarker/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id 'com.gradleup.shadow'
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.9.6'
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot-java-11/build.gradle
+++ b/dd-smoke-tests/springboot-java-11/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-java-17/build.gradle
+++ b/dd-smoke-tests/springboot-java-17/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-jetty-jsp/build.gradle
+++ b/dd-smoke-tests/springboot-jetty-jsp/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootWar
 plugins {
   id 'java'
   id 'war'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-jpa/build.gradle
+++ b/dd-smoke-tests/springboot-jpa/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootWar
 plugins {
   id 'java'
   id 'war'
-  id 'org.springframework.boot' version '2.6.0'
+  id 'org.springframework.boot' version '3.5.9'
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/dd-smoke-tests/springboot-thymeleaf/build.gradle
+++ b/dd-smoke-tests/springboot-thymeleaf/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-tomcat-jsp/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat-jsp/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootWar
 plugins {
   id 'java'
   id 'war'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootWar
 
 plugins {
   id 'war'
-  id 'org.springframework.boot' version '2.5.12'
+  id 'org.springframework.boot' version '3.5.9'
 }
 
 ext {
@@ -79,10 +79,6 @@ tasks.named('javadocJar') {
 }
 
 tasks.named('bootWar') {
-  dependsOn 'unzip'
-}
-
-tasks.named('bootWarMainClassName') {
   dependsOn 'unzip'
 }
 

--- a/dd-smoke-tests/springboot-velocity/build.gradle
+++ b/dd-smoke-tests/springboot-velocity/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '2.7.15'
+  id 'org.springframework.boot' version '3.5.9'
   id 'io.spring.dependency-management' version '1.0.15.RELEASE'
   id 'java-test-fixtures'
 }

--- a/gradle/java_deps.gradle
+++ b/gradle/java_deps.gradle
@@ -1,3 +1,6 @@
+// TODO: Gradle 9 Migration - The groovy plugin application causes conflicts with
+// the new JVM Test Suite system when java is already applied by another plugin.
+// This needs restructuring - see: https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html
 apply plugin: 'groovy'
 
 dependencies {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -38,7 +38,7 @@ publishing {
               def dependenciesNode = xml.asNode().appendNode('dependencies')
 
               project.configurations.api.allDependencies.each {
-                if ((it instanceof ProjectDependency) || !(it instanceof SelfResolvingDependency)) {
+                if (it instanceof ProjectDependency || it instanceof ExternalModuleDependency) {
                   def dependencyNode = dependenciesNode.appendNode('dependency')
                   dependencyNode.appendNode('groupId', it.group)
                   dependencyNode.appendNode('artifactId', it.name)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=d18ae4e38c4572d1e1546d585110c807f13476223e063b40324f891bf7b5e39c
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-3-bin.zip
+distributionSha256Sum=0d585f69da091fc5b2beced877feab55a3064d43b8a1d46aeb07996b0915e0e0
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,9 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-# Please note that the version specific cache directory in
-# .gitlab-ci.yml needs to match this version.
-distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionSha256Sum=d18ae4e38c4572d1e1546d585110c807f13476223e063b40324f891bf7b5e39c
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# What Does This Do

This is a workspace to try upgrading to Gradle 9.

# Motivation

Keep tool up-to-date. Support later JDKs and libraries.

# Gradle 9.3 Compatibility Report

## Executive Summary

This report documents the compatibility issues encountered when upgrading dd-trace-java to Gradle 9.3.0. While several issues have been resolved, a fundamental blocker remains: **Spring Boot 2.x Gradle plugin is incompatible with Gradle 9**.

Related work: 
* #11272

## Issues Fixed

- [x] **Provider API Changes** (`TestJvmSpec.kt`) 👉 Superseded by #11336
  <details>

  **Commit:** `23f79d6821`

  **Problem:** Gradle 9 changed the Provider API for handling nullable types. The old code used `project.providers.provider<JavaLauncher?> { null }` which is no longer compatible.

  **Fix:**
  ```kotlin
  // Before (Gradle 8)
  project.providers.provider<JavaLauncher?> { null }

  // After (Gradle 9)
  project.objects.property(JavaLauncher::class.java) // Empty property - no value set
  ```

  **File:** `buildSrc/src/main/kotlin/datadog/gradle/plugin/testJvmConstraints/TestJvmSpec.kt:141`

  </details>

- [ ] ~~**Dependency Locking Configuration** (`dd-trace-java.dependency-locking.gradle.kts`)~~ **not needed**
  <details>

  **Commit:** `23f79d6821`

  **Problem:** Gradle 9's new JVM Test Suite plugin automatically creates test configurations when the `java` plugin is applied. The dependency locking configuration was being applied too early, causing conflicts.

  **Fix:** Wrap dependency locking in `pluginManager.withPlugin("java")`:
  ```kotlin
  pluginManager.withPlugin("java") {
    project.dependencyLocking {
      lockAllConfigurations()
      lockMode = LockMode.LENIENT
    }
  }
  ```

  **File:** `buildSrc/src/main/kotlin/dd-trace-java.dependency-locking.gradle.kts:13-23`

  </details>

- [x] **SelfResolvingDependency API Removal** (`publish.gradle`) 👉 Superseded by #11340
  <details>

  **Commit:** `23f79d6821`

  **Problem:** The `SelfResolvingDependency` class was removed from Gradle 9.

  **Fix:**
  ```groovy
  // Before (Gradle 8)
  if ((it instanceof ProjectDependency) || !(it instanceof SelfResolvingDependency)) {

  // After (Gradle 9)
  if (it instanceof ProjectDependency || it instanceof ExternalModuleDependency) {
  ```

  **File:** `gradle/publish.gradle:41`

  </details>

- [x] **`sourceCompatibility`/`targetCompatibility` Configuration** (`benchmark-integration/build.gradle`) 👉 Superseded by #11306
  <details>

  **Commit:** `23f79d6821`

  **Problem:** Gradle 9 requires that `sourceCompatibility` and `targetCompatibility` be set within the `java {}` configuration block rather than at the project root level.

  **Fix:**
  ```gradle
  // Before (Gradle 8)
  sourceCompatibility = JavaVersion.VERSION_1_8
  targetCompatibility = JavaVersion.VERSION_1_8

  // After (Gradle 9)
  java {
    sourceCompatibility = JavaVersion.VERSION_1_8
    targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```

  **File:** `dd-java-agent/benchmark-integration/build.gradle:28-31`

  </details>

- [x] **Protobuf Gradle Plugin Updates** 👉 Superseded by #11310
  <details>

  **Commit:** `23f79d6821`

  **Problem:** Old protobuf plugin versions (0.8.18 and 0.9.4) are not compatible with Gradle 9.

  **Fix:** Update to version `0.9.6`

  **Files affected (8 modules):**
  - `dd-java-agent/agent-iast/build.gradle`
  - `dd-java-agent/instrumentation/grpc-1.5/build.gradle`
  - `dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle`
  - `dd-java-agent/instrumentation/protobuf-3.0/build.gradle`
  - `dd-smoke-tests/springboot-grpc/build.gradle`
  - `dd-smoke-tests/grpc-1.5/build.gradle`
  - `dd-smoke-tests/armeria-grpc/build.gradle`
  - `dd-smoke-tests/armeria-grpc/application/build.gradle`

  </details>

- [x] **Configuration Creation Order** (`log4j-1.2.4/build.gradle`) 👉 Superseded by #11306
  <details>

  **Problem:** Accessing `testImplementation` configuration before applying `java.gradle` caused the configuration to be created prematurely. When the Java plugin later tried to create its JVM Test Suite, it failed because `testImplementation` already existed.

  **Error:**
  ```
  Cannot add a configuration with name 'testImplementation' as a configuration with that name already exists.
  ```

  **Fix:** Move `apply from: "$rootDir/gradle/java.gradle"` before the `configurations {}` block.

  **File:** `dd-java-agent/instrumentation/log4j/log4j-1.2.4/build.gradle`

  </details>

- [x] **Bnd Plugin Compatibility** (`osgi/build.gradle`) 👉 Superseded by #11341
  <details>

  **Problem:** The bnd plugin version 6.4.0 uses the removed `Convention` API (`Jar.getConvention()`).

  **Error:**
  ```
  'org.gradle.api.plugins.Convention org.gradle.api.tasks.bundling.Jar.getConvention()'
  ```

  **Fix:** Upgrade bnd plugin from `6.4.0` to `7.2.3`

  **File:** `dd-smoke-tests/osgi/build.gradle:4`

  </details>

- [x] **`Project.exec()` Removal** (`version.gradle`), 👉  superseded by #11345
  <details>

  **Problem:** `project.exec()` method was removed in Gradle 9.

  **Error:**
  ```
  Could not find method exec() for arguments [...] on project
  ```

  **Fix:** Inject `ExecOperations` via `@Inject` and use `execOperations.exec()` instead:
  ```groovy
  import javax.inject.Inject
  import org.gradle.process.ExecOperations

  abstract class WriteVersionNumberFile extends DefaultTask {
    @Inject
    abstract ExecOperations getExecOperations()

    // Use execOperations.exec { } instead of project.exec { }
  }
  ```

  **File:** `gradle/version.gradle:11-12, 19`

  </details>

- [x] **Protobuf Generated Source Path Change** 👉 Superseded by #11310, #11343
  <details>

  **Problem:** Protobuf Gradle plugin 0.9.x changed the generated source path from `source` (singular) to `sources` (plural).

  **Error:**
  ```
  unable to resolve class com.datadog.iast.protobuf.Test2
  ```

  **Fix:**
  ```groovy
  // Before
  srcDirs += ["$buildDir/generated/source/proto/test/java"]

  // After
  srcDirs += [layout.buildDirectory.dir("generated/sources/proto/test/java")]
  ```

  **Files:**
  - `dd-java-agent/agent-iast/build.gradle:121`
  - `dd-java-agent/instrumentation/protobuf-3.0/build.gradle:40`

  </details>

- [x] **Cross-Project Test Source Sharing via `sourceSets`** 👉 Fixed in #11367, and #11416
  <details>

  **Problem:** Gradle 9.5 added a `DependencyHandler.project(String)` overload returning a `ProjectDependency`. In Groovy DSL `dependencies {}` closures, this shadows the previously-used `Project.project(String)` fallback, so expressions like `project(':foo').sourceSets` now fail because `DefaultProjectDependency` has no `sourceSets` property.

  **Error:**
  ```
  Could not get unknown property 'sourceSets' for project '...' of type DefaultProjectDependency
  ```

  **Fix:**
  - `profiling-controller-jfr`: migrated test resource sharing to the `java-test-fixtures` plugin; JFP resource paths are now provided by `JfpTestResources`, which extracts classpath resources to temp files (test-fixture JARs are not accessible via `File` directly).
  - Nine mongo driver/test consumers: removed redundant `testImplementation project(':...:mongo-common').sourceSets.test.output` declarations that duplicated an already-correct `testFixtures(project(':...:mongo-common'))` dependency.

  </details>

- [x] Spring Boot 2.x Incompatibility, done via #11405 and follow ups: #11406, #11407, #11408, #11417, #11421 
  <details>

  **Problem:** The Spring Boot Gradle plugin versions 2.x use the `Configuration.getUploadTaskName()` method which was **removed in Gradle 9**.

  **Error:**
  ```
  java.lang.NoSuchMethodError: 'java.lang.String org.gradle.api.artifacts.Configuration.getUploadTaskName()'
      at org.springframework.boot.gradle.plugin.SpringBootPlugin.registerPluginActions(SpringBootPlugin.java:122)
  ```

    **Compatibility Matrix**

    | Spring Boot Version | Gradle 9 Support | Servlet API |
    |---------------------|------------------|-------------|
    | 2.5.x | :x: No | javax.servlet |
    | 2.6.x | :x: No | javax.servlet |
    | 2.7.x | :x: No | javax.servlet |
    | 3.0.x | :x: No | jakarta.servlet |
    | 3.1.x | :x: No | jakarta.servlet |
    | 3.2.x | :x: No | jakarta.servlet |
    | 3.3.x | :x: No | jakarta.servlet |
    | 3.4.x | :x: No | jakarta.servlet |
    | **3.5.x+** | :white_check_mark: Yes | jakarta.servlet |

    **Affected Smoke Tests**

    The following smoke tests use Spring Boot 2.x and are incompatible with Gradle 9:

    | Module | Current Version | Notes |
    |--------|-----------------|-------|
    | `dd-smoke-tests/apm-tracing-disabled` | 2.7.18 | Uses javax.servlet |
    | `dd-smoke-tests/springboot-jpa` | 2.6.0 | Uses javax.persistence |
    | `dd-smoke-tests/springboot-freemarker` | 2.7.15 | |
    | `dd-smoke-tests/springboot-java-11` | 2.7.15 | |
    | `dd-smoke-tests/springboot-java-17` | 2.7.15 | |
    | `dd-smoke-tests/springboot-jetty-jsp` | 2.7.15 | |
    | `dd-smoke-tests/springboot-thymeleaf` | 2.7.15 | |
    | `dd-smoke-tests/springboot-tomcat-jsp` | 2.7.15 | |
    | `dd-smoke-tests/springboot-tomcat` | 2.5.12 | |
    | `dd-smoke-tests/springboot-velocity` | 2.7.15 | |
    | `dd-smoke-tests/kafka-2` | 2.7.15 | |
    | `dd-smoke-tests/openfeature` | 2.7.15 | |
    | `dd-smoke-tests/spring-boot-2.7-webflux` | 2.7.4 | |
    | `dd-smoke-tests/datastreams/kafkaschemaregistry` | 2.6.3 | |

    **Root Cause**

    Spring Boot 3.0 migrated from Java EE (`javax.*`) to Jakarta EE (`jakarta.*`). This is a breaking change that requires source code modifications:

    ```java
    // Spring Boot 2.x (Java EE)
    import javax.servlet.http.HttpServletRequest;
    import javax.persistence.Entity;

    // Spring Boot 3.x (Jakarta EE)
    import jakarta.servlet.http.HttpServletRequest;
    import jakarta.persistence.Entity;
    ```

    Additionally, Spring Boot 3.x requires **Java 17 or later**, whereas several smoke tests target Java 8 or 11.

    Explored ways to do that in #11379 and #11404 before moving to smaller PRs

  </details>

- [x] `:dd-smoke-tests:gradle` inherits Groovy 4 which is incompatible with pock 2.4.0-groovy-3.0, Fixed by #11439 
  <details>
  
  **Problem:** Spock's 2.4-groovy-3.0 artifact only works when Groovy 3.x is on the test classpath. Groovy 4 reaches a module via `gradleTestKit()`, `gradleApi()`, `localGroovy()`, used by this module.

  Fix: Bump to Groovy 4, or convert the test to java (but they are inheriting a parent)

  </details>


- [x] **`java9-modules` jlink action uses Gradle 9.5.1-compatible exec** 👉 Fixed by #11489
  <details>

  **Problem:** Gradle 9.5.1 no longer resolves the bare `exec {}` method from the `:dd-smoke-tests:java9-modules:test` `Test.doFirst` action.

  **Error:**
  ```
  Could not find method exec() for arguments [...] on task :dd-smoke-tests:java9-modules:test
  ```

  **Fix:** use `providers.exec { ... }.result.get().assertNormalExitValue()` for the `jlink` invocation.

  **File:** `dd-smoke-tests/java9-modules/build.gradle:42`

  </details>

- [x] **Gradle smoke tests under Gradle 9.5.1 TestKit** 👉 Fixed by #11490
  <details>

  **Problem:** Gradle 9.5.1 TestKit no longer supports the old Gradle 3.5 fixture, and nested wrapper setup could inherit user or CI Gradle state.

  **Fix:** skip Gradle rows below the current TestKit minimum as a documented best-effort boundary for earliest legacy coverage, isolate nested wrapper runs with a temporary `GRADLE_USER_HOME`, and refresh the expected ITR tests-skipping metadata.

  **Files:**
  - `dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java`
  - `dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleLauncherSmokeTest.java`
  - `dd-smoke-tests/gradle/src/test/resources/**/events.ftl`

  </details>

- [x] **Test discovery now fails the build with no tests** (`failOnNoDiscoveredTests`) 👉 Fixed by the Gradle update PR #11436 
  <details>

  **Problem:** Gradle 9 introduces `Test.failOnNoDiscoveredTests` and defaults it to `true`. Every `Test` task that has compiled test sources but discovers zero executable tests (typical for `latestDepTest` / `latest*Test` / extra `addTestSuite` variants that only ship sources for some JVM/library combinations) now fails the build.

  **Error:**
  ```
  There are test sources present and no filters are applied, but the test
  task did not discover any tests to execute. This is likely due to a
  misconfiguration. Please check your test configuration. If this is not
  a misconfiguration, this error can be disabled by setting the
  'failOnNoDiscoveredTests' property to false.
  ```

  **Affected jobs (pipeline 114751498):**
  - `test_inst: [*, 8/8]` — `:aws-java-sdk-2.2:payloadTaggingTest`, `:vertx-redis-client-3.9:redis4xTest`
  - `test_inst: [8, 7/8]` — `:ignite-2.0:ignite216Test`
  - `test_inst_latest: [*, {1,2,4,5}/6]` — many `*latestDepTest` / `latestPre207Test` / `latest7DepTest` / `latestPayloadTaggingTest` across `hazelcast-{3.6,3.9,4.0}`, `wildfly-9.0`, `valkey-java-5.3`, `aerospike-4.0`, `aws-java-sdk-2.2`, `javax-servlet-2.2`, `vertx-mysql-client-{3.9,4.0}`, `vertx-pg-client-4.0`, `vertx-redis-client-3.9`, `jedis-4.0`, `jax-rs-client-1.1`, `synapse-3.0`, `finatra-2.9`

  **Fix:** disable globally on every `Test` task in `buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts`, alongside the other `tasks.withType<Test>().configureEach { ... }` configuration:
  ```kotlin
  tasks.withType<Test>().configureEach {
    failOnNoDiscoveredTests = false
  }
  ```

  </details>

- [x] **On `test_published_artifacts` project, the JUnit Platform launcher is no longer auto-injected** 👉 Fixed by #11445
  <details>

  **Problem:** Gradle 9 stopped putting `junit-platform-launcher` on the test runtime classpath automatically. Subprojects that only depend on `junit-jupiter` now fail at startup.

  **Error:**
  ```
  Caused by: org.gradle.api.internal.tasks.testing.TestSuiteExecutionException:
    Could not start Gradle Test Executor N.
  Caused by: RequiresTestFrameworkTestDefinitionProcessor$TestFrameworkNotAvailableException:
    Failed to load JUnit Platform. Please ensure that all JUnit Platform
    dependencies are available on the test's runtime classpath, including
    the JUnit Platform launcher.
  ```

  **Affected job:** `test_published_artifacts` — `:agent-logs-on-java-7:test`, `:ot-pulls-in-api:test`

  **Fix:** add `testRuntimeOnly("org.junit.platform:junit-platform-launcher")` in both `test-published-dependencies/agent-logs-on-java-7/build.gradle(.kts)` and `test-published-dependencies/ot-pulls-in-api/build.gradle(.kts)`. Handled in #11445.

  </details>

- [x] **GraalVM native build plugin too old for Gradle 9** (`org.graalvm.buildtools.native:0.9.28`) 👉 Fixed by #11468
  <details>

  **Problem:** The native-image plugin pinned in `dd-smoke-tests/spring-boot-3.0-native/application/build.gradle` calls `LenientConfiguration.getArtifacts(Spec)`, an overload that was removed in Gradle 9.

  **Error:** (from the nested `./gradlew nativeCompile` invocation in `springNativeBuild`)
  ```
  Could not determine the dependencies of task ':nativeCompile'.
  > Failed to notify dependency resolution listener.
     > 'java.util.Set org.gradle.api.artifacts.LenientConfiguration.getArtifacts(org.gradle.api.specs.Spec)'
  ```

  **Affected jobs:** `test_smoke_graalvm: [graalvm17]`, `[graalvm21]`, `[graalvm25]`

  **Fix:** ~~bump `org.graalvm.buildtools.native` from `0.9.28` to a Gradle-9-compatible release (≥ `0.10.6`).~~ Or use the smokeTestApp to drive the build with a specific gradle version.

  **File:** `dd-smoke-tests/spring-boot-3.0-native/application/build.gradle:5`

  </details>



---

Missed

- [x] Gradle dropped the convention to add same sources dir to new registered Test tasks. Fixed by #11538
- [x] Cache key needs to be the same as Gradle version. Fixed by #11552 


---

## References

- [Gradle 9 Upgrade Guide](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html)
- [Spring Boot Gradle 9 Support Issue #43573](https://github.com/spring-projects/spring-boot/issues/43573)
- [JVM Test Suite Plugin](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html)
- [Jakarta EE Migration Guide](https://jakarta.ee/resources/jakarta-ee-10-migration/)


