### PR TITLE
Exclude grizzly 5.0.0 from muzzle

### DIFF
--- a/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/build.gradle
@@ -2,12 +2,10 @@ muzzle {
   pass {
     group = "org.glassfish.grizzly"
     module = 'grizzly-http'
-    if (JavaVersion.current().isJava11Compatible()) {
-      versions = "[2.3.20,)"
-    } else {
-      versions = "[2.3.20,4.0.0)"
-    }
+    versions = "[2.3.20,)"
+    javaVersion = '11'
     assertInverse = false
+    skipVersions += "5.0.0"
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Solves

```
Execution failed for task ':dd-java-agent:instrumentation:grizzly:grizzly-http-2.3.20:muzzle-AssertPass-org.glassfish.grizzly-grizzly-http-5.0.0'.
> Could not resolve all files for configuration ':dd-java-agent:instrumentation:grizzly:grizzly-http-2.3.20:muzzle-AssertPass-org.glassfish.grizzly-grizzly-http-5.0.0'.
   > Could not resolve org.glassfish.grizzly:grizzly-http:5.0.0.
     Required by:
         project :dd-java-agent:instrumentation:grizzly:grizzly-http-2.3.20
      > Could not resolve org.glassfish.grizzly:grizzly-http:5.0.0.
         > Could not parse POM https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http/5.0.0/grizzly-http-5.0.0.pom
            > Could not resolve org.glassfish.grizzly:grizzly-project:5.0.0.
               > Could not resolve org.glassfish.grizzly:grizzly-project:5.0.0.
                  > Could not parse POM https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-project/5.0.0/grizzly-project-5.0.0.pom
                     > Could not find org.glassfish.grizzly:grizzly-bom:5.0.0-SNAPSHOT.
                       Searched in the following locations:
                         - file:/Users/andrea.marziali/.m2/repository/org/glassfish/grizzly/grizzly-bom/5.0.0-SNAPSHOT/maven-metadata.xml
                         - file:/Users/andrea.marziali/.m2/repository/org/glassfish/grizzly/grizzly-bom/5.0.0-SNAPSHOT/grizzly-bom-5.0.0-SNAPSHOT.pom
                         - https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-bom/5.0.0-SNAPSHOT/maven-metadata.xml
                         - https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-bom/5.0.0-SNAPSHOT/grizzly-bom-5.0.0-SNAPSHOT.pom
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
