### PR TITLE
Handle HTTP/2 status for netty server spans

### DIFF
--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -16,6 +16,8 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
 
 @ChannelHandler.Sharable
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
@@ -26,12 +28,40 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     final Context storedContext = ctx.channel().attr(CONTEXT_ATTRIBUTE_KEY).get();
     final AgentSpan span = spanFromContext(storedContext);
 
-    if (span == null || !(msg instanceof HttpResponse)) {
+    if (span == null
+        || !(msg instanceof HttpResponse || msg instanceof Http2HeadersFrame)) {
       ctx.write(msg, prm);
       return;
     }
 
     try (final ContextScope scope = storedContext.attach()) {
+      if (msg instanceof Http2HeadersFrame) {
+        final Http2HeadersFrame headersFrame = (Http2HeadersFrame) msg;
+        final Http2Headers headers = headersFrame.headers();
+        try {
+          ctx.write(msg, prm);
+        } catch (final Throwable throwable) {
+          DECORATE.onError(span, throwable);
+          span.setHttpStatusCode(500);
+          span.finish();
+          ctx.channel().attr(CONTEXT_ATTRIBUTE_KEY).remove();
+          throw throwable;
+        }
+
+        final CharSequence status = headers.status();
+        if (status != null) {
+          try {
+            DECORATE.onResponseStatus(span, HttpResponseStatus.parseLine(status).code());
+          } catch (IllegalArgumentException ignored) {
+            // ignore unparsable status and finish without setting http.status_code
+          }
+        }
+        DECORATE.beforeFinish(scope.context());
+        span.finish();
+        ctx.channel().attr(CONTEXT_ATTRIBUTE_KEY).remove();
+        return;
+      }
+
       final HttpResponse response = (HttpResponse) msg;
 
       try {

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41Http2StatusPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41Http2StatusPropagationTest.groovy
@@ -1,0 +1,38 @@
+import datadog.context.Context
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.instrumentation.netty41.AttributeKeys
+import datadog.trace.instrumentation.netty41.server.HttpServerResponseTracingHandler
+import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.DefaultHttpRequest
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpVersion
+import io.netty.handler.codec.http2.DefaultHttp2Headers
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame
+
+class Netty41Http2StatusPropagationTest extends InstrumentationSpecification {
+
+  def "http2 headers frame sets status on netty server span"() {
+    setup:
+    def channel = new EmbeddedChannel(HttpServerResponseTracingHandler.INSTANCE)
+    def request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test")
+    def context = NettyHttpServerDecorator.DECORATE.startSpan(request, Context.root())
+    channel.attr(AttributeKeys.CONTEXT_ATTRIBUTE_KEY).set(context)
+
+    when:
+    def headers = new DefaultHttp2Headers().status("200")
+    channel.writeAndFlush(new DefaultHttp2HeadersFrame(headers, true))
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags { "http.status_code" 200 }
+        }
+      }
+    }
+
+    cleanup:
+    channel.finishAndReleaseAll()
+  }
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"aed11a9e-47a0-485e-80a2-0335fc730ce8","source":"chat","resourceId":"50c9bed7-dfb4-422d-9aad-970188a1f016","workflowId":"a95c6454-304a-4428-8a8b-450d6e2292ad","codeChangeId":"a95c6454-304a-4428-8a8b-450d6e2292ad","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/50c9bed7-dfb4-422d-9aad-970188a1f016)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

# What Does This Do
NOTE: This is an experiment to see how Datadog CodeGen performs on integration issue

- Add HTTP/2 headers frame handling in the Netty server response tracing handler so http.status_code is set on netty.request spans
- Add a regression test covering HTTP/2 responses to ensure the status code is recorded

# Motivation
- HTTP/2 responses in Spring Cloud Gateway/Netty are written as Http2HeadersFrame, so server spans were missing http.status_code and surfaced as N/A

# Additional Notes
- Tests and formatting could not be run in this sandbox because Gradle downloads require network access

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-18237]

[APMS-18237]: https://datadoghq.atlassian.net/browse/APMS-18237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ