### PR TITLE
Avoid primitive boxing in v0.4 serializer

### DIFF
--- a/.github/workflows/check-pull-request-labels.yaml
+++ b/.github/workflows/check-pull-request-labels.yaml
@@ -30,6 +30,7 @@ jobs:
               'comp:',
               'inst:',
               'tag:',
+              'mergequeue-status:',
               'performance:',  // To refactor to 'ci: ' in the future
               'run-tests:'     // Unused since GitLab migration
             ]

--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -1,4 +1,9 @@
 ---
 schema-version: v1
-kind: mergequeue
-enable: false
+kind: mergequeue # https://datadoghq.atlassian.net/wiki/x/XgUQug
+enable: true
+merge_method: squash
+branches:
+  master:
+    allow_skip_checks: true
+    require_reason_for_skip_checks: true


### PR DESCRIPTION
# What Does This Do
Updates V0.4 serializer to use TagMap.EntryReader API to avoid boxing primitives

# Motivation
Reduce allocation -> reduces garbage collection -> improves throughput predictability

# Additional Notes
Builds on EntryReader API changes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
