### PR TITLE
Updated `testcontainers` library version to 1.21.4.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ junit5 = "5.14.1"
 junit-platform = "1.14.1"
 mockito = "4.4.0"
 spock = "2.4-groovy-3.0"
-testcontainers = "1.21.3"
+testcontainers = "1.21.4"
 
 [libraries]
 # Build


### PR DESCRIPTION
# What Does This Do
Upgrades `testcontainers` from **1.21.3** to **1.21.4**.

# Motivation
Local testing.

# Additional Notes
After I updated the `Docker Desktop` app on my laptop, tests started to fail with the following error:
```
Caused by: com.github.dockerjava.api.exception.BadRequestException:
 Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
```
Bumping the `testcontainers` version fixed this issue.
