### PR TITLE
Compute basehash without allocating a stringbuilder

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/BaseHash.java
+++ b/internal-api/src/main/java/datadog/trace/api/BaseHash.java
@@ -41,19 +41,15 @@ public final class BaseHash {
       String primaryTag,
       CharSequence processTags,
       String containerTagsHash) {
-    StringBuilder builder = new StringBuilder(64);
-    builder.append(serviceName);
-    builder.append(env);
-
-    if (primaryTag != null) {
-      builder.append(primaryTag);
-    }
+    long hash = FNV64Hash.generateHash(serviceName.toString(), FNV64Hash.Version.v1);
+    hash = FNV64Hash.continueHash(hash, env.toString(), FNV64Hash.Version.v1);
+    if (primaryTag != null) hash = FNV64Hash.continueHash(hash, primaryTag, FNV64Hash.Version.v1);
     if (processTags != null) {
-      builder.append(processTags);
+      hash = FNV64Hash.continueHash(hash, processTags.toString(), FNV64Hash.Version.v1);
       if (containerTagsHash != null && !containerTagsHash.isEmpty()) {
-        builder.append(containerTagsHash);
+        hash = FNV64Hash.continueHash(hash, containerTagsHash, FNV64Hash.Version.v1);
       }
     }
-    return FNV64Hash.generateHash(builder.toString(), FNV64Hash.Version.v1);
+    return hash;
   }
 }


### PR DESCRIPTION
# What Does This Do

Tiny change to the BaseHash class to compute the hash iteratively rather than building a string for it.
I still have to `toString` the CharSqeuences but I think the stringbuilder was doing it too anyway.

# Motivation

Less allocations, less GC, faster...

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
