### PR TITLE
Update tags to replace legacy runners with the latest ones.

### DIFF
--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -5,11 +5,10 @@ build-exploration-tests-image:
   stage: exploration-tests
   when: manual
   needs: []
-  tags: [ "runner:docker" ]
-  image: $REGISTRY/docker:20.10.3
+  tags: [ "arch:amd64" ]
+  image: $REGISTRY/docker:27.3.1
   script:
-    - docker build --tag $EXPLORATION_TESTS_IMAGE -f dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests dd-java-agent/agent-debugger/exploration-tests
-    - docker push $EXPLORATION_TESTS_IMAGE
+    - docker buildx build --tag $EXPLORATION_TESTS_IMAGE -f dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests --push dd-java-agent/agent-debugger/exploration-tests
 
 .common-exploration-tests: &common-exploration-tests
   rules:
@@ -37,7 +36,7 @@ build-exploration-tests-image:
     - tar czf ${PROJECT}_surefire-reports.tar.gz /exploration-tests/${PROJECT}/target/surefire-reports
     - tar czf ${PROJECT}_debugger-dumps.tar.gz /tmp/debugger
   stage: exploration-tests
-  tags: [ "runner:main"]
+  tags: [ "arch:amd64"]
   image: $EXPLORATION_TESTS_IMAGE
   artifacts:
     paths:


### PR DESCRIPTION
# What Does This Do
Updates runner tags to replace legacy runners with the latest supported runners.

# Motivation
Ensure CI jobs run on the latest runners.

# Additional Notes
This PR was created in collaboration with @jorgetomtz 