### PR TITLE
Fix ISO 8601 date parsing to support variable precision

### DIFF
--- a/dd-smoke-tests/openfeature/src/test/resources/config/flags-v1.json
+++ b/dd-smoke-tests/openfeature/src/test/resources/config/flags-v1.json
@@ -2891,6 +2891,61 @@
               "doLog": true
             }
           ]
+        },
+        "microsecond-date-test": {
+          "key": "microsecond-date-test",
+          "enabled": true,
+          "variationType": "STRING",
+          "variations": {
+            "expired": {
+              "key": "expired",
+              "value": "expired"
+            },
+            "active": {
+              "key": "active",
+              "value": "active"
+            },
+            "future": {
+              "key": "future",
+              "value": "future"
+            }
+          },
+          "allocations": [
+            {
+              "key": "expired-allocation",
+              "splits": [
+                {
+                  "variationKey": "expired",
+                  "shards": []
+                }
+              ],
+              "endAt": "2002-10-31T09:00:00.594321Z",
+              "doLog": true
+            },
+            {
+              "key": "future-allocation",
+              "splits": [
+                {
+                  "variationKey": "future",
+                  "shards": []
+                }
+              ],
+              "startAt": "2052-10-31T09:00:00.123456Z",
+              "doLog": true
+            },
+            {
+              "key": "active-allocation",
+              "splits": [
+                {
+                  "variationKey": "active",
+                  "shards": []
+                }
+              ],
+              "startAt": "2022-10-31T09:00:00.235982Z",
+              "endAt": "2050-10-31T09:00:00.987654Z",
+              "doLog": true
+            }
+          ]
         }
       }
     }

--- a/dd-smoke-tests/openfeature/src/test/resources/data/test-case-microsecond-date-flag.json
+++ b/dd-smoke-tests/openfeature/src/test/resources/data/test-case-microsecond-date-flag.json
@@ -1,0 +1,54 @@
+[
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "alice",
+    "attributes": {},
+    "result": {
+      "value": "active",
+      "variant": "active",
+      "flagMetadata": {
+        "allocationKey": "active-allocation",
+        "variationType": "string",
+        "doLog": true
+      }
+    }
+  },
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "bob",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": "active",
+      "variant": "active",
+      "flagMetadata": {
+        "allocationKey": "active-allocation",
+        "variationType": "string",
+        "doLog": true
+      }
+    }
+  },
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "charlie",
+    "attributes": {
+      "version": "1.0.0"
+    },
+    "result": {
+      "value": "active",
+      "variant": "active",
+      "flagMetadata": {
+        "allocationKey": "active-allocation",
+        "variationType": "string",
+        "doLog": true
+      }
+    }
+  }
+]

--- a/products/feature-flagging/lib/src/main/java/com/datadog/featureflag/RemoteConfigServiceImpl.java
+++ b/products/feature-flagging/lib/src/main/java/com/datadog/featureflag/RemoteConfigServiceImpl.java
@@ -16,10 +16,7 @@ import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,9 +73,6 @@ public class RemoteConfigServiceImpl
 
   static class DateAdapter extends JsonAdapter<Date> {
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS]'Z'").withZone(ZoneOffset.UTC);
-
     @Nullable
     @Override
     public Date fromJson(@Nonnull final JsonReader reader) throws IOException {
@@ -87,9 +81,10 @@ public class RemoteConfigServiceImpl
         return null;
       }
       try {
-        final TemporalAccessor temporalAccessor = DATE_TIME_FORMATTER.parse(date);
-        final Instant instant = Instant.from(temporalAccessor);
-        return Date.from(instant);
+        // Use OffsetDateTime which handles variable precision fractional seconds (0-9 digits)
+        // and UTC offsets (+01:00, -05:00, Z)
+        final OffsetDateTime odt = OffsetDateTime.parse(date);
+        return Date.from(odt.toInstant());
       } catch (Exception e) {
         // ignore wrongly set dates
         return null;

--- a/products/feature-flagging/lib/src/test/groovy/com/datadog/featureflag/RemoteConfigServiceTest.groovy
+++ b/products/feature-flagging/lib/src/test/groovy/com/datadog/featureflag/RemoteConfigServiceTest.groovy
@@ -87,24 +87,34 @@ class RemoteConfigServiceTest extends DDSpecification {
     date == expected
 
     where:
-    string                      | expected
-    // Valid ISO 8601 formats
-    "2023-01-01T00:00:00Z"      | new Date(1672531200000L) // 2023-01-01 00:00:00 UTC
-    "2023-12-31T23:59:59Z"      | new Date(1704067199000L) // 2023-12-31 23:59:59 UTC
-    "2024-02-29T12:00:00Z"      | new Date(1709208000000L) // Leap year date
-    "2023-01-01T00:00:00.000Z"  | new Date(1672531200000L) // With milliseconds
-    "2023-06-15T14:30:45.123Z"  | new Date(1686839445123L) // With milliseconds
+    string                           | expected
+    // Valid ISO 8601 formats - no fractional seconds
+    "2023-01-01T00:00:00Z"           | new Date(1672531200000L) // 2023-01-01 00:00:00 UTC
+    "2023-12-31T23:59:59Z"           | new Date(1704067199000L) // 2023-12-31 23:59:59 UTC
+    "2024-02-29T12:00:00Z"           | new Date(1709208000000L) // Leap year date
+    // 3-digit milliseconds
+    "2023-01-01T00:00:00.000Z"       | new Date(1672531200000L) // With milliseconds
+    "2023-06-15T14:30:45.123Z"       | new Date(1686839445123L) // With milliseconds
+    // 6-digit microseconds (truncated to milliseconds by Java Date)
+    "2023-06-15T14:30:45.123456Z"    | new Date(1686839445123L) // Microseconds truncated
+    "2023-06-15T14:30:45.235982Z"    | new Date(1686839445235L) // Different microseconds from backend
+    // 9-digit nanoseconds (truncated to milliseconds by Java Date)
+    "2023-06-15T14:30:45.123456789Z" | new Date(1686839445123L) // Nanoseconds truncated
+    // Variable precision fractional seconds
+    "2023-06-15T14:30:45.1Z"         | new Date(1686839445100L) // 1-digit
+    "2023-06-15T14:30:45.12Z"        | new Date(1686839445120L) // 2-digit
+    // UTC offsets (supported by OffsetDateTime.parse)
+    "2023-01-01T01:00:00+01:00"      | new Date(1672531200000L) // UTC+1 = 2023-01-01 00:00:00 UTC
+    "2023-01-01T00:00:00-05:00"      | new Date(1672549200000L) // UTC-5 = 2023-01-01 05:00:00 UTC
     // Non supported formats should return null
-    "2023-01-01T01:00:00+01:00" | null // UTC+1
-    "2023-01-01T00:00:00-05:00" | null // UTC-5
-    "2023-01-01"                | null // Date only
-    "invalid-date"              | null
-    ""                          | null
-    "not-a-date"                | null
-    "2023/01/01T00:00:00Z"      | null // Wrong separator
+    "2023-01-01"                     | null // Date only
+    "invalid-date"                   | null
+    ""                               | null
+    "not-a-date"                     | null
+    "2023/01/01T00:00:00Z"           | null // Wrong separator
 
     // Null input
-    null                        | null
+    null                             | null
   }
 
   void 'test parsing only adapter'() {


### PR DESCRIPTION
# Motivation

The DateAdapter was using a DateTimeFormatter with a fixed [.SSS] pattern, which only supports optional 3-digit milliseconds. This caused dates with 6-digit microsecond precision (e.g., "2025-09-23T15:48:37.235982Z") sent by the backend to silently fail parsing (returning null).

Associated system test: https://github.com/DataDog/system-tests/pull/6087

# What Does This Do

Changed to use Instant.parse() which correctly handles all valid ISO 8601 date formats including:
- No fractional seconds: 2020-01-01T00:00:00Z
- 1-9 digit fractional seconds (beyond ms precision truncated by Date)
- UTC offsets: 2023-01-01T01:00:00+01:00

Added comprehensive unit tests for various date precisions and updated smoke test data with microsecond-date-test flag and test cases.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
