### PR TITLE
[RUM-9221] add the `crossorigin` attribute to the Browser SDK snippet

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/rum/RumInjectorConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/rum/RumInjectorConfig.java
@@ -141,7 +141,7 @@ public class RumInjectorConfig {
     return "<script>\n"
         + "(function(h,o,u,n,d) {\n"
         + "  h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}\n"
-        + "  d=o.createElement(u);d.async=1;d.src=n\n"
+        + "  d=o.createElement(u);d.async=1;d.src=n;d.crossorigin=''\n"
         + "  n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)\n"
         + "})(window,document,'script','"
         + getCdnUrl()


### PR DESCRIPTION
# What Does This Do

Add the `crossorigin` attribute to the Browser SDK snippet

# Motivation

We want to eventually use [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) in the SDK. As CDN bundles are hosted in a cross origin URL, specifying the crossorigin attribute is required for this to work.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [RUM-9221]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[RUM-9221]: https://datadoghq.atlassian.net/browse/RUM-9221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ