### PR TITLE
Extract metrics as a separate product

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -14,7 +14,7 @@ import datadog.common.container.ContainerInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.metrics.api.Monitoring;
 import datadog.metrics.api.Recording;
-import datadog.metrics.statsd.DDAgentStatsDClientManager;
+import datadog.metrics.impl.statsd.DDAgentStatsDClientManager;
 import datadog.trace.api.BaseHash;
 import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.util.Strings;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1012,7 +1012,7 @@ public class Agent {
 
   private static StatsDClientManager statsDClientManager() throws Exception {
     final Class<?> statsdClientManagerClass =
-        AGENT_CLASSLOADER.loadClass("datadog.metrics.statsd.DDAgentStatsDClientManager");
+        AGENT_CLASSLOADER.loadClass("datadog.metrics.impl.statsd.DDAgentStatsDClientManager");
     final Method statsDClientManagerMethod =
         statsdClientManagerClass.getMethod("statsDClientManager");
     return (StatsDClientManager) statsDClientManagerMethod.invoke(null);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
@@ -22,7 +22,6 @@ public final class Constants {
     "datadog.instrument",
     "datadog.appsec.api",
     "datadog.metrics.api",
-    "datadog.metrics.statsd",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.config.inversion",

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/OOMENotifier.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/OOMENotifier.java
@@ -1,6 +1,6 @@
 package datadog.crashtracking;
 
-import static datadog.metrics.statsd.DDAgentStatsDClientManager.statsDClientManager;
+import static datadog.metrics.impl.statsd.DDAgentStatsDClientManager.statsDClientManager;
 
 import datadog.metrics.statsd.StatsDClient;
 import de.thetaphi.forbiddenapis.SuppressForbidden;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -2,7 +2,7 @@ package com.datadog.debugger.agent;
 
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.timgroup.statsd.StatsDClientErrorHandler;
-import datadog.metrics.statsd.DDAgentStatsDClientManager;
+import datadog.metrics.impl.statsd.DDAgentStatsDClientManager;
 import datadog.metrics.statsd.StatsDClient;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.util;
 
-import datadog.metrics.statsd.DDAgentStatsDClientManager;
+import datadog.metrics.impl.statsd.DDAgentStatsDClientManager;
 import datadog.metrics.statsd.StatsDClient;
 import datadog.trace.api.Config;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/MeterInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/MeterInstaller.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling;
 
-import static datadog.metrics.statsd.DDAgentStatsDClientManager.statsDClientManager;
+import static datadog.metrics.impl.statsd.DDAgentStatsDClientManager.statsDClientManager;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import datadog.metrics.agent.AgentMeter;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/nativeimage/TracerActivation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/nativeimage/TracerActivation.java
@@ -2,7 +2,7 @@ package datadog.trace.agent.tooling.nativeimage;
 
 import com.datadog.profiling.controller.openjdk.JFREventContextIntegration;
 import datadog.communication.ddagent.SharedCommunicationObjects;
-import datadog.metrics.statsd.DDAgentStatsDClientManager;
+import datadog.metrics.impl.statsd.DDAgentStatsDClientManager;
 import datadog.metrics.statsd.StatsDClientManager;
 import datadog.trace.agent.jmxfetch.JMXFetch;
 import datadog.trace.agent.tooling.MeterInstaller;

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
@@ -69,7 +69,6 @@ public class BootstrapClasspathSetupListener implements LauncherSessionListener 
     "datadog.instrument",
     "datadog.appsec.api",
     "datadog.metrics.api",
-    "datadog.metrics.statsd",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.config.inversion",

--- a/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDClient.java
+++ b/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDClient.java
@@ -1,7 +1,8 @@
-package datadog.metrics.statsd;
+package datadog.metrics.impl.statsd;
 
 import com.timgroup.statsd.Event;
 import com.timgroup.statsd.ServiceCheck;
+import datadog.metrics.statsd.StatsDClient;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDClientManager.java
+++ b/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDClientManager.java
@@ -1,7 +1,9 @@
-package datadog.metrics.statsd;
+package datadog.metrics.impl.statsd;
 
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.LOGGING_WRITER_TYPE;
 
+import datadog.metrics.statsd.StatsDClient;
+import datadog.metrics.statsd.StatsDClientManager;
 import datadog.trace.api.Config;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.cache.DDCache;

--- a/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDConnection.java
+++ b/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDConnection.java
@@ -1,4 +1,4 @@
-package datadog.metrics.statsd;
+package datadog.metrics.impl.statsd;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_SOCKET_PATH;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.STATSD_CLIENT;

--- a/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/LoggingStatsDClient.java
+++ b/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/LoggingStatsDClient.java
@@ -1,5 +1,6 @@
-package datadog.metrics.statsd;
+package datadog.metrics.impl.statsd;
 
+import datadog.metrics.statsd.StatsDClient;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;

--- a/products/metrics/metrics-lib/src/test/groovy/datadog/metrics/impl/statsd/DDAgentStatsDClientTest.groovy
+++ b/products/metrics/metrics-lib/src/test/groovy/datadog/metrics/impl/statsd/DDAgentStatsDClientTest.groovy
@@ -1,6 +1,6 @@
-package datadog.metrics.statsd
+package datadog.metrics.impl.statsd
 
-import static datadog.metrics.statsd.DDAgentStatsDClientManager.statsDClientManager
+import static datadog.metrics.impl.statsd.DDAgentStatsDClientManager.statsDClientManager
 import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_START_DELAY
 import static datadog.trace.api.config.GeneralConfig.EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED
 


### PR DESCRIPTION
Exploration PR to fix issues on 
* #10399 

<details><summary>First attempt</summary>

I first attempted to use this organization in the final agent jar:

`metrics-api` in `shared/`
`metrics-lib` (and `sketches-java`) in `metrics/`

This forced to declare an exclude of sketches-java on each dependency declaration of `metrics-lib`.

</details>

<details><summary>Second attempt</summary>
The `sketches-java` is used for metrics in the metrics product and for encoding utils in the trace-core (for datastreams). So I choose to make `sketches-java` under shared. The final agent now looks like that.

```
bootstrap (root, files are classes)
  metrics-api
  metrics-agent

metrics/
  metrics-lib

tracer/
  dd-trace-core

shared/
  metrics-api
  sketches-java
  dogstatsd (as before)
```

</details>

Third attempt layed out things this way :

```
bootstrap (root, files are classes)
  metrics-api
  metrics-agent

metrics/
  metrics-lib

tracer/
  dd-trace-core

shared/
  sketches-java
  dogstatsd (as before)
```

Initialization of the histogram was tackled by using a `Factory`.

```mermaid
sequenceDiagram
    participant Agent as Agent Startup
    participant MeterInstaller
    participant CoreTracer
    participant Timer
    participant DDSketchHistograms
    participant Factory as Histograms.Factory
    participant DDTraceCore as dd-trace-core code

    Agent->>MeterInstaller: startup
    MeterInstaller->>MeterInstaller: creates MonitoringImpl
    MeterInstaller->>CoreTracer: construction begins
    CoreTracer->>Timer: creates first Timer (e.g., traceWriteTimer)
    Timer->>DDSketchHistograms: triggers class load
    DDSketchHistograms->>DDSketchHistograms: static initializer executes
    DDSketchHistograms->>Factory: register(INSTANCE)
    Note over Factory: Factory now holds DDSketchHistograms
    DDTraceCore->>Factory: Factory.get()
    Factory-->>DDTraceCore: returns DDSketchHistograms instance
```

In my opinion, the initialisation of the histograms deserves to be more explicit in the early init stage, i.e. around `MeterInstaller` or `MonitoringImpl`. 


The fact that `metrics-lib` and `metrics-api` both share the package `datadog.metrics.api` is actually a problem, as bootstrap classloader tried to load `metrics-lib` classes in the bootstrap, rather than under `metrics` "domain".

I also moved `datadog.metrics.statsd`, under `api`/`impl` to avoid the same problem. In particular this failed in graalvm smoke tests, this issue should have been found earlier than smoke tests in my opinion.
> ```
> Caused by: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved type during parsing: datadog.metrics.statsd.DDAgentStatsDClientManager. This error is reported at image build time because class datadog.trace.agent.tooling.nativeimage.TracerActivation is registered for linking at image build time by system default
> ```

* The `dd-trace-core`'s `AggregateMetricTest` need to initialize the metrics lib.
* The `integration-testing`'s `InstrumentSpecification` need to initialize the metrics lib.

----

Takeaway: Registering a product is not a straightforward task. 
1. It's not properly modelled in our build. 
2. The process of splitting and exposing API / Impl and "Agent", is not well defined.

----

Commits for review on this branch (since GitHub now says there's 0 commits)

<img width="2042" height="472" alt="image" src="https://github.com/user-attachments/assets/169f32c9-17e6-4ae1-97b6-006b37940035" />


* e0daf0f19c 2026-01-23 21:57 G fix: Move statsd package under api and impl  (HEAD -> bdu/communications, origin/bdu/communications) brice.dutheil@gmail.com
* a6ccf49707 2026-01-23 17:44 G fix: Boostrap classloader issue, metrics-api and metrics-lib classes had same package  brice.dutheil@gmail.com
* 5761549825 2026-01-23 14:18 G fix: Agent jar structure  brice.dutheil@gmail.com
* e28c1f6c0b 2026-01-23 11:15 G fix: Duplicate classes in metrics/  brice.dutheil@gmail.com
* 3b5fc1b0df 2026-01-23 10:04 G fix: Move sketches-java to shared and fix dd-trace-core compilation  brice.dutheil@gmail.com
* a293305d54 2026-01-22 18:09 G fix: Make metrics-lib land correctly in the tracer jar  brice.dutheil@gmail.com