### PR TITLE
🍒 10416 - Bump java profiler to 1.36.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ forbiddenapis = "3.10"
 spotbugs_annotations = "4.9.8"
 
 # DataDog libs and forks
-ddprof = "1.34.4"
+ddprof = "1.36.1"
 dogstatsd = "4.4.3"
 okhttp = "3.12.15" # Datadog fork to support Java 7
 


### PR DESCRIPTION
Backport #10416 to release/v1.58.x