### PR TITLE
disable jsoup exploration tests

### DIFF
--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -44,25 +44,26 @@ build-exploration-tests-image:
       - "*_surefire-reports.tar.gz"
       - "*_debugger-dumps.tar.gz"
 
-exploration-tests-method-jsoup:
-  needs: [ build ]
-  dependencies:
-    - build
-  <<: *common-exploration-tests
-  variables:
-    PROJECT: jsoup
-  script:
-    - ./run-exploration-tests.sh "method" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
-
-exploration-tests-line-jsoup:
-  needs: [ build ]
-  dependencies:
-    - build
-  <<: *common-exploration-tests
-  variables:
-    PROJECT: jsoup
-  script:
-    - ./run-exploration-tests.sh "line" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
+# TODO fix them
+# exploration-tests-method-jsoup:
+#   needs: [ build ]
+#   dependencies:
+#     - build
+#   <<: *common-exploration-tests
+#   variables:
+#     PROJECT: jsoup
+#   script:
+#     - ./run-exploration-tests.sh "method" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
+#
+# exploration-tests-line-jsoup:
+#   needs: [ build ]
+#   dependencies:
+#     - build
+#   <<: *common-exploration-tests
+#   variables:
+#     PROJECT: jsoup
+#   script:
+#     - ./run-exploration-tests.sh "line" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
 
 exploration-tests-method-jackson-core:
   needs: [ build ]


### PR DESCRIPTION
# What Does This Do
disable jsoup exploration test that are not passing anymore due to change in CI runner see #10414
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
