### PR TITLE
🪞 10309 - Add long running traces to flare report

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceDumpJsonExporter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceDumpJsonExporter.java
@@ -3,12 +3,9 @@ package datadog.trace.common.writer;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
-import datadog.trace.api.flare.TracerFlare;
 import datadog.trace.core.DDSpan;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.zip.ZipOutputStream;
 
 public class TraceDumpJsonExporter implements Writer {
 
@@ -17,11 +14,9 @@ public class TraceDumpJsonExporter implements Writer {
           .add(DDSpanJsonAdapter.buildFactory(false))
           .build()
           .adapter(Types.newParameterizedType(Collection.class, DDSpan.class));
-  private StringBuilder dumpText;
-  private ZipOutputStream zip;
+  private final StringBuilder dumpText;
 
-  public TraceDumpJsonExporter(ZipOutputStream zip) {
-    this.zip = zip;
+  public TraceDumpJsonExporter() {
     dumpText = new StringBuilder();
   }
 
@@ -32,7 +27,8 @@ public class TraceDumpJsonExporter implements Writer {
 
   @Override
   public void write(List<DDSpan> trace) {
-    // Do nothing
+    Collection<DDSpan> collectionTrace = trace;
+    write(collectionTrace);
   }
 
   @Override
@@ -42,12 +38,12 @@ public class TraceDumpJsonExporter implements Writer {
 
   @Override
   public boolean flush() {
-    try {
-      TracerFlare.addText(zip, "pending_traces.txt", dumpText.toString());
-    } catch (IOException e) {
-      // do nothing
-    }
+    // do nothing
     return true;
+  }
+
+  public String getDumpJson() {
+    return dumpText.toString();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
@@ -1,15 +1,29 @@
 package datadog.trace.core;
 
+import static java.util.Comparator.comparingLong;
+
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.internal.VisibleForTesting;
+import datadog.trace.api.flare.TracerFlare;
+import datadog.trace.common.writer.TraceDumpJsonExporter;
 import datadog.trace.core.monitor.HealthMetrics;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class LongRunningTracesTracker {
+public class LongRunningTracesTracker implements TracerFlare.Reporter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LongRunningTracesTracker.class);
+  private static final int MAX_DUMPED_TRACES = 50;
+  private static final Comparator<PendingTrace> TRACE_BY_START_TIME =
+      comparingLong(PendingTrace::getRunningTraceStartTime);
+
   private final DDAgentFeaturesDiscovery features;
   private final HealthMetrics healthMetrics;
   private long lastFlushMilli = 0;
@@ -42,6 +56,8 @@ public class LongRunningTracesTracker {
         (int) TimeUnit.SECONDS.toMillis(config.getLongRunningTraceFlushInterval());
     this.features = sharedCommunicationObjects.featuresDiscovery(config);
     this.healthMetrics = healthMetrics;
+
+    TracerFlare.addReporter(this);
   }
 
   public boolean add(PendingTraceBuffer.Element element) {
@@ -57,7 +73,7 @@ public class LongRunningTracesTracker {
     return true;
   }
 
-  private void addTrace(PendingTrace trace) {
+  private synchronized void addTrace(PendingTrace trace) {
     if (trace.empty()) {
       return;
     }
@@ -68,7 +84,7 @@ public class LongRunningTracesTracker {
     traceArray.add(trace);
   }
 
-  public void flushAndCompact(long nowMilli) {
+  public synchronized void flushAndCompact(long nowMilli) {
     if (nowMilli < lastFlushMilli + TimeUnit.SECONDS.toMillis(1)) {
       return;
     }
@@ -149,5 +165,26 @@ public class LongRunningTracesTracker {
   @VisibleForTesting
   int getDropped() {
     return dropped;
+  }
+
+  public String getTracesAsJson() {
+    try (TraceDumpJsonExporter writer = new TraceDumpJsonExporter()) {
+      List<PendingTrace> traces;
+      synchronized (this) {
+        traces = new ArrayList<>(traceArray);
+      }
+      traces.sort(TRACE_BY_START_TIME);
+
+      int limit = Math.min(traces.size(), MAX_DUMPED_TRACES);
+      for (int i = 0; i < limit; i++) {
+        writer.write(traces.get(i).getSpans());
+      }
+      return writer.getDumpJson();
+    }
+  }
+
+  @Override
+  public void addReportToFlare(ZipOutputStream zip) throws IOException {
+    TracerFlare.addText(zip, "long_running_traces.txt", getTracesAsJson());
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -66,6 +66,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
     private final MessagePassingBlockingQueue<Element> queue;
     private final Thread worker;
     private final TimeSource timeSource;
+    private final HealthMetrics healthMetrics;
 
     private volatile boolean closed = false;
     private final AtomicInteger flushCounter = new AtomicInteger(0);
@@ -104,6 +105,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
           if (!pendingTrace.writeOnBufferFull()) {
             return;
           }
+          healthMetrics.onPendingWriteAround();
           pendingTrace.write();
         }
       }
@@ -326,6 +328,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
       this.queue = Queues.mpscBlockingConsumerArrayQueue(bufferSize);
       this.worker = newAgentThread(TRACE_MONITOR, new Worker());
       this.timeSource = timeSource;
+      this.healthMetrics = healthMetrics;
       boolean runningSpansEnabled = config.isLongRunningTraceEnabled();
       this.runningTracesTracker =
           runningSpansEnabled

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -73,6 +73,23 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
     private final LongRunningTracesTracker runningTracesTracker;
 
+    private void dumpTraces() {
+      if (worker.isAlive()) {
+        int count = dumpCounter.get();
+        int loop = 1;
+        boolean signaled = queue.offer(DUMP_ELEMENT);
+        while (!closed && !signaled) {
+          yieldOrSleep(loop++);
+          signaled = queue.offer(DUMP_ELEMENT);
+        }
+        int newCount = dumpCounter.get();
+        while (!closed && count >= newCount) {
+          yieldOrSleep(loop++);
+          newCount = dumpCounter.get();
+        }
+      }
+    }
+
     public boolean longRunningSpansEnabled() {
       return runningTracesTracker != null;
     }
@@ -135,6 +152,18 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
           yieldOrSleep(loop++);
           newCount = flushCounter.get();
         }
+      }
+    }
+
+    private String getDumpJson() {
+      try (TraceDumpJsonExporter writer = new TraceDumpJsonExporter()) {
+        for (Element e : DumpDrain.DUMP_DRAIN.collectTraces()) {
+          if (e instanceof PendingTrace) {
+            PendingTrace trace = (PendingTrace) e;
+            writer.write(trace.getSpans());
+          }
+        }
+        return writer.getDumpJson();
       }
     }
 
@@ -371,32 +400,12 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
     @Override
     public void prepareForFlare() {
-      if (buffer.worker.isAlive()) {
-        int count = buffer.dumpCounter.get();
-        int loop = 1;
-        boolean signaled = buffer.queue.offer(DelayingPendingTraceBuffer.DUMP_ELEMENT);
-        while (!buffer.closed && !signaled) {
-          buffer.yieldOrSleep(loop++);
-          signaled = buffer.queue.offer(DelayingPendingTraceBuffer.DUMP_ELEMENT);
-        }
-        int newCount = buffer.dumpCounter.get();
-        while (!buffer.closed && count >= newCount) {
-          buffer.yieldOrSleep(loop++);
-          newCount = buffer.dumpCounter.get();
-        }
-      }
+      buffer.dumpTraces();
     }
 
     @Override
     public void addReportToFlare(ZipOutputStream zip) throws IOException {
-      TraceDumpJsonExporter writer = new TraceDumpJsonExporter(zip);
-      for (Element e : DelayingPendingTraceBuffer.DumpDrain.DUMP_DRAIN.collectTraces()) {
-        if (e instanceof PendingTrace) {
-          PendingTrace trace = (PendingTrace) e;
-          writer.write(trace.getSpans());
-        }
-      }
-      writer.flush();
+      TracerFlare.addText(zip, "pending_traces.txt", buffer.getDumpJson());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -71,6 +71,8 @@ public abstract class HealthMetrics implements AutoCloseable {
   public void onFailedSend(
       final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}
 
+  public void onPendingWriteAround() {}
+
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {}
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -85,6 +85,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final LongAdder scopeCloseErrors = new LongAdder();
   private final LongAdder userScopeCloseErrors = new LongAdder();
 
+  private final LongAdder pendingWriteAround = new LongAdder();
+
   private final LongAdder longRunningTracesWrite = new LongAdder();
   private final LongAdder longRunningTracesDropped = new LongAdder();
   private final LongAdder longRunningTracesExpired = new LongAdder();
@@ -299,6 +301,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
+  public void onPendingWriteAround() {
+    pendingWriteAround.increment();
+  }
+
+  @Override
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {
     longRunningTracesWrite.add(write);
     longRunningTracesDropped.add(dropped);
@@ -488,6 +495,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(
             target.statsd, "scope.user.close.error", target.userScopeCloseErrors, NO_TAGS);
 
+        reportIfChanged(target.statsd, "pending.write_around", target.pendingWriteAround, NO_TAGS);
+
         reportIfChanged(
             target.statsd, "long-running.write", target.longRunningTracesWrite, NO_TAGS);
         reportIfChanged(
@@ -626,6 +635,9 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         + scopeCloseErrors.sum()
         + "\nuserScopeCloseErrors="
         + userScopeCloseErrors.sum()
+        + "\n"
+        + "\npendingWriteAround="
+        + pendingWriteAround.sum()
         + "\n"
         + "\nlongRunningTracesWrite="
         + longRunningTracesWrite.sum()


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/10309
**Original Author:** @deejgregor
**Original Branch:** deejgregor/dd-trace-java:feature-add-long-running-traces-to-flare

Closes #10309

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*