### PR TITLE
Avoid final field mutation in CapturedSnapshotTest

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CorrelationAccess.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CorrelationAccess.java
@@ -19,6 +19,9 @@ public final class CorrelationAccess {
 
   private static volatile boolean REUSE_INSTANCE = true;
 
+  // Only for testing
+  private static volatile CorrelationAccess TEST_INSTANCE = null;
+
   private static class Singleton {
     private static final CorrelationAccess INSTANCE = new CorrelationAccess();
   }
@@ -59,7 +62,18 @@ public final class CorrelationAccess {
   }
 
   public static CorrelationAccess instance() {
-    return REUSE_INSTANCE ? Singleton.INSTANCE : new CorrelationAccess();
+    if (TEST_INSTANCE != null) {
+      return TEST_INSTANCE;
+    } else if (REUSE_INSTANCE) {
+      return Singleton.INSTANCE;
+    } else {
+      return new CorrelationAccess();
+    }
+  }
+
+  // Only for testing
+  public static void setTestInstance(CorrelationAccess testInstance) {
+    TEST_INSTANCE = testInstance;
   }
 
   public boolean isAvailable() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -67,8 +67,6 @@ import groovy.lang.GroovyClassLoader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -2845,19 +2843,8 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     return listener;
   }
 
-  // TODO: JEP 500 - avoid mutating final fields
-  private void setCorrelationSingleton(Object instance) {
-    Class<?> singletonClass = CorrelationAccess.class.getDeclaredClasses()[0];
-    try {
-      Field instanceField = singletonClass.getDeclaredField("INSTANCE");
-      instanceField.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
-      modifiersField.setAccessible(true);
-      modifiersField.setInt(instanceField, instanceField.getModifiers() & ~Modifier.FINAL);
-      instanceField.set(null, instance);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      e.printStackTrace();
-    }
+  private void setCorrelationSingleton(CorrelationAccess instance) {
+    CorrelationAccess.setTestInstance(instance);
   }
 
   private Snapshot assertOneSnapshot(TestSnapshotListener listener) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -20,6 +20,7 @@ import com.datadog.debugger.util.TestSnapshotListener;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -67,6 +68,7 @@ public class CapturingTestBase {
     ProbeRateLimiter.resetAll();
     Assertions.assertFalse(DebuggerContext.isInProbe());
     Redaction.clearUserDefinedTypes();
+    CorrelationAccess.setTestInstance(null);
   }
 
   @BeforeEach


### PR DESCRIPTION
# What Does This Do

Add a test-only `TEST_INSTANCE` to the `CorrelationAccess` class. Now instead of mutating a final field in `CapturedSnapshotTest` to introduce a `spy`, we can set the `spy` to be a non-final `TEST_INSTANCE`.

# Motivation

Mutating final fields will introduce warnings starting in Java 26 and be disallowed in a later release ([JEP 500](https://openjdk.org/jeps/500)).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/APMLP-594

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
