### PR TITLE
Support DD_TRACE_LOG_LEVEL

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1481,9 +1481,12 @@ public class Agent {
     if (isDebugMode()) {
       logLevel = "DEBUG";
     } else {
-      logLevel = ddGetProperty("dd.log.level");
+      logLevel = ddGetProperty("dd.trace.log.level");
       if (null == logLevel) {
-        logLevel = EnvironmentVariables.get("OTEL_LOG_LEVEL");
+        logLevel = ddGetProperty("dd.log.level");
+        if (null == logLevel) {
+          logLevel = EnvironmentVariables.get("OTEL_LOG_LEVEL");
+        }
       }
     }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -35,6 +35,7 @@ public final class GeneralConfig {
       "experimental.propagate.process.tags.enabled";
 
   public static final String LOG_LEVEL = "log.level";
+  public static final String TRACE_LOG_LEVEL = "trace.log.level";
   public static final String TRACE_DEBUG = "trace.debug";
   public static final String TRACE_TRIAGE = "trace.triage";
   public static final String TRIAGE_REPORT_TRIGGER = "triage.report.trigger";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -403,6 +403,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESO
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
+import static datadog.trace.api.config.GeneralConfig.TRACE_LOG_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_COMPUTATION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_TAGS;
 import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
@@ -2718,7 +2719,7 @@ public class Config {
 
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
-    logLevel = configProvider.getString(LOG_LEVEL);
+    logLevel = configProvider.getString(TRACE_LOG_LEVEL, null, LOG_LEVEL);
     debugEnabled = configProvider.getBoolean(TRACE_DEBUG, false);
     triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, instrumenterConfig.isTriageEnabled());
     triageReportTrigger = configProvider.getString(TRIAGE_REPORT_TRIGGER);

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -2209,12 +2209,12 @@
         "aliases": ["DD_LOGS_INJECTION"]
       }
     ],
-    "DD_LOG_LEVEL": [
+    "DD_TRACE_LOG_LEVEL": [
       {
-        "version": "B",
+        "version": "A",
         "type": "string",
         "default": null,
-        "aliases": []
+        "aliases": ["DD_LOG_LEVEL"]
       }
     ],
     "DD_LOG_FORMAT_JSON": [


### PR DESCRIPTION
# What Does This Do

Support `DD_TRACE_LOG_LEVEL` as an alias for `DD_LOG_LEVEL`, with `DD_TRACE_LOG_LEVEL` taking precedence.

# Motivation

Consistency with other languages, provides a way for users to control the tracer's log level separate to the main agent.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
