### PR TITLE
Log profiler flare messages at WARN level

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilerFlareLogger.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilerFlareLogger.java
@@ -7,10 +7,14 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
 public final class ProfilerFlareLogger implements TracerFlare.Reporter {
+  private static final Logger log = LoggerFactory.getLogger(ProfilerFlareLogger.class);
+
   private static final class Singleton {
     private static final ProfilerFlareLogger INSTANCE = new ProfilerFlareLogger();
   }
@@ -36,6 +40,9 @@ public final class ProfilerFlareLogger implements TracerFlare.Reporter {
    * @return Returns {@literal true} if the message was stored for flare, {@literal false} otherwise
    */
   public boolean log(String msgFormat, Object... args) {
+    // if something is important enough to store in flare, perhaps logging at WARN level is fine
+    log.warn(msgFormat, args);
+
     FormattingTuple ft = MessageFormatter.arrayFormat(msgFormat, args);
     StringBuilder sb =
         new StringBuilder(Instant.now().atZone(ZoneOffset.UTC).toString())


### PR DESCRIPTION
# What Does This Do

Logs profiler flare messages at WARN level in addition to storing them for the flare report. This ensures important profiler diagnostic messages are visible in application logs.

# Motivation

Messages logged via `ProfilerFlareLogger` are important enough to be included in flare reports, which means they likely indicate issues worth investigating. By also logging them at WARN level, operators can see these messages in real-time without waiting for a flare to be generated.

# Additional Notes

N/A

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [[PROF-13551](https://datadoghq.atlassian.net/browse/PROF-13551)]

[PROF-13551]: https://datadoghq.atlassian.net/browse/PROF-13551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ