### PR TITLE
Add test case for OF.7: empty targeting key compliance

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -213,6 +213,11 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("simple-string")
             .result(new Result<>("default").reason(ERROR.name()).errorCode(TARGETING_KEY_MISSING)),
+        // OF.7: Empty string is a valid targeting key - evaluation should proceed as normal
+        new TestCase<>("default")
+            .flag("simple-string")
+            .targetingKey("")
+            .result(new Result<>("test-value").reason(TARGETING_MATCH.name()).variant("on")),
         new TestCase<>("default")
             .flag("non-existent-flag")
             .targetingKey("user-123")


### PR DESCRIPTION
## Motivation

OpenFeature specification rule OF.7 states that an empty string shall be accepted as a valid targeting key, and flag evaluation should proceed as normal. Previously, the OpenFeature Java SDK's `MutableContext` incorrectly converted empty string targeting keys to `null`, breaking OF.7 compliance.

This was fixed upstream in [open-feature/java-sdk#1807](https://github.com/open-feature/java-sdk/pull/1807) and released in SDK version 1.20.1 (already in dd-trace-java master).

## Changes

- Added a test case in `DDEvaluatorTest` to verify that empty string targeting keys are handled correctly per OF.7
- The test ensures evaluation proceeds normally (returns `TARGETING_MATCH`) rather than failing with `TARGETING_KEY_MISSING`

## Test Plan

- [x] `./gradlew :products:feature-flagging:feature-flagging-api:test` passes