### PR TITLE
Add support for content parts and image URLs in AI Guard

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/custom/aiguard/MessageWriter.java
+++ b/communication/src/main/java/datadog/communication/serialization/custom/aiguard/MessageWriter.java
@@ -14,14 +14,49 @@ public class MessageWriter implements ValueWriter<AIGuard.Message> {
       final AIGuard.Message value, final Writable writable, final EncodingCache encodingCache) {
     final int[] size = {0};
     final boolean hasRole = isNotBlank(value.getRole(), size);
-    final boolean hasContent = isNotBlank(value.getContent(), size);
     final boolean hasToolCallId = isNotBlank(value.getToolCallId(), size);
     final boolean hasToolCalls = isNotEmpty(value.getToolCalls(), size);
+
+    final boolean hasContentParts = isNotEmpty(value.getContentParts(), size);
+    final boolean hasContentString = !hasContentParts && isNotBlank(value.getContent(), size);
+
     writable.startMap(size[0]);
     writeString(hasRole, "role", value.getRole(), writable, encodingCache);
-    writeString(hasContent, "content", value.getContent(), writable, encodingCache);
+
+    if (hasContentParts) {
+      writeContentParts("content", value.getContentParts(), writable, encodingCache);
+    } else {
+      writeString(hasContentString, "content", value.getContent(), writable, encodingCache);
+    }
+
     writeString(hasToolCallId, "tool_call_id", value.getToolCallId(), writable, encodingCache);
     writeToolCallArray(hasToolCalls, "tool_calls", value.getToolCalls(), writable, encodingCache);
+  }
+
+  private static void writeContentParts(
+      final String key,
+      final List<AIGuard.ContentPart> contentParts,
+      final Writable writable,
+      final EncodingCache encodingCache) {
+    writable.writeString(key, encodingCache);
+    writable.startArray(contentParts.size());
+
+    for (final AIGuard.ContentPart part : contentParts) {
+      writable.startMap(2);
+
+      writable.writeString("type", encodingCache);
+      writable.writeString(part.getType().toString(), encodingCache);
+
+      if (part.getType() == AIGuard.ContentPart.Type.TEXT) {
+        writable.writeString("text", encodingCache);
+        writable.writeString(part.getText(), encodingCache);
+      } else if (part.getType() == AIGuard.ContentPart.Type.IMAGE_URL) {
+        writable.writeString("image_url", encodingCache);
+        writable.startMap(1);
+        writable.writeString("url", encodingCache);
+        writable.writeString(part.getImageUrl().getUrl(), encodingCache);
+      }
+    }
   }
 
   private static void writeString(

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/AIGuardController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/AIGuardController.java
@@ -65,6 +65,21 @@ public class AIGuardController {
     }
   }
 
+  @GetMapping(value = "/multimodal")
+  public ResponseEntity<?> multimodal() {
+    final Evaluation result =
+        AIGuard.evaluate(
+            asList(
+                Message.message("system", "You are a beautiful AI"),
+                Message.message(
+                    "user",
+                    asList(
+                        AIGuard.ContentPart.text("Describe this image:"),
+                        AIGuard.ContentPart.imageUrl("https://example.com/image.jpg"),
+                        AIGuard.ContentPart.text("What do you see?")))));
+    return ResponseEntity.ok(result);
+  }
+
   /** Mocking endpoint for the AI Guard REST API */
   @SuppressWarnings("unchecked")
   @PostMapping(
@@ -80,18 +95,40 @@ public class AIGuardController {
     final Map<String, Object> last = messages.get(messages.size() - 1);
     String action = "ALLOW";
     String reason = "The prompt looks harmless";
-    String content = (String) last.get("content");
-    if (content.startsWith("You should not trust me")) {
-      action = "DENY";
-      reason = "I am feeling suspicious today";
-    } else if (content.startsWith("Nuke yourself")) {
-      action = "ABORT";
-      reason = "The user is trying to destroy me";
+
+    // Handle both string content and content parts
+    Object contentObj = last.get("content");
+    String content = null;
+    boolean hasContentParts = false;
+
+    if (contentObj instanceof String) {
+      content = (String) contentObj;
+    } else if (contentObj instanceof List) {
+      // Content parts - check if it contains an image
+      List<Map<String, Object>> contentParts = (List<Map<String, Object>>) contentObj;
+      hasContentParts = true;
+      for (Map<String, Object> part : contentParts) {
+        if ("image_url".equals(part.get("type"))) {
+          reason = "Multimodal prompt detected";
+          break;
+        }
+      }
     }
+
+    if (content != null) {
+      if (content.startsWith("You should not trust me")) {
+        action = "DENY";
+        reason = "I am feeling suspicious today";
+      } else if (content.startsWith("Nuke yourself")) {
+        action = "ABORT";
+        reason = "The user is trying to destroy me";
+      }
+    }
+
     final Map<String, Object> evaluation = new HashMap<>(3);
     evaluation.put("action", action);
     evaluation.put("reason", reason);
-    evaluation.put("is_blocking_enabled", content.endsWith("[block]"));
+    evaluation.put("is_blocking_enabled", content != null && content.endsWith("[block]"));
     return ResponseEntity.ok()
         .body(Collections.singletonMap("data", Collections.singletonMap("attributes", evaluation)));
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/aiguard/AIGuard.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/aiguard/AIGuard.java
@@ -2,7 +2,12 @@ package datadog.trace.api.aiguard;
 
 import datadog.trace.api.aiguard.noop.NoOpEvaluator;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * SDK for calling the AIGuard REST API to evaluate AI prompts and tool calls for security threats.
@@ -187,14 +192,174 @@ public abstract class AIGuard {
   }
 
   /**
-   * Represents a message in an AI conversation. Messages can represent user prompts, assistant
-   * responses, system messages, or tool outputs.
+   * Represents an image URL in a content part. Images can be provided as URLs or data URIs.
    *
    * <p>Example usage:
    *
    * <pre>{@code
-   * // User prompt
+   * // Image from URL
+   * var imageUrl = new AIGuard.ImageURL("https://example.com/image.jpg");
+   *
+   * // Image from data URI
+   * var dataUri = new AIGuard.ImageURL("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA...");
+   * }</pre>
+   */
+  public static class ImageURL {
+
+    private final String url;
+
+    /**
+     * Creates a new ImageURL with the specified URL.
+     *
+     * @param url the image URL or data URI
+     * @throws NullPointerException if url is null
+     */
+    public ImageURL(@Nonnull final String url) {
+      this.url = Objects.requireNonNull(url, "url cannot be null");
+    }
+
+    /**
+     * Returns the image URL.
+     *
+     * @return the image URL or data URI
+     */
+    @Nonnull
+    public String getUrl() {
+      return url;
+    }
+  }
+
+  /**
+   * Represents a content part within a message. Content parts can be text or images, enabling
+   * multimodal AI prompts.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * // Text content
+   * var textPart = AIGuard.ContentPart.text("Describe this image:");
+   *
+   * // Image content from URL
+   * var imagePart = AIGuard.ContentPart.imageUrl("https://example.com/image.jpg");
+   *
+   * // Multimodal message with text and image
+   * var message = AIGuard.Message.message("user", List.of(textPart, imagePart));
+   * }</pre>
+   */
+  public static class ContentPart {
+
+    /** Type of content part. */
+    public enum Type {
+      /** Text content */
+      TEXT,
+      /** Image URL content */
+      IMAGE_URL;
+
+      @Override
+      public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+      }
+    }
+
+    private final Type type;
+    @Nullable private final String text;
+    @Nullable private final ImageURL imageUrl;
+
+    /**
+     * Private constructor to enforce use of factory methods.
+     *
+     * @param type the content part type
+     * @param text the text content (required for TEXT type)
+     * @param imageUrl the image URL (required for IMAGE_URL type)
+     */
+    private ContentPart(
+        @Nonnull final Type type, @Nullable final String text, @Nullable final ImageURL imageUrl) {
+      this.type = type;
+      this.text = text;
+      this.imageUrl = imageUrl;
+
+      if (type == Type.TEXT && text == null) {
+        throw new IllegalArgumentException("text content part requires text field");
+      }
+      if (type == Type.IMAGE_URL && imageUrl == null) {
+        throw new IllegalArgumentException("image_url content part requires imageUrl field");
+      }
+    }
+
+    /**
+     * Returns the type of this content part.
+     *
+     * @return the content part type (TEXT or IMAGE_URL)
+     */
+    @Nonnull
+    public Type getType() {
+      return type;
+    }
+
+    /**
+     * Returns the text content of this part.
+     *
+     * @return the text content, or null if this is an IMAGE_URL part
+     */
+    @Nullable
+    public String getText() {
+      return text;
+    }
+
+    /**
+     * Returns the image URL of this part.
+     *
+     * @return the image URL, or null if this is a TEXT part
+     */
+    @Nullable
+    public ImageURL getImageUrl() {
+      return imageUrl;
+    }
+
+    /**
+     * Creates a text content part.
+     *
+     * @param text the text content
+     * @return a new ContentPart with TEXT type
+     * @throws NullPointerException if text is null
+     */
+    @Nonnull
+    public static ContentPart text(@Nonnull final String text) {
+      Objects.requireNonNull(text, "text cannot be null");
+      return new ContentPart(Type.TEXT, text, null);
+    }
+
+    /**
+     * Creates an image content part from a URL string.
+     *
+     * @param url the image URL or data URI
+     * @return a new ContentPart with IMAGE_URL type
+     * @throws NullPointerException if url is null
+     */
+    @Nonnull
+    public static ContentPart imageUrl(@Nonnull final String url) {
+      return new ContentPart(Type.IMAGE_URL, null, new ImageURL(url));
+    }
+  }
+
+  /**
+   * Represents a message in an AI conversation. Messages can represent user prompts, assistant
+   * responses, system messages, or tool outputs.
+   *
+   * <p>Messages can contain either plain text content or structured content parts (text and
+   * images):
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * // User prompt with text
    * var userPrompt = AIGuard.Message.message("user", "What's the weather like?");
+   *
+   * // User prompt with text and image
+   * var multimodalPrompt = AIGuard.Message.message("user", List.of(
+   *     AIGuard.ContentPart.text("Describe this image:"),
+   *     AIGuard.ContentPart.imageUrl("https://example.com/image.jpg")
+   * ));
    *
    * // Assistant response with tool calls
    * var assistantWithTools = AIGuard.Message.assistant(
@@ -208,7 +373,8 @@ public abstract class AIGuard {
   public static class Message {
 
     private final String role;
-    private final String content;
+    @Nullable private final String content;
+    @Nullable private final List<ContentPart> contentParts;
     private final List<ToolCall> toolCalls;
     private final String toolCallId;
 
@@ -223,12 +389,41 @@ public abstract class AIGuard {
      *     response
      */
     public Message(
-        final String role,
-        final String content,
-        final List<ToolCall> toolCalls,
-        final String toolCallId) {
+        @Nonnull final String role,
+        @Nullable final String content,
+        @Nullable final List<ToolCall> toolCalls,
+        @Nullable final String toolCallId) {
       this.role = role;
       this.content = content;
+      this.contentParts = null;
+      this.toolCalls = toolCalls;
+      this.toolCallId = toolCallId;
+    }
+
+    /**
+     * Creates a new message with content parts (text and/or images).
+     *
+     * @param role the role of the message sender
+     * @param contentParts list of content parts
+     * @param toolCalls list of tool calls, or null
+     * @param toolCallId the tool call ID this message responds to, or null
+     * @throws IllegalArgumentException if contentParts contains null elements
+     */
+    public Message(
+        @Nonnull final String role,
+        @Nonnull final List<ContentPart> contentParts,
+        @Nullable final List<ToolCall> toolCalls,
+        @Nullable final String toolCallId) {
+      this.role = role;
+      this.content = null;
+
+      for (final ContentPart part : contentParts) {
+        if (part == null) {
+          throw new IllegalArgumentException("contentParts must not contain null elements");
+        }
+      }
+
+      this.contentParts = Collections.unmodifiableList(contentParts);
       this.toolCalls = toolCalls;
       this.toolCallId = toolCallId;
     }
@@ -245,10 +440,22 @@ public abstract class AIGuard {
     /**
      * Returns the text content of the message.
      *
-     * @return the message content, or null for assistant messages with only tool calls
+     * @return the message content, or null if using content parts or for assistant messages with
+     *     only tool calls
      */
+    @Nullable
     public String getContent() {
       return content;
+    }
+
+    /**
+     * Returns the content parts of the message.
+     *
+     * @return the content parts (text and images), or null if using plain text content
+     */
+    @Nullable
+    public List<ContentPart> getContentParts() {
+      return contentParts;
     }
 
     /**
@@ -276,8 +483,22 @@ public abstract class AIGuard {
      * @param content the text content of the message
      * @return a new Message instance
      */
-    public static Message message(final String role, final String content) {
+    @Nonnull
+    public static Message message(@Nonnull final String role, @Nonnull final String content) {
       return new Message(role, content, null, null);
+    }
+
+    /**
+     * Creates a message with specified role and content parts (text and/or images).
+     *
+     * @param role the role of the message sender (e.g., "user", "system")
+     * @param contentParts list of content parts (text and/or images)
+     * @return a new Message instance
+     */
+    @Nonnull
+    public static Message message(
+        @Nonnull final String role, @Nonnull final List<ContentPart> contentParts) {
+      return new Message(role, contentParts, null, null);
     }
 
     /**
@@ -297,8 +518,9 @@ public abstract class AIGuard {
      * @param toolCalls the tool calls the assistant wants to make
      * @return a new Message instance with role "assistant" and no text content
      */
-    public static Message assistant(final ToolCall... toolCalls) {
-      return new Message("assistant", null, Arrays.asList(toolCalls), null);
+    @Nonnull
+    public static Message assistant(@Nonnull final ToolCall... toolCalls) {
+      return new Message("assistant", (String) null, Arrays.asList(toolCalls), null);
     }
   }
 


### PR DESCRIPTION
# What Does This Do

* Add support for content parts in LLM messages sent with the AI Guard SDK. See [docs](https://docs-staging.datadoghq.com/smola/ai-guard-api-update/security/ai_guard/onboarding/?tab=python#user-prompt-format). See also the [PR for system-tests](https://github.com/DataDog/system-tests/pull/6115). The syntax here is a subset of OpenAI's Chat Completion API to send images ([docs](https://platform.openai.com/docs/guides/images-vision?api-mode=chat#analyze-images)).
* This lets customers send multi-modal prompts (text + images) to AI Guard. These images can be either HTTP URLs, or base64-encoded images in data URLs.


# Motivation

Support multi-modal prompts (text + images) in AI Guard.

# Additional Notes

Validated with system tests at https://github.com/DataDog/system-tests/pull/6131

Reference PR for dd-trace-py at https://github.com/DataDog/dd-trace-py/pull/15939

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-60264](https://datadoghq.atlassian.net/browse/APPSEC-60264)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-60264]: https://datadoghq.atlassian.net/browse/APPSEC-60264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ