### PR TITLE
Fix SymDB  when processing corrupted jars

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -143,7 +143,8 @@ public class SymDBEnablement implements ProductListener {
       try {
         jarPath = JarScanner.extractJarPath(clazz, symDBReport);
       } catch (URISyntaxException e) {
-        throw new RuntimeException(e);
+        LOGGER.debug("Failed to extract jar path for class {}", clazz.getTypeName(), e);
+        continue;
       }
       if (jarPath == null) {
         continue;
@@ -152,7 +153,11 @@ public class SymDBEnablement implements ProductListener {
         symDBReport.addMissingJar(jarPath.toString());
         continue;
       }
-      symbolAggregator.scanJar(symDBReport, jarPath, baos, buffer);
+      try {
+        symbolAggregator.scanJar(symDBReport, jarPath, baos, buffer);
+      } catch (Exception ex) {
+        LOGGER.debug("Failed to scan jar {}", jarPath, ex);
+      }
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
@@ -158,7 +158,11 @@ public class SymbolAggregator {
     while (!jarsToScanQueue.isEmpty()) {
       String jarPath = jarsToScanQueue.poll();
       LOGGER.debug("Scanning queued jar: {}", jarPath);
-      scanJar(SymDBReport.NO_OP, Paths.get(jarPath), baos, buffer);
+      try {
+        scanJar(SymDBReport.NO_OP, Paths.get(jarPath), baos, buffer);
+      } catch (Exception ex) {
+        LOGGER.debug("Failed to scan jar {}", jarPath, ex);
+      }
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolAggregatorTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolAggregatorTest.java
@@ -47,6 +47,36 @@ class SymbolAggregatorTest {
   }
 
   @Test
+  void testScanQueuedCorruptedJars() {
+    SymbolSink symbolSink = mock(SymbolSink.class);
+    SymbolAggregator symbolAggregator =
+        spy(new SymbolAggregator(ClassNameFiltering.allowAll(), emptyList(), symbolSink, 1));
+    // add first a corrupted jar
+    URL corruptedUrl = getClass().getResource("/com/datadog/debugger/classfiles/CommandLine.class");
+    CodeSource corruptedCodeSource =
+        new CodeSource(corruptedUrl, (java.security.cert.Certificate[]) null);
+    ProtectionDomain corruptedProtectionDomain = new ProtectionDomain(corruptedCodeSource, null);
+    symbolAggregator.parseClass(null, null, corruptedProtectionDomain);
+    // add second a clean jar
+    URL jarFileUrl = getClass().getResource("/debugger-symbol.jar");
+    CodeSource codeSource = new CodeSource(jarFileUrl, (java.security.cert.Certificate[]) null);
+    ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
+    symbolAggregator.parseClass(null, null, protectionDomain);
+    symbolAggregator.scanQueuedJars(null);
+    // clean jar should have been processed
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(symbolAggregator, atLeastOnce())
+        .parseClass(any(), captor.capture(), any(), eq(jarFileUrl.getFile()));
+    // captor.getAllValues().get(0) is the first argument of the first invocation of parseClass with
+    // null
+    assertEquals(
+        "com/datadog/debugger/symbol/SymbolExtraction01.class", captor.getAllValues().get(1));
+    assertEquals(
+        "BOOT-INF/classes/org/springframework/samples/petclinic/vet/VetController.class",
+        captor.getAllValues().get(2));
+  }
+
+  @Test
   @DisabledIf(
       value = "datadog.environment.JavaVirtualMachine#isJ9",
       disabledReason = "Flaky on J9 JVMs")


### PR DESCRIPTION

# What Does This Do
when processing jar file that are corrupted exceptions can be raised and will stop the process. Make sure we can process the next jars.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4950]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4950]: https://datadoghq.atlassian.net/browse/DEBUG-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ