### PR TITLE
Exclude broken dependency jersey-common:4.0.1

### DIFF
--- a/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey-2.0/build.gradle
@@ -3,6 +3,8 @@ muzzle {
     group = 'org.glassfish.jersey.core'
     module = 'jersey-common'
     versions = '[2,)'
+    // Version 4.0.1 is broken, see https://github.com/eclipse-ee4j/jersey/issues/6064
+    skipVersions = ['4.0.1']
     assertInverse = true
   }
 }
@@ -97,7 +99,8 @@ configurations.configureEach {
     all {
       if (candidate.group == 'org.glassfish.jersey.core'
         && candidate.module == 'jersey-common'
-        && candidate.version.startsWith('4.0.1')) {
+        && candidate.version.startsWith('4.0.1')
+        && name.startsWith('latestDep')) {
         reject('Version 4.0.1 is broken, see https://github.com/eclipse-ee4j/jersey/issues/6064')
       }
     }


### PR DESCRIPTION
# What Does This Do

This excludes the automatic addition of the broken `jersey-common:4.0.1` into the lockfile.

# Motivation

# Additional Notes

With this fix it won't set the broken 4.0.1 dependency when run:
`./gradlew :dd-java-agent:instrumentation:jersey:jersey-2.0:dependencies --write-locks`

https://github.com/DataDog/dd-trace-java/pull/10443#issuecomment-3800664171

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
