### PR TITLE
Avoid throwing exception for invalid modifiers

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -195,7 +195,7 @@ public class SymbolExtractor {
           results.add("deprecated");
           break;
         default:
-          throw new IllegalArgumentException("Invalid access modifiers: " + bit);
+          LOGGER.debug("Invalid class access modifiers: {}", bit);
       }
     }
     return results;
@@ -250,8 +250,11 @@ public class SymbolExtractor {
           results.add("deprecated");
           break;
         default:
-          throw new IllegalArgumentException(
-              "Invalid access modifiers method[" + methodNode.name + methodNode.desc + "]: " + bit);
+          LOGGER.debug(
+              "Invalid access modifiers method[{}::{}]: {}",
+              classNode.name,
+              methodNode.name + methodNode.desc,
+              bit);
       }
     }
     // if class is an interface && method has code && non-static this is a default method
@@ -302,7 +305,7 @@ public class SymbolExtractor {
           results.add("deprecated");
           break;
         default:
-          throw new IllegalArgumentException("Invalid access modifiers: " + bit);
+          LOGGER.debug("Invalid access modifiers: {}", bit);
       }
     }
     return results;


### PR DESCRIPTION
# What Does This Do
OpenJ9 is behaving weirdly for access modifiers

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-5053]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5053]: https://datadoghq.atlassian.net/browse/DEBUG-5053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ