### PR TITLE
Bump Gradle develocity plugin.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.3"
+  id("com.gradle.develocity") version "4.3.1"
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
# What Does This Do
Bump Gradle develocity plugin to `4.3.1`.

# Motivation
Latest tools.

# Additional Notes
