### PR TITLE
Enable Code Origin by default for JDK21+

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginConfigTest.java
@@ -22,8 +22,8 @@ public class CodeOriginConfigTest {
   @EnabledOnJre(JRE.JAVA_21)
   @Test
   public void defaultConfigJDK21() {
-    assertFalse(Config.get().isDebuggerCodeOriginEnabled());
-    assertFalse(InstrumenterConfig.get().isCodeOriginEnabled());
+    assertTrue(Config.get().isDebuggerCodeOriginEnabled());
+    assertTrue(InstrumenterConfig.get().isCodeOriginEnabled());
   }
 
   @EnabledOnJre(JRE.JAVA_17)

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -690,8 +690,8 @@ public class InstrumenterConfig {
               : ConfigProvider.getInstance());
 
   public static boolean getDefaultCodeOriginForSpanEnabled() {
-    if (JavaVirtualMachine.isJavaVersionAtLeast(25)) {
-      // activate by default Code Origin only for JDK25+
+    if (JavaVirtualMachine.isJavaVersionAtLeast(21)) {
+      // activate by default Code Origin only for JDK21+
       return true;
     }
     return false;


### PR DESCRIPTION
# What Does This Do
Modified test to ensure enablement by JDK version

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-4173]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-4173]: https://datadoghq.atlassian.net/browse/DEBUG-4173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ