### PR TITLE
Fix exploration tests

### DIFF
--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -44,26 +44,25 @@ build-exploration-tests-image:
       - "*_surefire-reports.tar.gz"
       - "*_debugger-dumps.tar.gz"
 
-# TODO fix them
-# exploration-tests-method-jsoup:
-#   needs: [ build ]
-#   dependencies:
-#     - build
-#   <<: *common-exploration-tests
-#   variables:
-#     PROJECT: jsoup
-#   script:
-#     - ./run-exploration-tests.sh "method" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
-#
-# exploration-tests-line-jsoup:
-#   needs: [ build ]
-#   dependencies:
-#     - build
-#   <<: *common-exploration-tests
-#   variables:
-#     PROJECT: jsoup
-#   script:
-#     - ./run-exploration-tests.sh "line" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
+exploration-tests-method-jsoup:
+  needs: [ build ]
+  dependencies:
+    - build
+  <<: *common-exploration-tests
+  variables:
+    PROJECT: jsoup
+  script:
+    - ./run-exploration-tests.sh "method" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
+
+exploration-tests-line-jsoup:
+  needs: [ build ]
+  dependencies:
+    - build
+  <<: *common-exploration-tests
+  variables:
+    PROJECT: jsoup
+  script:
+    - ./run-exploration-tests.sh "line" "$PROJECT" "mvn verify" "include_${PROJECT}.txt" "exclude_${PROJECT}.txt"
 
 exploration-tests-method-jackson-core:
   needs: [ build ]

--- a/dd-java-agent/agent-debugger/exploration-tests/jackson-core_exploration-tests.patch
+++ b/dd-java-agent/agent-debugger/exploration-tests/jackson-core_exploration-tests.patch
@@ -1,3 +1,16 @@
+diff --git a/pom.xml b/pom.xml
+index ae027596..5bbe70de 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -8,7 +8,7 @@
+   <parent>
+     <groupId>com.fasterxml.jackson</groupId>
+     <artifactId>jackson-base</artifactId>
+-    <version>2.16.3-SNAPSHOT</version>
++    <version>2.16.2</version>
+   </parent>
+   <groupId>com.fasterxml.jackson.core</groupId>
+   <artifactId>jackson-core</artifactId>
 diff --git a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncConcurrencyTest.java b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncConcurrencyTest.java
 index 2f7957d1..7a8ea388 100644
 --- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncConcurrencyTest.java

--- a/dd-java-agent/agent-debugger/exploration-tests/jackson-databind_exploration-tests.patch
+++ b/dd-java-agent/agent-debugger/exploration-tests/jackson-databind_exploration-tests.patch
@@ -1,3 +1,16 @@
+diff --git a/pom.xml b/pom.xml
+index 7c1510841..c539f5978 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -9,7 +9,7 @@
+   <parent>
+     <groupId>com.fasterxml.jackson</groupId>
+     <artifactId>jackson-base</artifactId>
+-    <version>2.16.3-SNAPSHOT</version>
++    <version>2.16.2</version>
+   </parent>
+   <groupId>com.fasterxml.jackson.core</groupId>
+   <artifactId>jackson-databind</artifactId>
 diff --git forkSrcPrefix/src/test/java/com/fasterxml/jackson/databind/misc/ThreadSafety1759Test.java forkDstPrefix/src/test/java/com/fasterxml/jackson/databind/misc/ThreadSafety1759Test.java
 index 68c52b600550268242d16614e6143104ce37961d..29f453c8c0e07d139edd095d1614dd287aa5d283 100644
 --- forkSrcPrefix/src/test/java/com/fasterxml/jackson/databind/misc/ThreadSafety1759Test.java

--- a/dd-java-agent/agent-debugger/exploration-tests/jsoup_exploration-tests.patch
+++ b/dd-java-agent/agent-debugger/exploration-tests/jsoup_exploration-tests.patch
@@ -1,15 +1,35 @@
+diff --git a/src/test/java/org/jsoup/integration/ProxyTest.java b/src/test/java/org/jsoup/integration/ProxyTest.java
+index 18c1a60b..b79d5ee7 100644
+--- a/src/test/java/org/jsoup/integration/ProxyTest.java
++++ b/src/test/java/org/jsoup/integration/ProxyTest.java
+@@ -12,6 +12,7 @@ import org.jsoup.nodes.Document;
+ import org.jsoup.nodes.Element;
+ import org.junit.jupiter.api.BeforeAll;
+ import org.junit.jupiter.api.Test;
++import org.junit.jupiter.api.Disabled;
+ import org.junit.jupiter.params.ParameterizedTest;
+ import org.junit.jupiter.params.provider.MethodSource;
+
+@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
+
+ /**
+  Tests Jsoup.connect proxy support */
++@Disabled
+ public class ProxyTest {
+     private static String echoUrl;
+     private static TestServer.ProxySettings proxy;
 diff --git a/src/test/java/org/jsoup/parser/HtmlParserTest.java b/src/test/java/org/jsoup/parser/HtmlParserTest.java
 index a67003a8..1201d1af 100644
 --- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
 +++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
 @@ -1033,7 +1033,7 @@ public class HtmlParserTest {
- 
+
          // Assert
          assertEquals(50000, doc.body().childNodeSize());
 -        assertTrue(System.currentTimeMillis() - start < 1000);
 +        //assertTrue(System.currentTimeMillis() - start < 10000);
      }
- 
+
      @Test
 diff --git a/src/test/java/org/jsoup/parser/ParserIT.java b/src/test/java/org/jsoup/parser/ParserIT.java
 index 54d757e7..467c10bc 100644


### PR DESCRIPTION
# What Does This Do
disable proxy tests for jsoup
update jackson-base to point on a stable release

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-5044]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5044]: https://datadoghq.atlassian.net/browse/DEBUG-5044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ