### PR TITLE
Avoid final field mutation in UnsafeUtils

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 def generalShadowJarConfig(ShadowJar shadowJarTask) {
   shadowJarTask.with {
     mergeServiceFiles()
+    zip64 = true
 
     duplicatesStrategy = DuplicatesStrategy.FAIL
 

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/TestDescriptorHandle.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/TestDescriptorHandle.java
@@ -2,10 +2,14 @@ package datadog.trace.instrumentation.junit5.execution;
 
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.util.MethodHandles;
-import datadog.trace.util.UnsafeUtils;
 import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.engine.TestDescriptor;
@@ -40,7 +44,7 @@ public class TestDescriptorHandle {
      * Cloning has to be done before each test retry to
      * compensate for the state modifications.
      */
-    this.testDescriptor = UnsafeUtils.tryShallowClone(testDescriptor);
+    this.testDescriptor = cloneIfNeeded(testDescriptor);
   }
 
   public TestDescriptor withIdSuffix(Map<String, Object> suffices) {
@@ -49,8 +53,99 @@ public class TestDescriptorHandle {
       updatedId = updatedId.append(e.getKey(), String.valueOf(e.getValue()));
     }
 
-    TestDescriptor descriptorClone = UnsafeUtils.tryShallowClone(testDescriptor);
+    TestDescriptor descriptorClone = cloneIfNeeded(testDescriptor);
     METHOD_HANDLES.invoke(UNIQUE_ID_SETTER, descriptorClone, updatedId);
     return descriptorClone;
+  }
+
+  private TestDescriptor cloneIfNeeded(TestDescriptor original) {
+    Class<?> clazz = original.getClass();
+    String name = clazz.getName();
+
+    if (name.endsWith(".TestMethodTestDescriptor")) {
+      // No need to clone for TestMethodTestDescriptor because no states are modified
+      return original;
+    }
+
+    if (name.endsWith(".TestTemplateInvocationTestDescriptor")) {
+      return copyConstructor(
+          original,
+          clazz,
+          "uniqueId",
+          "testClass",
+          "testMethod",
+          "invocationContext",
+          "index",
+          "configuration");
+    }
+
+    if (name.endsWith(".DynamicTestTestDescriptor")) {
+      return copyConstructor(
+          original, clazz, "uniqueId", "index", "dynamicTest", "source", "configuration");
+    }
+
+    throw new IllegalStateException("Unexpected class of TestDescriptor: " + name);
+  }
+
+  private TestDescriptor copyConstructor(TestDescriptor original, Class<?> clazz, String... names) {
+    try {
+      Map<String, Object> fields = getFields(clazz, original);
+      for (Constructor<?> ctr : clazz.getDeclaredConstructors()) {
+        Object[] args = match(ctr, fields, original, names);
+        if (args != null) {
+          ctr.setAccessible(true);
+          return (TestDescriptor) ctr.newInstance(args);
+        }
+      }
+      throw new IllegalStateException(
+          "Failed to find appropriate constructor to clone: " + clazz.getName());
+    } catch (Throwable e) {
+      throw new IllegalStateException("Failed to clone via constructor", e);
+    }
+  }
+
+  private Map<String, Object> getFields(Class<?> clazz, Object original)
+      throws IllegalAccessException {
+    Map<String, Object> fields = new HashMap<>();
+    while (clazz != null && clazz != Object.class) {
+      for (Field field : clazz.getDeclaredFields()) {
+        field.setAccessible(true);
+        Object value = field.get(original);
+
+        // Constructor may need `testClass` and `testMethod` parameters, but they are wrapped by
+        // `methodInfo`.
+        // Expand `methodInfo` to be used in constructor later.
+        if (field.getName().equals("methodInfo")) {
+          Map<String, Object> methodInfoFields = getFields(field.getType(), value);
+          fields.putAll(methodInfoFields);
+        }
+
+        fields.put(field.getName(), value);
+      }
+      clazz = clazz.getSuperclass();
+    }
+    return fields;
+  }
+
+  private Object[] match(
+      Constructor<?> ctr, Map<String, Object> fields, Object original, String... names)
+      throws IllegalAccessException {
+    int cnt = ctr.getParameterCount();
+
+    List<Object> args = new ArrayList<>();
+
+    for (String name : names) {
+      for (Map.Entry<String, Object> field : fields.entrySet()) {
+        String k = field.getKey();
+        Object v = field.getValue();
+
+        if (k.equals(name)) {
+          args.add(v);
+          break;
+        }
+      }
+    }
+
+    return args.size() == cnt ? args.toArray() : null;
   }
 }

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -270,6 +270,8 @@ dependencies {
   // it contains annotations that are also present in the instrumented application classes
   api("com.datadoghq:dd-javac-plugin-client:0.2.2")
 
+  implementation(libs.bytebuddy)
+
   testImplementation("org.snakeyaml:snakeyaml-engine:2.9")
   testImplementation(project(":utils:test-utils"))
   testImplementation(libs.bundles.junit5)

--- a/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
@@ -1,6 +1,5 @@
 package datadog.trace.util;
 
-import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import org.slf4j.Logger;
@@ -58,11 +57,12 @@ public abstract class UnsafeUtils {
     }
   }
 
-  // TODO: JEP 500 - avoid mutating final fields
-  @SuppressForbidden
   private static void cloneFields(Class<?> clazz, Object original, Object clone) throws Exception {
     for (Field field : clazz.getDeclaredFields()) {
-      if ((field.getModifiers() & Modifier.STATIC) != 0) {
+      if ((field.getModifiers() & Modifier.FINAL) != 0) {
+        log.debug(
+            "Skipping cloning final field {}. Final fields cannot be mutated. See JEP 500 for more details.",
+            field.getName());
         continue;
       }
       field.setAccessible(true);

--- a/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
@@ -1,5 +1,6 @@
 package datadog.trace.util;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import org.slf4j.Logger;
@@ -57,6 +58,10 @@ public abstract class UnsafeUtils {
     }
   }
 
+  // Field::set() is forbidden because it may be used to mutate final fields, disallowed by
+  // https://openjdk.org/jeps/500.
+  // However, in this case we skip final fields, so it is safe.
+  @SuppressForbidden
   private static void cloneFields(Class<?> clazz, Object original, Object clone) throws Exception {
     for (Field field : clazz.getDeclaredFields()) {
       if ((field.getModifiers() & Modifier.FINAL) != 0) {

--- a/internal-api/src/test/groovy/datadog/trace/util/UnsafeUtilsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/UnsafeUtilsTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class UnsafeUtilsTest extends Specification {
 
-  def "test try shallow clone"() {
+  def "test try shallow clone does not clone final fields"() {
     given:
     def inner = new MyClass("a", false, [], "b", 2, null, null)
     def instance = new MyClass("aaa", true, [ 4, 5, 6, ], "ddd", 1, new int[] {
@@ -16,13 +16,27 @@ class UnsafeUtilsTest extends Specification {
 
     then:
     clone !== instance
-    clone.a === instance.a
-    clone.b == instance.b
-    clone.c === instance.c
-    clone.d === instance.d
-    clone.e == instance.e
-    clone.f === instance.f
-    clone.g === instance.g
+    clone.a == null
+    clone.b == false
+    clone.c == null
+    clone.d == null
+    clone.e == 0
+    clone.f == null
+    clone.g == null
+  }
+
+  def "test try shallow clone clones non-final fields"() {
+    given:
+    def instance = new MyNonFinalClass("a", 1, [2, 3, 4])
+
+    when:
+    def clone = UnsafeUtils.tryShallowClone(instance)
+
+    then:
+    clone !== instance
+    clone.h == instance.h
+    clone.j == instance.j
+    clone.k === instance.k
   }
 
   private static class MyParentClass {
@@ -63,6 +77,18 @@ class UnsafeUtilsTest extends Specification {
       this.e = e
       this.f = f
       this.g = g
+    }
+  }
+
+  private static class MyNonFinalClass {
+    private String h
+    private int j
+    private List<Integer> k
+
+    MyNonFinalClass(String h, int j, List<Integer> k) {
+      this.h = h
+      this.j = j
+      this.k = k
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

When attempting to clone a final field using `UnsafeUtils::cloneFields`, skip and instead emit a debug warning that final fields cannot be mutated. Update tests to reflect this as well.

# Motivation

Prepare for [JEP 500](https://openjdk.org/jeps/500) which disallows final field mutations.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/APMLP-594

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
