### PR TITLE
Fix Synapse passthru spans finishing before status code is available

### DIFF
--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
@@ -114,7 +114,7 @@ public final class SynapseClientInstrumentation extends InstrumenterModule.Traci
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope beginResponse(
         @Advice.Argument(0) final NHttpClientConnection connection) {
-      // check and remove context so it won't be finished twice
+      // don't remove stored context here because the response callback may run multiple times
       Context context = (Context) connection.getContext().getAttribute(SYNAPSE_CONTEXT_KEY);
       if (null != context) {
         return context.attach();

--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
@@ -93,7 +93,7 @@ public final class SynapseServerInstrumentation extends InstrumenterModule.Traci
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope beginResponse(
         @Advice.Argument(0) final NHttpServerConnection connection) {
-      // check and remove context so it won't be finished twice
+      // don't remove stored context here because the response callback may run multiple times
       Context context = (Context) connection.getContext().getAttribute(SYNAPSE_CONTEXT_KEY);
       if (null != context) {
         return context.attach();


### PR DESCRIPTION
# What Does This Do
Fixed flaky Synapse passthru tracing by changing when we finish the HTTP span.
`responseReady` and `responseReceived` may be called before the `HttpResponse` (and status code) is available.
Instead of removing the stored context and finish span of the first callback, we keep the context until we see the real response status (or error), then finish the span once.

# Motivation
Test `test passthru request is traced` was sometimes failing with, because the span was finishing too early, before status code was known

# Additional Notes
With the passthru/NIO transport, `SourceHandler.responseReady()` and `TargetHandler.responseReceived()` can be called multiple times for the same connection
The first call can happen while the response is still null, and the actual 200 OK is set later.
Previously we removed the context and finished the span on that first call, so the later callback couldn’t tag the span

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
