### PR TITLE
Exclude 'testWallclockProfilingWithoutTracing' from running on Oracle JDK 8

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -495,6 +495,12 @@ class JFRBasedProfilingIntegrationTest {
   @DisplayName("Test wallclock profiling without tracing")
   public void testWallclockProfilingWithoutTracing(final TestInfo testInfo) throws Exception {
     Assumptions.assumeTrue(OperatingSystem.isLinux());
+    // TODO: Exclude the test on Oracle JDK 8 - the JMC parser in the test runner
+    //       is having troubles reading the generated JFR file; however, when downloaded
+    //       and opened locally, JMC will read it just fine.
+    //       We will need to investigate the root cause, but now we need to unblock the master
+    // builds
+    Assumptions.assumeFalse(JavaVirtualMachine.isOracleJDK8());
     testWithRetry(
         () -> {
           try {


### PR DESCRIPTION
# What Does This Do
It skips the mentioned test on Oracle JDK 8

# Motivation
For some reason, the generated JFR file can not be read back by the JMC parser on the runners used to run the Oracle JDK 8 tests. When I download the same file and open it locally, it is fine. 
The reason is not really clear and for the sakes of unblocking master failures, let's just skip the test on Oracle JDK 8 for now.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
