### PR TITLE
Pin system tests for release/v1.59.x

### DIFF
--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -61,7 +61,7 @@ jobs:
     needs:
     - build
     # If you change the following comment, update the pattern in the update_system_test_reference.sh script to match.
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main # system tests are pinned for releases only
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3b281e70d1fc9b51687f50e1c7e0811e3a626b55 # system tests are pinned for releases only
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DATADOG_API_KEY_PROD }}
     permissions:
@@ -71,7 +71,7 @@ jobs:
     with:
       library: java
        # If you change the following comment, update the pattern in the update_system_test_reference.sh script to match.
-      ref: main # system tests are pinned for releases only
+      ref: 3b281e70d1fc9b51687f50e1c7e0811e3a626b55 # system tests are pinned for releases only
       binaries_artifact: binaries
       desired_execution_time: 900  # 15 minutes
       scenarios_groups: tracer-release


### PR DESCRIPTION
## Summary
Pin system tests to commit 3b281e70d1fc9b51687f50e1c7e0811e3a626b55 for the v1.59.x release branch.

This ensures the release uses a specific, tested version of system tests.

## Changes
- Updated `.github/workflows/run-system-tests.yaml` to pin system tests reference

Generated by running `./tooling/update_system_test_reference.sh`