### PR TITLE
Set default codeowner file path to UNKNOWN

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,21 +6,20 @@
 
 
 # @DataDog/apm-idm-java
-# temporarily disable for testing
-# /dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/  @DataDog/apm-idm-java
-# /dd-java-agent/instrumentation/                                                                  @DataDog/apm-idm-java
-# /dd-smoke-tests/armeria-grpc/                                                                    @DataDog/apm-idm-java
-# /dd-smoke-tests/cli/                                                                             @DataDog/apm-idm-java
-# /dd-smoke-tests/jersey-2/                                                                        @DataDog/apm-idm-java
-# /dd-smoke-tests/jersey-3/                                                                        @DataDog/apm-idm-java
-# /dd-smoke-tests/play-*/                                                                          @DataDog/apm-idm-java
-# /dd-smoke-tests/quarkus/                                                                         @DataDog/apm-idm-java
-# /dd-smoke-tests/quarkus-native/                                                                  @DataDog/apm-idm-java
-# /dd-smoke-tests/ratpack-1.5/                                                                     @DataDog/apm-idm-java
-# /dd-smoke-tests/resteasy/                                                                        @DataDog/apm-idm-java
-# /dd-smoke-tests/spring*/                                                                         @DataDog/apm-idm-java
-# /dd-smoke-tests/vertx-*/                                                                         @DataDog/apm-idm-java
-# /dd-smoke-tests/wildfly/                                                                         @DataDog/apm-idm-java
+/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/  @DataDog/apm-idm-java
+/dd-java-agent/instrumentation/                                                                  @DataDog/apm-idm-java
+/dd-smoke-tests/armeria-grpc/                                                                    @DataDog/apm-idm-java
+/dd-smoke-tests/cli/                                                                             @DataDog/apm-idm-java
+/dd-smoke-tests/jersey-2/                                                                        @DataDog/apm-idm-java
+/dd-smoke-tests/jersey-3/                                                                        @DataDog/apm-idm-java
+/dd-smoke-tests/play-*/                                                                          @DataDog/apm-idm-java
+/dd-smoke-tests/quarkus/                                                                         @DataDog/apm-idm-java
+/dd-smoke-tests/quarkus-native/                                                                  @DataDog/apm-idm-java
+/dd-smoke-tests/ratpack-1.5/                                                                     @DataDog/apm-idm-java
+/dd-smoke-tests/resteasy/                                                                        @DataDog/apm-idm-java
+/dd-smoke-tests/spring*/                                                                         @DataDog/apm-idm-java
+/dd-smoke-tests/vertx-*/                                                                         @DataDog/apm-idm-java
+/dd-smoke-tests/wildfly/                                                                         @DataDog/apm-idm-java
 
 # @DataDog/apm-release-platform
 /.gitlab/                              @DataDog/apm-release-platform


### PR DESCRIPTION
# What Does This Do

If the codeowner file is not found, set as `UNKNOWN`. Also clean up the script slightly.

# Motivation

Previously, an unknown codeowner file would be set as `"/"`, which would not pattern-match to the default codeowner setting of `*`. See [this link](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20-%40test.codeowners%3A%2A%20%40git.branch%3A%28main%20OR%20master%29&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1769457455631&end=1770062255631&paused=false) for tests without codeowners for `master`, and [this link](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20-%40test.codeowners%3A%2A%20%40git.branch%3Asarahchen6%2Ffix-codeowners&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1769457455631&end=1770062255631&paused=false) for tests without codeowners for this branch.

# Additional Notes

As another test, I commented out a few `apm-idm-java` team file paths in `CODEOWNERS`. We can see [here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Amaster%20%40test.suite%3ARedisson%2A&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1770303600000&end=1770306900000&paused=true) that these tests should be assigned properly on `master`; however, since their file paths were missing, they were instead assigned to the default `apm-java` codeowner [here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Asarahchen6%2Ffix-codeowners%20%40test.suite%3ARedisson%2A&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1770303600000&end=1770306900000&paused=true).

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
