### PR TITLE
Adjust pin-system-tests workflow trigger to be release tag

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -59,3 +59,11 @@ jobs:
         run: |
           git checkout -b "${{ steps.define-branch.outputs.branch }}"
           git push -u origin "${{ steps.define-branch.outputs.branch }}"
+
+      - name: Dispatch repository event to pin system tests
+        if: steps.check-branch.outputs.creating_new_branch == 'true'
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: pin-system-tests
+          client-payload: '{"release-branch-name": "${{ steps.define-branch.outputs.branch }}"}'

--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           scope: DataDog/dd-trace-java
           policy: self.pin-system-tests.create-pr
 
-      - name: Define base branch
+      - name: Define base release branch
         id: define-base-branch
         run: |
           if [[ -n "${{ github.event.inputs.release-branch-name }}" ]]; then
@@ -51,21 +51,21 @@ jobs:
           fi
           echo "base_branch=${BASE_BRANCH}" >> $GITHUB_OUTPUT
       
-      - name: Checkout the repository
+      - name: Checkout the dd-trace-java repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.define-base-branch.outputs.base_branch }}
       
-      - name: Get latest commit SHA of base branch
+      - name: Get latest commit SHA of base release branch
         id: get-latest-commit-sha
         run: |
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Define branch name
+      - name: Define pin-system-tests branch name
         id: define-branch
         run: echo "branch=ci/pin-system-tests-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
-      - name: Check if branch already exists
+      - name: Check if pin-system-tests branch already exists
         id: check-branch
         run: |
           BRANCH=${{ steps.define-branch.outputs.branch }}

--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -7,11 +7,11 @@ on:
         description: 'The minor release branch name (e.g. release/v1.54.x)'
         required: true
         type: string
-  # run workflow when any branch is created
+  # run workflow when any branch or tag is created
   create:
 
 jobs:
-  # TODO: Remove this job after confirming the github.ref when a release branch is created
+  # TODO: Remove this job after confirming the workflow succeeds for release branches
   print-github-ref:
     name: "Print full github.ref"
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
 
   pin-system-tests:
     name: "Pin system tests"
-    if: github.event_name != 'create' || contains(github.ref, 'release/v')
+    if: github.event_name != 'create' || (contains(github.ref, 'tags/v') && endsWith(github.ref, '.0'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,7 +40,14 @@ jobs:
           if [[ -n "${{ github.event.inputs.release-branch-name }}" ]]; then
             BASE_BRANCH=${{ github.event.inputs.release-branch-name }}
           else
-            BASE_BRANCH=${GITHUB_REF#refs/heads/}
+            # Convert tag (e.g. v1.54.0) to release branch name (e.g. release/v1.54.x)
+            TAG=${GITHUB_REF#refs/tags/}
+            if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
+              BASE_BRANCH="release/${TAG%.0}.x"
+            else
+              echo "ERROR: Tag $TAG is not in the expected format: vX.Y.0"
+              exit 1
+            fi
           fi
           echo "base_branch=${BASE_BRANCH}" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -7,10 +7,8 @@ on:
         description: 'The minor release branch name (e.g. release/v1.54.x)'
         required: true
         type: string
-  workflow_run:
-    workflows: [Create Release Branch]
-    types:
-      - completed
+  repository_dispatch:
+    types: [pin-system-tests]
 
 jobs:
   # TODO: Remove this job after confirming the workflow succeeds for release branches
@@ -24,7 +22,6 @@ jobs:
 
   pin-system-tests:
     name: "Pin system tests"
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,33 +33,16 @@ jobs:
           scope: DataDog/dd-trace-java
           policy: self.pin-system-tests.create-pr
 
-      - name: Checkout repository for tag lookup
-        if: github.event_name == 'workflow_run'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          fetch-depth: 0 # fetch entire history, including tags
-
-      - name: Get release branch name from tag
-        if: github.event_name == 'workflow_run'
-        id: get-release-branch
-        run: |
-          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-          TAG=$(git tag --points-at "$HEAD_SHA" | grep -E '^v[0-9]+\.[0-9]+\.0$' | head -n 1)
-          if [[ -z "$TAG" ]]; then
-            echo "ERROR: Could not find tag that matches pattern 'vX.Y.0' and points at commit $HEAD_SHA"
-            exit 1
-          fi
-          echo "branch=release/${TAG%.0}.x" >> $GITHUB_OUTPUT
-
       - name: Define base release branch
         id: define-base-branch
         run: |
           if [[ -n "${{ github.event.inputs.release-branch-name }}" ]]; then
             BASE_BRANCH=${{ github.event.inputs.release-branch-name }}
-          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            BASE_BRANCH="${{ steps.get-release-branch.outputs.branch }}"
           else
-            echo "ERROR: Unable to determine base branch."
+            BASE_BRANCH="${{ github.event.client_payload.release-branch-name }}"
+          fi
+          if [[ -z "$BASE_BRANCH" ]]; then
+            echo "ERROR: Could not determine release branch"
             exit 1
           fi
           echo "base_branch=${BASE_BRANCH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pin-system-tests.yaml
+++ b/.github/workflows/pin-system-tests.yaml
@@ -7,8 +7,10 @@ on:
         description: 'The minor release branch name (e.g. release/v1.54.x)'
         required: true
         type: string
-  # run workflow when any branch or tag is created
-  create:
+  workflow_run:
+    workflows: [Create Release Branch]
+    types:
+      - completed
 
 jobs:
   # TODO: Remove this job after confirming the workflow succeeds for release branches
@@ -22,7 +24,7 @@ jobs:
 
   pin-system-tests:
     name: "Pin system tests"
-    if: github.event_name != 'create' || (contains(github.ref, 'tags/v') && endsWith(github.ref, '.0'))
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,20 +36,34 @@ jobs:
           scope: DataDog/dd-trace-java
           policy: self.pin-system-tests.create-pr
 
+      - name: Checkout repository for tag lookup
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0 # fetch entire history, including tags
+
+      - name: Get release branch name from tag
+        if: github.event_name == 'workflow_run'
+        id: get-release-branch
+        run: |
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          TAG=$(git tag --points-at "$HEAD_SHA" | grep -E '^v[0-9]+\.[0-9]+\.0$' | head -n 1)
+          if [[ -z "$TAG" ]]; then
+            echo "ERROR: Could not find tag that matches pattern 'vX.Y.0' and points at commit $HEAD_SHA"
+            exit 1
+          fi
+          echo "branch=release/${TAG%.0}.x" >> $GITHUB_OUTPUT
+
       - name: Define base release branch
         id: define-base-branch
         run: |
           if [[ -n "${{ github.event.inputs.release-branch-name }}" ]]; then
             BASE_BRANCH=${{ github.event.inputs.release-branch-name }}
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            BASE_BRANCH="${{ steps.get-release-branch.outputs.branch }}"
           else
-            # Convert tag (e.g. v1.54.0) to release branch name (e.g. release/v1.54.x)
-            TAG=${GITHUB_REF#refs/tags/}
-            if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
-              BASE_BRANCH="release/${TAG%.0}.x"
-            else
-              echo "ERROR: Tag $TAG is not in the expected format: vX.Y.0"
-              exit 1
-            fi
+            echo "ERROR: Unable to determine base branch."
+            exit 1
           fi
           echo "base_branch=${BASE_BRANCH}" >> $GITHUB_OUTPUT
       


### PR DESCRIPTION
# What Does This Do

Adjust the `pin-system-tests` workflow to be off the release tag instead of a release branch. For the `v1.59.0` release, we see that `github.ref: refs/tags/v1.59.0` triggered the workflow, not the previously expected `refs/heads/release/v1.59.x` branch creation [here](https://github.com/DataDog/dd-trace-java/actions/runs/21592180088/job/62214869219).

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
