### PR TITLE
Fix Exception Replay in Lambda

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
@@ -160,6 +160,11 @@ public abstract class AbstractExceptionDebugger implements DebuggerContext.Excep
       int[] mapping = createThrowableMapping(currentEx, t);
       StackTraceElement[] innerTrace = currentEx.getStackTrace();
       int currentIdx = innerTrace.length - snapshot.getStack().size();
+      if (currentIdx < 0) {
+        // This means the innerTrace was truncated by the underlying environment.
+        // This is known to happen in AWS Lambda, but may also happen elsewhere.
+        currentIdx = i;
+      }
       if (!sanityCheckSnapshotAssignment(snapshot, innerTrace, currentIdx)) {
         continue;
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -278,6 +278,44 @@ public class DefaultExceptionDebuggerTest {
     verify(manager, times(0)).isAlreadyInstrumented(any());
   }
 
+  @Test
+  public void lambdaTruncatedInnerTraceFallback() {
+    RuntimeException exception =
+        new RuntimeException("lambda") {
+          // mock the stacktrace to simulate a truncated one
+          @Override
+          public StackTraceElement[] getStackTrace() {
+            return new StackTraceElement[] {
+              new StackTraceElement("Main", "handleRequest", "Main.java", 11),
+              new StackTraceElement(
+                  "jdk.internal.reflect.DirectMethodHandleAccessor",
+                  "invoke",
+                  "Unknown Source",
+                  -1),
+              new StackTraceElement("java.lang.reflect.Method", "invoke", "Unknown Source", -1)
+            };
+          }
+        };
+    String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
+    AgentSpan span = mock(AgentSpan.class);
+    doAnswer(this::recordTags).when(span).setTag(anyString(), anyString());
+    when(span.getTag(anyString())).thenAnswer(inv -> spanTags.get(inv.getArgument(0)));
+    when(span.getTags()).thenReturn(spanTags);
+    exceptionDebugger.handleException(exception, span);
+    assertWithTimeout(
+        () -> exceptionDebugger.getExceptionProbeManager().isAlreadyInstrumented(fingerprint),
+        Duration.ofSeconds(30));
+    generateSnapshots(exception);
+    ExceptionProbeManager.ThrowableState state =
+        exceptionDebugger.getExceptionProbeManager().getStateByThrowable(exception);
+    List<Snapshot> snapshots = state.getSnapshots();
+    // This should hit the `currentIdx < 0` branch and fallback to i=0
+    exceptionDebugger.handleException(exception, span);
+    String tagName = String.format(SNAPSHOT_ID_TAG_FMT, 0);
+    assertTrue(spanTags.containsKey(tagName));
+    assertEquals(snapshots.get(0).getId(), spanTags.get(tagName));
+  }
+
   private Object recordTags(InvocationOnMock invocationOnMock) {
     Object[] args = invocationOnMock.getArguments();
     String key = (String) args[0];


### PR DESCRIPTION
# What Does This Do
In Lambda, the inner stack trace is truncated -- stack frames from fileName='AWSLambda.java' are removed. Therefore, in the original code, we would end up with a negative currentIdx, resulting in an error occurring in sanityCheckSnapshotAssignment. This PR adds a fallback to fix the mismatched pointer.

# Motivation
[SVLS-6855](https://datadoghq.atlassian.net/browse/SVLS-6855)

# Additional Notes
Related to #10380 & #8849 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SVLS-6855]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SVLS-6855]: https://datadoghq.atlassian.net/browse/SVLS-6855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-6855]: https://datadoghq.atlassian.net/browse/SVLS-6855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ