### PR TITLE
Stabilize new CICS test

### DIFF
--- a/dd-java-agent/instrumentation/cics-9.1/src/test/groovy/JavaGatewayInterfaceInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/cics-9.1/src/test/groovy/JavaGatewayInterfaceInstrumentationTest.groovy
@@ -108,7 +108,7 @@ class JavaGatewayInterfaceInstrumentationTest extends InstrumentationSpecificati
           tags {
             // Component and rpc.system are NOT set because we didn't create a new span
             // We only added connection tags to the existing parent span
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOSTNAME" { it == null || it == "127.0.0.1" }
             "$Tags.PEER_PORT" port
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             errorTags IOException, String


### PR DESCRIPTION
# Motivation

Adjust test expectations to avoid flakiness seen in Test Optimization Dashboard

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
