### PR TITLE
Add /techdebt claude skill

### DIFF
--- a/.claude/skills/techdebt/SKILL.md
+++ b/.claude/skills/techdebt/SKILL.md
@@ -18,18 +18,22 @@ Analyze changes on the current branch to identify and fix technical debt, code d
 
 ### Step 1: Get Branch Changes
 
-Find the upstream remote and compare against it:
+Find the merge-base (where this branch diverged from master) and compare against it:
 
 ```bash
-# Find upstream (DataDog org repo) and show changes
+# Find upstream (DataDog org repo)
 UPSTREAM=$(git remote -v | grep -E 'DataDog/[^/]+(.git)?\s' | head -1 | awk '{print $1}')
 if [ -z "$UPSTREAM" ]; then
   echo "No DataDog upstream found, using origin"
   UPSTREAM="origin"
 fi
-echo "Comparing against: $UPSTREAM/master"
-git diff ${UPSTREAM}/master --stat
-git diff ${UPSTREAM}/master --name-status
+
+# Find the merge-base (commit where this branch diverged from master)
+MERGE_BASE=$(git merge-base HEAD ${UPSTREAM}/master)
+echo "Comparing changes introduced on this branch since diverging from master using base commit: $MERGE_BASE"
+
+git diff $MERGE_BASE --stat
+git diff $MERGE_BASE --name-status
 ```
 
 If no changes exist, inform the user and stop.


### PR DESCRIPTION
# What Does This Do

This PR introduces a `/techdebt` skill to try limit the techdebt introduced by LLM and gen AI.
The code tends to duplicate patterns and usually benefits from a refactoring or a complete redo once the working solution is found. The `/techdebt` asks the tool to review the changes from the branch in order limit this behavior once the changes are ready.  

## Usage

It's a Claude skill to clean up your branch before committing the PR.
From Claude code, type `/techdebt`. It will fetch the changes from the branch, and look for the LLM anti-patterns.
If it finds some, it propose to fix them.

You can add some context or ask him to focus on something specific using: `/techdebt <custom request here>`.
The skill is using a subagent, so it should not pollute your context reviewing the changes.
Once it fixes the issues it found, don't hesitate to run multiple time until it founds nothing to clean up.  

Here is an output example:
```
 Techdebt Analysis Summary

  After reviewing the HTTP API changes on this branch, here are the issues found:

  1. Dead Code / Unused Code
  ┌────────────────────────┬─────────┬─────────────────────────────────────────────────────────────────────────────────────────────────┐
  │          File          │  Line   │                                              Issue                                              │
  ├────────────────────────┼─────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpClient.java     │ 31-51   │ Commented-out wrap() and unwrap() methods - should be removed if not needed                     │
  ├────────────────────────┼─────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpRequest.java    │ 27      │ TODO comment "Remove if not used" for wrap() method - verify and remove if unused               │
  ├────────────────────────┼─────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ OkHttpRequestBody.java │ 144-165 │ HttpRequestBodyAdapter class is defined but never used outside MultipartBuilder.toRequestBody() │
  └────────────────────────┴─────────┴─────────────────────────────────────────────────────────────────────────────────────────────────┘
  2. Unclear Design / TODO Comments Left Behind
  ┌───────────────────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │         File          │  Line   │                                                       Issue                                                        │
  ├───────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ HttpResponse.java     │ 71      │ TODO comment: "Not sure if it's the response that should be closed, or the response body" - design decision needed │
  ├───────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpResponse.java  │ 117     │ TODO comment: "Need review. Unclear if needed" in close() method                                                   │
  ├───────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpClient.Builder │ 127-128 │ Unused fields unixDomainSocket and namedPipe are stored but never used                                             │
  └───────────────────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  3. Redundant Code
  ┌───────────────────────┬──────┬───────────────────────────────────────────────────────────────────────────────────────────┐
  │         File          │ Line │                                           Issue                                           │
  ├───────────────────────┼──────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpClient.Builder │ 129  │ clearText field is stored but never used (comment says "No special configuration needed") │
  ├───────────────────────┼──────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ OkHttpClient.Builder  │ 123  │ eventListener field is declared but never written to                                      │
  └───────────────────────┴──────┴───────────────────────────────────────────────────────────────────────────────────────────┘
  4. Inconsistent Patterns
  ┌────────────────────┬───────┬────────────────────────────────────────────────────────────────────────────────────┐
  │        File        │ Line  │                                       Issue                                        │
  ├────────────────────┼───────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ OkHttpClient.java  │ 32-37 │ Type check uses if (!(request instanceof OkHttpRequest))                           │
  ├────────────────────┼───────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpClient.java │ 56-58 │ Same pattern but both could benefit from a shared utility or better error messages │
  └────────────────────┴───────┴────────────────────────────────────────────────────────────────────────────────────┘
  5. Minor Issues
  ┌─────────────────────────┬──────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │          File           │ Line │                                               Issue                                                │
  ├─────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ JdkHttpRequestBody.java │ 17   │ Imports UUID and Random but randomBoundary() only uses ThreadLocalRandom - Random import is unused │
  └─────────────────────────┴──────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ---
  Would you like me to fix these issues? I can:
  1. Remove all dead/commented code
  2. Clean up unused fields
  3. Resolve or remove TODO comments (with your guidance on the design decisions)
```

# Motivation

Inspired from [Boris Cherny’s thread](https://xcancel.com/bcherny/status/2017742741636321619).

# Additional Notes

This skill was defined by Claude itself as recommended. Not sure why the claude code product is not able to apply this recommendation by itself then 🤷 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMSP-2343]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMSP-2343]: https://datadoghq.atlassian.net/browse/APMSP-2343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ