### PR TITLE
Fix Capture Expressions support for multi-probes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -53,6 +53,11 @@ public class CapturedContext implements ValueReferenceResolver {
     this.arguments = other.arguments;
     this.locals = other.getLocals();
     this.throwable = other.throwable;
+    this.staticFields = other.staticFields;
+    this.limits = other.limits;
+    this.thisClassName = other.thisClassName;
+    this.duration = other.duration;
+    this.captureExpressions = other.captureExpressions;
     this.extensions.putAll(other.extensions);
     this.extensions.putAll(extensions);
   }
@@ -175,6 +180,14 @@ public class CapturedContext implements ValueReferenceResolver {
       }
     }
     return result != null ? result : Values.UNDEFINED_OBJECT;
+  }
+
+  public CapturedContext copyWithoutCaptureExpressions() {
+    CapturedContext newContext = new CapturedContext(this, Collections.emptyMap());
+    if (newContext.captureExpressions != null) {
+      newContext.captureExpressions = null;
+    }
+    return newContext;
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -781,6 +781,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     LogProbe.Capture capture = null;
     boolean captureSnapshot = false;
     ProbeCondition probeCondition = null;
+    List<LogProbe.CaptureExpression> captureExpressions = null;
     Where where = capturedContextProbes.get(0).getWhere();
     ProbeId probeId = capturedContextProbes.get(0).getProbeId();
     for (ProbeDefinition definition : capturedContextProbes) {
@@ -792,6 +793,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
         LogProbe logProbe = (LogProbe) definition;
         captureSnapshot = captureSnapshot | logProbe.isCaptureSnapshot();
         capture = mergeCapture(capture, logProbe.getCapture());
+        // captureExpressions = mergeCaptureExpressions(captureExpressions,
+        // logProbe.getCaptureExpressions());
         if (probeCondition == null) {
           probeCondition = logProbe.getProbeCondition();
         }
@@ -835,6 +838,19 @@ public class DebuggerTransformer implements ClassFileTransformer {
         Math.max(current.getMaxCollectionSize(), newCapture.getMaxCollectionSize()),
         Math.max(current.getMaxLength(), newCapture.getMaxLength()),
         Math.max(current.getMaxFieldCount(), newCapture.getMaxFieldCount()));
+  }
+
+  private static List<LogProbe.CaptureExpression> mergeCaptureExpressions(
+      List<LogProbe.CaptureExpression> captureExpressions,
+      List<LogProbe.CaptureExpression> newCaptureExpressions) {
+    if (captureExpressions == null) {
+      return newCaptureExpressions;
+    }
+    if (newCaptureExpressions == null) {
+      return captureExpressions;
+    }
+    captureExpressions.addAll(newCaptureExpressions);
+    return captureExpressions;
   }
 
   private InstrumentationResult.Status preCheckInstrumentation(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1523,6 +1523,120 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
+  public void mergedProbesWithCaptureExpressionsMixed() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe probe1 =
+        createProbeBuilder(PROBE_ID1, CLASS_NAME, "doit", null)
+            .evaluateAt(MethodLocation.EXIT)
+            .captureSnapshot(false)
+            .captureExpressions(
+                Arrays.asList(
+                    new LogProbe.CaptureExpression(
+                        "typed_fld_fld_msg",
+                        new ValueScript(
+                            DSL.getMember(
+                                DSL.getMember(DSL.getMember(DSL.ref("typed"), "fld"), "fld"),
+                                "msg"),
+                            "typed.fld.fld.msg"),
+                        null),
+                    new LogProbe.CaptureExpression(
+                        "nullTyped_fld",
+                        new ValueScript(
+                            DSL.getMember(DSL.ref("nullTyped"), "fld"), "nullTyped.fld"),
+                        null)))
+            .build();
+    LogProbe probe2 = createMethodProbeAtExit(PROBE_ID2, CLASS_NAME, "doit", null);
+    TestSnapshotListener listener = installProbes(probe1, probe2);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "1").get();
+    assertEquals(3, result);
+    List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
+    // snapshot with Capture Expressions
+    Snapshot snapshot0 = snapshots.get(0);
+    assertEquals(2, snapshot0.getCaptures().getReturn().getCaptureExpressions().size());
+    assertCaptureExpressions(
+        snapshot0.getCaptures().getReturn(),
+        "typed_fld_fld_msg",
+        String.class.getTypeName(),
+        "hello");
+    assertCaptureExpressions(
+        snapshot0.getCaptures().getReturn(), "nullTyped_fld", Object.class.getTypeName(), null);
+    assertNull(snapshot0.getCaptures().getReturn().getArguments());
+    assertNull(snapshot0.getCaptures().getReturn().getLocals());
+    // Snapshot without Capture Expressions
+    Snapshot snapshot1 = snapshots.get(1);
+    assertNull(snapshot1.getCaptures().getReturn().getCaptureExpressions());
+    assertCaptureArgs(snapshot1.getCaptures().getReturn(), "arg", String.class.getTypeName(), "1");
+    assertCaptureLocals(
+        snapshot1.getCaptures().getReturn(), "var1", Integer.TYPE.getTypeName(), "3");
+    assertCaptureLocals(
+        snapshot1.getCaptures().getReturn(), "@return", Integer.TYPE.getTypeName(), "3");
+  }
+
+  @Test
+  public void mergedProbesWithDifferentCaptureExpressions() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe probe1 =
+        createProbeBuilder(PROBE_ID1, CLASS_NAME, "doit", null)
+            .evaluateAt(MethodLocation.EXIT)
+            .captureSnapshot(false)
+            .captureExpressions(
+                Arrays.asList(
+                    new LogProbe.CaptureExpression(
+                        "typed_fld_fld_msg",
+                        new ValueScript(
+                            DSL.getMember(
+                                DSL.getMember(DSL.getMember(DSL.ref("typed"), "fld"), "fld"),
+                                "msg"),
+                            "typed.fld.fld.msg"),
+                        null),
+                    new LogProbe.CaptureExpression(
+                        "nullTyped_fld",
+                        new ValueScript(
+                            DSL.getMember(DSL.ref("nullTyped"), "fld"), "nullTyped.fld"),
+                        null)))
+            .build();
+    LogProbe probe2 =
+        createProbeBuilder(PROBE_ID2, CLASS_NAME, "doit", null)
+            .evaluateAt(MethodLocation.EXIT)
+            .captureSnapshot(false)
+            .captureExpressions(
+                Arrays.asList(
+                    new LogProbe.CaptureExpression(
+                        "var1", new ValueScript(DSL.ref("var1"), "var1"), null),
+                    new LogProbe.CaptureExpression(
+                        "this_fld",
+                        new ValueScript(DSL.getMember(DSL.ref("this"), "fld"), "this.fld"),
+                        null)))
+            .build();
+    TestSnapshotListener listener = installProbes(probe1, probe2);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "1").get();
+    assertEquals(3, result);
+    List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
+    // Snapshot 0
+    Snapshot snapshot0 = snapshots.get(0);
+    assertEquals(2, snapshot0.getCaptures().getReturn().getCaptureExpressions().size());
+    assertCaptureExpressions(
+        snapshot0.getCaptures().getReturn(),
+        "typed_fld_fld_msg",
+        String.class.getTypeName(),
+        "hello");
+    assertCaptureExpressions(
+        snapshot0.getCaptures().getReturn(), "nullTyped_fld", Object.class.getTypeName(), null);
+    assertNull(snapshot0.getCaptures().getReturn().getArguments());
+    assertNull(snapshot0.getCaptures().getReturn().getLocals());
+    // Snapshot 1
+    Snapshot snapshot1 = snapshots.get(1);
+    assertCaptureExpressions(
+        snapshot1.getCaptures().getReturn(), "var1", Integer.class.getTypeName(), "3");
+    assertCaptureExpressions(
+        snapshot1.getCaptures().getReturn(), "this_fld", Integer.class.getTypeName(), "11");
+    assertNull(snapshot1.getCaptures().getReturn().getArguments());
+    assertNull(snapshot1.getCaptures().getReturn().getLocals());
+  }
+
+  @Test
   public void fields() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
     TestSnapshotListener listener =


### PR DESCRIPTION
# What Does This Do
When multiple probes are created on the same location we previously assume that the context can be shared for all snapshots of the probes. With Capture Expressions we now need to differentiate the captures to respect the probe definitions.
We are now creating CapturedContext specifically based on the probe definiton and we are filtering Capture Expressions.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-5097]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5097]: https://datadoghq.atlassian.net/browse/DEBUG-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ