### PR TITLE
Fix method parameters JVM bug

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
   testRuntimeOnly group: 'org.scala-lang', name: 'scala-compiler', version: libs.versions.scala213.get()
   testRuntimeOnly group: 'antlr', name: 'antlr', version: '2.7.7'
+  testRuntimeOnly group: 'org.springframework', name: 'spring-web', version: '6.0.0'
 }
 
 tasks.named("shadowJar", ShadowJar) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Sampled;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.util.ExceptionHelper;
+import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -20,6 +21,9 @@ import datadog.trace.bootstrap.debugger.ProbeRateLimiter;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.TagsHelper;
 import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -39,6 +43,8 @@ import org.slf4j.LoggerFactory;
  * re-transformation of required classes
  */
 public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, ConfigurationAcceptor {
+
+  private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
 
   public interface TransformerSupplier {
     DebuggerTransformer supply(
@@ -177,11 +183,53 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     }
     List<Class<?>> changedClasses =
         finder.getAllLoadedChangedClasses(instrumentation.getAllLoadedClasses(), changes);
+    changedClasses = detectMethodParameters(changedClasses);
     retransformClasses(changedClasses);
     // ensures that we have at least re-transformed 1 class
     if (changedClasses.size() > 0) {
       LOGGER.debug("Re-transformation done");
     }
+  }
+
+  /*
+   * Because of this bug (https://bugs.openjdk.org/browse/JDK-8240908), classes compiled with
+   * method parameters (javac -parameters) strip this attribute once retransformed
+   * Spring 6/Spring boot 3 rely exclusively on this attribute and may throw an exception
+   * if no attribute found.
+   */
+  private List<Class<?>> detectMethodParameters(List<Class<?>> changedClasses) {
+    if (JAVA_AT_LEAST_19) {
+      // bug is fixed since JDK19, no need to perform detection
+      return changedClasses;
+    }
+    List<Class<?>> result = new ArrayList<>();
+    for (Class<?> changedClass : changedClasses) {
+      Method[] declaredMethods = changedClass.getDeclaredMethods();
+      boolean addClass = true;
+      // capping scanning of methods to 100 to avoid generated class with thousand of methods
+      // assuming that in those first 100 methods there is at least one with at least one parameter
+      for (int methodIdx = 0; methodIdx < declaredMethods.length && methodIdx < 100; methodIdx++) {
+        Method method = declaredMethods[methodIdx];
+        Parameter[] parameters = method.getParameters();
+        if (parameters.length == 0) {
+          continue;
+        }
+        if (parameters[0].isNamePresent()) {
+          LOGGER.debug(
+              "Detecting method parameter: method={} param={}, Skipping retransforming this class",
+              method.getName(),
+              parameters[0].getName());
+          // skip the class: compiled with -parameters
+          addClass = false;
+        }
+        // we found at leat a method with one parameter if name is not present we can stop there
+        break;
+      }
+      if (addClass) {
+        result.add(changedClass);
+      }
+    }
+    return result;
   }
 
   private void reportReceived(ConfigurationComparer changes) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Sampled;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.util.ExceptionHelper;
+import com.datadog.debugger.util.SpringHelper;
 import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -216,6 +217,9 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
           continue;
         }
         if (parameters[0].isNamePresent()) {
+          if (!SpringHelper.isSpringUsingOnlyMethodParameters(instrumentation)) {
+            return changedClasses;
+          }
           LOGGER.debug(
               "Detecting method parameter: method={} param={}, Skipping retransforming this class",
               method.getName(),

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -463,6 +463,10 @@ public class DebuggerAgent {
     return sink;
   }
 
+  static Instrumentation getInstrumentation() {
+    return instrumentation;
+  }
+
   private static DebuggerTransformer createTransformer(
       Config config,
       Configuration configuration,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -25,6 +25,7 @@ import com.datadog.debugger.sink.SymbolSink;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.ClassFileLines;
 import com.datadog.debugger.util.DebuggerMetrics;
+import com.datadog.debugger.util.SpringHelper;
 import datadog.environment.JavaVirtualMachine;
 import datadog.environment.SystemProperties;
 import datadog.trace.agent.tooling.AgentStrategies;
@@ -309,7 +310,9 @@ public class DebuggerTransformer implements ClassFileTransformer {
         // use the equals method for this
         continue;
       }
-      if (methodNode.parameters != null && !methodNode.parameters.isEmpty()) {
+      if (methodNode.parameters != null
+          && !methodNode.parameters.isEmpty()
+          && SpringHelper.isSpringUsingOnlyMethodParameters(DebuggerAgent.getInstrumentation())) {
         throw new RuntimeException(
             "Method Parameters attribute detected, instrumentation not supported");
       } else {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -138,6 +138,10 @@ public class ASMHelper {
     return Modifier.isFinal(field.getModifiers());
   }
 
+  public static boolean isRecord(ClassNode classNode) {
+    return (classNode.access & Opcodes.ACC_RECORD) > 0;
+  }
+
   public static void invokeStatic(
       InsnList insnList,
       org.objectweb.asm.Type owner,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -139,7 +139,7 @@ public class ASMHelper {
   }
 
   public static boolean isRecord(ClassNode classNode) {
-    return (classNode.access & Opcodes.ACC_RECORD) > 0;
+    return (classNode.access & Opcodes.ACC_RECORD) != 0;
   }
 
   public static void invokeStatic(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -208,6 +208,10 @@ public class DebuggerSink {
     probeStatusSink.addBlocked(probeId);
   }
 
+  public void addError(ProbeId probeId, String msg) {
+    probeStatusSink.addError(probeId, msg);
+  }
+
   public void removeDiagnostics(ProbeId probeId) {
     probeStatusSink.removeDiagnostics(probeId);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SpringHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SpringHelper.java
@@ -1,0 +1,19 @@
+package com.datadog.debugger.util;
+
+import java.lang.instrument.Instrumentation;
+
+public class SpringHelper {
+
+  public static boolean isSpringUsingOnlyMethodParameters(Instrumentation inst) {
+    for (Class<?> clazz : inst.getAllLoadedClasses()) {
+      if ("org.springframework.web.bind.annotation.ControllerMappingReflectiveProcessor"
+          .equals(clazz.getName())) {
+        // If this class (coming from Spring web since version 6) is found loaded it means Spring
+        // supports only getting parameter names from the MethodParameter attribute
+        return true;
+      }
+    }
+    // class not found, probably no Spring
+    return false;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2997,7 +2997,7 @@ public class CapturedSnapshotTest extends CapturingTestBase {
       verify(probeStatusSink, times(1)).addError(probeIdCaptor.capture(), strCaptor.capture());
       assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(0).getId());
       assertEquals(
-          "Instrumentation fails for com.datadog.debugger.MyRecord1",
+          "Instrumentation failed for com.datadog.debugger.MyRecord1: java.lang.RuntimeException: Method Parameters attribute detected, instrumentation not supported",
           strCaptor.getAllValues().get(0));
     }
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2969,7 +2969,9 @@ public class CapturedSnapshotTest extends CapturingTestBase {
       ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
       verify(probeStatusSink, times(1)).addError(probeIdCaptor.capture(), strCaptor.capture());
       assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(0).getId());
-      assertEquals("Instrumentation fails for CapturedSnapshot01", strCaptor.getAllValues().get(0));
+      assertEquals(
+          "Instrumentation failed for CapturedSnapshot01: java.lang.RuntimeException: Method Parameters attribute detected, instrumentation not supported",
+          strCaptor.getAllValues().get(0));
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -599,6 +599,7 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
+  @EnabledForJreRange(min = JRE.JAVA_21)
   public void sourceFileProbeScala() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot101";
     final String FILE_NAME = CLASS_NAME + SCALA_EXT;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -651,6 +651,13 @@ public class ConfigurationUpdaterTest {
     } else {
       verify(inst).getAllLoadedClasses();
       verify(inst, times(0)).retransformClasses(any());
+      ArgumentCaptor<ProbeId> probeIdCaptor = ArgumentCaptor.forClass(ProbeId.class);
+      ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
+      verify(probeStatusSink, times(1)).addError(probeIdCaptor.capture(), strCaptor.capture());
+      assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(0).getId());
+      assertEquals(
+          "Method Parameters detected, instrumentation not supported for CapturedSnapshot01",
+          strCaptor.getAllValues().get(0));
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -338,9 +338,21 @@ public class DebuggerTransformerTest {
     assertEquals("logprobe1", probeIdCaptor.getAllValues().get(0).getId());
     assertEquals("logprobe2", probeIdCaptor.getAllValues().get(1).getId());
     assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(2).getId());
-    assertEquals("Instrumentation fails for " + CLASS_NAME, strCaptor.getAllValues().get(0));
-    assertEquals("Instrumentation fails for " + CLASS_NAME, strCaptor.getAllValues().get(1));
-    assertEquals("Instrumentation fails for " + CLASS_NAME, strCaptor.getAllValues().get(2));
+    assertEquals(
+        "Instrumentation failed for "
+            + CLASS_NAME
+            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
+        strCaptor.getAllValues().get(0));
+    assertEquals(
+        "Instrumentation failed for "
+            + CLASS_NAME
+            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
+        strCaptor.getAllValues().get(1));
+    assertEquals(
+        "Instrumentation failed for "
+            + CLASS_NAME
+            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
+        strCaptor.getAllValues().get(2));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -339,15 +339,30 @@ public class DebuggerTransformerTest {
     assertEquals("logprobe1", probeIdCaptor.getAllValues().get(0).getId());
     assertEquals("logprobe2", probeIdCaptor.getAllValues().get(1).getId());
     assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(2).getId());
-    assertTrue(strCaptor.getAllValues().get(0).startsWith("Instrumentation failed for "
-            + CLASS_NAME
-            + ": java.lang.ArrayIndexOutOfBoundsException:"));
-    assertTrue(strCaptor.getAllValues().get(1).startsWith("Instrumentation failed for "
-        + CLASS_NAME
-        + ": java.lang.ArrayIndexOutOfBoundsException:"));
-    assertTrue(strCaptor.getAllValues().get(2).startsWith("Instrumentation failed for "
-        + CLASS_NAME
-        + ": java.lang.ArrayIndexOutOfBoundsException:"));
+    assertTrue(
+        strCaptor
+            .getAllValues()
+            .get(0)
+            .startsWith(
+                "Instrumentation failed for "
+                    + CLASS_NAME
+                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
+    assertTrue(
+        strCaptor
+            .getAllValues()
+            .get(1)
+            .startsWith(
+                "Instrumentation failed for "
+                    + CLASS_NAME
+                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
+    assertTrue(
+        strCaptor
+            .getAllValues()
+            .get(2)
+            .startsWith(
+                "Instrumentation failed for "
+                    + CLASS_NAME
+                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
@@ -158,10 +159,10 @@ public class DebuggerTransformerTest {
           ArrayList.class,
           null,
           getClassFileBytes(ArrayList.class));
-      Assertions.assertTrue(instrumentedClassFile.exists());
-      Assertions.assertTrue(origClassFile.exists());
-      Assertions.assertTrue(instrumentedClassFile.delete());
-      Assertions.assertTrue(origClassFile.delete());
+      assertTrue(instrumentedClassFile.exists());
+      assertTrue(origClassFile.exists());
+      assertTrue(instrumentedClassFile.delete());
+      assertTrue(origClassFile.delete());
     } finally {
       DebuggerTransformer.DUMP_PATH = initialTmpDir;
     }
@@ -264,7 +265,7 @@ public class DebuggerTransformerTest {
             getClassFileBytes(String.class));
     assertNull(newClassBuffer);
     Assertions.assertNotNull(lastResult.get());
-    Assertions.assertTrue(lastResult.get().isBlocked());
+    assertTrue(lastResult.get().isBlocked());
     Assertions.assertFalse(lastResult.get().isInstalled());
     assertEquals("java.lang.String", lastResult.get().getTypeName());
   }
@@ -294,7 +295,7 @@ public class DebuggerTransformerTest {
     Assertions.assertNotNull(newClassBuffer);
     Assertions.assertNotNull(lastResult.get());
     Assertions.assertFalse(lastResult.get().isBlocked());
-    Assertions.assertTrue(lastResult.get().isInstalled());
+    assertTrue(lastResult.get().isInstalled());
     assertEquals("java.util.ArrayList", lastResult.get().getTypeName());
   }
 
@@ -338,21 +339,15 @@ public class DebuggerTransformerTest {
     assertEquals("logprobe1", probeIdCaptor.getAllValues().get(0).getId());
     assertEquals("logprobe2", probeIdCaptor.getAllValues().get(1).getId());
     assertEquals(PROBE_ID.getId(), probeIdCaptor.getAllValues().get(2).getId());
-    assertEquals(
-        "Instrumentation failed for "
+    assertTrue(strCaptor.getAllValues().get(0).startsWith("Instrumentation failed for "
             + CLASS_NAME
-            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
-        strCaptor.getAllValues().get(0));
-    assertEquals(
-        "Instrumentation failed for "
-            + CLASS_NAME
-            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
-        strCaptor.getAllValues().get(1));
-    assertEquals(
-        "Instrumentation failed for "
-            + CLASS_NAME
-            + ": java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0",
-        strCaptor.getAllValues().get(2));
+            + ": java.lang.ArrayIndexOutOfBoundsException:"));
+    assertTrue(strCaptor.getAllValues().get(1).startsWith("Instrumentation failed for "
+        + CLASS_NAME
+        + ": java.lang.ArrayIndexOutOfBoundsException:"));
+    assertTrue(strCaptor.getAllValues().get(2).startsWith("Instrumentation failed for "
+        + CLASS_NAME
+        + ": java.lang.ArrayIndexOutOfBoundsException:"));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/SpringHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/SpringHelperTest.java
@@ -1,0 +1,31 @@
+package com.datadog.debugger.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.instrument.Instrumentation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+class SpringHelperTest {
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_17)
+  void isSpringUsingOnlyMethodParametersTrue() throws Exception {
+    Class<?> clazz =
+        Class.forName(
+            "org.springframework.web.bind.annotation.ControllerMappingReflectiveProcessor");
+    Instrumentation inst = mock(Instrumentation.class);
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {clazz});
+    assertTrue(SpringHelper.isSpringUsingOnlyMethodParameters(inst));
+  }
+
+  @Test
+  void isSpringUsingOnlyMethodParametersFalse() throws Exception {
+    Instrumentation inst = mock(Instrumentation.class);
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[0]);
+    assertFalse(SpringHelper.isSpringUsingOnlyMethodParameters(inst));
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/utils/InstrumentationTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/utils/InstrumentationTestHelper.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,8 +53,17 @@ public class InstrumentationTestHelper {
   public static Map<String, byte[]> compile(
       String className, SourceCompiler.DebugInfo debugInfo, String version)
       throws IOException, URISyntaxException {
+    return compile(className, debugInfo, version, Collections.emptyList());
+  }
+
+  public static Map<String, byte[]> compile(
+      String className,
+      SourceCompiler.DebugInfo debugInfo,
+      String version,
+      List<String> additionalOptions)
+      throws IOException, URISyntaxException {
     String classSource = getFixtureContent("/" + className.replace('.', '/') + ".java");
-    return SourceCompiler.compile(className, classSource, debugInfo, version);
+    return SourceCompiler.compile(className, classSource, debugInfo, version, additionalOptions);
   }
 
   public static Class<?> loadClass(String className, String classFileName) throws IOException {

--- a/dd-java-agent/agent-debugger/src/test/java/utils/SourceCompiler.java
+++ b/dd-java-agent/agent-debugger/src/test/java/utils/SourceCompiler.java
@@ -18,7 +18,11 @@ public final class SourceCompiler {
   }
 
   public static Map<String, byte[]> compile(
-      String className, String source, DebugInfo debug, String version) {
+      String className,
+      String source,
+      DebugInfo debug,
+      String version,
+      List<String> additionalOptions) {
     JavaCompiler jc = ToolProvider.getSystemJavaCompiler();
     if (jc == null) throw new RuntimeException("Compiler unavailable");
 
@@ -26,7 +30,7 @@ public final class SourceCompiler {
 
     Iterable<? extends JavaFileObject> fileObjects = Collections.singletonList(jsfs);
 
-    List<String> options = new ArrayList<>();
+    List<String> options = new ArrayList<>(additionalOptions);
     switch (debug) {
       case ALL:
         {


### PR DESCRIPTION
# What Does This Do
Prevent classfiles with Method Parameters attribute (javac -parameters) to be (re)transformed when on JDK < 19. Spring 6+ or SpringBoot3+ rely exclusively on method parameters to get param name and if the attribute is not present throw an exception and returns 500 on endpoints.
see OpenJDK bug JDK-8240908.
we are scanning method with at least on parameter to detect if the class was compiled with method parameters attribute and if the JDK is < 19 we prevent instrumentation to happen.
Even at load time we prevent it because we need to call retransform to remove instrumentation. Therefore the attribute can be strip at that time.
Then we are trying to scan for a specific Spring6+ only class. If the class is not present we are considering this is
safe to retransform as those versions of Spring are not relying on this.
Note: because Scala compiler always emits Method Parameters attribute, probe cannot work on scala if running on JDK < 19 

# Motivation

# Additional Notes
[OpenJDK bug](https://bugs.openjdk.org/browse/JDK-8240908)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-5131]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5131]: https://datadoghq.atlassian.net/browse/DEBUG-5131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ