### PR TITLE
Improve gradle locks update

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -29,59 +29,71 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Define branch names
+        id: define-branches
+        run: |
+          DATE=$(date +'%Y%m%d')
+          echo "core_branch=ci/update-gradle-dependencies-${DATE}" >> $GITHUB_OUTPUT
+          echo "instrumentation_branch=ci/update-gradle-dependencies-instrumentation-${DATE}" >> $GITHUB_OUTPUT
+
       - name: Update Gradle dependencies
         env:
           ORG_GRADLE_PROJECT_akkaRepositoryToken: ${{ secrets.AKKA_REPO_TOKEN }}
         run: |
-          find . -name 'gradle.lockfile' \
-            -not -path './dd-smoke-tests/*' \
-            -not -path './dd-java-agent/instrumentation/*' \
-            -delete
+          find . -name 'gradle.lockfile' -delete
           GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms2G -Xmx3G'" \
           ./gradlew resolveAndLockAll --write-locks --parallel --stacktrace --no-daemon --max-workers=4
-      - name: Check if changes should be committed
-        id: check-changes
+
+      - name: Save instrumentation lock files
+        run: |
+          mkdir -p /tmp/instrumentation-lockfiles
+          find dd-smoke-tests dd-java-agent/instrumentation -name 'gradle.lockfile' -exec cp --parents {} /tmp/instrumentation-lockfiles/ \;
+          # Restore instrumentation dirs to original state (keep only core changes)
+          git restore -- 'dd-smoke-tests/' 'dd-java-agent/instrumentation/'
+
+      # ==================== Core modules PR ====================
+      - name: Check if core changes exist
+        id: check-core-changes
         run: |
           if [[ -z "$(git status -s)" ]]; then
-            echo "No changes to commit, exiting."
+            echo "No core changes to commit."
             echo "commit_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
           else
             echo "commit_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Pick a branch name
-        if: steps.check-changes.outputs.commit_changes == 'true'
-        id: define-branch
-        run: echo "branch=ci/update-gradle-dependencies-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Commit changes
-        if: steps.check-changes.outputs.commit_changes == 'true'
-        id: create-commit
+
+      - name: Create core commit
+        if: steps.check-core-changes.outputs.commit_changes == 'true'
+        id: create-core-commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add --all
           git commit -m "chore: Update Gradle dependencies"
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - name: Push changes
+
+      - name: Push core changes
+        if: steps.check-core-changes.outputs.commit_changes == 'true'
         uses: DataDog/commit-headless@05d7b7ee023e2c7d01c47832d420c2503cd416f3 # action/v2.0.3
-        if: steps.check-changes.outputs.commit_changes == 'true'
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
-          branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          branch: "${{ steps.define-branches.outputs.core_branch }}"
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
-      - name: Create pull request
-        if: steps.check-changes.outputs.commit_changes == 'true'
+          commits: "${{ steps.create-core-commit.outputs.commit }}"
+
+      - name: Create core pull request
+        if: steps.check-core-changes.outputs.commit_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           gh pr create --title "Update Gradle dependencies" \
             --base master \
-            --head ${{ steps.define-branch.outputs.branch }} \
+            --head ${{ steps.define-branches.outputs.core_branch }} \
             --label "tag: dependencies" \
             --label "tag: no release notes" \
             --body "$(cat <<'EOF'
@@ -99,81 +111,49 @@ jobs:
           EOF
           )"
 
-  update-gradle-dependencies-instrumentation:
-    runs-on: ubuntu-latest
-    name: Update Instrumentation Gradle dependencies
-    permissions:
-      contents: read
-      id-token: write # Required for OIDC token federation
-    steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/dd-trace-java
-          policy: self.update-gradle-dependencies.create-pr
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          submodules: "recursive"
-
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'gradle'
-
-      - name: Update Gradle dependencies
-        env:
-          ORG_GRADLE_PROJECT_akkaRepositoryToken: ${{ secrets.AKKA_REPO_TOKEN }}
+      # ==================== Instrumentation PR ====================
+      - name: Reset and apply instrumentation changes
         run: |
-          find ./dd-smoke-tests -name 'gradle.lockfile' -delete
-          find ./dd-java-agent/instrumentation -name 'gradle.lockfile' -delete
-          GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms2G -Xmx3G'" \
-          ./gradlew resolveAndLockAll --write-locks --parallel --stacktrace --no-daemon --max-workers=4
-      - name: Check if changes should be committed
-        id: check-changes
+          git reset --hard ${{ github.sha }}
+          cp -r /tmp/instrumentation-lockfiles/* .
+
+      - name: Check if instrumentation changes exist
+        id: check-instrumentation-changes
         run: |
           if [[ -z "$(git status -s)" ]]; then
-            echo "No changes to commit, exiting."
+            echo "No instrumentation changes to commit."
             echo "commit_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
           else
             echo "commit_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Pick a branch name
-        if: steps.check-changes.outputs.commit_changes == 'true'
-        id: define-branch
-        run: echo "branch=ci/update-gradle-dependencies-instrumentation-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Commit changes
-        if: steps.check-changes.outputs.commit_changes == 'true'
-        id: create-commit
+
+      - name: Create instrumentation commit
+        if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'
+        id: create-instrumentation-commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add --all
           git commit -m "chore: Update instrumentation Gradle dependencies"
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - name: Push changes
+
+      - name: Push instrumentation changes
+        if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'
         uses: DataDog/commit-headless@05d7b7ee023e2c7d01c47832d420c2503cd416f3 # action/v2.0.3
-        if: steps.check-changes.outputs.commit_changes == 'true'
         with:
           token: "${{ steps.octo-sts.outputs.token }}"
-          branch: "${{ steps.define-branch.outputs.branch }}"
-          # for scheduled runs, sha is the tip of the default branch
-          # for dispatched runs, sha is the tip of the branch it was dispatched on
+          branch: "${{ steps.define-branches.outputs.instrumentation_branch }}"
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
-      - name: Create pull request
-        if: steps.check-changes.outputs.commit_changes == 'true'
+          commits: "${{ steps.create-instrumentation-commit.outputs.commit }}"
+
+      - name: Create instrumentation pull request
+        if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           gh pr create --title "Update instrumentation Gradle dependencies" \
             --base master \
-            --head ${{ steps.define-branch.outputs.branch }} \
+            --head ${{ steps.define-branches.outputs.instrumentation_branch }} \
             --label "tag: dependencies" \
             --label "tag: no release notes" \
             --body "$(cat <<'EOF'
@@ -186,7 +166,7 @@ jobs:
           Refresh Gradle dependencies to make sure to test latest versions of dependencies within their supported versions.
 
           # Contributor Checklist
-          
+
           - [ ] Update PR title if a code change is needed to support one of those new dependencies
           EOF
           )"


### PR DESCRIPTION
# What Does This Do

This PR splits the Gradle lock update into two PRs:
* One for instrumentations and their tests,
* One for core modules and products (only supposed to be upgraded on core lib change as most won't use version range).

Additionally, it improves the JDK setup, gradle cache and generated PR description.

# Motivation

The current workflow updates all 516 lock files in a single PR, which creates large PRs that are difficult to review and mixes unrelated dependency changes (core vs instrumentation). Splitting into two jobs creates smaller, focused PRs (77 files for core, 439 files for instrumentation) and allows independent review and merge of each category.

# Additional Notes

I tested the Java setup and the build works fine. But the PR creation requires to be run from `master` to get the proper token.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
