### PR TITLE
Marked as flaky.

### DIFF
--- a/dd-smoke-tests/concurrent/java-21/src/test/groovy/datadog/smoketest/concurrent/VirtualThreadTest.groovy
+++ b/dd-smoke-tests/concurrent/java-21/src/test/groovy/datadog/smoketest/concurrent/VirtualThreadTest.groovy
@@ -1,5 +1,7 @@
 package datadog.smoketest.concurrent
 
+import datadog.trace.test.util.Flaky
+
 class VirtualThreadStartTest extends AbstractConcurrentTest {
   @Override
   protected List<String> getTestArguments() {
@@ -54,6 +56,7 @@ class VirtualThreadSubmitRunnableTest extends AbstractConcurrentTest {
     return ['virtualThreadSubmitRunnable']
   }
 
+  @Flaky("Sometimes fails on CI with: Condition not satisfied after 30.00 seconds and 31 attempts")
   def 'test VirtualThread submit runnable'() {
     expect:
     receivedCorrectTrace()


### PR DESCRIPTION
# What Does This Do
Mark test as flaky.

# Motivation
Green CI.

# Additional Notes
For quite a long time this test behaves flaky on CI with error like:
```
Condition not satisfied after 30.00 seconds and 31 attempts

Condition not satisfied after 30.00 seconds and 31 attempts
	at app//spock.util.concurrent.PollingConditions.within(PollingConditions.java:206)
	at app//spock.util.concurrent.PollingConditions.eventually(PollingConditions.java:158)
	at app//datadog.smoketest.AbstractSmokeTest.waitForTrace(AbstractSmokeTest.groovy:327)
	at app//datadog.smoketest.concurrent.AbstractConcurrentTest.receivedCorrectTrace(AbstractConcurrentTest.groovy:68)
	at datadog.smoketest.concurrent.VirtualThreadSubmitRunnableTest.test VirtualThread submit runnable(VirtualThreadTest.groovy:59)
Caused by: Condition not satisfied:

decodeTraces.find { predicate.apply(it) } != null
|            |                            |
[]           null                         false

	at datadog.smoketest.AbstractSmokeTest.waitForTrace_closure2(AbstractSmokeTest.groovy:331)
	at datadog.smoketest.AbstractSmokeTest.waitForTrace_closure2(AbstractSmokeTest.groovy)
	at app//spock.util.concurrent.PollingConditions.within(PollingConditions.java:186)
	... 4 more
```