### PR TITLE
Migrate benchmarks to Merge Queue

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -13,7 +13,14 @@
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
       interruptible: false
-    - when: on_success
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+      when: on_success
+      interruptible: false
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//'
+      when: on_success
+      interruptible: false
+    - when: manual
+      allow_failure: true
       interruptible: true
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
@@ -83,9 +90,14 @@ check-big-regressions:
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /backport-pr-/'
       when: never
-    - if: '$CI_COMMIT_BRANCH !~ /^(master|release\/)/'
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|release\\/)/'
+      when: never
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success
-    - when: never
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//'
+      when: on_success
+    - when: manual
+      allow_failure: true
   # ARTIFACTS_DIR /go/src/github.com/DataDog/apm-reliability/dd-trace-java/reports/
   # need to convert them
   script:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -90,7 +90,7 @@ check-big-regressions:
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /backport-pr-/'
       when: never
-    - if: '$CI_COMMIT_BRANCH =~ /^(master|release\\/)/'
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|release\/)/'
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success

--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -1,21 +1,47 @@
+# Benchmarks run on master, merge queue, or when manually triggered.
+.parallel_benchmark_rules: &parallel_benchmark_rules
+  - if: '$POPULATE_CACHE'
+    when: never
+  - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
+    when: manual
+    allow_failure: true
+  - if: '$CI_COMMIT_BRANCH == "master"'
+    when: on_success
+    interruptible: false
+  - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+    when: on_success
+    interruptible: true
+  - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//'
+    when: on_success
+    interruptible: true
+  - when: manual
+    interruptible: true
+    allow_failure: true
+
 # Ensure the tracer artifact publish finishes before the benchmark jobs start.
 linux-java-spring-petclinic-parallel:
   needs: ["publish-artifacts-to-s3"]
 
 linux-java-insecure-bank-load-parallel:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
 
 linux-java-spring-petclinic-load-parallel:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
 
 linux-java-insecure-bank-startup-parallel:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
 
 linux-java-spring-petclinic-startup-parallel:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
 
 linux-java-dacapo-parallel-1:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
 
 linux-java-dacapo-parallel-2:
   needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules


### PR DESCRIPTION
# What Does This Do

Run `startup`, `load`, and `dacapo` benchmarks on the merge queue instead of for every PR push. Allow these benchmarks to be run manually in the corresponding Gitlab pipeline as well.

# Motivation

By migrating these benchmarks to the merge queue, we can greatly reduce CI runtime (from ~60 min to ~30 min) and support faster development experiences. At the same time, however, we don't want to lose benchmarking ability nor merge in unknown regressions. This is addressed by still allowing manual benchmark runs on PRs and the `check-big-regressions` gate.

# Additional Notes

The `check-big-regressions` check will still be in place and fail on regressions of 10+%; however, it will not catch small or unstable regressions. Developers should still manually run benchmarks once done iterating to see results.

See [this 30 min pipeline run](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/110263227) with benchmarks on MQ, and [this 52 min pipeline](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/110468322) run with manually run benchmarks.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
