### PR TITLE
Avoid racy indefinite wait in netty ws tests

### DIFF
--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -202,7 +202,8 @@ abstract class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
     void awaitConnected() {
       while (WsEndpoint.activeSession == null) {
         synchronized (WsEndpoint) {
-          WsEndpoint.wait()
+          // this can be racy so we need to wait with timeout and retry
+          WsEndpoint.wait(1_000)
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

If think that the issue with the previous implementation is that there can be a race that cause the test to wait infinitely for a connection.
In fact if the activeSession is null, the awaiting thread tries to lock and await on the monitor. 
However, in the same time, the server thread might be faster in notifyingAll before the wait is called.

With the proposed fix, the while loop is retried since the wait times out after one second. So that, even if this race is not solved, it is now handled correctly.


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
