### PR TITLE
Avoid race in ws tests linked to volatile+wait-notify

### DIFF
--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/testFixtures/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/testFixtures/groovy/JettyServer.groovy
@@ -131,7 +131,7 @@ class JettyServer implements WebsocketServer {
     synchronized (Lock) {
       try {
         while (Lock.activeSession == null) {
-          Lock.wait()
+          Lock.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee10/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee10/groovy/JettyServer.groovy
@@ -102,7 +102,7 @@ class JettyServer implements WebsocketServer {
     synchronized (Lock) {
       try {
         while (Lock.activeSession == null) {
-          Lock.wait()
+          Lock.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee8/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee8/groovy/JettyServer.groovy
@@ -119,7 +119,7 @@ class JettyServer implements WebsocketServer {
     synchronized (Lock) {
       try {
         while (Lock.activeSession == null) {
-          Lock.wait()
+          Lock.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee9/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/test/ee9/groovy/JettyServer.groovy
@@ -113,7 +113,7 @@ class JettyServer implements WebsocketServer {
     synchronized (Lock) {
       try {
         while (Lock.activeSession == null) {
-          Lock.wait()
+          Lock.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/src/testFixtures/groovy/test/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/src/testFixtures/groovy/test/JettyServer.groovy
@@ -92,7 +92,7 @@ class JettyServer implements WebsocketServer {
     synchronized (Lock) {
       try {
         while (Lock.activeSession == null) {
-          Lock.wait()
+          Lock.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/netty/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
@@ -244,7 +244,7 @@ abstract class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
     void awaitConnected() {
       while (WsEndpoint.activeSession == null) {
         synchronized (WsEndpoint) {
-          WsEndpoint.wait()
+          WsEndpoint.wait(1000)
         }
       }
     }

--- a/dd-java-agent/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -176,7 +176,7 @@ abstract class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
     void awaitConnected() {
       while (WsEndpoint.activeSession == null) {
         synchronized (WsEndpoint) {
-          WsEndpoint.wait()
+          WsEndpoint.wait(1000)
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
@@ -63,7 +63,7 @@ public class WsHandler implements WebSocketHandler {
         return;
       }
       try {
-        wait();
+        wait(1000);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/dd/trace/instrumentation/springwebflux/server/WsHandler.java
@@ -63,7 +63,7 @@ public class WsHandler implements WebSocketHandler {
         return;
       }
       try {
-        wait();
+        wait(1000);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootServer.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootServer.groovy
@@ -86,7 +86,7 @@ class SpringBootServer implements WebsocketServer {
     synchronized (WebsocketEndpoint) {
       try {
         while (endpoint?.activeSession == null) {
-          WebsocketEndpoint.wait()
+          WebsocketEndpoint.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootServer.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootServer.groovy
@@ -87,7 +87,7 @@ class SpringBootServer implements WebsocketServer {
     synchronized (WebsocketEndpoint) {
       try {
         while (endpoint?.activeSession == null) {
-          WebsocketEndpoint.wait()
+          WebsocketEndpoint.wait(1000)
         }
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
@@ -137,7 +137,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       synchronized (WebsocketEndpoint) {
         try {
           while (endpoint?.activeSession == null) {
-            WebsocketEndpoint.wait()
+            WebsocketEndpoint.wait(1000)
           }
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/latestDepTest/groovy/TomcatServer.groovy
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/latestDepTest/groovy/TomcatServer.groovy
@@ -139,7 +139,7 @@ class TomcatServer implements WebsocketServer {
     synchronized (WsEndpoint) {
       try {
         while (WsEndpoint.activeSession == null) {
-          WsEndpoint.wait()
+          WsEndpoint.wait(1000)
         }
       } catch (InterruptedException _) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/tomcat9Test/groovy/TomcatServer.groovy
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/tomcat9Test/groovy/TomcatServer.groovy
@@ -90,7 +90,7 @@ class TomcatServer implements WebsocketServer {
     synchronized (WsEndpoint) {
       try {
         while (WsEndpoint.activeSession == null) {
-          WsEndpoint.wait()
+          WsEndpoint.wait(1000)
         }
       } catch (InterruptedException _) {
         Thread.currentThread().interrupt()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
@@ -99,7 +99,7 @@ abstract class UndertowServletTest extends HttpServerTest<Undertow> {
     void awaitConnected() {
       while (TestEndpoint.activeSession == null) {
         synchronized (TestEndpoint) {
-          TestEndpoint.wait()
+          TestEndpoint.wait(1000)
         }
       }
     }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
@@ -91,7 +91,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
     void awaitConnected() {
       while (TestEndpoint.activeSession == null) {
         synchronized (TestEndpoint) {
-          TestEndpoint.wait()
+          TestEndpoint.wait(1000)
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

Same as #10539  but extended to all other websocket tests using the same wait mechanism

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
