### PR TITLE
disable mergequeue labels

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -3,6 +3,7 @@ schema-version: v1
 kind: mergequeue # https://datadoghq.atlassian.net/wiki/x/XgUQug
 enable: true
 merge_method: squash
+skip_labels: true
 branches:
   master:
     allow_skip_checks: true


### PR DESCRIPTION
This PR disables merge queue labels (e.g. `mergequeue-status: done`). 

The merge queue labels may trigger [this workflow](https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/check-pull-requests.yaml) which retriggers the pull request mergeability evaluation. This leads to the PR getting rejected by the merge queue.