### PR TITLE
Fix Capture Expression on primitives

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -24,7 +24,7 @@ public class CapturedContext implements ValueReferenceResolver {
   public static final CapturedContext EMPTY_CONTEXT = new CapturedContext(null);
   public static final CapturedContext EMPTY_CAPTURING_CONTEXT =
       new CapturedContext(ProbeImplementation.UNKNOWN);
-  private final transient Map<String, Object> extensions = new HashMap<>();
+  private final transient Map<String, CapturedValue> extensions = new HashMap<>();
 
   private Map<String, CapturedValue> arguments;
   private Map<String, CapturedValue> locals;
@@ -49,7 +49,7 @@ public class CapturedContext implements ValueReferenceResolver {
     this.throwable = throwable;
   }
 
-  private CapturedContext(CapturedContext other, Map<String, Object> extensions) {
+  private CapturedContext(CapturedContext other, Map<String, CapturedValue> extensions) {
     this.arguments = other.arguments;
     this.locals = other.getLocals();
     this.throwable = other.throwable;
@@ -85,11 +85,11 @@ public class CapturedContext implements ValueReferenceResolver {
   }
 
   @Override
-  public Object lookup(String name) {
+  public CapturedValue lookup(String name) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("empty name for lookup operation");
     }
-    Object target;
+    CapturedValue target;
     if (name.startsWith(ValueReferences.SYNTHETIC_PREFIX)) {
       String rawName = name.substring(ValueReferences.SYNTHETIC_PREFIX.length());
       target = tryRetrieveSynthetic(rawName);
@@ -98,36 +98,39 @@ public class CapturedContext implements ValueReferenceResolver {
       target = tryRetrieve(name);
       checkUndefined(target, name, "Cannot find symbol: ");
     }
-    return target instanceof CapturedValue ? ((CapturedValue) target).getValue() : target;
+    return target;
   }
 
-  private void checkUndefined(Object target, String name, String msg) {
-    if (target == Values.UNDEFINED_OBJECT) {
+  private void checkUndefined(CapturedValue target, String name, String msg) {
+    if (target == CapturedValue.UNDEFINED || target.notCapturedReason != null) {
       String errorMsg = msg + name;
       throw new RuntimeException(errorMsg);
     }
   }
 
   @Override
-  public Object getMember(Object target, String memberName) {
+  public CapturedValue getMember(Object target, String memberName) {
     if (target == Values.UNDEFINED_OBJECT) {
-      return target;
+      return CapturedValue.UNDEFINED;
     }
     if (Redaction.isRedactedKeyword(memberName)) {
-      return REDACTED_VALUE;
+      return CapturedValue.redacted(memberName, null);
     }
+    CapturedValue result;
     if (target instanceof CapturedValue) {
       Map<String, CapturedValue> fields = ((CapturedValue) target).fields;
       if (fields.containsKey(memberName)) {
-        target = fields.get(memberName);
+        result = fields.get(memberName);
       } else {
         CapturedValue capturedTarget = ((CapturedValue) target);
-        target = capturedTarget.getValue();
-        if (target != null) {
+        Object targetedValue = capturedTarget.getValue();
+        if (targetedValue != null) {
           // resolve to a CapturedValue instance
-          target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), memberName);
+          result =
+              ReflectiveFieldValueResolver.getFieldAsCapturedValue(
+                  targetedValue.getClass(), targetedValue, memberName);
         } else {
-          target = Values.UNDEFINED_OBJECT;
+          result = CapturedValue.UNDEFINED;
         }
       }
     } else {
@@ -138,25 +141,27 @@ public class CapturedContext implements ValueReferenceResolver {
         if (specialFieldAccess != null) {
           CapturedValue specialField = specialFieldAccess.apply(target);
           if (specialField != null && specialField.getName().equals(memberName)) {
-            return specialField.getValue();
+            return specialField;
           }
         }
       }
-      target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), memberName);
+      result =
+          ReflectiveFieldValueResolver.getFieldAsCapturedValue(
+              target.getClass(), target, memberName);
     }
-    checkUndefined(target, memberName, "Cannot dereference field: ");
-    return target;
+    checkUndefined(result, memberName, "Cannot dereference field: ");
+    return result;
   }
 
-  private Object tryRetrieveSynthetic(String name) {
+  private CapturedValue tryRetrieveSynthetic(String name) {
     if (extensions == null || extensions.isEmpty()) {
-      return Values.UNDEFINED_OBJECT;
+      return CapturedValue.UNDEFINED;
     }
-    return extensions.getOrDefault(name, Values.UNDEFINED_OBJECT);
+    return extensions.getOrDefault(name, CapturedValue.UNDEFINED);
   }
 
-  private Object tryRetrieve(String name) {
-    Object result = null;
+  private CapturedValue tryRetrieve(String name) {
+    CapturedValue result = null;
     if (arguments != null && !arguments.isEmpty()) {
       result = arguments.get(name);
     }
@@ -174,12 +179,12 @@ public class CapturedContext implements ValueReferenceResolver {
     }
     CapturedValue thisValue;
     if (arguments != null && (thisValue = arguments.get("this")) != null) {
-      result = getMember(thisValue.getValue(), name);
-      if (result != Values.UNDEFINED_OBJECT) {
+      result = getMember(thisValue, name);
+      if (result != CapturedValue.UNDEFINED) {
         return result;
       }
     }
-    return result != null ? result : Values.UNDEFINED_OBJECT;
+    return result != null ? result : CapturedValue.UNDEFINED;
   }
 
   public CapturedContext copyWithoutCaptureExpressions() {
@@ -191,12 +196,12 @@ public class CapturedContext implements ValueReferenceResolver {
   }
 
   @Override
-  public ValueReferenceResolver withExtensions(Map<String, Object> extensions) {
+  public ValueReferenceResolver withExtensions(Map<String, CapturedValue> extensions) {
     return new CapturedContext(this, extensions);
   }
 
   @Override
-  public void addExtension(String name, Object value) {
+  public void addExtension(String name, CapturedValue value) {
     extensions.put(name, value);
   }
 
@@ -235,8 +240,9 @@ public class CapturedContext implements ValueReferenceResolver {
   public void addThrowable(Throwable t) {
     addThrowable(new CapturedThrowable(t));
     // special local name for throwable
-    putInLocals(ValueReferences.EXCEPTION_REF, CapturedValue.of(t.getClass().getTypeName(), t));
-    extensions.put(ValueReferences.EXCEPTION_EXTENSION_NAME, t);
+    CapturedValue capturedException = CapturedValue.of(t.getClass().getTypeName(), t);
+    putInLocals(ValueReferences.EXCEPTION_REF, capturedException);
+    extensions.put(ValueReferences.EXCEPTION_EXTENSION_NAME, capturedException);
   }
 
   public void addThrowable(CapturedThrowable capturedThrowable) {
@@ -319,7 +325,8 @@ public class CapturedContext implements ValueReferenceResolver {
     if (methodLocation == MethodLocation.EXIT && startTimestamp > 0) {
       duration = System.nanoTime() - startTimestamp;
       addExtension(
-          ValueReferences.DURATION_EXTENSION_NAME, duration / 1_000_000.0); // convert to ms
+          ValueReferences.DURATION_EXTENSION_NAME,
+          CapturedValue.of(duration / 1_000_000.0)); // convert to ms
     }
     this.thisClassName = thisClassName;
     boolean shouldEvaluate =
@@ -446,7 +453,7 @@ public class CapturedContext implements ValueReferenceResolver {
 
   /** Stores a captured value */
   public static class CapturedValue {
-    public static final CapturedValue UNDEFINED = CapturedValue.of(null, Values.UNDEFINED_OBJECT);
+    public static final CapturedValue UNDEFINED = CapturedValue.of(Values.UNDEFINED_OBJECT);
 
     private String name;
     private final String declaredType;
@@ -517,16 +524,16 @@ public class CapturedContext implements ValueReferenceResolver {
       this.name = name;
     }
 
+    public static CapturedValue of(Object value) {
+      return of(null, value);
+    }
+
     public static CapturedValue of(String declaredType, Object value) {
       return build(null, declaredType, value, Limits.DEFAULT, null);
     }
 
     public static CapturedValue of(String name, String declaredType, Object value) {
       return build(name, declaredType, value, Limits.DEFAULT, null);
-    }
-
-    public CapturedValue derive(String name, String type, Object value) {
-      return build(name, type, value, limits, null);
     }
 
     public static CapturedValue of(

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
@@ -1,18 +1,19 @@
 package datadog.trace.bootstrap.debugger.el;
 
+import datadog.trace.bootstrap.debugger.CapturedContext.CapturedValue;
 import java.util.Map;
 
 /** Debugger EL specific value reference resolver. */
 public interface ValueReferenceResolver {
-  Object lookup(String name);
+  CapturedValue lookup(String name);
 
-  Object getMember(Object target, String name);
+  CapturedValue getMember(Object target, String name);
 
-  default void addExtension(String name, Object value) {}
+  default void addExtension(String name, CapturedValue value) {}
 
   default void removeExtension(String name) {}
 
-  default ValueReferenceResolver withExtensions(Map<String, Object> extensions) {
+  default ValueReferenceResolver withExtensions(Map<String, CapturedValue> extensions) {
     return this;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/BooleanValueExpressionAdapter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/BooleanValueExpressionAdapter.java
@@ -20,7 +20,7 @@ public class BooleanValueExpressionAdapter implements ValueExpression<BooleanVal
       throw new EvaluationException(
           "Boolean expression returning null", PrettyPrintVisitor.print(this));
     }
-    return new BooleanValue(result);
+    return new BooleanValue(result, ValueType.OBJECT);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -127,11 +127,11 @@ public class DSL {
   }
 
   public static Literal<Boolean> value(boolean value) {
-    return new BooleanValue(value);
+    return new BooleanValue(value, ValueType.BOOLEAN);
   }
 
   public static Literal<Number> value(Number value) {
-    return new NumericValue(value);
+    return new NumericValue(value, ValueType.OBJECT);
   }
 
   public static Literal<String> value(String value) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Literal.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Literal.java
@@ -9,9 +9,11 @@ import java.util.Objects;
 public class Literal<ConstantType>
     implements Value<ConstantType>, ValueExpression<Value<ConstantType>> {
   protected final ConstantType value;
+  protected final ValueType type;
 
-  protected Literal(ConstantType value) {
+  protected Literal(ConstantType value, ValueType type) {
     this.value = value;
+    this.type = type;
   }
 
   @Override
@@ -32,6 +34,11 @@ public class Literal<ConstantType>
   @Override
   public ConstantType getValue() {
     return value;
+  }
+
+  @Override
+  public ValueType getType() {
+    return type;
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueType.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueType.java
@@ -1,0 +1,52 @@
+package com.datadog.debugger.el;
+
+public enum ValueType {
+  OBJECT,
+  BOOLEAN,
+  INT,
+  LONG,
+  DOUBLE,
+  BYTE,
+  SHORT,
+  CHAR,
+  FLOAT;
+
+  public static String toString(ValueType type) {
+    switch (type) {
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case DOUBLE:
+      case BYTE:
+      case SHORT:
+      case CHAR:
+      case FLOAT:
+        return type.name().toLowerCase();
+      default:
+        return Object.class.getTypeName();
+    }
+  }
+
+  public static ValueType of(String type) {
+    switch (type) {
+      case "boolean":
+        return BOOLEAN;
+      case "int":
+        return INT;
+      case "long":
+        return LONG;
+      case "double":
+        return DOUBLE;
+      case "byte":
+        return BYTE;
+      case "short":
+        return SHORT;
+      case "char":
+        return CHAR;
+      case "float":
+        return FLOAT;
+      default:
+        return OBJECT;
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/FilterCollectionExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/FilterCollectionExpression.java
@@ -13,6 +13,7 @@ import com.datadog.debugger.el.values.CollectionValue;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.SetValue;
+import datadog.trace.bootstrap.debugger.CapturedContext.CapturedValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import java.util.ArrayList;
@@ -50,7 +51,8 @@ public final class FilterCollectionExpression implements ValueExpression<Collect
       try {
         for (int i = 0; i < len; i++) {
           Object value = materialized.get(i).getValue();
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, value);
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(value));
           if (filterExpression.evaluate(valueRefResolver)) {
             filtered.add(value);
           }
@@ -66,10 +68,12 @@ public final class FilterCollectionExpression implements ValueExpression<Collect
       try {
         for (Value<?> key : materialized.getKeys()) {
           Value<?> value = key.isUndefined() ? Value.undefinedValue() : materialized.get(key);
-          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, key);
-          valueRefResolver.addExtension(ValueReferences.VALUE_EXTENSION_NAME, value);
+          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, CapturedValue.of(key));
           valueRefResolver.addExtension(
-              ValueReferences.ITERATOR_EXTENSION_NAME, new MapValue.Entry(key, value));
+              ValueReferences.VALUE_EXTENSION_NAME, CapturedValue.of(value));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME,
+              CapturedValue.of(new MapValue.Entry(key, value)));
           if (filterExpression.evaluate(valueRefResolver)) {
             filtered.put(key.getValue(), value.getValue());
           }
@@ -86,7 +90,8 @@ public final class FilterCollectionExpression implements ValueExpression<Collect
       Set<?> setHolder = checkSupportedSet(materialized, this);
       try {
         for (Object value : setHolder) {
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, value);
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(value));
           if (filterExpression.evaluate(valueRefResolver)) {
             filtered.add(value);
           }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -4,7 +4,9 @@ import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Generated;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
+import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.util.Redaction;
 import java.util.Objects;
@@ -24,17 +26,22 @@ public class GetMemberExpression implements ValueExpression<Value<?>> {
     if (targetValue == Value.undefined()) {
       return targetValue;
     }
-    Object member;
+    CapturedContext.CapturedValue member;
     try {
       member = valueRefResolver.getMember(targetValue.getValue(), memberName);
     } catch (RuntimeException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }
-    if (member == Redaction.REDACTED_VALUE
-        || (member != null && Redaction.isRedactedType(member.getClass().getTypeName()))) {
+    Object memberValue = null;
+    if (member != null) {
+      memberValue = member.getValue();
+    }
+    if (memberValue != null
+        && (memberValue == Redaction.REDACTED_VALUE
+            || Redaction.isRedactedType(memberValue.getClass().getTypeName()))) {
       ExpressionHelper.throwRedactedException(this);
     }
-    return Value.of(member);
+    return Value.of(member.getValue(), ValueType.of(member.getType()));
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.SetValue;
+import datadog.trace.bootstrap.debugger.CapturedContext.CapturedValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import java.util.Set;
@@ -41,7 +42,8 @@ public final class HasAllExpression extends MatchingExpression {
       int len = collection.count();
       try {
         for (int i = 0; i < len; i++) {
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, collection.get(i));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(collection.get(i)));
           if (!filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.FALSE;
           }
@@ -61,10 +63,12 @@ public final class HasAllExpression extends MatchingExpression {
       try {
         for (Value<?> key : map.getKeys()) {
           Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
-          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, key);
-          valueRefResolver.addExtension(ValueReferences.VALUE_EXTENSION_NAME, val);
+          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, CapturedValue.of(key));
           valueRefResolver.addExtension(
-              ValueReferences.ITERATOR_EXTENSION_NAME, new MapValue.Entry(key, val));
+              ValueReferences.VALUE_EXTENSION_NAME, CapturedValue.of(val));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME,
+              CapturedValue.of(new MapValue.Entry(key, val)));
           if (!filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.FALSE;
           }
@@ -85,7 +89,8 @@ public final class HasAllExpression extends MatchingExpression {
       }
       try {
         for (Object val : setHolder) {
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, val);
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(val));
           if (!filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.FALSE;
           }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.SetValue;
+import datadog.trace.bootstrap.debugger.CapturedContext.CapturedValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import java.util.Set;
@@ -42,7 +43,8 @@ public final class HasAnyExpression extends MatchingExpression {
       try {
         int len = collection.count();
         for (int i = 0; i < len; i++) {
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, collection.get(i));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(collection.get(i)));
           if (filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.TRUE;
           }
@@ -64,10 +66,12 @@ public final class HasAnyExpression extends MatchingExpression {
         }
         for (Value<?> key : map.getKeys()) {
           Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
-          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, key);
-          valueRefResolver.addExtension(ValueReferences.VALUE_EXTENSION_NAME, val);
+          valueRefResolver.addExtension(ValueReferences.KEY_EXTENSION_NAME, CapturedValue.of(key));
           valueRefResolver.addExtension(
-              ValueReferences.ITERATOR_EXTENSION_NAME, new MapValue.Entry(key, val));
+              ValueReferences.VALUE_EXTENSION_NAME, CapturedValue.of(val));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME,
+              CapturedValue.of(new MapValue.Entry(key, val)));
           if (filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.TRUE;
           }
@@ -89,7 +93,8 @@ public final class HasAnyExpression extends MatchingExpression {
           return Boolean.FALSE;
         }
         for (Object val : setHolder) {
-          valueRefResolver.addExtension(ValueReferences.ITERATOR_EXTENSION_NAME, Value.of(val));
+          valueRefResolver.addExtension(
+              ValueReferences.ITERATOR_EXTENSION_NAME, CapturedValue.of(val));
           if (filterPredicateExpression.evaluate(valueRefResolver)) {
             return Boolean.TRUE;
           }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -65,7 +65,7 @@ public class IndexExpression implements ValueExpression<Value<?>> {
     if (obj != null && Redaction.isRedactedType(obj.getClass().getTypeName())) {
       ExpressionHelper.throwRedactedException(this);
     }
-    return Value.of(result.getValue());
+    return Value.of(result.getValue(), result.getType());
   }
 
   public <R> R accept(Visitor<R> visitor) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.el.expressions;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
 import com.datadog.debugger.el.values.NumericValue;
@@ -35,9 +36,9 @@ public final class LenExpression implements ValueExpression<Value<? extends Numb
       } else if (materialized.isUndefined()) {
         throw new RuntimeException("Cannot evaluate the expression for undefined value");
       } else if (materialized instanceof StringValue) {
-        return (NumericValue) Value.of(((StringValue) materialized).length());
+        return (NumericValue) Value.of(((StringValue) materialized).length(), ValueType.INT);
       } else if (materialized instanceof CollectionValue) {
-        return (NumericValue) Value.of(((CollectionValue) materialized).count());
+        return (NumericValue) Value.of(((CollectionValue) materialized).count(), ValueType.INT);
       }
     } catch (RuntimeException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this));

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.el.expressions;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
@@ -37,7 +38,7 @@ public class SubStringExpression implements ValueExpression<Value<String>> {
 
   private Value<String> internalEvaluate(String sourceStr) {
     try {
-      return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex));
+      return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex), ValueType.OBJECT);
     } catch (StringIndexOutOfBoundsException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/BooleanValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/BooleanValue.java
@@ -1,15 +1,16 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 
 /** Constant boolean value */
 public final class BooleanValue extends Literal<Boolean> {
-  public static final BooleanValue TRUE = new BooleanValue(true);
-  public static final BooleanValue FALSE = new BooleanValue(false);
+  public static final BooleanValue TRUE = new BooleanValue(true, ValueType.BOOLEAN);
+  public static final BooleanValue FALSE = new BooleanValue(false, ValueType.BOOLEAN);
 
-  public BooleanValue(Boolean value) {
-    super(value);
+  public BooleanValue(Boolean value, ValueType type) {
+    super(value, type);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/CollectionValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/CollectionValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import datadog.trace.bootstrap.debugger.el.Values;
 
 /**
@@ -29,6 +30,11 @@ public interface CollectionValue<T> extends Value<T> {
         @Override
         public Object getValue() {
           return Values.UNDEFINED_OBJECT;
+        }
+
+        @Override
+        public ValueType getType() {
+          return ValueType.OBJECT;
         }
 
         @Override
@@ -67,6 +73,11 @@ public interface CollectionValue<T> extends Value<T> {
         @Override
         public Object getValue() {
           return Value.nullValue();
+        }
+
+        @Override
+        public ValueType getType() {
+          return ValueType.OBJECT;
         }
 
         @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -99,7 +100,7 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
       throw new IllegalArgumentException("index[" + index + "] out of bounds: [0-" + len + "]");
     }
     if (listHolder instanceof List) {
-      return Value.of(((List<?>) listHolder).get(index));
+      return Value.of(((List<?>) listHolder).get(index), ValueType.OBJECT);
     } else if (listHolder instanceof Set) {
       throw new UnsupportedOperationException("Cannot access Set by index");
     } else if (listHolder instanceof Value) {
@@ -107,24 +108,24 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
     } else if (arrayHolder != null) {
       if (arrayType.isPrimitive()) {
         if (arrayType == byte.class) {
-          return Value.of(Array.getByte(arrayHolder, index));
+          return Value.of(Array.getByte(arrayHolder, index), ValueType.BYTE);
         } else if (arrayType == char.class) {
-          return Value.of(Array.getChar(arrayHolder, index));
+          return Value.of(Array.getChar(arrayHolder, index), ValueType.CHAR);
         } else if (arrayType == short.class) {
-          return Value.of(Array.getShort(arrayHolder, index));
+          return Value.of(Array.getShort(arrayHolder, index), ValueType.SHORT);
         } else if (arrayType == int.class) {
-          return Value.of(Array.getInt(arrayHolder, index));
+          return Value.of(Array.getInt(arrayHolder, index), ValueType.INT);
         } else if (arrayType == long.class) {
-          return Value.of(Array.getLong(arrayHolder, index));
+          return Value.of(Array.getLong(arrayHolder, index), ValueType.LONG);
         } else if (arrayType == float.class) {
-          return Value.of(Array.getFloat(arrayHolder, index));
+          return Value.of(Array.getFloat(arrayHolder, index), ValueType.FLOAT);
         } else if (arrayType == double.class) {
-          return Value.of(Array.getDouble(arrayHolder, index));
+          return Value.of(Array.getDouble(arrayHolder, index), ValueType.DOUBLE);
         } else if (arrayType == boolean.class) {
-          return Value.of(Array.getBoolean(arrayHolder, index));
+          return Value.of(Array.getBoolean(arrayHolder, index), ValueType.BOOLEAN);
         }
       } else {
-        return Value.of(Array.get(arrayHolder, index));
+        return Value.of(Array.get(arrayHolder, index), ValueType.OBJECT);
       }
     }
     return Value.undefinedValue();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -73,7 +74,9 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
     if (mapHolder instanceof Map) {
       if (WellKnownClasses.isSafe((Map<?, ?>) mapHolder)) {
         Map<?, ?> map = (Map<?, ?>) mapHolder;
-        return map.keySet().stream().map(Value::of).collect(Collectors.toSet());
+        return map.keySet().stream()
+            .map(obj -> Value.of(obj, ValueType.OBJECT))
+            .collect(Collectors.toSet());
       }
       throw new UnsupportedOperationException(
           "Unsupported Map class: " + mapHolder.getClass().getTypeName());
@@ -95,7 +98,7 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
         Map<?, ?> map = (Map<?, ?>) mapHolder;
         key = key instanceof Value ? ((Value<?>) key).getValue() : key;
         Object value = map.get(key);
-        return value != null ? Value.of(value) : Value.nullValue();
+        return value != null ? Value.of(value, ValueType.OBJECT) : Value.nullValue();
       }
       throw new UnsupportedOperationException(
           "Unsupported Map class: " + mapHolder.getClass().getTypeName());

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NullValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NullValue.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.Values;
 
@@ -10,7 +11,7 @@ public final class NullValue extends Literal<Object> {
   public static final NullValue INSTANCE = new NullValue();
 
   private NullValue() {
-    super(Values.NULL_OBJECT);
+    super(Values.NULL_OBJECT, ValueType.OBJECT);
   }
 
   @SuppressWarnings("unchecked")

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NumericValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NumericValue.java
@@ -1,12 +1,13 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 
 /** A numeric {@linkplain com.datadog.debugger.el.Value} */
 public final class NumericValue extends Literal<Number> {
-  public NumericValue(Number value) {
-    super(value);
+  public NumericValue(Number value, ValueType type) {
+    super(value, type);
   }
 
   private static Number widen(Number value) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.Values;
 
@@ -12,7 +13,7 @@ public final class ObjectValue extends Literal<Object> {
   public static final ObjectValue THIS = new ObjectValue(Values.THIS_OBJECT);
 
   public ObjectValue(Object value) {
-    super(value == null ? Values.NULL_OBJECT : value);
+    super(value == null ? Values.NULL_OBJECT : value, ValueType.OBJECT);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -75,7 +76,7 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
       if (WellKnownClasses.isSafe((Collection<?>) setHolder)) {
         Set<?> set = (Set<?>) setHolder;
         key = key instanceof Value ? ((Value<?>) key).getValue() : key;
-        return Value.of(set.contains(key));
+        return Value.of(set.contains(key), ValueType.BOOLEAN);
       }
       throw new UnsupportedOperationException(
           "Unsupported Set class: " + setHolder.getClass().getTypeName());

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/StringValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/StringValue.java
@@ -1,12 +1,13 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.Visitor;
 
 /** A string {@linkplain com.datadog.debugger.el.Value} */
 public final class StringValue extends Literal<String> {
   public StringValue(String value) {
-    super(value);
+    super(value, ValueType.OBJECT);
   }
 
   public boolean isEmpty() {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/UndefinedValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/UndefinedValue.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
 
@@ -15,7 +16,7 @@ public final class UndefinedValue extends Literal<Object> {
   public static final UndefinedValue INSTANCE = new UndefinedValue();
 
   private UndefinedValue() {
-    super(Values.UNDEFINED_OBJECT);
+    super(Values.UNDEFINED_OBJECT, ValueType.OBJECT);
   }
 
   @SuppressWarnings("unchecked")

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
@@ -33,8 +33,8 @@ class ExpressionTest {
 
   private static Stream<Arguments> literalExpressions() {
     return Stream.of(
-        Arguments.of(new BooleanValue(true), true),
-        Arguments.of(new NumericValue(15.8d), 15.8d),
+        Arguments.of(new BooleanValue(true, ValueType.BOOLEAN), true),
+        Arguments.of(new NumericValue(15.8d, ValueType.DOUBLE), 15.8d),
         Arguments.of(new StringValue("Hello world"), "Hello world"));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
@@ -8,6 +8,7 @@ import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RedactedException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NumericValue;
@@ -48,7 +49,7 @@ class IndexExpressionTest {
   @Test
   void testArray() {
     IndexExpression expr =
-        new IndexExpression(new ValueRefExpression("strArray"), new NumericValue(1));
+        new IndexExpression(new ValueRefExpression("strArray"), new NumericValue(1, ValueType.INT));
     Value<?> val = expr.evaluate(RefResolverHelper.createResolver(this));
     assertNotNull(val);
     assertFalse(val.isUndefined());
@@ -59,7 +60,7 @@ class IndexExpressionTest {
   @Test
   void testList() {
     IndexExpression expr =
-        new IndexExpression(new ValueRefExpression("strList"), new NumericValue(1));
+        new IndexExpression(new ValueRefExpression("strList"), new NumericValue(1, ValueType.INT));
     Value<?> val = expr.evaluate(RefResolverHelper.createResolver(this));
     assertNotNull(val);
     assertFalse(val.isUndefined());
@@ -93,7 +94,8 @@ class IndexExpressionTest {
   @Test
   void testUnsupportedList() {
     IndexExpression expr =
-        new IndexExpression(new ListValue(new ArrayList<String>() {}), new NumericValue(0));
+        new IndexExpression(
+            new ListValue(new ArrayList<String>() {}), new NumericValue(0, ValueType.INT));
     EvaluationException evaluationException =
         assertThrows(
             EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
@@ -105,7 +107,8 @@ class IndexExpressionTest {
   @Test
   void testOutOfBoundsList() {
     IndexExpression expr =
-        new IndexExpression(new ListValue(new ArrayList<String>()), new NumericValue(42));
+        new IndexExpression(
+            new ListValue(new ArrayList<String>()), new NumericValue(42, ValueType.INT));
     EvaluationException evaluationException =
         assertThrows(
             EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
@@ -126,7 +129,8 @@ class IndexExpressionTest {
 
   @Test
   void undefined() {
-    IndexExpression expr = new IndexExpression(ValueExpression.UNDEFINED, new NumericValue(1));
+    IndexExpression expr =
+        new IndexExpression(ValueExpression.UNDEFINED, new NumericValue(1, ValueType.INT));
     EvaluationException exception =
         assertThrows(
             EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
@@ -165,7 +169,8 @@ class IndexExpressionTest {
     try {
       Redaction.addUserDefinedTypes(Config.get());
       IndexExpression exprArray =
-          new IndexExpression(new ValueRefExpression("secretArray"), new NumericValue(0));
+          new IndexExpression(
+              new ValueRefExpression("secretArray"), new NumericValue(0, ValueType.INT));
       RedactedException redactedException =
           assertThrows(
               RedactedException.class,
@@ -174,7 +179,8 @@ class IndexExpressionTest {
           "Could not evaluate the expression because 'secretArray[0]' was redacted",
           redactedException.getMessage());
       IndexExpression exprList =
-          new IndexExpression(new ValueRefExpression("secretList"), new NumericValue(0));
+          new IndexExpression(
+              new ValueRefExpression("secretList"), new NumericValue(0, ValueType.INT));
       redactedException =
           assertThrows(
               RedactedException.class,
@@ -199,9 +205,11 @@ class IndexExpressionTest {
   @Test
   void stringPrimitives() {
     IndexExpression expr =
-        new IndexExpression(new ValueRefExpression("uuidArray"), new NumericValue(1));
+        new IndexExpression(
+            new ValueRefExpression("uuidArray"), new NumericValue(1, ValueType.INT));
     assertEquals(UUID_2, expr.evaluate(RefResolverHelper.createResolver(this)).getValue());
-    expr = new IndexExpression(new ValueRefExpression("uuidList"), new NumericValue(1));
+    expr =
+        new IndexExpression(new ValueRefExpression("uuidList"), new NumericValue(1, ValueType.INT));
     assertEquals(UUID_2, expr.evaluate(RefResolverHelper.createResolver(this)).getValue());
     expr = new IndexExpression(new ValueRefExpression("uuidMap"), new StringValue("foo"));
     assertEquals(UUID_1, expr.evaluate(RefResolverHelper.createResolver(this)).getValue());

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsDefinedExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsDefinedExpressionTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.values.BooleanValue;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
@@ -46,9 +47,9 @@ class IsDefinedExpressionTest {
 
   @Test
   void testNumericLiteral() {
-    NumericValue zero = new NumericValue(0);
-    NumericValue one = new NumericValue(1);
-    NumericValue none = new NumericValue(null);
+    NumericValue zero = new NumericValue(0, ValueType.INT);
+    NumericValue one = new NumericValue(1, ValueType.INT);
+    NumericValue none = new NumericValue(null, ValueType.OBJECT);
 
     IsDefinedExpression expression = new IsDefinedExpression(zero);
     assertTrue(expression.evaluate(resolver));
@@ -65,7 +66,7 @@ class IsDefinedExpressionTest {
   void testBooleanLiteral() {
     BooleanValue yes = BooleanValue.TRUE;
     BooleanValue no = BooleanValue.FALSE;
-    BooleanValue none = new BooleanValue(null);
+    BooleanValue none = new BooleanValue(null, ValueType.OBJECT);
 
     IsDefinedExpression expression = new IsDefinedExpression(yes);
     assertTrue(expression.evaluate(resolver));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import com.datadog.debugger.el.values.BooleanValue;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
@@ -50,9 +51,9 @@ class IsEmptyExpressionTest {
 
   @Test
   void testNumericLiteral() {
-    NumericValue zero = new NumericValue(0);
-    NumericValue one = new NumericValue(1);
-    NumericValue none = new NumericValue(null);
+    NumericValue zero = new NumericValue(0, ValueType.INT);
+    NumericValue one = new NumericValue(1, ValueType.INT);
+    NumericValue none = new NumericValue(null, ValueType.OBJECT);
 
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(zero);
@@ -70,7 +71,7 @@ class IsEmptyExpressionTest {
   void testBooleanLiteral() {
     BooleanValue yes = BooleanValue.TRUE;
     BooleanValue no = BooleanValue.FALSE;
-    BooleanValue none = new BooleanValue(null);
+    BooleanValue none = new BooleanValue(null, ValueType.OBJECT);
 
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(yes);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
@@ -10,6 +10,7 @@ import com.datadog.debugger.el.RedactedException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.CapturedContext.CapturedValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import datadog.trace.bootstrap.debugger.util.Redaction;
@@ -69,10 +70,10 @@ class ValueRefExpressionTest {
     long duration = TimeUnit.NANOSECONDS.convert(680, TimeUnit.MILLISECONDS);
     boolean returnVal = true;
     Throwable exception = new RuntimeException("oops");
-    Map<String, Object> exts = new HashMap<>();
-    exts.put(ValueReferences.RETURN_EXTENSION_NAME, returnVal);
-    exts.put(ValueReferences.DURATION_EXTENSION_NAME, duration);
-    exts.put(ValueReferences.EXCEPTION_EXTENSION_NAME, exception);
+    Map<String, CapturedValue> exts = new HashMap<>();
+    exts.put(ValueReferences.RETURN_EXTENSION_NAME, CapturedValue.of(returnVal));
+    exts.put(ValueReferences.DURATION_EXTENSION_NAME, CapturedValue.of(duration));
+    exts.put(ValueReferences.EXCEPTION_EXTENSION_NAME, CapturedValue.of(exception));
     ValueReferenceResolver resolver =
         RefResolverHelper.createResolver(new Obj()).withExtensions(exts);
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/BooleanValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/BooleanValueTest.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.el.values;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.el.ValueType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -10,7 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class BooleanValueTest {
   @Test
   void testNullLiteral() {
-    BooleanValue instance = new BooleanValue(null);
+    BooleanValue instance = new BooleanValue(null, ValueType.OBJECT);
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertNull(instance.getValue());
@@ -20,7 +21,7 @@ class BooleanValueTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testNonNullLiteral(boolean expected) {
-    BooleanValue instance = new BooleanValue(expected);
+    BooleanValue instance = new BooleanValue(expected, ValueType.BOOLEAN);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,12 +39,12 @@ class MapValueTest {
 
   @Test
   void get() {
-    assertEquals(Value.of("a"), instance.get("a"));
-    assertEquals(Value.of("a"), instance.get(Value.of("a")));
+    assertEquals(Value.of("a", ValueType.OBJECT), instance.get("a"));
+    assertEquals(Value.of("a", ValueType.OBJECT), instance.get(Value.of("a", ValueType.OBJECT)));
     assertEquals(Value.nullValue(), instance.get("b"));
-    assertEquals(Value.nullValue(), instance.get(Value.of("b")));
+    assertEquals(Value.nullValue(), instance.get(Value.of("b", ValueType.OBJECT)));
     assertEquals(Value.nullValue(), instance.get("c"));
-    assertEquals(Value.nullValue(), instance.get(Value.of("c")));
+    assertEquals(Value.nullValue(), instance.get(Value.of("c", ValueType.OBJECT)));
     assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
     assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
   }
@@ -55,10 +56,10 @@ class MapValueTest {
     map.put(2, 2);
     instance = new MapValue(map);
     assertEquals(2, instance.count());
-    assertEquals(Value.of(1), instance.get(1));
-    assertEquals(Value.of(2), instance.get(2));
-    Value<?> key = Value.of(1);
-    assertEquals(Value.of(1), instance.get(key));
+    assertEquals(Value.of(1, ValueType.INT), instance.get(1));
+    assertEquals(Value.of(2, ValueType.INT), instance.get(2));
+    Value<?> key = Value.of(1, ValueType.INT);
+    assertEquals(Value.of(1, ValueType.INT), instance.get(key));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/NumericValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/NumericValueTest.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.el.values;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.el.ValueType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class NumericValueTest {
   @Test
   void testNullLiteral() {
-    NumericValue instance = new NumericValue(null);
+    NumericValue instance = new NumericValue(null, ValueType.OBJECT);
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertNull(instance.getValue());
@@ -20,7 +21,7 @@ class NumericValueTest {
   @Test
   void testByteLiteral() {
     byte expected = 1;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.BYTE);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -30,7 +31,7 @@ class NumericValueTest {
   @Test
   void testShortLiteral() {
     short expected = 1;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.SHORT);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -40,7 +41,7 @@ class NumericValueTest {
   @Test
   void testIntLiteral() {
     int expected = 1;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.INT);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -50,7 +51,7 @@ class NumericValueTest {
   @Test
   void testLongLiteral() {
     long expected = 1;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.LONG);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -60,7 +61,7 @@ class NumericValueTest {
   @Test
   void testFloatLiteral() {
     float expected = 1.0f;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.FLOAT);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -70,7 +71,7 @@ class NumericValueTest {
   @Test
   void testDoubleLiteral() {
     double expected = 1.0;
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.DOUBLE);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -80,7 +81,7 @@ class NumericValueTest {
   @Test
   void testBigDecimalLiteral() {
     BigDecimal expected = new BigDecimal("1.0");
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.OBJECT);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
@@ -90,7 +91,7 @@ class NumericValueTest {
   @Test
   void testBigIntegerLiteral() {
     BigInteger expected = new BigInteger("1234567890");
-    NumericValue instance = new NumericValue(expected);
+    NumericValue instance = new NumericValue(expected, ValueType.OBJECT);
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.ValueType;
 import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.HashSet;
 import java.util.Set;
@@ -38,12 +39,14 @@ class SetValueTest {
 
   @Test
   void get() {
-    assertEquals(Value.of(true), instance.get("foo"));
+    assertEquals(Value.of(true, ValueType.BOOLEAN), instance.get("foo"));
     assertEquals(BooleanValue.TRUE, instance.get("foo"));
-    assertEquals(Value.of(true), instance.get(Value.of("foo")));
-    assertEquals(Value.of(false), instance.get("oof"));
+    assertEquals(
+        Value.of(true, ValueType.BOOLEAN), instance.get(Value.of("foo", ValueType.OBJECT)));
+    assertEquals(Value.of(false, ValueType.BOOLEAN), instance.get("oof"));
     assertEquals(BooleanValue.FALSE, instance.get("oof"));
-    assertEquals(Value.of(false), instance.get(Value.of("oof")));
+    assertEquals(
+        Value.of(false, ValueType.BOOLEAN), instance.get(Value.of("oof", ValueType.OBJECT)));
     assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
     assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
   }


### PR DESCRIPTION
# What Does This Do
As CapturedValue are evaluated through Expression Language, we are dropping types in the process and resulting having boxed primitives captured and serialized into the snapshot.
We introduce keeping track of the type in EL values by introducing ValueType enum. This way each EL expression evaluated can return a value that keep the existing type (Object, int, long, double, ...) Also lookup and getMember methods from ValueReferenceResolver are now returning CapturedValue to get the type and be able to transfer it to EL values

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-5148]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
