### PR TITLE
Update Java 26 Gradle compatibility

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/AbstractGradleTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/AbstractGradleTest.groovy
@@ -94,8 +94,6 @@ class AbstractGradleTest extends CiVisibilitySmokeTest {
   private static boolean isSupported(ComparableVersion gradleVersion) {
     // https://docs.gradle.org/current/userguide/compatibility.html
     if (Jvm.current.isJavaVersionCompatible(26)) {
-      // TODO: Fix for Java 26. Check compatibility doc / issue to confirm the minimum version.
-      // https://github.com/gradle/gradle/issues/35406
       return gradleVersion.compareTo(new ComparableVersion("9.4")) >= 0
     } else if (Jvm.current.isJavaVersionCompatible(25)) {
       return gradleVersion.compareTo(new ComparableVersion("9.1")) >= 0


### PR DESCRIPTION
# What Does This Do

Remove the `TODO: Fix for Java 26...` comment related to Gradle version support of Java 26.

# Motivation

https://github.com/gradle/gradle/issues/35406 confirms that Java 26 support is added in Gradle 9.4.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
