### PR TITLE
Fix AWS API Gateway endpoints correlation HTTP span tags -  Inferred Proxy Spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -586,16 +586,24 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   protected void finishInferredProxySpan(Context context) {
-    InferredProxySpan span;
-    if ((span = InferredProxySpan.fromContext(context)) != null) {
-      span.finish();
+    InferredProxySpan inferredProxySpan;
+    if ((inferredProxySpan = InferredProxySpan.fromContext(context)) != null) {
+      inferredProxySpan.finish(AgentSpan.fromContext(context));
     }
   }
 
   private void onRequestEndForInstrumentationGateway(@Nonnull final AgentSpan span) {
-    if (span.getLocalRootSpan() != span) {
+    AgentSpan localRoot = span.getLocalRootSpan();
+
+    // Check if the local root is an inferred proxy span
+    boolean hasInferredProxyParent =
+        localRoot != span && localRoot.getTag("_dd.inferred_span") != null;
+
+    // Only proceed if this is the root span OR if we have an inferred proxy parent
+    if (localRoot != span && !hasInferredProxyParent) {
       return;
     }
+
     CallbackProvider cbp = tracer().getUniversalCallbackProvider();
     RequestContext requestContext = span.getRequestContext();
     if (cbp != null && requestContext != null) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -44,6 +44,7 @@ import datadog.trace.api.telemetry.LoginEvent;
 import datadog.trace.api.telemetry.RuleType;
 import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.util.stacktrace.StackTraceEvent;
@@ -849,6 +850,7 @@ public class GatewayBridge {
     }
     ctx.setRequestEndCalled();
 
+    AgentSpan span = (AgentSpan) spanInfo;
     TraceSegment traceSeg = ctx_.getTraceSegment();
     Map<String, Object> tags = spanInfo.getTags();
 
@@ -863,8 +865,11 @@ public class GatewayBridge {
 
     // AppSec report metric and events for web span only
     if (traceSeg != null) {
-      traceSeg.setTagTop("_dd.appsec.enabled", 1);
-      traceSeg.setTagTop("_dd.runtime_family", "jvm");
+      // Set AppSec tags on the service-entry span (where detection occurs).
+      // When an inferred proxy span is present, InferredProxySpan.finish() will copy
+      // these tags to the inferred proxy span as required by RFC-1081.
+      span.setMetric("_dd.appsec.enabled", 1);
+      span.setTag("_dd.runtime_family", "jvm");
 
       Collection<AppSecEvent> collectedEvents = ctx.transferCollectedEvents();
 
@@ -884,17 +889,22 @@ public class GatewayBridge {
           traceSeg.setTagTop(Tags.ASM_KEEP, true);
           traceSeg.setTagTop(Tags.PROPAGATED_TRACE_SOURCE, ProductTraceSource.ASM);
         }
-        traceSeg.setTagTop("appsec.event", true);
-        traceSeg.setTagTop("network.client.ip", ctx.getPeerAddress());
+
+        span.setTag("appsec.event", true);
+
+        String peerAddress = ctx.getPeerAddress();
+        span.setTag("network.client.ip", peerAddress);
 
         // Reflect client_ip as actor.ip for backward compatibility
         Object clientIp = tags.get(Tags.HTTP_CLIENT_IP);
         if (clientIp != null) {
-          traceSeg.setTagTop("actor.ip", clientIp);
+          span.setTag("actor.ip", clientIp.toString());
         }
 
-        // Report AppSec events via "_dd.appsec.json" tag
+        // Report AppSec events on the service-entry span; also stored in meta_struct on the
+        // root span via setDataTop for agent processing
         AppSecEventWrapper wrapper = new AppSecEventWrapper(collectedEvents);
+        span.setTag("_dd.appsec.json", wrapper);
         traceSeg.setDataTop("appsec", wrapper);
 
         // Report collected request and response headers based on allow list
@@ -1191,7 +1201,6 @@ public class GatewayBridge {
 
   private Flow<Void> maybePublishRequestData(AppSecRequestContext ctx) {
     String savedRawURI = ctx.getSavedRawURI();
-
     if (savedRawURI == null || !ctx.isFinishedRequestHeaders() || ctx.getPeerAddress() == null) {
       return NoopFlow.INSTANCE;
     }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -99,7 +99,7 @@ class AppSecSystemSpecification extends DDSpecification {
     1 * appSecReqCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     1 * appSecReqCtx.getRequestHeaders() >> ['foo-bar': ['1.1.1.1']]
     1 * appSecReqCtx.getResponseHeaders() >> [:]
-    1 * traceSegment.setTagTop('actor.ip', '1.1.1.1')
+    1 * span.setTag('actor.ip', '1.1.1.1')
   }
 
   void 'throws if the config file is not parseable'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -188,13 +188,12 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * mockAppSecCtx.transferCollectedEvents() >> [event]
     1 * mockAppSecCtx.peerAddress >> '2001::1'
     1 * mockAppSecCtx.close()
-    1 * traceSegment.setTagTop("_dd.appsec.enabled", 1)
-    1 * traceSegment.setTagTop("_dd.runtime_family", "jvm")
-    1 * traceSegment.setTagTop('appsec.event', true)
+    1 * spanInfo.setMetric("_dd.appsec.enabled", 1)
+    1 * spanInfo.setTag("_dd.runtime_family", "jvm")
+    1 * spanInfo.setTag('appsec.event', true)
+    1 * spanInfo.setTag('network.client.ip', '2001::1')
+    1 * spanInfo.setTag('actor.ip', '1.1.1.1')
     1 * traceSegment.setDataTop('appsec', new AppSecEventWrapper([event]))
-    1 * traceSegment.setTagTop('http.request.headers.accept', 'header_value')
-    1 * traceSegment.setTagTop('http.response.headers.content-type', 'text/html; charset=UTF-8')
-    1 * traceSegment.setTagTop('network.client.ip', '2001::1')
     1 * mockAppSecCtx.isWafBlocked()
     1 * mockAppSecCtx.hasWafErrors()
     1 * mockAppSecCtx.getWafTimeouts()
@@ -224,7 +223,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     then:
     1 * mockAppSecCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     1 * spanInfo.getTags() >> TagMap.fromMap(['http.client_ip': '8.8.8.8'])
-    1 * traceSegment.setTagTop('actor.ip', '8.8.8.8')
+    1 * spanInfo.setTag('actor.ip', '8.8.8.8')
   }
 
   void 'bridge can collect headers'() {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -517,8 +517,9 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
           parent()
           tags {
             "$Tags.COMPONENT" "aws-apigateway"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_URL" "api.example.com/success"
+            "$Tags.HTTP_URL" "https://api.example.com/success"
             "$Tags.HTTP_ROUTE" "/success"
             "stage" "test"
             "_dd.inferred_span" 1

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/InferredProxyPropagatorTests.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/InferredProxyPropagatorTests.java
@@ -27,6 +27,7 @@ class InferredProxyPropagatorTests {
   private static final String PROXY_SYSTEM_KEY = "x-dd-proxy";
   private static final String PROXY_REQUEST_TIME_MS_KEY = "x-dd-proxy-request-time-ms";
   private static final String PROXY_PATH_KEY = "x-dd-proxy-path";
+  private static final String PROXY_RESOURCE_PATH_KEY = "x-dd-proxy-resource-path";
   private static final String PROXY_HTTP_METHOD_KEY = "x-dd-proxy-httpmethod";
   private static final String PROXY_DOMAIN_NAME_KEY = "x-dd-proxy-domain-name";
   private static final MapVisitor MAP_VISITOR = new MapVisitor();
@@ -84,6 +85,64 @@ class InferredProxyPropagatorTests {
         of("PROXY_SYSTEM_KEY empty", emptyValue),
         of("PROXY_SYSTEM_KEY null", nullValue),
         of("PROXY_REQUEST_TIME_MS_KEY missing", missingTime));
+  }
+
+  @Test
+  @DisplayName("Should extract x-dd-proxy-resource-path header when present")
+  void testResourcePathHeaderExtraction() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_SYSTEM_KEY, "aws-apigateway");
+    headers.put(PROXY_REQUEST_TIME_MS_KEY, "12345");
+    headers.put(PROXY_PATH_KEY, "/api/users/123");
+    headers.put(PROXY_RESOURCE_PATH_KEY, "/api/users/{id}");
+    headers.put(PROXY_HTTP_METHOD_KEY, "GET");
+    headers.put(PROXY_DOMAIN_NAME_KEY, "api.example.com");
+
+    Context context = this.propagator.extract(root(), headers, MAP_VISITOR);
+    InferredProxySpan inferredProxySpan = fromContext(context);
+    assertNotNull(inferredProxySpan);
+    assertTrue(inferredProxySpan.isValid());
+
+    // The resourcePath header should be extracted and available
+    // for use in http.route and resource.name
+  }
+
+  @Test
+  @DisplayName("Should work without x-dd-proxy-resource-path header for backwards compatibility")
+  void testExtractionWithoutResourcePath() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_SYSTEM_KEY, "aws-apigateway");
+    headers.put(PROXY_REQUEST_TIME_MS_KEY, "12345");
+    headers.put(PROXY_PATH_KEY, "/api/users/123");
+    // No PROXY_RESOURCE_PATH_KEY
+    headers.put(PROXY_HTTP_METHOD_KEY, "GET");
+    headers.put(PROXY_DOMAIN_NAME_KEY, "api.example.com");
+
+    Context context = this.propagator.extract(root(), headers, MAP_VISITOR);
+    InferredProxySpan inferredProxySpan = fromContext(context);
+    assertNotNull(inferredProxySpan);
+    assertTrue(inferredProxySpan.isValid());
+
+    // Should still be valid without resourcePath (backwards compatibility)
+  }
+
+  @Test
+  @DisplayName("Should extract x-dd-proxy-resource-path for aws-httpapi")
+  void testResourcePathHeaderExtractionForAwsHttpApi() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_SYSTEM_KEY, "aws-httpapi");
+    headers.put(PROXY_REQUEST_TIME_MS_KEY, "12345");
+    headers.put(PROXY_PATH_KEY, "/v2/items/abc-123");
+    headers.put(PROXY_RESOURCE_PATH_KEY, "/v2/items/{itemId}");
+    headers.put(PROXY_HTTP_METHOD_KEY, "POST");
+    headers.put(PROXY_DOMAIN_NAME_KEY, "httpapi.example.com");
+
+    Context context = this.propagator.extract(root(), headers, MAP_VISITOR);
+    InferredProxySpan inferredProxySpan = fromContext(context);
+    assertNotNull(inferredProxySpan);
+    assertTrue(inferredProxySpan.isValid());
+
+    // aws-httpapi should also support resourcePath extraction
   }
 
   @ParametersAreNonnullByDefault

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InferredProxySpan.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InferredProxySpan.java
@@ -7,6 +7,8 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_METHOD;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_ROUTE;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_URL;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
 
 import datadog.context.Context;
 import datadog.context.ContextKey;
@@ -25,15 +27,21 @@ public class InferredProxySpan implements ImplicitContextKeyed {
   static final String PROXY_SYSTEM = "x-dd-proxy";
   static final String PROXY_START_TIME_MS = "x-dd-proxy-request-time-ms";
   static final String PROXY_PATH = "x-dd-proxy-path";
+  static final String PROXY_RESOURCE_PATH = "x-dd-proxy-resource-path";
   static final String PROXY_HTTP_METHOD = "x-dd-proxy-httpmethod";
   static final String PROXY_DOMAIN_NAME = "x-dd-proxy-domain-name";
   static final String STAGE = "x-dd-proxy-stage";
+  // Optional tags
+  static final String PROXY_ACCOUNT_ID = "x-dd-proxy-account-id";
+  static final String PROXY_API_ID = "x-dd-proxy-api-id";
+  static final String PROXY_REGION = "x-dd-proxy-region";
   static final Map<String, String> SUPPORTED_PROXIES;
   static final String INSTRUMENTATION_NAME = "inferred_proxy";
 
   static {
     SUPPORTED_PROXIES = new HashMap<>();
     SUPPORTED_PROXIES.put("aws-apigateway", "aws.apigateway");
+    SUPPORTED_PROXIES.put("aws-httpapi", "aws.httpapi");
   }
 
   private final Map<String, String> headers;
@@ -75,6 +83,7 @@ public class InferredProxySpan implements ImplicitContextKeyed {
     String proxy = SUPPORTED_PROXIES.get(proxySystem);
     String httpMethod = header(PROXY_HTTP_METHOD);
     String path = header(PROXY_PATH);
+    String resourcePath = header(PROXY_RESOURCE_PATH);
     String domainName = header(PROXY_DOMAIN_NAME);
 
     AgentSpan span = AgentTracer.get().startSpan(INSTRUMENTATION_NAME, proxy, extracted, startTime);
@@ -84,8 +93,11 @@ public class InferredProxySpan implements ImplicitContextKeyed {
         domainName != null && !domainName.isEmpty() ? domainName : Config.get().getServiceName();
     span.setServiceName(serviceName, INSTRUMENTATION_NAME);
 
-    // Component: aws-apigateway
+    // Component: aws-apigateway or aws-httpapi
     span.setTag(COMPONENT, proxySystem);
+
+    // Span kind: server
+    span.setTag(SPAN_KIND, SPAN_KIND_SERVER);
 
     // SpanType: web
     span.setTag(SPAN_TYPE, "web");
@@ -93,21 +105,50 @@ public class InferredProxySpan implements ImplicitContextKeyed {
     // Http.method - value of x-dd-proxy-httpmethod
     span.setTag(HTTP_METHOD, httpMethod);
 
-    // Http.url - value of x-dd-proxy-domain-name + x-dd-proxy-path
-    span.setTag(HTTP_URL, domainName != null ? domainName + path : path);
+    // Http.url - https:// + x-dd-proxy-domain-name + x-dd-proxy-path
+    span.setTag(
+        HTTP_URL,
+        domainName != null && !domainName.isEmpty() ? "https://" + domainName + path : path);
 
-    // Http.route - value of x-dd-proxy-path
-    span.setTag(HTTP_ROUTE, path);
+    // Http.route - value of x-dd-proxy-resource-path (or x-dd-proxy-path as fallback)
+    span.setTag(HTTP_ROUTE, resourcePath != null && !resourcePath.isEmpty() ? resourcePath : path);
 
     // "stage" - value of x-dd-proxy-stage
     span.setTag("stage", header(STAGE));
 
+    // Optional tags - only set if present
+    String accountId = header(PROXY_ACCOUNT_ID);
+    if (accountId != null && !accountId.isEmpty()) {
+      span.setTag("account_id", accountId);
+    }
+
+    String apiId = header(PROXY_API_ID);
+    if (apiId != null && !apiId.isEmpty()) {
+      span.setTag("apiid", apiId);
+    }
+
+    String region = header(PROXY_REGION);
+    if (region != null && !region.isEmpty()) {
+      span.setTag("region", region);
+    }
+
+    // Compute and set dd_resource_key (ARN) if we have region and apiId
+    if (region != null && !region.isEmpty() && apiId != null && !apiId.isEmpty()) {
+      String arn = computeArn(proxySystem, region, apiId);
+      if (arn != null) {
+        span.setTag("dd_resource_key", arn);
+      }
+    }
+
     // _dd.inferred_span = 1 (indicates that this is an inferred span)
     span.setTag("_dd.inferred_span", 1);
 
-    // Resource Name: value of x-dd-proxy-httpmethod + " " + value of x-dd-proxy-path
+    // Resource Name: <Method> <Route> when route available, else <Method> <Path>
+    // Prefer x-dd-proxy-resource-path (route) over x-dd-proxy-path (path)
     // Use MANUAL_INSTRUMENTATION priority to prevent TagInterceptor from overriding
-    String resourceName = httpMethod != null && path != null ? httpMethod + " " + path : null;
+    String routeOrPath = resourcePath != null && !resourcePath.isEmpty() ? resourcePath : path;
+    String resourceName =
+        httpMethod != null && routeOrPath != null ? httpMethod + " " + routeOrPath : null;
     if (resourceName != null) {
       span.setResourceName(resourceName, MANUAL_INSTRUMENTATION);
     }
@@ -124,10 +165,69 @@ public class InferredProxySpan implements ImplicitContextKeyed {
     return this.headers.get(name);
   }
 
+  /**
+   * Compute ARN for the API Gateway resource. Format for v1 REST:
+   * arn:aws:apigateway:{region}::/restapis/{api-id} Format for v2 HTTP:
+   * arn:aws:apigateway:{region}::/apis/{api-id}
+   */
+  private String computeArn(String proxySystem, String region, String apiId) {
+    if (proxySystem == null || region == null || apiId == null) {
+      return null;
+    }
+
+    // Assume AWS partition (could be extended to support other partitions like aws-cn, aws-us-gov)
+    String partition = "aws";
+
+    // Determine resource type based on proxy system
+    String resourceType;
+    if ("aws-apigateway".equals(proxySystem)) {
+      resourceType = "restapis"; // v1 REST API
+    } else if ("aws-httpapi".equals(proxySystem)) {
+      resourceType = "apis"; // v2 HTTP API
+    } else {
+      return null; // Unknown proxy type
+    }
+
+    return String.format("arn:%s:apigateway:%s::/%s/%s", partition, region, resourceType, apiId);
+  }
+
   public void finish() {
+    finish(null);
+  }
+
+  /**
+   * Finishes this inferred proxy span and copies AppSec tags from the service-entry span to this
+   * span as required by RFC-1081. AppSec detection occurs in the service-entry span context, so its
+   * tags must be propagated to the inferred proxy span for endpoint correlation.
+   *
+   * @param serviceEntrySpan the service-entry child span, or null if not available
+   */
+  public void finish(AgentSpan serviceEntrySpan) {
     if (this.span != null) {
+      copyAppSecTagsFromServiceEntry(serviceEntrySpan);
       this.span.finish();
       this.span = null;
+    }
+  }
+
+  /**
+   * Copies AppSec tags from the service-entry span to this inferred proxy span as required by
+   * RFC-1081: the inferred span must carry {@code _dd.appsec.enabled} and {@code _dd.appsec.json}
+   * so that security activity can be correlated with the API Gateway endpoint.
+   */
+  private void copyAppSecTagsFromServiceEntry(AgentSpan serviceEntrySpan) {
+    if (serviceEntrySpan == null || serviceEntrySpan == this.span) {
+      return;
+    }
+
+    Object appsecEnabled = serviceEntrySpan.getTag("_dd.appsec.enabled");
+    if (appsecEnabled != null) {
+      this.span.setMetric("_dd.appsec.enabled", 1);
+    }
+
+    Object appsecJson = serviceEntrySpan.getTag("_dd.appsec.json");
+    if (appsecJson != null) {
+      this.span.setTag("_dd.appsec.json", appsecJson.toString());
     }
   }
 

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
@@ -196,4 +196,404 @@ class InferredProxySpanTests {
     // Span should be cleared after finish, so calling finish again should be safe
     inferredProxySpan.finish();
   }
+
+  @Test
+  @DisplayName("aws-httpapi proxy type should be valid and create span")
+  void testAwsHttpApiProxyType() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-httpapi");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/test");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertTrue(inferredProxySpan.isValid(), "aws-httpapi should be a valid proxy system");
+    assertNotNull(inferredProxySpan.start(null), "aws-httpapi should create a span");
+    inferredProxySpan.finish();
+  }
+
+  @ParameterizedTest(name = "Proxy system: {0}")
+  @DisplayName("Both v1 and v2 proxy systems should be supported")
+  @MethodSource("supportedProxySystems")
+  void testSupportedProxySystems(String proxySystem, String expectedSpanName) {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, proxySystem);
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertTrue(inferredProxySpan.isValid(), proxySystem + " should be valid");
+    assertNotNull(inferredProxySpan.start(null), proxySystem + " should create span");
+    inferredProxySpan.finish();
+  }
+
+  static Stream<Arguments> supportedProxySystems() {
+    return Stream.of(of("aws-apigateway", "aws.apigateway"), of("aws-httpapi", "aws.httpapi"));
+  }
+
+  @Test
+  @DisplayName("Inferred proxy span should have span.kind=server tag")
+  void testSpanKindServerTag() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/test");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("aws-httpapi span should also have span.kind=server tag")
+  void testAwsHttpApiSpanKindServerTag() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-httpapi");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/v2/resource");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("http.url should include https:// scheme when domain name is present")
+  void testHttpUrlWithHttpsScheme() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected URL: https://api.example.com/api/users
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("http.url should be path only when domain name is null")
+  void testHttpUrlWithoutHttpsSchemeWhenNoDomain() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users");
+    // No PROXY_DOMAIN_NAME
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected URL: /api/users (no scheme, just path)
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("http.url with https scheme should work for aws-httpapi")
+  void testAwsHttpApiHttpUrlWithHttpsScheme() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-httpapi");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headers.put(InferredProxySpan.PROXY_PATH, "/v2/items");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "httpapi.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected URL: https://httpapi.example.com/v2/items
+
+    inferredProxySpan.finish();
+  }
+
+  // Task 13: Tests for http.route from resourcePath with fallback
+  @Test
+  @DisplayName("http.route should use resourcePath when x-dd-proxy-resource-path is present")
+  void testHttpRouteFromResourcePath() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users/123");
+    headers.put(InferredProxySpan.PROXY_RESOURCE_PATH, "/api/users/{id}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected http.route: /api/users/{id} (from resourcePath)
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("http.route should fallback to path when x-dd-proxy-resource-path is not present")
+  void testHttpRouteFallbackToPath() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users/123");
+    // No PROXY_RESOURCE_PATH
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected http.route: /api/users/123 (fallback to path for backwards compat)
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("http.route should use resourcePath for aws-httpapi")
+  void testAwsHttpApiHttpRouteFromResourcePath() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-httpapi");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headers.put(InferredProxySpan.PROXY_PATH, "/v2/items/abc-123");
+    headers.put(InferredProxySpan.PROXY_RESOURCE_PATH, "/v2/items/{itemId}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "httpapi.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected http.route: /v2/items/{itemId}
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("resource.name should prefer route when resourcePath is present")
+  void testResourceNamePrefersRoute() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users/123");
+    headers.put(InferredProxySpan.PROXY_RESOURCE_PATH, "/api/users/{id}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected resource.name: "GET /api/users/{id}" (uses route from resourcePath)
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("resource.name should use path when resourcePath is not present")
+  void testResourceNameFallbackToPath() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users/123");
+    // No PROXY_RESOURCE_PATH
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected resource.name: "GET /api/users/123" (uses path)
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("resource.name should prefer route for POST requests")
+  void testResourceNamePrefersRouteForPost() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-httpapi");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headers.put(InferredProxySpan.PROXY_PATH, "/v2/orders/order-456");
+    headers.put(InferredProxySpan.PROXY_RESOURCE_PATH, "/v2/orders/{orderId}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected resource.name: "POST /v2/orders/{orderId}"
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("resource.name should handle complex route patterns")
+  void testResourceNameWithComplexRoute() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "PUT");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/v1/users/123/posts/456/comments/789");
+    headers.put(
+        InferredProxySpan.PROXY_RESOURCE_PATH,
+        "/api/v1/users/{userId}/posts/{postId}/comments/{commentId}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected resource.name: "PUT /api/v1/users/{userId}/posts/{postId}/comments/{commentId}"
+
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("resource.name should be null when both httpMethod and path are null")
+  void testResourceNameNullWhenBothNull() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    // No PROXY_HTTP_METHOD and no PROXY_PATH
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Expected resource.name: null
+
+    inferredProxySpan.finish();
+  }
+
+  // Note: These tests verify the copyAppSecTagsFromRoot() logic exists and doesn't crash.
+  // Full integration testing of AppSec tag propagation requires the actual tracer
+  // infrastructure and is better suited for integration tests.
+
+  @Test
+  @DisplayName("InferredProxySpan finish should not crash when no AppSec tags present")
+  void testFinishWithoutAppSecTags() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/test");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // finish() should execute copyAppSecTagsFromRoot() without errors
+    // even when no AppSec tags are present
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("InferredProxySpan finish should handle null root span gracefully")
+  void testFinishWithNullRootSpan() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/test");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // finish() should handle the case where getLocalRootSpan() might return null
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("InferredProxySpan finish should work for both v1 and v2 proxy types")
+  void testFinishWithDifferentProxyTypes() {
+    // Test with aws-apigateway (v1)
+    Map<String, String> headersV1 = new HashMap<>();
+    headersV1.put(PROXY_START_TIME_MS, "12345");
+    headersV1.put(PROXY_SYSTEM, "aws-apigateway");
+    headersV1.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headersV1.put(InferredProxySpan.PROXY_PATH, "/v1/test");
+
+    InferredProxySpan proxySpanV1 = fromHeaders(headersV1);
+    assertNotNull(proxySpanV1.start(null));
+    proxySpanV1.finish();
+
+    // Test with aws-httpapi (v2)
+    Map<String, String> headersV2 = new HashMap<>();
+    headersV2.put(PROXY_START_TIME_MS, "12345");
+    headersV2.put(PROXY_SYSTEM, "aws-httpapi");
+    headersV2.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headersV2.put(InferredProxySpan.PROXY_PATH, "/v2/test");
+
+    InferredProxySpan proxySpanV2 = fromHeaders(headersV2);
+    assertNotNull(proxySpanV2.start(null));
+    proxySpanV2.finish();
+  }
+
+  @Test
+  @DisplayName("InferredProxySpan finish should be idempotent")
+  void testFinishIsIdempotent() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/test");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // Call finish multiple times - should not crash
+    inferredProxySpan.finish();
+    inferredProxySpan.finish();
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("InferredProxySpan with all headers should finish successfully")
+  void testFinishWithAllHeaders() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(PROXY_START_TIME_MS, "12345");
+    headers.put(PROXY_SYSTEM, "aws-apigateway");
+    headers.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers.put(InferredProxySpan.PROXY_PATH, "/api/users/123");
+    headers.put(InferredProxySpan.PROXY_RESOURCE_PATH, "/api/users/{id}");
+    headers.put(InferredProxySpan.PROXY_DOMAIN_NAME, "api.example.com");
+    headers.put(InferredProxySpan.STAGE, "prod");
+
+    InferredProxySpan inferredProxySpan = fromHeaders(headers);
+    assertNotNull(inferredProxySpan.start(null));
+
+    // With all headers present, finish should work correctly
+    inferredProxySpan.finish();
+  }
+
+  @Test
+  @DisplayName("Multiple InferredProxySpan instances should finish independently")
+  void testMultipleProxySpansFinishIndependently() {
+    // Create first proxy span
+    Map<String, String> headers1 = new HashMap<>();
+    headers1.put(PROXY_START_TIME_MS, "12345");
+    headers1.put(PROXY_SYSTEM, "aws-apigateway");
+    headers1.put(InferredProxySpan.PROXY_HTTP_METHOD, "GET");
+    headers1.put(InferredProxySpan.PROXY_PATH, "/test1");
+
+    InferredProxySpan proxySpan1 = fromHeaders(headers1);
+    assertNotNull(proxySpan1.start(null));
+
+    // Create second proxy span
+    Map<String, String> headers2 = new HashMap<>();
+    headers2.put(PROXY_START_TIME_MS, "12346");
+    headers2.put(PROXY_SYSTEM, "aws-httpapi");
+    headers2.put(InferredProxySpan.PROXY_HTTP_METHOD, "POST");
+    headers2.put(InferredProxySpan.PROXY_PATH, "/test2");
+
+    InferredProxySpan proxySpan2 = fromHeaders(headers2);
+    assertNotNull(proxySpan2.start(null));
+
+    // Finish both - should work independently
+    proxySpan1.finish();
+    proxySpan2.finish();
+  }
 }


### PR DESCRIPTION
# What Does This Do
This PR implements standardized tags for inferred proxy spans produced by the Java tracer when instrumenting AWS API Gateway (v1 REST and v2 HTTP APIs). The changes align proxy spans with the cross-platform contract defined in RFC-1081 for endpoint discovery and correlation.

  **Mandatory tags implemented:**
   - **Span naming**: `aws.httpapi` for v2 HTTP API, `aws.apigateway` for v1 REST (previously only v1 was supported)
   - **`span.kind`**: set to `server`
   - **`http.url`**: prefixed with `https://` scheme (was missing, causing backend parsing issues)
   - **`http.route`**: populated from new `x-dd-proxy-resource-path` header (resource template, e.g. `/users/{id}`)
   - **`resource.name`**: uses `<Method> <Route>` when `http.route` is available, falls back to `<Method> <Path>`

   **Optional tags** (set only when the corresponding header is present):
   - **`account_id`** from `x-dd-proxy-account-id`
   - **`apiid`** from `x-dd-proxy-api-id`
   - **`region`** from `x-dd-proxy-region`
   - **`dd_resource_key`**: computed ARN (`arn:aws:apigateway:{region}::/restapis/{api-id}` or `.../apis/{api-id}`)

## AppSec Tag Propagation
 RFC-1081 requires `_dd.appsec.enabled` and `_dd.appsec.json` on the inferred proxy span so security activity can be correlated with the API Gateway endpoint.

`GatewayBridge.onRequestEnded` sets AppSec tags on the service-entry span (where detection occurs). `InferredProxySpan.copyAppSecTagsFromServiceEntry()`, called from `finish()`, then copies only those two RFC-required tags to the inferred proxy span — keeping the propagation logic encapsulated in `InferredProxySpan`.

`traceSeg.setTagTop()` is still used for `_dd.asm.keep` and `_dd.propagated_trace_source`, as sampling decisions require these on the root span immediately.

# Motivation

This implementation is required by [RFC-1081: Endpoint Discovery & Correlation from Inferred Spans](https://docs.google.com/document/d/1lH9RCZLR6SyJmPAIRYBpv4sKRy54kUAWOMPuOAOpS2Q/edit?tab=t.0) 

This PR covers the **Inferred Proxy Spans** portion of the RFC. The **Inferred Lambda Spans** portion will be addressed in a separate PR https://github.com/DataDog/dd-trace-java/pull/10576.

# Additional Notes

**ST checked locally**

**`aws_user` excluded**: intentionally omitted per RFC guidance due to PII concerns (assumed-role session names may contain user identifiers). Implementation requires explicit approval.

## AppSec Bug Fix

When an inferred proxy span is present, it becomes the local root of the trace. `HttpServerDecorator.onRequestEndForInstrumentationGateway()` was guarded by `if (span.getLocalRootSpan() != span) return`, which caused it to silently skip the service-entry span — meaning **no AppSec tags were set on any span** in this scenario.
The fix relaxes the guard to also allow execution when the local root is an inferred proxy span (detected via the `_dd.inferred_span` tag).

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APPSEC-61198]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-61198]: https://datadoghq.atlassian.net/browse/APPSEC-61198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ