### PR TITLE
Fix flaky tracer tests on Semeru JDK caused by NPE in TracerHealthMetrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -34,7 +34,6 @@ import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
 import datadog.trace.core.tagprocessor.TagsPostProcessorFactory;
 import datadog.trace.util.TagsHelper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -1124,27 +1123,11 @@ public class DDSpanContext
               samplingPriority != PrioritySampling.UNSET ? samplingPriority : getSamplingPriority(),
               measured,
               topLevel,
-              httpStatusCode == 0 ? null : shortStatusCodeToString(httpStatusCode),
+              httpStatusCode == 0 ? null : HTTP_STATUSES.get(httpStatusCode),
               // Get origin from rootSpan.context
               getOrigin(),
               longRunningVersion,
               ProcessTags.getTagsForSerialization()));
-    }
-  }
-
-  @SuppressFBWarnings("DCN") // only interested in catching NullPointerException (see note below)
-  private static UTF8BytesString shortStatusCodeToString(short httpStatusCode) {
-    try {
-      return HTTP_STATUSES.get(httpStatusCode);
-    } catch (NullPointerException e) {
-      // Intermittent NPE observed in JDK code on Semeru 11.0.29: java.lang.NullPointerException:
-      // at j.l.i.ArrayVarHandle$...Operations$OpObject.computeOffset(ArrayVarHandle.java:142)
-      // at j.l.i.ArrayVarHandle$...Operations$OpObject.compareAndSet(ArrayVarHandle.java:201)
-      // at j.u.c.atomic.AtomicReferenceArray.compareAndSet(AtomicReferenceArray.java:152)
-      // at datadog.trace.api.cache.RadixTreeCache.computeIfAbsent(RadixTreeCache.java:59)
-      // Location indicates JDK's VarHandle used to access the backing array has returned null
-      // To mitigate this rare JDK bug we skip the cache and fall back to manual string creation
-      return UTF8BytesString.create(Short.toString(httpStatusCode));
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.cache;
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.IntFunction;
 
@@ -49,12 +50,24 @@ public final class RadixTreeCache<T> {
   }
 
   @SuppressWarnings("unchecked")
+  @SuppressFBWarnings("DCN") // only interested in catching NullPointerException (see note below)
   private T computeIfAbsent(int prefix, int primitive) {
     Object[] page = tree.get(prefix);
     if (null == page) {
-      page = new Object[level2];
-      if (!tree.compareAndSet(prefix, null, page)) {
-        page = tree.get(prefix);
+      try {
+        page = new Object[level2];
+        if (!tree.compareAndSet(prefix, null, page)) {
+          page = tree.get(prefix);
+        }
+      } catch (NullPointerException e) {
+        // Intermittent NPE observed in JDK code on Semeru 11.0.29: java.lang.NullPointerException:
+        // at j.l.i.ArrayVarHandle$...Operations$OpObject.computeOffset(ArrayVarHandle.java:142)
+        // at j.l.i.ArrayVarHandle$...Operations$OpObject.compareAndSet(ArrayVarHandle.java:201)
+        // at j.u.c.atomic.AtomicReferenceArray.compareAndSet(AtomicReferenceArray.java:152)
+        // at datadog.trace.api.cache.RadixTreeCache.computeIfAbsent(RadixTreeCache.java:59)
+        // Location indicates JDK's VarHandle used to access the backing array has returned null
+        // To mitigate this rare JDK bug we still map the primitive but skip caching the result
+        return mapper.apply(primitive);
       }
     }
     // it's safe to race here


### PR DESCRIPTION
# What Does This Do

Move the fix in #10236 up to RadixTreeCache to avoid similar test flakiness on Semeru JDKs involving TracerHealthMetrics:
```
java.lang.NullPointerException: Cannot read the array length because "array" is null
	at java.base@17.0.17/java.util.concurrent.atomic.AtomicReferenceArray.compareAndSet(AtomicReferenceArray.java:153)
	at app//datadog.trace.api.cache.RadixTreeCache.computeIfAbsent(RadixTreeCache.java:56)
	at app//datadog.trace.api.cache.RadixTreeCache.get(RadixTreeCache.java:48)
	at app//datadog.trace.api.cache.RadixTreeCache.<init>(RadixTreeCache.java:38)
	at app//datadog.trace.core.monitor.TracerHealthMetrics.<init>(TracerHealthMetrics.java:34)
	at app//datadog.trace.core.monitor.TracerHealthMetrics.<init>(TracerHealthMetrics.java:114)
	at app//datadog.trace.core.CoreTracer.<init>(CoreTracer.java:717)
	at app//datadog.trace.core.CoreTracer.<init>(CoreTracer.java:133)
	at app//datadog.trace.core.CoreTracer$CoreTracerBuilder.build(CoreTracer.java:513)
	at app//datadog.trace.core.test.DDCoreSpecification$AutoCloseableCoreTracerBuilder.build(DDCoreSpecification.groovy:31)
	at app//datadog.trace.core.scopemanager.ScopeManagerTest.setup(ScopeManagerTest.groovy:61)
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
