### PR TITLE
Update Test Optimization codeowners to library team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,26 +98,26 @@
 **/*Waf*.java                                                   @DataDog/asm-java
 **/*Waf*.groovy                                                 @DataDog/asm-java
 
-# @DataDog/ci-app-libraries-java
-/dd-java-agent/agent-ci-visibility/                 @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/cucumber-5.4/        @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/jacoco-0.8.9/        @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/junit                @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/karate/              @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/scalatest-3.0.8/     @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/selenium/            @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/testng/              @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/gradle/              @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/gradle-testing/      @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/maven                @DataDog/ci-app-libraries-java
-/dd-java-agent/instrumentation/weaver-0.9/          @DataDog/ci-app-libraries-java
-/dd-smoke-tests/gradle/                             @DataDog/ci-app-libraries-java
-/dd-smoke-tests/junit-console/                      @DataDog/ci-app-libraries-java
-/dd-smoke-tests/maven/                              @DataDog/ci-app-libraries-java
-/internal-api/src/main/java/datadog/trace/api/git/  @DataDog/ci-app-libraries-java
-**/civisibility/                                    @DataDog/ci-app-libraries-java
-**/CiVisibility*.java                               @DataDog/ci-app-libraries-java
-**/CiVisibility*.groovy                             @DataDog/ci-app-libraries-java
+# @DataDog/ci-app-libraries
+/dd-java-agent/agent-ci-visibility/                 @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/cucumber-5.4/        @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/jacoco-0.8.9/        @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/junit                @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/karate/              @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/scalatest-3.0.8/     @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/selenium/            @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/testng/              @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/gradle/              @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/gradle-testing/      @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/maven                @DataDog/ci-app-libraries
+/dd-java-agent/instrumentation/weaver-0.9/          @DataDog/ci-app-libraries
+/dd-smoke-tests/gradle/                             @DataDog/ci-app-libraries
+/dd-smoke-tests/junit-console/                      @DataDog/ci-app-libraries
+/dd-smoke-tests/maven/                              @DataDog/ci-app-libraries
+/internal-api/src/main/java/datadog/trace/api/git/  @DataDog/ci-app-libraries
+**/civisibility/                                    @DataDog/ci-app-libraries
+**/CiVisibility*.java                               @DataDog/ci-app-libraries
+**/CiVisibility*.groovy                             @DataDog/ci-app-libraries
 
 # @DataDog/debugger-java (Live Debugger)
 /dd-java-agent/agent-debugger/                                  @DataDog/debugger-java


### PR DESCRIPTION
# What Does This Do

- Changes all Test Optimization/CI Visibility codeowners from `@ci-app-libraries-java` to `@ci-app-libraries`

# Motivation

This will allow me to get reviews and approvals from the general Test Optimization libraries team, after becoming the sole maintainer of the tracer.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
