### PR TITLE
Remove final field usage in ThirdPartyLibraries

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ThirdPartyLibraries.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ThirdPartyLibraries.java
@@ -87,10 +87,8 @@ public class ThirdPartyLibraries {
   }
 
   private static class InternalConfig {
-    // TODO: JEP 500 - avoid mutating final fields
-    private final String version;
-    // TODO: JEP 500 - avoid mutating final fields
-    private final List<String> prefixes;
+    private String version;
+    private List<String> prefixes;
 
     public InternalConfig(String version, List<String> prefixes) {
       this.version = version;

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,6 +76,7 @@ CachedData.deps.shared = [
   // Force specific version of okio required by com.squareup.moshi:moshi
   // When all of the dependencies are declared in dd-trace-core, moshi overrides the okhttp's
   // transitive dependency.  Since okhttp is declared here and moshi is not, this lead to an incompatible version
+  // TODO: Consider migrating away from Moshi, Okio, etc. to more modern JSON libraries with better (de)serialization support
   libs.okio,
   libs.okhttp,
   libs.dogstatsd,


### PR DESCRIPTION
# What Does This Do

Remove `final` field from `moshi`'s usage in `ThirdPartyLibraries`. Add a comment considering replacing `moshi`, etc. with more modern JSON tools.

# Motivation

Final field mutation will eventually be disallowed by [JEP 500](https://openjdk.org/jeps/500). We can pre-emptively address this now and consider migrating away from `moshi` at a further point (lib will likely go away with `okhttp`).

# Additional Notes

I tested this by running the current `dd-java-agent.jar` with `--illegal-final-field-mutation=debug` and Java 26 (where the flag is introduced). From there I saw the following output:
```
...
Final field prefixes in class com.datadog.debugger.agent.ThirdPartyLibraries$InternalConfig has been mutated reflectively by class com.squareup.moshi.ClassJsonAdapter$FieldBinding in unnamed module @7a0ac6e3 (file:/Users/sarah.chen/Downloads/dd-java-agent.jar)
	at java.base/java.lang.reflect.Field.postSetFinal(Field.java:1534)
	at java.base/java.lang.reflect.Field.setFinal(Field.java:1449)
	at java.base/java.lang.reflect.Field.set(Field.java:909)
	at com.squareup.moshi.ClassJsonAdapter$FieldBinding.read(ClassJsonAdapter.java:244)
	at com.squareup.moshi.ClassJsonAdapter.fromJson(ClassJsonAdapter.java:203)
	at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
	at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:51)
	at com.datadog.debugger.agent.ThirdPartyLibraries.readConfig(ThirdPartyLibraries.java:85)
	at com.datadog.debugger.agent.ThirdPartyLibraries.getThirdPartyLibraries(ThirdPartyLibraries.java:46)
	at com.datadog.debugger.util.ClassNameFiltering.<init>(ClassNameFiltering.java:21)
	at com.datadog.debugger.agent.DebuggerAgent.initClassNameFilter(DebuggerAgent.java:149)
	at com.datadog.debugger.agent.DebuggerAgent.startCodeOriginForSpans(DebuggerAgent.java:289)
	at com.datadog.debugger.agent.DebuggerAgent.run(DebuggerAgent.java:85)
	at datadog.trace.bootstrap.Agent.startDebuggerAgent(Agent.java:1452)
	at datadog.trace.bootstrap.Agent.maybeStartDebugger(Agent.java:1433)
	at datadog.trace.bootstrap.Agent.access$900(Agent.java:87)
	at datadog.trace.bootstrap.Agent$InstallDatadogTracerCallback.execute(Agent.java:686)
	at datadog.trace.bootstrap.Agent.start(Agent.java:399)
	at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:166)
	at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:73)
	at datadog.trace.bootstrap.AgentPreCheck.continueBootstrap(AgentPreCheck.java:169)
	at datadog.trace.bootstrap.AgentPreCheck.agentmain(AgentPreCheck.java:24)
	at datadog.trace.bootstrap.AgentPreCheck.premain(AgentPreCheck.java:17)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:544)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:556)
...
```

After removing the `final` fields , rebuilding the jar, and running again, I saw no errors.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
