### PR TITLE
Send debugger logs to DEBUGGER track

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -268,19 +268,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
         }
       }
 
-      if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V1)) {
-        newState.debuggerLogEndpoint = DEBUGGER_ENDPOINT_V1;
-      }
-      // both debugger v2 and diagnostics endpoints are forwarding events to the DEBUGGER intake
-      // because older agents support diagnostics from DD agent 7.49
-      if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V2)) {
-        newState.debuggerSnapshotEndpoint = DEBUGGER_ENDPOINT_V2;
-      } else if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
-        newState.debuggerSnapshotEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
-      }
-      if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
-        newState.debuggerDiagnosticsEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
-      }
+      setDebuggerEndpoints(newState, endpoints);
 
       for (String endpoint : dataStreamsEndpoints) {
         if (containsEndpoint(endpoints, endpoint)) {
@@ -333,6 +321,26 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       log.debug("Error parsing trace agent /info response", error);
     }
     return false;
+  }
+
+  private static void setDebuggerEndpoints(State newState, Set<String> endpoints) {
+    // both debugger v2 and diagnostics endpoints are forwarding events to the DEBUGGER intake
+    // because older agents support diagnostics from DD agent 7.49
+    if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V2)) {
+      newState.debuggerLogEndpoint = DEBUGGER_ENDPOINT_V2;
+    } else if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
+      newState.debuggerLogEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
+    } else if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V1)) {
+      newState.debuggerLogEndpoint = DEBUGGER_ENDPOINT_V1;
+    }
+    if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT_V2)) {
+      newState.debuggerSnapshotEndpoint = DEBUGGER_ENDPOINT_V2;
+    } else if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
+      newState.debuggerSnapshotEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
+    }
+    if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
+      newState.debuggerDiagnosticsEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
+    }
   }
 
   private static boolean containsEndpoint(Set<String> endpoints, String endpoint) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/AgentDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/AgentDebuggerIntegrationTest.java
@@ -116,7 +116,7 @@ public class AgentDebuggerIntegrationTest extends SimpleAppDebuggerIntegrationTe
               }
               if (line.contains("Started BatchUploader[Logs]")) {
                 return !line.matches(
-                    ".* Started BatchUploader\\[Logs] with target url http://localhost:\\d+/debugger/v1/input");
+                    ".* Started BatchUploader\\[Logs] with target url http://localhost:\\d+/debugger/v1/diagnostics");
               }
               if (line.contains("Started BatchUploader[SymDB]")) {
                 return !line.matches(


### PR DESCRIPTION
# What Does This Do
DEBUGGER track now apply SDS rules. We want to redact by default the content of debugger logs (not only snapshots). `debugger/v2/input` and `debugger/v1/diagnostics` endpoints send data to DEBUGGER track. We privilege `debugger/v2/input` but fallback to `debugger/v1/diagnostics` like snapshots

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5017]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
