### PR TITLE
Rework #10551 to properly align Java 21+ modules with the latest Logback version.

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
@@ -47,13 +47,9 @@ tasks.named("check") {
   dependsOn "previewTest"
 }
 
-// Use latest logback for Java 21+ tests with better virtual thread support.
-configurations.named("testRuntimeClasspath") {
-  resolutionStrategy {
-    force libs.logback.classic.latest
-  }
-}
-
 dependencies {
+  // Use latest logback for Java 21+ tests with better virtual thread support.
+  testImplementation(libs.logback.classic.latest)
+
   testImplementation project(':dd-java-agent:instrumentation:datadog:tracing:trace-annotation')
 }

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-25.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-25.0/build.gradle
@@ -16,9 +16,7 @@ idea {
   }
 }
 
-// Use latest logback for Java 21+ tests with better virtual thread support.
-configurations.named("testRuntimeClasspath") {
-  resolutionStrategy {
-    force libs.logback.classic.latest
-  }
+dependencies {
+  // Use latest logback for Java 21+ tests with better virtual thread support.
+  testImplementation(libs.logback.classic.latest)
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/build.gradle
@@ -26,13 +26,8 @@ tasks.named("compileTestJava", JavaCompile) {
 }
 
 dependencies {
+  // Use latest logback for Java 21+ tests with better virtual thread support.
+  testImplementation(libs.logback.classic.latest)
+
   testImplementation project(':dd-java-agent:instrumentation:datadog:tracing:trace-annotation')
 }
-
-// Use latest logback for Java 21+ tests with better virtual thread support.
-configurations.named("testRuntimeClasspath") {
-  resolutionStrategy {
-    force libs.logback.classic.latest
-  }
-}
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ lz4 = "1.7.1"
 # Logging
 slf4j = "1.7.30"
 logback = "1.2.13" # required by Java 8 modules.
-logback-latest = "1.5.27" # recommended for Java 11+ modules.
+logback-latest = "1.5.28" # recommended for Java 11+ modules.
 
 # JSON
 jackson = "2.20.0"


### PR DESCRIPTION
# What Does This Do
Reworks the fix introduced in #10551 to properly ensure that Java 21+ modules use the latest Logback version at test runtime.

# Motivation
Fixes CI instability (hanging tests) caused by an outdated Logback version being used during test execution.

# Additional Notes
The previous approach relied on forcing `resolutionStrategy` for `testRuntimeClasspath`, but this did not work as expected — CI tests continued to hang.

During local investigation, I found that Logback `1.2.13` was still being used at test runtime.

Following @bric3’s suggestion, this PR switches to using `testImplementation` instead.
After this change, the latest Logback version is correctly loaded at runtime (verified by checking the class version).