### PR TITLE
Bump `googleJavaFormat` to latest `1.34.1`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
   java {
     removeUnusedImports()
 
-    googleJavaFormat("1.33.0")
+    googleJavaFormat("1.34.1")
   }
   groovyGradle {
     greclipse()

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ spotless {
     target("src/**/*.java")
     // ignore embedded test projects
     targetExclude("src/test/resources/**")
-    googleJavaFormat("1.33.0")
+    googleJavaFormat("1.34.1")
   }
 }
 

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -22,7 +22,7 @@ spotless {
       target 'src/**/*.java'
       // ignore embedded test projects and everything in build dir, e.g. generated sources
       targetExclude('src/test/resources/**', buildDirectoryFiles)
-      googleJavaFormat('1.33.0')
+      googleJavaFormat('1.34.1')
     }
   }
 


### PR DESCRIPTION
# What Does This Do
Bump `googleJavaFormat` to latest `1.34.1`.

# Motivation
Latest tools.

# Additional Notes
Minor update.
