### PR TITLE
Remove use of AtomicReferenceArray in RadixTreeCache

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
@@ -1,8 +1,6 @@
 package datadog.trace.api.cache;
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.IntFunction;
 
 /** Sparse cache of values associated with a small integer */
@@ -25,11 +23,11 @@ public final class RadixTreeCache<T> {
   private final int shift;
   private final int mask;
 
-  private final AtomicReferenceArray<Object[]> tree;
+  private final Object[][] tree;
   private final IntFunction<T> mapper;
 
   public RadixTreeCache(int level1, int level2, IntFunction<T> mapper, int... commonValues) {
-    this.tree = new AtomicReferenceArray<>(level1);
+    this.tree = new Object[level1][];
     this.mapper = mapper;
     this.level1 = level1;
     this.level2 = level2;
@@ -50,31 +48,15 @@ public final class RadixTreeCache<T> {
   }
 
   @SuppressWarnings("unchecked")
-  @SuppressFBWarnings("DCN") // only interested in catching NullPointerException (see note below)
   private T computeIfAbsent(int prefix, int primitive) {
-    Object[] page = tree.get(prefix);
-    if (null == page) {
-      try {
-        page = new Object[level2];
-        if (!tree.compareAndSet(prefix, null, page)) {
-          page = tree.get(prefix);
-        }
-      } catch (NullPointerException e) {
-        // Intermittent NPE observed in JDK code on Semeru 11.0.29: java.lang.NullPointerException:
-        // at j.l.i.ArrayVarHandle$...Operations$OpObject.computeOffset(ArrayVarHandle.java:142)
-        // at j.l.i.ArrayVarHandle$...Operations$OpObject.compareAndSet(ArrayVarHandle.java:201)
-        // at j.u.c.atomic.AtomicReferenceArray.compareAndSet(AtomicReferenceArray.java:152)
-        // at datadog.trace.api.cache.RadixTreeCache.computeIfAbsent(RadixTreeCache.java:59)
-        // Location indicates JDK's VarHandle used to access the backing array has returned null
-        // To mitigate this rare JDK bug we still map the primitive but skip caching the result
-        return mapper.apply(primitive);
-      }
+    Object[] page = tree[prefix];
+    if (page == null) {
+      page = tree[prefix] = new Object[level2]; // tolerate race to cache sub-array
     }
-    // it's safe to race here
     int suffix = primitive & mask;
     Object cached = page[suffix];
     if (cached == null) {
-      cached = page[suffix] = mapper.apply(primitive);
+      cached = page[suffix] = mapper.apply(primitive); // tolerate race to cache value
     }
     return (T) cached;
   }


### PR DESCRIPTION
# What Does This Do

Instead we tolerate racing to cache sub-arrays, like we do for individual values. This does mean two or more threads might create the same sub-array, with only one winning, but this should be rare with later calls picking up the same sub-array.

# Motivation

Ongoing issues on Semeru related to behaviour of `AtomicReferenceArray`.

Benchmarks show removing `AtomicReferenceArray` speeds up the cache, at the expense of recreating a few sub-arrays and their cached values when there is initial contention. Since these sub-arrays are small and we already created new arrays before the compare-and-swap, the issue is more about losing some cached values in the overwritten sub-array.

We already tolerate racing to cache these values - so IMHO this is an acceptable simplification.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
