### PR TITLE
Refactor to store samplers inside probes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
@@ -5,8 +5,6 @@ import datadog.trace.api.sampling.ConstantSampler;
 import datadog.trace.api.sampling.Sampler;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.DoubleFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,19 +18,15 @@ public class ProbeRateLimiter {
   private static final Duration TEN_SECONDS_WINDOW = Duration.of(10, ChronoUnit.SECONDS);
   private static final double DEFAULT_GLOBAL_SNAPSHOT_RATE = DEFAULT_SNAPSHOT_RATE * 100;
   private static final double DEFAULT_GLOBAL_LOG_RATE = 5000.0;
-  private static final ConcurrentMap<String, RateLimitInfo> PROBE_SAMPLERS =
-      new ConcurrentHashMap<>();
-  private static Sampler GLOBAL_SNAPSHOT_SAMPLER = createSampler(DEFAULT_GLOBAL_SNAPSHOT_RATE);
-  private static Sampler GLOBAL_LOG_SAMPLER = createSampler(DEFAULT_GLOBAL_LOG_RATE);
-  private static DoubleFunction<Sampler> samplerSupplier = ProbeRateLimiter::createSampler;
+  private static Sampler GLOBAL_SNAPSHOT_SAMPLER =
+      defaultCreateSampler(DEFAULT_GLOBAL_SNAPSHOT_RATE);
+  private static Sampler GLOBAL_LOG_SAMPLER = defaultCreateSampler(DEFAULT_GLOBAL_LOG_RATE);
+  private static DoubleFunction<Sampler> samplerSupplier = ProbeRateLimiter::defaultCreateSampler;
 
-  public static boolean tryProbe(String probeId) {
-    RateLimitInfo rateLimitInfo =
-        PROBE_SAMPLERS.computeIfAbsent(probeId, ProbeRateLimiter::getDefaultRateLimitInfo);
-    Sampler globalSampler =
-        rateLimitInfo.isCaptureSnapshot ? GLOBAL_SNAPSHOT_SAMPLER : GLOBAL_LOG_SAMPLER;
+  public static boolean tryProbe(Sampler sampler, boolean useGlobalLowRate) {
+    Sampler globalSampler = useGlobalLowRate ? GLOBAL_SNAPSHOT_SAMPLER : GLOBAL_LOG_SAMPLER;
     if (globalSampler.sample()) {
-      return rateLimitInfo.sampler.sample();
+      return sampler.sample();
     }
     return false;
   }
@@ -42,8 +36,8 @@ public class ProbeRateLimiter {
     return new RateLimitInfo(samplerSupplier.apply(DEFAULT_SNAPSHOT_RATE), true);
   }
 
-  public static void setRate(String probeId, double rate, boolean isCaptureSnapshot) {
-    PROBE_SAMPLERS.put(probeId, new RateLimitInfo(samplerSupplier.apply(rate), isCaptureSnapshot));
+  public static Sampler createSampler(double rate) {
+    return samplerSupplier.apply(rate);
   }
 
   public static void setGlobalSnapshotRate(double rate) {
@@ -54,25 +48,16 @@ public class ProbeRateLimiter {
     GLOBAL_LOG_SAMPLER = samplerSupplier.apply(rate);
   }
 
-  public static void resetRate(String probeId) {
-    PROBE_SAMPLERS.remove(probeId);
-  }
-
   public static void resetGlobalRate() {
     setGlobalSnapshotRate(DEFAULT_GLOBAL_LOG_RATE);
   }
 
-  public static void resetAll() {
-    PROBE_SAMPLERS.clear();
-    resetGlobalRate();
-  }
-
   public static void setSamplerSupplier(DoubleFunction<Sampler> samplerSupplier) {
     ProbeRateLimiter.samplerSupplier =
-        samplerSupplier != null ? samplerSupplier : ProbeRateLimiter::createSampler;
+        samplerSupplier != null ? samplerSupplier : ProbeRateLimiter::defaultCreateSampler;
   }
 
-  private static Sampler createSampler(double rate) {
+  private static Sampler defaultCreateSampler(double rate) {
     if (rate < 0) {
       return new ConstantSampler(true);
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -370,6 +370,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
             .where(methodInfo.getClassNode().name, methodInfo.getMethodNode().name)
             .captureSnapshot(false)
             .build();
+    probe.initSamplers();
     probes.add(probe);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -50,6 +50,7 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
         null);
     this.exceptionProbeManager = exceptionProbeManager;
     this.chainedExceptionIdx = chainedExceptionIdx;
+    initSamplers();
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Sampled.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Sampled.java
@@ -1,9 +1,5 @@
 package com.datadog.debugger.probe;
 
 public interface Sampled {
-  Sampling getSampling();
-
-  String getId();
-
-  boolean isCaptureSnapshot();
+  void initSamplers();
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -13,6 +13,8 @@ import static utils.InstrumentationTestHelper.getLineForLineProbe;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.probe.LogProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Sampled;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.TestSnapshotListener;
@@ -55,7 +57,7 @@ public class LogProbesInstrumentationTest {
     if (currentTransformer != null) {
       instr.removeTransformer(currentTransformer);
     }
-    ProbeRateLimiter.resetAll();
+    ProbeRateLimiter.resetGlobalRate();
   }
 
   @Test
@@ -564,6 +566,11 @@ public class LogProbesInstrumentationTest {
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDynamicInstrumentationUploadBatchSize()).thenReturn(100);
+    for (ProbeDefinition probe : configuration.getDefinitions()) {
+      if (probe instanceof Sampled) {
+        ((Sampled) probe).initSamplers();
+      }
+    }
     ProbeMetadata probeMetadata = new ProbeMetadata();
     currentTransformer = new DebuggerTransformer(config, probeMetadata, configuration);
     instr.addTransformer(currentTransformer);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -28,6 +28,7 @@ import com.datadog.debugger.el.expressions.BooleanExpression;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Sampled;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
@@ -79,7 +80,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   public void after() {
     super.after();
     Redaction.clearUserDefinedTypes();
-    ProbeRateLimiter.resetAll();
+    ProbeRateLimiter.resetGlobalRate();
   }
 
   @Test
@@ -758,6 +759,11 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     probeStatusSink = mock(ProbeStatusSink.class);
+    for (ProbeDefinition probe : configuration.getDefinitions()) {
+      if (probe instanceof Sampled) {
+        ((Sampled) probe).initSamplers();
+      }
+    }
     ProbeMetadata probeMetadata = new ProbeMetadata();
     currentTransformer =
         new DebuggerTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -114,7 +114,7 @@ public class ExceptionProbeInstrumentationTest {
       instr.removeTransformer(currentTransformer);
     }
     ProbeRateLimiter.setSamplerSupplier(null);
-    ProbeRateLimiter.resetAll();
+    ProbeRateLimiter.resetGlobalRate();
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -143,7 +143,7 @@ public class LogProbeTest {
         builder.tags("session_id:" + sessionId);
       }
       LogProbe logProbe = builder.build();
-      ProbeRateLimiter.setRate(logProbe.id, -1, captureSnapshot);
+      logProbe.initSamplers();
 
       CapturedContext entryContext = capturedContext(span, logProbe);
       CapturedContext exitContext = capturedContext(span, logProbe);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -140,7 +140,7 @@ public abstract class BaseIntegrationTest {
     }
     datadogAgentServer.shutdown();
     statsDServer.close();
-    ProbeRateLimiter.resetAll();
+    ProbeRateLimiter.resetGlobalRate();
     LOG.info("===== Ending {} ====", testInfo.getDisplayName());
   }
 


### PR DESCRIPTION
# What Does This Do
Samplers were stored inside ProbeRateLimiter singleton into a concurrent map. and only one sampler per probe. Now to allow different samplers for probe, we are storing them directly into the probe instance.
Samplers are created when probes are received from the configuration through initSamplers method from Sampled interface.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5208]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5208]: https://datadoghq.atlassian.net/browse/DEBUG-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ