### PR TITLE
Relaxed filter to skip `redhat` releases.

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleVersionUtils.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleVersionUtils.kt
@@ -57,7 +57,7 @@ internal object MuzzleVersionUtils {
           v.contains("public_draft") ||
           v.contains("-cr") ||
           v.contains("-preview") ||
-          v.contains(".redhat-") || // redhat releases often cause ArtifactNotFoundException
+          v.contains("redhat") || // redhat releases often cause ArtifactNotFoundException
           skipVersions.contains(v) ||
           END_NMN_PATTERN.matches(v) ||
           GIT_SHA_PATTERN.matches(v))


### PR DESCRIPTION
# What Does This Do
Relaxed filter to skip `redhat` releases.
Skip redhat versions, which are frequently broken.

# Motivation
Green CI. Dev Ex.

# Additional Notes
This is a follow up for #10378

Muzzle failed on master, so just matching `redhat` in the version should fix this issue.
```
* What went wrong:
Execution failed for task ':dd-java-agent:instrumentation:snakeyaml-1.33:muzzle-AssertPass-org.yaml-snakeyaml-1.33.0.SP1-redhat-00001-snakeyaml-1-x'.
> A failure occurred while executing datadog.gradle.plugin.muzzle.MuzzleAction
   > Muzzle validation failed
```
