### PR TITLE
Reduce verbosity of StatsD connection errors

### DIFF
--- a/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDConnection.java
+++ b/products/metrics/metrics-lib/src/main/java/datadog/metrics/impl/statsd/DDAgentStatsDConnection.java
@@ -178,11 +178,12 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
             // Display full stack traces on debug logs
             log.warn("Unable to create StatsD client - {} - Will not retry", statsDAddress(), t);
           } else {
-            // Only report the top and root cause message
             Throwable rootCause = t;
-            while (rootCause.getCause() != null) {
+            int i = 100; // arbitrary limit to avoid infinite loops with cycling causes
+            do {
               rootCause = rootCause.getCause();
-            }
+              i--;
+            } while (rootCause.getCause() != null && i > 0);
             log.warn(
                 "Unable to create StatsD client - {} - Will not retry: {}, {}",
                 statsDAddress(),


### PR DESCRIPTION
# What Does This Do

This PR reduces verbosity of StatsD connection error.
It keeps full details / stack trace in debug logs.

# Motivation

Using read-only file system, users get the following log message which is quite verbose and scary:
```
[dd.trace 2026-02-13 13:42:08:766 -0500] [dd-task-scheduler] ERROR datadog.metrics.impl.statsd.DDAgentStatsDConnection - Unable to create StatsD client - /var/run/datadog/dsd.socket - Will not retry
java.lang.UnsatisfiedLinkError: could not load FFI provider jnr.ffi.provider.jffi.Provider
at jnr.ffi.provider.InvalidRuntime.newLoadError(InvalidRuntime.java:102)
at jnr.ffi.provider.InvalidRuntime.findType(InvalidRuntime.java:43)
at jnr.ffi.Struct$NumberField.<init>(Struct.java:978)
at jnr.ffi.Struct$Unsigned16.<init>(Struct.java:1346)
at jnr.unixsocket.SockAddrUnix$DefaultSockAddrUnix.<init>(SockAddrUnix.java:209)
at jnr.unixsocket.SockAddrUnix.create(SockAddrUnix.java:174)
at jnr.unixsocket.UnixSocketAddress.<init>(UnixSocketAddress.java:53)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder$1.call(NonBlockingStatsDClientBuilder.java:332)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder$1.call(NonBlockingStatsDClientBuilder.java:330)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.staticAddressResolution(NonBlockingStatsDClientBuilder.java:357)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.staticAddress(NonBlockingStatsDClientBuilder.java:387)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.getAddressLookup(NonBlockingStatsDClientBuilder.java:267)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.resolve(NonBlockingStatsDClientBuilder.java:239)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.build(NonBlockingStatsDClientBuilder.java:211)
at datadog.metrics.impl.statsd.DDAgentStatsDConnection.doConnect(DDAgentStatsDConnection.java:161)
at datadog.metrics.impl.statsd.DDAgentStatsDConnection.access$000(DDAgentStatsDConnection.java:23)
at datadog.metrics.impl.statsd.DDAgentStatsDConnection$ConnectTask.run(DDAgentStatsDConnection.java:257)
at datadog.metrics.impl.statsd.DDAgentStatsDConnection$ConnectTask.run(DDAgentStatsDConnection.java:251)
at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:342)
at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:294)
at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.UnsatisfiedLinkError: could not get native definition for type `POINTER`, original error message follows: java.io.IOException: Unable to write jffi binary stub to `/tmp`. Set `TMPDIR` or Java property `java.io.tmpdir` to a read/write path that is not mounted "noexec".
```

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
