### PR TITLE
Fix OTel activation tests

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ActivationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ActivationTest.groovy
@@ -14,13 +14,13 @@ abstract class OpenTelemetry14ActivationTest extends InstrumentationSpecificatio
 
     expect:
     if (shouldBeInjected()) {
-      tracer.class.name.endsWith(".OtelTracer")
-      builder.class.name.endsWith(".OtelSpanBuilder")
-      result.class.name.endsWith(".OtelSpan")
-      context.class.name.endsWith(".OtelContext")
+      assert tracer.class.name.endsWith(".OtelTracer")
+      assert builder.class.name.endsWith(".OtelSpanBuilder")
+      assert result.class.name.endsWith(".OtelSpan")
+      assert context.class.name.endsWith(".OtelContext")
     } else {
-      tracer.class.name.endsWith(".DefaultTracer")
-      context.class.name.endsWith(".ArrayBasedContext")
+      assert tracer.class.name.endsWith(".DefaultTracer")
+      assert context.class.name.endsWith(".ArrayBasedContext")
     }
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.47/src/test/groovy/OpenTelemetry147ActivationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.47/src/test/groovy/OpenTelemetry147ActivationTest.groovy
@@ -10,9 +10,9 @@ abstract class OpenTelemetry147ActivationTest extends InstrumentationSpecificati
 
     expect:
     if (shouldBeInjected()) {
-      meter.class.name.endsWith(".OtelMeter")
+      assert meter.class.name.endsWith(".OtelMeter")
     } else {
-      meter.class.name.endsWith(".DefaultTracer")
+      assert meter.class.name.endsWith(".DefaultMeter")
     }
   }
 }
@@ -25,7 +25,7 @@ class OpenTelemetry147ActivationByInstrumentationNameForkedTest extends OpenTele
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
-    injectSysConfig("integration.opentelemetry.metrics.enabled", "true")
+    injectSysConfig("integration.opentelemetry-metrics.enabled", "true")
   }
 
   @Override


### PR DESCRIPTION
Noticed that the OTel activation tests weren't actually asserting properly - after fixing this I also fixed some copy-paste errors :)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
