### PR TITLE
Restored #9435 since even with latest logback Java 21+ tests with virtual threads have a chance to hang on CI.

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-21.0/build.gradle
@@ -1,5 +1,10 @@
+plugins {
+  id 'idea'
+}
+
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'idea'
+// Use slf4j-simple as default; logback has a high chance of getting stuck in a deadlock on CI.
+apply from: "$rootDir/gradle/slf4j-simple.gradle"
 
 testJvmConstraints {
   minJavaVersion = JavaVersion.VERSION_21
@@ -48,8 +53,5 @@ tasks.named("check") {
 }
 
 dependencies {
-  // Use latest logback for Java 21+ tests with better virtual thread support.
-  testImplementation(libs.logback.classic.latest)
-
   testImplementation project(':dd-java-agent:instrumentation:datadog:tracing:trace-annotation')
 }

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-25.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-25.0/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+// Use slf4j-simple as default; logback has a high chance of getting stuck in a deadlock on CI.
+apply from: "$rootDir/gradle/slf4j-simple.gradle"
 
 muzzle {
   pass {
@@ -14,9 +16,4 @@ idea {
   module {
     jdkName = '25'
   }
-}
-
-dependencies {
-  // Use latest logback for Java 21+ tests with better virtual thread support.
-  testImplementation(libs.logback.classic.latest)
 }

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+// Use slf4j-simple as default; logback has a high chance of getting stuck in a deadlock on CI.
+apply from: "$rootDir/gradle/slf4j-simple.gradle"
 
 testJvmConstraints {
   minJavaVersion = JavaVersion.VERSION_21
@@ -26,8 +28,5 @@ tasks.named("compileTestJava", JavaCompile) {
 }
 
 dependencies {
-  // Use latest logback for Java 21+ tests with better virtual thread support.
-  testImplementation(libs.logback.classic.latest)
-
   testImplementation project(':dd-java-agent:instrumentation:datadog:tracing:trace-annotation')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,6 @@ lz4 = "1.7.1"
 # Logging
 slf4j = "1.7.30"
 logback = "1.2.13" # required by Java 8 modules.
-logback-latest = "1.5.28" # recommended for Java 11+ modules.
 
 # JSON
 jackson = "2.20.0"
@@ -135,7 +134,6 @@ lz4 = { module = "org.lz4:lz4-java", version.ref = "lz4" }
 
 # Logging
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-logback-classic-latest = { module = "ch.qos.logback:logback-classic", version.ref = "logback-latest" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }

--- a/gradle/slf4j-simple.gradle
+++ b/gradle/slf4j-simple.gradle
@@ -1,0 +1,27 @@
+// Apply this script when `slf4j-simple` should be used instead of `logback`.
+
+configurations.configureEach { cfg ->
+  def name = cfg.name
+
+  if (name.containsIgnoreCase("test")) {
+    // Exclude Logback from all test-like runtimeClasspath configurations.
+    if (name.endsWithIgnoreCase("runtimeClasspath")) {
+      cfg.exclude group: "ch.qos.logback"
+    }
+
+    // Add slf4j-simple to all test-like runtimeOnly configurations.
+    if (name.endsWithIgnoreCase("runtimeOnly")) {
+      project.dependencies.add(name, "org.slf4j:slf4j-simple:${libs.versions.slf4j.get()}")
+    }
+  }
+}
+
+// Configure `slf4j-simple` logger.
+tasks.withType(Test).configureEach {
+  jvmArgs += [
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+    "-Dorg.slf4j.simpleLogger.showThreadName=true",
+    "-Dorg.slf4j.simpleLogger.showDateTime=true",
+    "-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
+  ]
+}


### PR DESCRIPTION
# What Does This Do
Restored #9435 since even with latest logback Java 21+ tests with virtual threads have a chance to hang on CI.

# Motivation
Green CI.

# Additional Notes
Unfortunatelly CI still frezes from time to time even with latest Logback (not that often, but still).
I checked that `OutputStreamAppender.java:211`  is from latest codebase, not from `1.2.13`.
```
"Test worker" #1 [11040] prio=5 os_prio=0 cpu=5342.68ms elapsed=1142.21s tid=0x00007ff2e8030160 nid=11040 waiting on condition  [0x00007ff2ec8fa000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@21.0.9/Native Method)
	- parking to wait for  <0x00000000c1800a18> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	at java.util.concurrent.locks.LockSupport.park(java.base@21.0.9/LockSupport.java:221)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.9/AbstractQueuedSynchronizer.java:788)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.9/AbstractQueuedSynchronizer.java:1024)
	at java.util.concurrent.locks.ReentrantLock$Sync.lock(java.base@21.0.9/ReentrantLock.java:153)
	at java.util.concurrent.locks.ReentrantLock.lock(java.base@21.0.9/ReentrantLock.java:322)
	at ch.qos.logback.core.OutputStreamAppender.writeBytes(OutputStreamAppender.java:211)
	at ch.qos.logback.core.OutputStreamAppender.writeOut(OutputStreamAppender.java:204)
	at ch.qos.logback.core.OutputStreamAppender.subAppend(OutputStreamAppender.java:257)
	at ch.qos.logback.core.OutputStreamAppender.append(OutputStreamAppender.java:111)
	at ch.qos.logback.core.UnsynchronizedAppenderBase.doAppend(UnsynchronizedAppenderBase.java:82)
	at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:51)
	at ch.qos.logback.classic.Logger.appendLoopOnAppenders(Logger.java:272)
	at ch.qos.logback.classic.Logger.callAppenders(Logger.java:259)
	at ch.qos.logback.classic.Logger.buildLoggingEventAndAppend(Logger.java:431)
	at ch.qos.logback.classic.Logger.filterAndLog_1(Logger.java:406)
	at ch.qos.logback.classic.Logger.debug(Logger.java:496)
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
