### PR TITLE
Force manual keep of traces for AI Guard

### DIFF
--- a/dd-java-agent/agent-aiguard/src/main/java/com/datadog/aiguard/AIGuardInternal.java
+++ b/dd-java-agent/agent-aiguard/src/main/java/com/datadog/aiguard/AIGuardInternal.java
@@ -12,6 +12,7 @@ import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.aiguard.AIGuard;
 import datadog.trace.api.aiguard.AIGuard.AIGuardAbortError;
 import datadog.trace.api.aiguard.AIGuard.AIGuardClientError;
@@ -218,6 +219,10 @@ public class AIGuardInternal implements Evaluator {
       builder.asChildOf(parent.context());
     }
     final AgentSpan span = builder.start();
+    final AgentSpan localRootSpan = span.getLocalRootSpan();
+    if (localRootSpan != null) {
+      localRootSpan.setTag(DDTags.MANUAL_KEEP, true);
+    }
     try (final AgentScope scope = tracer.activateSpan(span)) {
       final Message last = messages.get(messages.size() - 1);
       if (isToolCall(last)) {

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/AIGuardSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/AIGuardSmokeTest.groovy
@@ -69,9 +69,15 @@ class AIGuardSmokeTest extends AbstractAppSecServerSmokeTest {
     ?.find {
       it.resource == 'ai_guard'
     } as DecodedSpan
+    final rootSpan = traces*.spans
+    ?.flatten()
+    ?.find {
+      it.traceId == span.traceId && it.parentId == 0
+    } as DecodedSpan
     assert span.meta.get('ai_guard.action') == action
     assert span.meta.get('ai_guard.reason') == reason
     assert span.meta.get('ai_guard.target') == 'prompt'
+    assert rootSpan.metrics.get('_sampling_priority_v1') == 2
     final messages = span.metaStruct.get('ai_guard').messages as List<Map<String, Object>>
     assert messages.size() == 2
     with(messages[0]) {


### PR DESCRIPTION
# What Does This Do

* AI Guard UI depends on all its spans reaching our intake, and sampling is generally not acceptable here.
* Force `manual.keep` for traces when an AI Guard span is generated.

# Motivation

# Additional Notes

* system-tests: https://github.com/DataDog/system-tests/pull/6334
* Jira ticket:  [APPSEC-61364](https://datadoghq.atlassian.net/browse/APPSEC-61364)
* PR prepared with OpenCode.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors


***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-61364]: https://datadoghq.atlassian.net/browse/APPSEC-61364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ