### PR TITLE
Use Matcher.replaceAll in QueryObfuscator

### DIFF
--- a/dd-trace-core/src/jmh/java/datadog/trace/core/tagprocessor/QueryObfuscatorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/tagprocessor/QueryObfuscatorBenchmark.java
@@ -1,0 +1,45 @@
+package datadog.trace.core.tagprocessor;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import datadog.query.QueryObfuscator;
+
+@Fork(2)
+@Warmup(iterations=2)
+@Measurement(iterations=3)
+@Threads(8)
+public class QueryObfuscatorBenchmark {
+  static final QueryObfuscator obfuscator = new QueryObfuscator(null);
+  
+  static final String NO_REDACT = "foo=bar";
+  static final String SIMPLE_REDACT = "app_key=1111";
+  static final String LARGE_REDACT = repeat("app_key=1111&application_key=2222&token=0894-4832", '&', 4096);
+
+  static final String repeat(String repeat, char separator, int length) {
+    StringBuilder builder = new StringBuilder(length);
+    builder.append(repeat);
+    while ( builder.length() + repeat.length() + 1 < length ) {
+      builder.append(separator).append(repeat);
+    }
+    return builder.toString();
+  }
+  
+  @Benchmark
+  public String noRedact() {
+	return obfuscator.obfuscate(NO_REDACT);
+  }
+  
+  @Benchmark
+  public String simpleRedact() {
+	return obfuscator.obfuscate(SIMPLE_REDACT);
+  }
+  
+  @Benchmark
+  public String largeRedact() {	
+	return obfuscator.obfuscate(LARGE_REDACT);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
@@ -49,10 +49,8 @@ public final class QueryObfuscator extends TagsPostProcessor {
 
   private String obfuscate(String query) {
     if (pattern != null) {
-      Matcher matcher = pattern.matcher(query);
-      while (matcher.find()) {
-        query = Strings.replace(query, matcher.group(), "<redacted>");
-      }
+      java.util.regex.Matcher matcher = pattern.matcher(query);
+      return matcher.replaceAll("<redacted>");
     }
     return query;
   }


### PR DESCRIPTION
# What Does This Do
Changes QueryObfuscator to use Matcher.replaceAll to perform redaction
Improves worst case performance of QueryObfuscator at the expense of average case performance

# Motivation
In the QueryObfuscatorBenchmark, the no redact & simple redact cases drop-off by 4-6%, but the large redact case improves 3x.

# Additional Notes
In subsequent PR, I'm going to use regex matching on CharSequence that provide a view into the query string to further reduce the overhead.  This PR is just a stop gap to mitigate the worst case behavior.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
