### PR TITLE
Disable jdk.CPUTimeSample when ddprof handles CPU profiling

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -82,14 +82,19 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
       switch (mode) {
         case CPU:
           {
-            // CPU execution profiling will take over these events
+            // CPU execution profiling will take over these events, including
+            // jdk.CPUTimeSample (JEP 518, JDK 25+) which is enabled as a fallback
+            // when ddprof is unavailable
             log.debug("Disabling built-in CPU profiling events");
             recording.disable("jdk.ExecutionSample");
             recording.disable("jdk.NativeMethodSample");
+            recording.disable("jdk.CPUTimeSample");
+            recording.disable("jdk.CPUTimeSamplesLost");
             break;
           }
         case WALL:
           {
+            // wall-time profiling will take over these events
             log.debug("Disabling built-in wall-time tracing events");
             recording.disable("jdk.JavaMonitorWait");
             recording.disable("jdk.ThreadPark");
@@ -113,9 +118,7 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
             break;
           }
         default:
-          {
-            // do nothing
-          }
+          break;
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Disables `jdk.CPUTimeSample` (JEP 518, JDK 25+) and its companion `jdk.CPUTimeSamplesLost` event when ddprof is active and handling CPU profiling.

# Motivation

`jdk.CPUTimeSample` is enabled in `dd.jfp` and conditionally in `OpenJdkController` as a fallback CPU sampler for JDK 25+/Linux when ddprof is unavailable. However, `disableOverriddenEvents()` did not disable it when ddprof loaded successfully and claimed `ProfilingMode.CPU`. This left both ddprof's `datadog.ExecutionSample` and the JEP 518 cooperative sampler running simultaneously, adding unnecessary overhead.

The fix adds `jdk.CPUTimeSample` and `jdk.CPUTimeSamplesLost` to the set of events disabled in the `CPU` case of `disableOverriddenEvents()`, consistent with how `jdk.ExecutionSample` and `jdk.NativeMethodSample` are already handled.

# Additional Notes

- No behaviour change when ddprof is unavailable: `disableOverriddenEvents()` is only called when `context.isDatadogProfilerEnabled()` is true, so the JEP 518 fallback path is unaffected.
- Also adds the missing intro comment to the `WALL` case and cleans up the `default` case to use a bare `break` instead of `{ // do nothing }`.

Jira ticket: [PROF-13797]

[PROF-13797]: https://datadoghq.atlassian.net/browse/PROF-13797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ