### PR TITLE
Skip mule-core 4.6.27 due to missing artifacts

### DIFF
--- a/dd-java-agent/instrumentation/mule-4.5/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4.5/build.gradle
@@ -9,7 +9,7 @@ muzzle {
     group = 'org.mule.runtime'
     module = 'mule-core'
     versions = "[$muleVersion,)"
-    skipVersions = ['4.9.1'] // missing transitive dependency
+    skipVersions = ['4.6.27', '4.9.1'] // missing transitive dependency
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'
@@ -19,7 +19,7 @@ muzzle {
     group = 'org.mule.runtime'
     module = 'mule-tracer-customization-impl'
     versions = "[$muleVersion,)"
-    skipVersions = ['4.9.1'] // missing transitive dependency
+    skipVersions = ['4.6.27', '4.9.1'] // missing transitive dependency
     javaVersion = "17"
     excludeDependency 'om.google.guava:guava'
     excludeDependency 'com.google.code.findbugs:jsr305'


### PR DESCRIPTION
# What Does This Do

Skip `mule-core` release `v4.6.27` due to missing `mule-runtime-bom-parent:4.6.27` artifact causing muzzle tests to fail

# Motivation

Ref: https://repository.mulesoft.org/nexus/#browse/browse:releases:org%2Fmule%2Fmule-runtime-bom-parent

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
