### PR TITLE
Store accumulator-stage lookups directly

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -676,7 +676,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
 
     SparkPlanInfo sqlPlan = sqlPlans.get(sqlExecutionId);
     if (sqlPlan != null) {
-      SparkSQLUtils.addSQLPlanToStageSpan(span, sqlPlan, accumulatorToStageID, stageMetric, stageId);
+      SparkSQLUtils.addSQLPlanToStageSpan(
+          span, sqlPlan, accumulatorToStageID, stageMetric, stageId);
     }
 
     span.finish(completionTimeMs * 1000);

--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/SparkSQLUtils.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/SparkSQLUtils.java
@@ -88,7 +88,8 @@ public class SparkSQLUtils {
     return null;
   }
 
-  private static Set<Integer> stageIdsForPlan(SparkPlanInfo info, Map<Long, Integer> accumulatorToStageID) {
+  private static Set<Integer> stageIdsForPlan(
+      SparkPlanInfo info, Map<Long, Integer> accumulatorToStageID) {
     Set<Integer> stageIds = new HashSet<>();
 
     Collection<SQLMetricInfo> metrics =


### PR DESCRIPTION
# What Does This Do
Stores the map of accumulator ID to stage ID directly in a `Long` - `Integer` map, rather than storing the stage-level accumulators themselves.

# Motivation
The stage-level accumulators naively roll up metrics from the task level by summing all values. This means they are not accurate in all cases, particular for metrics that are better visualized as a distribution of values across all tasks instead of a single sum. 

In https://github.com/DataDog/dd-trace-java/pull/10553/ we rollup task-level metrics ourselves and encode them into the Spark SQL metrics as distributions in order to improve the granularity of information collected. This left one remaining use of the stage-level accumulators - mapping operations in Spark SQL plans to their respective stages. 

Since we do not need the entire accumulator to accomplish this, we should simplify that to a ID-ID map instead to save space. We can also remove the 50k limit since we are not storing the entire accumulator, allowing us to avoid creating orphaned operations (previously occurred when the `EldestHashMap` overflowed).

# Additional Notes
I didn't feel the explicit need for a FF here, since the change is fairly straightforwards and shouldn't negatively impact perf. However, if we feel strongly otherwise I'm happy to make that happen.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
