### PR TITLE
Added support for collecting thread dumps for IBM8 Java

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/dump/DumpHangedTestPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/dump/DumpHangedTestPlugin.kt
@@ -191,8 +191,6 @@ class DumpHangedTestPlugin : Plugin<Project> {
       .filter { it.contains("Gradle Test Executor") }
       .map { it.substringBefore(' ') }
 
-  private val ibmMarkers: List<String> = listOf("ibm", "openj9", "semeru")
-
   private fun extractPidsIbm8(file: File): List<String> =
     file.readLines()
       .filter { it.contains("Gradle Test Executor") }


### PR DESCRIPTION
# What Does This Do
Added support for collecting thread dumps for IBM8 Java.

# Motivation
On CI we have task that is hanging from time to time and only on IBM8 Java: `:dd-smoke-tests:osgi:test`
`jcmd` can not be used to collect thread dump for IBM8 Java.
I found that `kill -3 PID` will trigger generation of `javacore` that will contain information to debug hanged test.

# Additional Notes
Tested on CI manually:
- Created a fake test that will simply sleep for 21 minutes
- Triggered CI for Java 8 and IBM8
- Checked artifacts generated, found that `javacore` file generated and collected.
- Inside there was the following content:
```
3XMTHREADINFO      "Test worker" J9VMThread:0x0000000000020C00, omrthread_t:0x00007F1E48007AA0, java/lang/Thread:0x00000000C010A740, state:CW, rawStateValue:0x8, prio=5
3XMJAVALTHREAD            (java/lang/Thread getId:0x1, isDaemon:false)
3XMJAVALTHRCCL            sun/misc/Launcher$AppClassLoader(0x00000000C00F9570)
3XMTHREADINFO1            (native thread ID:0xF36, native priority:0x5, native policy:UNKNOWN, vmstate:CW, vm thread flags:0x00000481)
3XMTHREADINFO2            (native stack address range from:0x00007F1E4E4FB000, to:0x00007F1E4ECFB000, size:0x800000)
3XMCPUTIME               CPU usage total: 3.045660461 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=7114552 (0x6C8F38)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at java/lang/Thread.sleepImpl(Native Method)
4XESTACKTRACE                at java/lang/Thread.sleep(Thread.java:974)
4XESTACKTRACE                at java/lang/Thread.sleep(Thread.java:957)
4XESTACKTRACE                at datadog/smoketest/IbmDumpTest.testIbmDump(IbmDumpTest.java:14)
4XESTACKTRACE                at sun/reflect/NativeMethodAccessorImpl.invoke0(Native Method)
4XESTACKTRACE                at sun/reflect/NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
4XESTACKTRACE                at sun/reflect/DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55(Compiled Code))
4XESTACKTRACE                at java/lang/reflect/Method.invoke(Method.java:508(Compiled Code))
4XESTACKTRACE                at org/junit/platform/commons/util/ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
```
