### PR TITLE
 Always collect response headers in span when AppSec is enabled

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -920,10 +920,14 @@ public class GatewayBridge {
         // Report all collected request headers on user tracking event
         writeRequestHeaders(
             ctx, traceSeg, REQUEST_HEADERS_ALLOW_LIST, ctx.getRequestHeaders(), false);
+        writeResponseHeaders(
+            ctx, traceSeg, RESPONSE_HEADERS_ALLOW_LIST, ctx.getResponseHeaders(), false);
       } else {
         // Report minimum set of collected request headers
         writeRequestHeaders(
             ctx, traceSeg, DEFAULT_REQUEST_HEADERS_ALLOW_LIST, ctx.getRequestHeaders(), false);
+        writeResponseHeaders(
+            ctx, traceSeg, RESPONSE_HEADERS_ALLOW_LIST, ctx.getResponseHeaders(), false);
       }
       // If extracted any derivatives - commit them
       if (!ctx.commitDerivatives(traceSeg)) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -1192,6 +1192,10 @@ class GatewayBridgeSpecification extends DDSpecification {
       'x-sigsci-tags'                    : ['SQLI, XSS'],
       'akamai-user-risk'                 : ['uuid=913c4545-757b-4d8d-859d-e1361a828361;status=0'],
     ]
+    mockAppSecCtx.responseHeaders >> [
+      'content-type'  : ['text/plain'],
+      'content-length': ['13'],
+    ]
     final mockCtx = Stub(RequestContext) {
       getData(RequestContextSlot.APPSEC) >> mockAppSecCtx
       getTraceSegment() >> traceSegment
@@ -1217,6 +1221,8 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * traceSegment.setTagTop('http.request.headers.x-sigsci-requestid', '55c24b96ca84c02201000001')
     1 * traceSegment.setTagTop('http.request.headers.x-sigsci-tags', 'SQLI, XSS')
     1 * traceSegment.setTagTop('http.request.headers.akamai-user-risk', 'uuid=913c4545-757b-4d8d-859d-e1361a828361;status=0')
+    1 * traceSegment.setTagTop('http.response.headers.content-type', 'text/plain')
+    1 * traceSegment.setTagTop('http.response.headers.content-length', '13')
   }
 
   void 'request headers are always set when there are user tracking events'() {
@@ -1225,6 +1231,9 @@ class GatewayBridgeSpecification extends DDSpecification {
       transferCollectedEvents() >> []
       getRequestHeaders() >> [
         'host': ['localhost']
+      ]
+      getResponseHeaders() >> [
+        'content-type': ['text/plain']
       ]
     }
     final mockCtx = Stub(RequestContext) {
@@ -1239,6 +1248,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     then:
     (userTracking ? 1 : 0) * traceSegment.setTagTop('http.request.headers.host', 'localhost')
+    1 * traceSegment.setTagTop('http.response.headers.content-type', 'text/plain')
 
     where:
     tag                                       | userTracking


### PR DESCRIPTION
# What Does This Do

Writes response headers (`content-type, content-length, content-encoding, content-language`) into the span for every request when AppSec is enabled, not just when a WAF event is detected.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [[APPSEC-61289](https://datadoghq.atlassian.net/browse/APPSEC-61289)]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
