### PR TITLE
Skip maven instrumentation test case with latest dependencies

### DIFF
--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/build.gradle
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/build.gradle
@@ -11,6 +11,10 @@ muzzle {
 
 addTestSuiteForDir('latestDepTest', 'test')
 
+tasks.named("latestDepTest", Test) {
+  systemProperty 'test.isLatestDepTest', 'true'
+}
+
 dependencies {
   compileOnly 'org.apache.maven:maven-embedder:3.2.1'
 

--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
@@ -8,6 +8,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assumptions.abort
 
 class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
 
@@ -31,6 +32,10 @@ class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test #testcaseName"() {
+    if (skipLatest && Boolean.getBoolean("test.isLatestDepTest")) {
+      abort("Skipping latest dep test")
+    }
+
     String workingDirectory = projectFolder.toString()
 
     def exitCode = new MavenCli().doMain(args.toArray(new String[0]), workingDirectory, null, null)
@@ -39,15 +44,15 @@ class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
     assertSpansData(testcaseName)
 
     where:
-    testcaseName                                                                      | args                           | expectedExitCode
-    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0
-    "test_maven_build_with_incorrect_command_generates_spans"                         | ["-B", "unknownPhase"]         | 1
-    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0
-    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1
-    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1
-    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0
-    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0
-    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0
+    testcaseName                                                                      | args                           | expectedExitCode | skipLatest
+    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0                | false
+    "test_maven_build_with_incorrect_command_generates_spans"                          | ["-B", "unknownPhase"]         | 1                | false
+    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0                | false
+    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1                | false
+    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1                | false
+    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0                | false
+    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0                | true // temporary workaround to avoid failures with maven-failsafe-plugin 3.5.5
+    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0                | false
   }
 
   private void givenMavenProjectFiles(String projectFilesSources) {


### PR DESCRIPTION
# What Does This Do

- Temporal workaround to avoid failures in `MavenInstrumentationTest."test_maven_build_with_unit_and_integration_tests_generates_spans"` due to the newest release of `maven-failsafe-plugin 3.5.5`

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
