### PR TITLE
Workaround for latest maven-failsafe-plugin test

### DIFF
--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/build.gradle
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/build.gradle
@@ -11,10 +11,6 @@ muzzle {
 
 addTestSuiteForDir('latestDepTest', 'test')
 
-tasks.named("latestDepTest", Test) {
-  systemProperty 'test.isLatestDepTest', 'true'
-}
-
 dependencies {
   compileOnly 'org.apache.maven:maven-embedder:3.2.1'
 

--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
@@ -9,7 +9,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import static org.junit.jupiter.api.Assertions.assertEquals
-import static org.junit.jupiter.api.Assumptions.abort
 
 class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
 
@@ -41,10 +40,6 @@ class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
   }
 
   def "test #testcaseName"() {
-    if (skipLatest && Boolean.getBoolean("test.isLatestDepTest")) {
-      abort("Skipping latest dep test")
-    }
-
     String workingDirectory = projectFolder.toString()
 
     def exitCode = new MavenCli().doMain(args.toArray(new String[0]), workingDirectory, null, null)
@@ -53,15 +48,15 @@ class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
     assertSpansData(testcaseName)
 
     where:
-    testcaseName                                                                      | args                           | expectedExitCode | skipLatest
-    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0                | false
-    "test_maven_build_with_incorrect_command_generates_spans"                          | ["-B", "unknownPhase"]         | 1                | false
-    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0                | false
-    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1                | false
-    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1                | false
-    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0                | false
-    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0                | true // temporary workaround to avoid failures with maven-failsafe-plugin 3.5.5
-    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0                | false
+    testcaseName                                                                      | args                           | expectedExitCode
+    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0
+    "test_maven_build_with_incorrect_command_generates_spans"                         | ["-B", "unknownPhase"]         | 1
+    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0
+    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1
+    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1
+    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0
+    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0
+    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0
   }
 
   private void givenMavenProjectFiles(String projectFilesSources) {


### PR DESCRIPTION
# What Does This Do

- Avoids bug causing a forked JVM crash when running `MavenInstrumentationTest.test_maven_build_with_unit_and_integration_tests_generates_spans` on `latestDepTest` by initializing the MDC context map with `MDC.put()` on test setup.

# Motivation

The `latestDepTest` for `test_maven_build_with_unit_and_integration_tests_generates_spans` started failing after the 3.5.5 release with: 

```
The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Process Exit Code: 0
```

The new release added MDC context propagation in https://github.com/apache/maven-surefire/pull/3241 to `ThreadedStreamConsumer$Pumper` by capturing MDC context map on parent thread and setting it in daemon threads. 

This causes an NPE with `logback-classic` when `LogbackMDCAdapter.getCopyOfContextMap()` returns `null` and is later set with `LogbackMDCAdapter.setContextMap(null)` (https://jira.qos.ch/browse/LOGBACK-944). When there is no `slf4j` binding it defaults to a `NOPMDCAdapter`, which doesn't trigger the NPE. For the instrumentation tests, the Logback adapter seems to be active due to `MavenCli.doMain()` being used and Logback being available in the host JVM's classloader. The issue was also fixed in Logback in [1.4.2](https://github.com/qos-ch/logback/commit/7e3e2ae770), but we are limited to `1.2.13` due to Java 8 compatibility.

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
