### PR TITLE
Fix Windows path parsing in JarScanner

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.symbol;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -65,6 +66,13 @@ public class JarScanner {
   private static Path getPathFromPrefixedFileName(String locationStr, String prefix, int endIdx) {
     String fileName = locationStr.substring(prefix.length(), endIdx);
     LOGGER.debug("jar filename={}", fileName);
-    return Paths.get(fileName);
+    try {
+      // Reconstruct a file URI and use Paths.get(URI) to correctly handle
+      // platform-specific paths, including Windows drive letters (e.g. /C:/...)
+      return Paths.get(new URI("file:" + fileName));
+    } catch (URISyntaxException e) {
+      LOGGER.debug("Failed to parse as URI: {}, falling back to direct path", fileName, e);
+      return Paths.get(fileName);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
@@ -8,10 +8,13 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class JarScannerTest {
   @Test
@@ -49,5 +52,29 @@ class JarScannerTest {
     ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
     assertEquals(
         jarFileUrl.getFile(), JarScanner.extractJarPath(protectionDomain, null).toString());
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  public void extractJarPathFromFileOnWindows() throws URISyntaxException {
+    URL mockLocation = mock(URL.class);
+    when(mockLocation.toString()).thenReturn("file:/C:/apps/server/classes/");
+    CodeSource codeSource = new CodeSource(mockLocation, (Certificate[]) null);
+    ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
+    Path result = JarScanner.extractJarPath(protectionDomain, SymDBReport.NO_OP);
+    assertNotNull(result);
+    assertTrue(result.toString().contains("server"));
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  public void extractJarPathFromJarOnWindows() throws URISyntaxException {
+    URL mockLocation = mock(URL.class);
+    when(mockLocation.toString()).thenReturn("jar:file:/C:/libs/app.jar!/com/example/");
+    CodeSource codeSource = new CodeSource(mockLocation, (Certificate[]) null);
+    ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
+    Path result = JarScanner.extractJarPath(protectionDomain, SymDBReport.NO_OP);
+    assertNotNull(result);
+    assertTrue(result.toString().contains("app.jar"));
   }
 }


### PR DESCRIPTION
# What Does This Do

Use Paths.get(URI) instead of Paths.get(String) to correctly handle Windows drive letters in CodeSource locations (e.g. file:/C:/...).

# Motivation

Fixes a reported exception thrown by windows path parser

> Illegal char <:> at index 2: /C:/XXX/XXX/XXX

See [DYNIS-50](https://datadoghq.atlassian.net/browse/DYNIS-50) for full report

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: DYNIS-50

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DYNIS-50]: https://datadoghq.atlassian.net/browse/DYNIS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ