### PR TITLE
Don't skip Gradle projects when on merge queue

### DIFF
--- a/.gitlab/find-gh-base-ref.sh
+++ b/.gitlab/find-gh-base-ref.sh
@@ -14,6 +14,12 @@ if [[ $CI_COMMIT_BRANCH =~ ^(master|release/.*)$ ]]; then
   exit 1
 fi
 
+# See .test_job declaration
+if [[ $CI_COMMIT_BRANCH =~ ^(mq-working-branch-|gh-readonly-queue/) ]]; then
+  echo "CI_COMMIT_BRANCH is a merge queue branch, skipping base ref detection" >&2
+  exit 1
+fi
+
 CURRENT_HEAD_SHA="$(git rev-parse HEAD)"
 if [[ -z "${CURRENT_HEAD_SHA:-}" ]]; then
   echo "Failed to determine current HEAD SHA" >&2


### PR DESCRIPTION
# What Does This Do

Do not skip Gradle projects on merge queues.
Like with `master`, ignore base-ref detection on merge branches. 

# Motivation

We should run the whole test suites on merge queue branches (`mq-working-branch-*` and `gh-readonly-queue/*`). Enforcing a full test coverage.

## Additional notes

`CIJobsExtensions.kt` activates project-level test filtering (when invoking root aggregator tasks like `:baseTest`) when `-PgitBaseRef` is passed:

https://github.com/DataDog/dd-trace-java/blob/032229660ee0dd36650e04b5326fdaa04dedee54/buildSrc/src/main/kotlin/datadog/gradle/plugin/ci/CIJobsExtensions.kt#L104-L120

And `-PgitBaseRef` is only injected if `find-gh-base-ref.sh` resolves a base ref (see `gitlab_base_ref_params` anchor):

https://github.com/DataDog/dd-trace-java/blob/032229660ee0dd36650e04b5326fdaa04dedee54/.gitlab-ci.yml#L592-L592

https://github.com/DataDog/dd-trace-java/blob/032229660ee0dd36650e04b5326fdaa04dedee54/.gitlab-ci.yml#L135-L142

This is happening because the following guard in `find-gh-base-ref.sh` skips master and release branches, but **misses the merge queue branches**:

https://github.com/DataDog/dd-trace-java/blob/032229660ee0dd36650e04b5326fdaa04dedee54/.gitlab/find-gh-base-ref.sh#L12-L15

Since merge queue branches were treated as any other branches, the `find-gh-base-ref.sh` guard was not applied — this meant that the script resolved `master` as the base ref, and ultimately set `useGitChanges = true`, thus only projects touched by the PR diff were tested.

This is not what we want for merge queues.

This behavior started after daf2c01407dac47dea7c46d273261413bcb6b488 (#10623 running non-default JVM variants) that added the `gh-readonly-queue/*` and `mq-working-branch-*` rules to `.test_job` (via ).

* [skipping projects on merge queue branches](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fapm-reliability%2Fdd-trace-java%22%20%22not%20affected%20by%20changed%20files%22%20%40git.branch%3A%28gh-readonly-queue%2Fmaster%2A%20OR%20mq-working-branch-master%2A%29&agg_m=count&agg_m_source=base&agg_q=%40git.branch&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40git.branch&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=pattern&x_missing=true&from_ts=1770657098644&to_ts=1771953098644&live=false)
  
<img width="1959" height="913" alt="image" src="https://github.com/user-attachments/assets/3b6941e1-8813-4335-a6f5-4e8c36f5b6b9" />

