### PR TITLE
Workaround for Redisson test teardown to avoid shutdown hangs on CI.

### DIFF
--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/test/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/test/groovy/RedissonClientTest.groovy
@@ -73,8 +73,8 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
   }
 
   // Some shutdown paths in old Redisson versions can block forever.
-  // In tests this is acceptable as best-effort cleanup, so run shutdown in a daemon helper
-  // thread to make sure teardown cannot keep the JVM alive.
+  // In tests this is acceptable as best-effort cleanup, so run shutdown in
+  // a daemon helper thread to make sure teardown cannot keep the JVM alive.
   private static void tryShutdown(String component, Closure shutdownAction) {
     Thread shutdownThread = new Thread({
       try {
@@ -87,14 +87,13 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     shutdownThread.start()
 
     try {
-      // Keep test teardown bounded to avoid hanging CI jobs indefinitely.
       shutdownThread.join(10_000L)
     } catch (InterruptedException ignored) {
       Thread.currentThread().interrupt()
     }
 
     if (shutdownThread.isAlive()) {
-      println "Timed out shutting down ${component}"
+      println "Timed out shutting down of ${component}"
     }
   }
 


### PR DESCRIPTION
# What Does This Do
This PR addresses a flaky test that hangs on CI with a probability of ~5%.
The hang consistently occurs during test teardown, inside `Redisson.shutdown()`.
Thread dumps show the test blocking in Netty:
```
	at io.netty.util.concurrent.DefaultPromise.awaitUninterruptibly(DefaultPromise.java:286)
	- locked <0x00000000c3d03760> (a io.netty.util.concurrent.DefaultPromise)
	at io.netty.util.concurrent.DefaultPromise.syncUninterruptibly(DefaultPromise.java:225)
	at io.netty.util.concurrent.DefaultPromise.syncUninterruptibly(DefaultPromise.java:32)
	at org.redisson.connection.MasterSlaveConnectionManager.shutdown(MasterSlaveConnectionManager.java:472)
	at org.redisson.Redisson.shutdown(Redisson.java:301)
	at org.redisson.RedissonClient$shutdown$7.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(Abstract
```

# Motivation
Green CI.

# Additional Notes
After Googling and consulting various LLMs, I decided to implement a workaround that is good enough for this test. Since it hangs during teardown, all we really need is to ensure it does not hang indefinitely. Also, this test targets a very old version of the `Redisson` library that does not provide proper shutdown methods with a timeout.
