### PR TITLE
[WIP] Revisit and unify profiling settings

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -17,10 +17,16 @@ package com.datadog.profiling.controller.openjdk;
 
 import static com.datadog.profiling.controller.ProfilingSupport.*;
 import static datadog.environment.JavaVirtualMachine.isJavaVersionAtLeast;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOC_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CPU_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_MODE;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_MODE_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LATENCY_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LIVEHEAP_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LIVEHEAP_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS;
@@ -192,14 +198,101 @@ public final class OpenJdkController implements Controller {
 
     // Toggle settings from config
 
-    if (configProvider.getBoolean(
-        ProfilingConfig.PROFILING_HEAP_ENABLED, ProfilingConfig.PROFILING_HEAP_ENABLED_DEFAULT)) {
-      log.debug("Enabling OldObjectSample JFR event with the config.");
-      recordingSettings.put("jdk.OldObjectSample#enabled", "true");
+    // --- CPU profiling umbrella (profiling.cpu.enabled) ---
+    Boolean cpuUmbrella = configProvider.getBoolean(PROFILING_CPU_ENABLED);
+    if (cpuUmbrella != null) {
+      if (cpuUmbrella) {
+        // Re-enable the correct CPU sampling event for the current JDK
+        if (JavaVirtualMachine.isJavaVersionAtLeast(25) && OperatingSystem.isLinux()) {
+          enableEvent(recordingSettings, "jdk.CPUTimeSample", EXPLICITLY_ENABLED);
+          enableEvent(recordingSettings, "jdk.CPUTimeSamplesLost", EXPLICITLY_ENABLED);
+        } else {
+          enableEvent(recordingSettings, "jdk.ExecutionSample", EXPLICITLY_ENABLED);
+        }
+      } else {
+        disableEvent(recordingSettings, "jdk.ExecutionSample", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.CPUTimeSample", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.CPUTimeSamplesLost", EXPLICITLY_DISABLED);
+      }
     }
 
-    if (configProvider.getBoolean(
-        ProfilingConfig.PROFILING_ALLOCATION_ENABLED, isObjectAllocationSampleAvailable())) {
+    // --- Latency profiling umbrella (profiling.latency.enabled) ---
+    Boolean latencyUmbrella = configProvider.getBoolean(PROFILING_LATENCY_ENABLED);
+    if (latencyUmbrella != null) {
+      if (latencyUmbrella) {
+        enableEvent(recordingSettings, "jdk.JavaMonitorEnter", EXPLICITLY_ENABLED);
+        enableEvent(recordingSettings, "jdk.JavaMonitorWait", EXPLICITLY_ENABLED);
+        enableEvent(recordingSettings, "jdk.JavaMonitorInflate", EXPLICITLY_ENABLED);
+        enableEvent(recordingSettings, "jdk.FileRead", EXPLICITLY_ENABLED);
+        if (isFileWriteDurationCorrect()) {
+          enableEvent(recordingSettings, "jdk.FileWrite", EXPLICITLY_ENABLED);
+        }
+        enableEvent(recordingSettings, "jdk.SocketRead", EXPLICITLY_ENABLED);
+        enableEvent(recordingSettings, "jdk.SocketWrite", EXPLICITLY_ENABLED);
+        enableEvent(recordingSettings, "jdk.ThreadStart", EXPLICITLY_ENABLED);
+      } else {
+        disableEvent(recordingSettings, "jdk.JavaMonitorEnter", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.JavaMonitorWait", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.JavaMonitorInflate", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.FileRead", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.FileWrite", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.SocketRead", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.SocketWrite", EXPLICITLY_DISABLED);
+        disableEvent(recordingSettings, "jdk.ThreadStart", EXPLICITLY_DISABLED);
+      }
+    }
+
+    // --- Live heap profiling (profiling.liveheap.enabled / profiling.heap.enabled) ---
+    // profiling.heap.enabled (explicit JFR override) takes precedence over umbrella
+    Boolean heapExplicit = configProvider.getBoolean(ProfilingConfig.PROFILING_HEAP_ENABLED);
+    if (heapExplicit != null) {
+      if (heapExplicit) {
+        log.debug("Enabling OldObjectSample JFR event with the config.");
+        recordingSettings.put("jdk.OldObjectSample#enabled", "true");
+      } else {
+        disableEvent(recordingSettings, "jdk.OldObjectSample", EXPLICITLY_DISABLED);
+      }
+    } else {
+      // Umbrella defaults to true — all GA features enabled out of the box.
+      // Use nullable check to distinguish explicit user setting from default.
+      Boolean liveheapUmbrella = configProvider.getBoolean(PROFILING_LIVEHEAP_ENABLED);
+      boolean liveheapEnabled =
+          liveheapUmbrella != null ? liveheapUmbrella : PROFILING_LIVEHEAP_ENABLED_DEFAULT;
+      if (liveheapEnabled) {
+        // Enable liveheap on the best available backend.
+        // ddprof handles it when: ddprof is overall active AND liveheap not explicitly disabled.
+        boolean ddprofLiveheapExplicitlyDisabled =
+            Boolean.FALSE.equals(
+                configProvider.getBoolean(
+                    ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED,
+                    ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED));
+        boolean ddprofEnabled =
+            configProvider.getBoolean(ProfilingConfig.PROFILING_DATADOG_PROFILER_ENABLED, false);
+        if (ddprofEnabled && !ddprofLiveheapExplicitlyDisabled) {
+          // ddprof will handle live heap; suppress JFR OldObjectSample to avoid redundant overhead
+          disableEvent(
+              recordingSettings, "jdk.OldObjectSample", "ddprof backend handles live heap");
+        } else if (liveheapUmbrella != null || isOldObjectSampleAvailable()) {
+          // Explicit umbrella=true: force-enable OldObjectSample (even on older JDKs).
+          // Default (umbrella not set): only enable if OldObjectSample is inexpensive.
+          recordingSettings.put("jdk.OldObjectSample#enabled", "true");
+        }
+      } else {
+        disableEvent(recordingSettings, "jdk.OldObjectSample", EXPLICITLY_DISABLED);
+      }
+    }
+
+    // --- Allocation profiling (profiling.alloc.enabled / profiling.allocation.enabled) ---
+    // Priority: profiling.allocation.enabled (JFR override) > profiling.alloc.enabled (umbrella)
+    //           > default (ObjectAllocationSample availability)
+    Boolean allocationExplicit =
+        configProvider.getBoolean(ProfilingConfig.PROFILING_ALLOCATION_ENABLED);
+    Boolean allocationUmbrella = configProvider.getBoolean(PROFILING_ALLOC_ENABLED);
+    boolean allocationEnabled =
+        allocationExplicit != null
+            ? allocationExplicit
+            : allocationUmbrella != null ? allocationUmbrella : isObjectAllocationSampleAvailable();
+    if (allocationEnabled) {
       // jdk.ObjectAllocationSample is available and enabled by default
       if (!isObjectAllocationSampleAvailable()) {
         log.debug(
@@ -212,6 +305,16 @@ public final class OpenJdkController implements Controller {
       if (isObjectAllocationSampleAvailable()) {
         log.debug("Disabling ObjectAllocationSample JFR event with the config.");
         recordingSettings.put("jdk.ObjectAllocationSample#enabled", "false");
+      }
+    }
+
+    // --- Exception profiling umbrella (profiling.exception.enabled) ---
+    Boolean exceptionUmbrella = configProvider.getBoolean(PROFILING_EXCEPTION_ENABLED);
+    if (exceptionUmbrella != null) {
+      if (exceptionUmbrella) {
+        enableEvent(recordingSettings, "datadog.ExceptionSample", EXPLICITLY_ENABLED);
+      } else {
+        disableEvent(recordingSettings, "datadog.ExceptionSample", EXPLICITLY_DISABLED);
       }
     }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -4,15 +4,22 @@ import static com.datadog.profiling.controller.ProfilingSupport.isNativeMethodSa
 import static com.datadog.profiling.controller.ProfilingSupport.isObjectAllocationSampleAvailable;
 import static com.datadog.profiling.controller.ProfilingSupport.isOldObjectSampleAvailable;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOC_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_AUXILIARY_TYPE;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_AUXILIARY_TYPE_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CPU_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DISABLED_EVENTS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LATENCY_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LIVEHEAP_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.datadog.profiling.controller.ControllerContext;
 import com.datadog.profiling.controller.jfr.JfpUtilsTest;
@@ -231,6 +238,266 @@ public class OpenJdkControllerTest {
         assertTrue(
             Boolean.parseBoolean(recording.getSettings().get("jdk.NativeMethodSample#enabled")));
       }
+    }
+  }
+
+  @Test
+  public void testCpuUmbrellaDisablesTurnOffCpuEvents() throws Exception {
+    Properties props = getConfigProperties();
+    props.put(PROFILING_CPU_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ExecutionSample#enabled")),
+          "ExecutionSample should be disabled when profiling.cpu.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.CPUTimeSample#enabled")),
+          "CPUTimeSample should be disabled when profiling.cpu.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.CPUTimeSamplesLost#enabled")),
+          "CPUTimeSamplesLost should be disabled when profiling.cpu.enabled=false");
+    }
+  }
+
+  @Test
+  public void testLatencyUmbrellaDisablesLatencyEvents() throws Exception {
+    Properties props = getConfigProperties();
+    props.put(PROFILING_LATENCY_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.JavaMonitorEnter#enabled")),
+          "JavaMonitorEnter should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.JavaMonitorWait#enabled")),
+          "JavaMonitorWait should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.JavaMonitorInflate#enabled")),
+          "JavaMonitorInflate should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.FileRead#enabled")),
+          "FileRead should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.FileWrite#enabled")),
+          "FileWrite should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.SocketRead#enabled")),
+          "SocketRead should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.SocketWrite#enabled")),
+          "SocketWrite should be disabled when profiling.latency.enabled=false");
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ThreadStart#enabled")),
+          "ThreadStart should be disabled when profiling.latency.enabled=false");
+    }
+  }
+
+  @Test
+  public void testLiveheapUmbrellaFalseDisablesOldObjectSample() throws Exception {
+    assumeTrue(isOldObjectSampleAvailable());
+    Properties props = getConfigProperties();
+    props.put(PROFILING_LIVEHEAP_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")),
+          "OldObjectSample should be disabled when profiling.liveheap.enabled=false");
+    }
+  }
+
+  @Test
+  public void testLiveheapUmbrellaTrueEnablesOldObjectSampleWhenDdprofDisabled() throws Exception {
+    Properties props = getConfigProperties();
+    // ddprof disabled → JFR must handle liveheap
+    props.put(PROFILING_LIVEHEAP_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")),
+          "OldObjectSample should be enabled when profiling.liveheap.enabled=true and ddprof disabled");
+    }
+  }
+
+  @Test
+  public void testHeapEnabledFalseOverridesLiveheapUmbrella() throws Exception {
+    assumeTrue(isOldObjectSampleAvailable());
+    Properties props = getConfigProperties();
+    // Explicit JFR override takes precedence over umbrella
+    props.put(PROFILING_LIVEHEAP_ENABLED, "true");
+    props.put(PROFILING_HEAP_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")),
+          "profiling.heap.enabled=false should override profiling.liveheap.enabled=true");
+    }
+  }
+
+  @Test
+  public void testAllocUmbrellaDisablesAllocationOnModernJdk() throws Exception {
+    assumeTrue(isObjectAllocationSampleAvailable());
+    Properties props = getConfigProperties();
+    props.put(PROFILING_ALLOC_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ObjectAllocationSample#enabled")),
+          "ObjectAllocationSample should be disabled when profiling.alloc.enabled=false");
+    }
+  }
+
+  @Test
+  public void testAllocationEnabledOverridesAllocUmbrella() throws Exception {
+    assumeTrue(isObjectAllocationSampleAvailable());
+    Properties props = getConfigProperties();
+    // Explicit JFR-level override takes precedence over umbrella
+    props.put(PROFILING_ALLOC_ENABLED, "false");
+    props.put(PROFILING_ALLOCATION_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ObjectAllocationSample#enabled")),
+          "profiling.allocation.enabled=true should override profiling.alloc.enabled=false");
+    }
+  }
+
+  @Test
+  public void testExceptionUmbrellaDisablesExceptionSample() throws Exception {
+    Properties props = getConfigProperties();
+    props.put(PROFILING_EXCEPTION_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertFalse(
+          Boolean.parseBoolean(recording.getSettings().get("datadog.ExceptionSample#enabled")),
+          "datadog.ExceptionSample should be disabled when profiling.exception.enabled=false");
+    }
+  }
+
+  @Test
+  public void testCpuUmbrellaTrueReEnablesCpuEvents() throws Exception {
+    Properties props = getConfigProperties();
+    // First disable CPU events via disabled.events, then re-enable via umbrella
+    props.put(PROFILING_DISABLED_EVENTS, "jdk.ExecutionSample");
+    props.put(PROFILING_CPU_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ExecutionSample#enabled")),
+          "ExecutionSample should be re-enabled when profiling.cpu.enabled=true");
+    }
+  }
+
+  @Test
+  public void testLatencyUmbrellaTrueReEnablesLatencyEvents() throws Exception {
+    Properties props = getConfigProperties();
+    // First disable latency events via disabled.events, then re-enable via umbrella
+    props.put(PROFILING_DISABLED_EVENTS, "jdk.JavaMonitorEnter,jdk.FileRead");
+    props.put(PROFILING_LATENCY_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.JavaMonitorEnter#enabled")),
+          "JavaMonitorEnter should be re-enabled when profiling.latency.enabled=true");
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.FileRead#enabled")),
+          "FileRead should be re-enabled when profiling.latency.enabled=true");
+    }
+  }
+
+  @Test
+  public void testExceptionUmbrellaTrueReEnablesExceptionSample() throws Exception {
+    Properties props = getConfigProperties();
+    // First disable exception event via disabled.events, then re-enable via umbrella
+    props.put(PROFILING_DISABLED_EVENTS, "datadog.ExceptionSample");
+    props.put(PROFILING_EXCEPTION_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("datadog.ExceptionSample#enabled")),
+          "datadog.ExceptionSample should be re-enabled when profiling.exception.enabled=true");
+    }
+  }
+
+  @Test
+  public void testDefaultsPreservedWhenNoUmbrellaSet() throws Exception {
+    // Verify that JFR event defaults remain unchanged when no umbrella properties are set
+    Properties props = getConfigProperties();
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    OpenJdkController controller = new OpenJdkController(configProvider);
+    try (Recording recording =
+        ((OpenJdkRecordingData)
+                controller.createRecording(TEST_NAME, new ControllerContext().snapshot()).stop())
+            .getRecording()) {
+      // CPU events should follow template defaults (enabled)
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.ExecutionSample#enabled"))
+              || Boolean.parseBoolean(recording.getSettings().get("jdk.CPUTimeSample#enabled")),
+          "CPU sampling event should be enabled by default");
+      // OldObjectSample should match JVM support
+      assertEquals(
+          isOldObjectSampleAvailable(),
+          Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")),
+          "OldObjectSample should follow JVM support when no umbrella set");
+      // Latency events should be enabled by default (from template)
+      assertTrue(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.JavaMonitorEnter#enabled")),
+          "JavaMonitorEnter should be enabled by default");
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerFlareReporter.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerFlareReporter.java
@@ -99,6 +99,42 @@ public final class ProfilerFlareReporter implements TracerFlare.Reporter {
             ProfilingConfig.PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT),
         ProfilingConfig.PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT);
 
+    sb.append("\n=== Feature Umbrella Settings ===\n");
+    appendConfig(
+        sb,
+        "CPU Profiling",
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_CPU_ENABLED, ProfilingConfig.PROFILING_CPU_ENABLED_DEFAULT),
+        ProfilingConfig.PROFILING_CPU_ENABLED_DEFAULT);
+    appendConfig(
+        sb,
+        "Latency Profiling",
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_LATENCY_ENABLED,
+            ProfilingConfig.PROFILING_LATENCY_ENABLED_DEFAULT),
+        ProfilingConfig.PROFILING_LATENCY_ENABLED_DEFAULT);
+    appendConfig(
+        sb,
+        "Allocation Profiling (umbrella)",
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_ALLOC_ENABLED,
+            ProfilingConfig.PROFILING_ALLOC_ENABLED_DEFAULT),
+        ProfilingConfig.PROFILING_ALLOC_ENABLED_DEFAULT);
+    appendConfig(
+        sb,
+        "Live Heap Profiling",
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_LIVEHEAP_ENABLED,
+            ProfilingConfig.PROFILING_LIVEHEAP_ENABLED_DEFAULT),
+        ProfilingConfig.PROFILING_LIVEHEAP_ENABLED_DEFAULT);
+    appendConfig(
+        sb,
+        "Exception Profiling",
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_EXCEPTION_ENABLED,
+            ProfilingConfig.PROFILING_EXCEPTION_ENABLED_DEFAULT),
+        ProfilingConfig.PROFILING_EXCEPTION_ENABLED_DEFAULT);
+
     sb.append("\n=== Upload Settings ===\n");
     appendConfig(
         sb,

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -2,14 +2,16 @@ package com.datadog.profiling.ddprof;
 
 import static datadog.environment.JavaVirtualMachine.isJ9;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOC_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CPU_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CPU_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_INTERVAL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CSTACK;
@@ -20,7 +22,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_SAMPLE_PERCENT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_SAMPLE_PERCENT_DEFAULT;
@@ -47,6 +48,9 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_JVMTI_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_TRACK_GENERATIONS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_TRACK_GENERATIONS_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LATENCY_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LIVEHEAP_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LIVEHEAP_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_STACKDEPTH;
@@ -67,10 +71,15 @@ public class DatadogProfilerConfig {
   private static final Logger log = LoggerFactory.getLogger(DatadogProfilerConfig.class);
 
   public static boolean isCpuProfilerEnabled(ConfigProvider configProvider) {
-    return getBoolean(
-        configProvider,
-        PROFILING_DATADOG_PROFILER_CPU_ENABLED,
-        PROFILING_DATADOG_PROFILER_CPU_ENABLED_DEFAULT);
+    // profiling.ddprof.cpu.enabled takes precedence over the umbrella profiling.cpu.enabled
+    Boolean ddprofCpu =
+        configProvider.getBoolean(
+            PROFILING_DATADOG_PROFILER_CPU_ENABLED,
+            normalizeKey(PROFILING_DATADOG_PROFILER_CPU_ENABLED));
+    if (ddprofCpu != null) {
+      return ddprofCpu;
+    }
+    return configProvider.getBoolean(PROFILING_CPU_ENABLED, PROFILING_CPU_ENABLED_DEFAULT);
   }
 
   public static String getLibPath(ConfigProvider configProvider) {
@@ -120,8 +129,23 @@ public class DatadogProfilerConfig {
     boolean isUltraMinimal = getBoolean(configProvider, PROFILING_ULTRA_MINIMAL, false);
     boolean isTracingEnabled = configProvider.getBoolean(TRACE_ENABLED, true);
     boolean disableUnlessOptedIn = isUltraMinimal || !isTracingEnabled || isJ9();
-    boolean enabledByDefault = !disableUnlessOptedIn;
-    return getBoolean(configProvider, PROFILING_DATADOG_PROFILER_WALL_ENABLED, enabledByDefault);
+    // profiling.ddprof.wall.enabled takes precedence over the umbrella profiling.latency.enabled
+    Boolean ddprofWall =
+        configProvider.getBoolean(
+            PROFILING_DATADOG_PROFILER_WALL_ENABLED,
+            normalizeKey(PROFILING_DATADOG_PROFILER_WALL_ENABLED));
+    if (ddprofWall != null) {
+      return ddprofWall;
+    }
+    Boolean umbrella = configProvider.getBoolean(PROFILING_LATENCY_ENABLED);
+    if (umbrella != null) {
+      // Umbrella can serve as an explicit opt-in (e.g. on J9 where wall is off by default),
+      // but wall-clock still requires tracing (context filter depends on span contexts)
+      // and is not enabled in ultra-minimal mode or on J9.
+      // Use profiling.ddprof.wall.enabled=true to bypass all these guards.
+      return umbrella && !disableUnlessOptedIn;
+    }
+    return !disableUnlessOptedIn;
   }
 
   public static int getWallInterval(ConfigProvider configProvider) {
@@ -193,13 +217,29 @@ public class DatadogProfilerConfig {
     // JVMTI Allocation Sampler is available since Java 11
     if (JavaVirtualMachine.isJavaVersionAtLeast(11)) {
       boolean dflt = isJmethodIDSafe();
-      boolean enableDdprofAlloc =
-          getBoolean(
-              configProvider,
-              PROFILING_ALLOCATION_ENABLED,
-              dflt,
-              PROFILING_DATADOG_PROFILER_ALLOC_ENABLED);
-
+      // Priority: profiling.ddprof.alloc.enabled > profiling.alloc.enabled >
+      //           profiling.allocation.enabled > default
+      Boolean ddprofAlloc =
+          configProvider.getBoolean(
+              PROFILING_DATADOG_PROFILER_ALLOC_ENABLED,
+              normalizeKey(PROFILING_DATADOG_PROFILER_ALLOC_ENABLED));
+      if (ddprofAlloc != null) {
+        if (!dflt && ddprofAlloc) {
+          log.warn(
+              "Allocation profiling was enabled although it is not considered stable on this JVM version.");
+        }
+        return ddprofAlloc;
+      }
+      Boolean newUmbrella = configProvider.getBoolean(PROFILING_ALLOC_ENABLED);
+      if (newUmbrella != null) {
+        if (!dflt && newUmbrella) {
+          log.warn(
+              "Allocation profiling was enabled although it is not considered stable on this JVM version.");
+        }
+        return newUmbrella;
+      }
+      // Fall back to old umbrella / default
+      boolean enableDdprofAlloc = configProvider.getBoolean(PROFILING_ALLOCATION_ENABLED, dflt);
       if (!dflt && enableDdprofAlloc) {
         log.warn(
             "Allocation profiling was enabled although it is not considered stable on this JVM version.");
@@ -226,17 +266,25 @@ public class DatadogProfilerConfig {
 
   public static boolean isMemoryLeakProfilingEnabled(ConfigProvider configProvider) {
     boolean isSafe = isJmethodIDSafe();
-    boolean enableDdprofMemleak =
-        getBoolean(
-            configProvider,
+    // Priority: profiling.ddprof.liveheap.enabled (+ deprecated memleak alias) >
+    //           profiling.liveheap.enabled > default
+    Boolean ddprofLiveheap =
+        configProvider.getBoolean(
             PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED,
-            PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT,
-            PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED);
-    if (!isSafe && enableDdprofMemleak) {
+            PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED,
+            normalizeKey(PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED));
+    boolean enable;
+    if (ddprofLiveheap != null) {
+      enable = ddprofLiveheap;
+    } else {
+      enable =
+          configProvider.getBoolean(PROFILING_LIVEHEAP_ENABLED, PROFILING_LIVEHEAP_ENABLED_DEFAULT);
+    }
+    if (!isSafe && enable) {
       log.warn(
           "Memory leak profiling was enabled although it is not considered stable on this JVM version.");
     }
-    return enableDdprofMemleak;
+    return enable;
   }
 
   public static boolean isMemoryLeakProfilingEnabled() {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerConfigTest.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerConfigTest.java
@@ -1,13 +1,18 @@
 package com.datadog.profiling.ddprof;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.util.Properties;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -125,5 +130,182 @@ class DatadogProfilerConfigTest {
         Arguments.of("fp", "fp"),
         Arguments.of("lbr", "lbr"),
         Arguments.of("no", "no"));
+  }
+
+  // --- Umbrella property tests ---
+
+  @Test
+  void testCpuUmbrellaFalseDisablesCpu() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_CPU_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(DatadogProfilerConfig.isCpuProfilerEnabled(configProvider));
+  }
+
+  @Test
+  void testCpuUmbrellaTrueEnablesCpu() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_CPU_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(DatadogProfilerConfig.isCpuProfilerEnabled(configProvider));
+  }
+
+  @Test
+  void testDdprofCpuOverridesTrueWinsOverUmbrellaFalse() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_CPU_ENABLED, "false");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(
+        DatadogProfilerConfig.isCpuProfilerEnabled(configProvider),
+        "profiling.ddprof.cpu.enabled=true should override profiling.cpu.enabled=false");
+  }
+
+  @Test
+  void testLatencyUmbrellaFalseDisablesWall() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LATENCY_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider));
+  }
+
+  @Test
+  void testLatencyUmbrellaTrueEnablesWall() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LATENCY_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider));
+  }
+
+  @Test
+  void testDdprofWallOverridesFalseWinsOverLatencyUmbrellaTrue() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LATENCY_ENABLED, "true");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(
+        DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider),
+        "profiling.ddprof.wall.enabled=false should override profiling.latency.enabled=true");
+  }
+
+  @Test
+  void testLiveheapUmbrellaFalseDisablesDdprofLiveheap() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LIVEHEAP_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(DatadogProfilerConfig.isMemoryLeakProfilingEnabled(configProvider));
+  }
+
+  @Test
+  void testLiveheapUmbrellaTrueEnablesDdprofLiveheap() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LIVEHEAP_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(DatadogProfilerConfig.isMemoryLeakProfilingEnabled(configProvider));
+  }
+
+  @Test
+  void testDdprofLiveheapFalseOverridesUmbrellaTrue() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LIVEHEAP_ENABLED, "true");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(
+        DatadogProfilerConfig.isMemoryLeakProfilingEnabled(configProvider),
+        "profiling.ddprof.liveheap.enabled=false should override profiling.liveheap.enabled=true");
+  }
+
+  @Test
+  void testAllocUmbrellaTrueEnablesDdprofAlloc() {
+    assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(11));
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ALLOC_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(DatadogProfilerConfig.isAllocationProfilingEnabled(configProvider));
+  }
+
+  @Test
+  void testAllocUmbrellaFalseDisablesDdprofAlloc() {
+    assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(11));
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ALLOC_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(DatadogProfilerConfig.isAllocationProfilingEnabled(configProvider));
+  }
+
+  @Test
+  void testDdprofAllocTrueOverridesAllocUmbrellaFalse() {
+    assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(11));
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ALLOC_ENABLED, "false");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(
+        DatadogProfilerConfig.isAllocationProfilingEnabled(configProvider),
+        "profiling.ddprof.alloc.enabled=true should override profiling.alloc.enabled=false");
+  }
+
+  @Test
+  void testDdprofWallTrueBypassesTracingGuard() {
+    Properties props = new Properties();
+    props.put("trace.enabled", "false");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(
+        DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider),
+        "profiling.ddprof.wall.enabled=true should bypass the tracing-disabled guard");
+  }
+
+  @Test
+  void testDdprofWallTrueBypassesUltraMinimalGuard() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ULTRA_MINIMAL, "true");
+    props.put(ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED, "true");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertTrue(
+        DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider),
+        "profiling.ddprof.wall.enabled=true should bypass the ultra-minimal guard");
+  }
+
+  @Test
+  void testLatencyUmbrellaTrueWithTracingDisabledDoesNotEnableWall() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_LATENCY_ENABLED, "true");
+    props.put("trace.enabled", "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(
+        DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider),
+        "profiling.latency.enabled=true should not enable wall-clock when tracing is disabled");
+  }
+
+  @Test
+  void testDefaultsPreservedWhenNoUmbrellaSet() {
+    // Verify that with no umbrella properties set, existing defaults are preserved
+    Properties props = new Properties();
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    // CPU default: true
+    assertTrue(
+        DatadogProfilerConfig.isCpuProfilerEnabled(configProvider),
+        "CPU profiling should be enabled by default when no umbrella set");
+
+    // Wall default: depends on tracing/J9/ultra-minimal, but on HotSpot with tracing=true it's ON
+    assertTrue(
+        DatadogProfilerConfig.isWallClockProfilerEnabled(configProvider),
+        "Wall-clock profiling should be enabled by default on HotSpot with tracing");
+
+    // Liveheap default: true (all GA features enabled by default)
+    assertTrue(
+        DatadogProfilerConfig.isMemoryLeakProfilingEnabled(configProvider),
+        "Liveheap profiling should be enabled by default");
+  }
+
+  @Test
+  void testOldAllocationUmbrellaFalseDisablesDdprofAlloc() {
+    assumeTrue(JavaVirtualMachine.isJavaVersionAtLeast(11));
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ALLOCATION_ENABLED, "false");
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+    assertFalse(DatadogProfilerConfig.isAllocationProfilingEnabled(configProvider));
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -5,10 +5,149 @@ package datadog.trace.api.config;
  *
  * <p>Configure via system properties, environment variables, or config properties file. See online
  * documentation for details.
+ *
+ * <h2>GA feature umbrella properties</h2>
+ *
+ * <p>Each GA profiling feature has a single umbrella property of the form {@code
+ * profiling.<feature>.enabled}. All umbrella properties default to {@code true}, meaning every GA
+ * feature is enabled out of the box. Setting a property to {@code false} disables the feature
+ * entirely. The agent automatically selects the best available backend for the current JVM.
+ *
+ * <p>The low-level backend properties (e.g. {@code profiling.ddprof.cpu.enabled}) remain fully
+ * supported and take precedence over the umbrella when both are set. This allows fine-grained
+ * control: for example, {@code profiling.liveheap.enabled=true} together with {@code
+ * profiling.ddprof.liveheap.enabled=false} enables live-heap profiling via JFR OldObjectSample even
+ * though the ddprof backend is also available.
+ *
+ * <table border="1">
+ *   <caption>GA feature umbrella properties</caption>
+ *   <tr><th>Feature</th><th>Umbrella property</th><th>JFR mechanism</th><th>ddprof mechanism</th></tr>
+ *   <tr><td>CPU</td><td>{@value #PROFILING_CPU_ENABLED}</td>
+ *       <td>jdk.ExecutionSample / jdk.CPUTimeSample (JDK 25+ on Linux)</td>
+ *       <td>{@value #PROFILING_DATADOG_PROFILER_CPU_ENABLED}</td></tr>
+ *   <tr><td>Latency (lock / I/O / thread)</td><td>{@value #PROFILING_LATENCY_ENABLED}</td>
+ *       <td>jdk.JavaMonitor*, jdk.File*, jdk.Socket*, jdk.ThreadStart</td>
+ *       <td>{@value #PROFILING_DATADOG_PROFILER_WALL_ENABLED} (wall-clock)</td></tr>
+ *   <tr><td>Allocation</td><td>{@value #PROFILING_ALLOC_ENABLED}</td>
+ *       <td>jdk.ObjectAllocationSample (see also {@value #PROFILING_ALLOCATION_ENABLED})</td>
+ *       <td>{@value #PROFILING_DATADOG_PROFILER_ALLOC_ENABLED}</td></tr>
+ *   <tr><td>Live heap</td><td>{@value #PROFILING_LIVEHEAP_ENABLED}</td>
+ *       <td>jdk.OldObjectSample (see also {@value #PROFILING_HEAP_ENABLED})</td>
+ *       <td>{@value #PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED}</td></tr>
+ *   <tr><td>Exception</td><td>{@value #PROFILING_EXCEPTION_ENABLED}</td>
+ *       <td>datadog.ExceptionSample (instrumentation-based)</td><td>n/a</td></tr>
+ * </table>
  */
 public final class ProfilingConfig {
   public static final String PROFILING_ENABLED = "profiling.enabled";
   public static final boolean PROFILING_ENABLED_DEFAULT = false;
+
+  // spotless:off
+  /**
+   * Enables or disables CPU profiling across all backends. Defaults to {@code true}.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — activates JFR ExecutionSample (or CPUTimeSample on JDK 25+ /
+   *       Linux) and, when the ddprof backend is available,
+   *       {@value #PROFILING_DATADOG_PROFILER_CPU_ENABLED}.
+   *   <li>{@code false} — disables both JFR CPU events and ddprof CPU profiling.
+   * </ul>
+   *
+   * <p>Fine-grained override: {@value #PROFILING_DATADOG_PROFILER_CPU_ENABLED} takes precedence
+   * over this property for the ddprof backend.
+   */
+  // spotless:on
+  public static final String PROFILING_CPU_ENABLED = "profiling.cpu.enabled";
+
+  public static final boolean PROFILING_CPU_ENABLED_DEFAULT = true;
+
+  // spotless:off
+  /**
+   * Enables or disables latency profiling (lock contention, I/O waits, and thread creation) across
+   * all backends. Defaults to {@code true}.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — JFR monitor / file / socket / thread events are active and
+   *       ddprof wall-clock profiling is enabled (if the ddprof backend is available and the JVM
+   *       supports it — e.g. wall-clock is not available on J9 or in ultra-minimal mode).
+   *   <li>{@code false} — disables the JFR lock/I/O/thread events and ddprof wall-clock profiling.
+   * </ul>
+   *
+   * <p>Fine-grained override: {@value #PROFILING_DATADOG_PROFILER_WALL_ENABLED} takes precedence
+   * over this property for the ddprof backend.
+   */
+  // spotless:on
+  public static final String PROFILING_LATENCY_ENABLED = "profiling.latency.enabled";
+
+  public static final boolean PROFILING_LATENCY_ENABLED_DEFAULT = true;
+
+  // spotless:off
+  /**
+   * Enables or disables allocation profiling across all backends. Defaults to {@code true}.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — activates JFR ObjectAllocationSample (JDK 16+) and ddprof
+   *       allocation profiling (if the ddprof backend is available and the JVM is considered stable
+   *       for jmethodID usage).
+   *   <li>{@code false} — disables both JFR allocation events and ddprof allocation profiling.
+   * </ul>
+   *
+   * <p>Fine-grained overrides: {@value #PROFILING_DATADOG_PROFILER_ALLOC_ENABLED} for the ddprof
+   * backend; {@value #PROFILING_ALLOCATION_ENABLED} for the JFR backend. Both take precedence over
+   * this property for their respective backends.
+   */
+  // spotless:on
+  public static final String PROFILING_ALLOC_ENABLED = "profiling.alloc.enabled";
+
+  public static final boolean PROFILING_ALLOC_ENABLED_DEFAULT = true;
+
+  // spotless:off
+  /**
+   * Enables or disables live heap profiling, automatically selecting the best available backend.
+   * Defaults to {@code true}.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — when the ddprof backend is active and
+   *       {@value #PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED} is not explicitly disabled, ddprof
+   *       live-heap profiling is used and JFR OldObjectSample is suppressed to avoid redundant
+   *       overhead. When ddprof is not active (or is explicitly disabled for live heap), JFR
+   *       OldObjectSample is enabled instead (on supported JDK versions).
+   *   <li>{@code false} — disables both ddprof live-heap profiling and JFR OldObjectSample.
+   * </ul>
+   *
+   * <p>Fine-grained overrides: {@value #PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED} for the
+   * ddprof backend; {@value #PROFILING_HEAP_ENABLED} for the JFR backend. Both take precedence
+   * over this property for their respective backends.
+   *
+   * <p>Example — prefer JFR even when ddprof is available:
+   * <pre>
+   *   profiling.liveheap.enabled=true
+   *   profiling.ddprof.liveheap.enabled=false
+   * </pre>
+   */
+  // spotless:on
+  public static final String PROFILING_LIVEHEAP_ENABLED = "profiling.liveheap.enabled";
+
+  public static final boolean PROFILING_LIVEHEAP_ENABLED_DEFAULT = true;
+
+  // spotless:off
+  /**
+   * Enables or disables exception profiling. Defaults to {@code true}.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — the {@code datadog.ExceptionSample} JFR event is active,
+   *       rate-limited by {@value #PROFILING_EXCEPTION_SAMPLE_LIMIT}.
+   *   <li>{@code false} — exception profiling is disabled.
+   * </ul>
+   *
+   * <p>There is no ddprof backend for exception profiling; this property controls only the JFR
+   * instrumentation path.
+   */
+  // spotless:on
+  public static final String PROFILING_EXCEPTION_ENABLED = "profiling.exception.enabled";
+
+  public static final boolean PROFILING_EXCEPTION_ENABLED_DEFAULT = true;
+
   public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
   public static final String PROFILING_HEAP_ENABLED = "profiling.heap.enabled";
   public static final boolean PROFILING_HEAP_ENABLED_DEFAULT = false;

--- a/tasks/in-progress/PROF-10633/diary.md
+++ b/tasks/in-progress/PROF-10633/diary.md
@@ -1,0 +1,36 @@
+# PROF-10633 — Unified Profiling Configuration
+
+## 2026-02-26 — Implementation complete, review passed
+
+### Status: COMPLETE — all GA features default to true
+
+## 2026-02-26 — Enable all GA features by default
+
+### User feedback
+> All GA features are to be enabled by default.
+
+### Changes made
+
+**ProfilingConfig.java**: Added 5 `_DEFAULT = true` constants and updated Javadoc.
+
+**DatadogProfilerConfig.java**:
+- `isCpuProfilerEnabled`: Uses `PROFILING_CPU_ENABLED_DEFAULT` (no behavior change).
+- `isMemoryLeakProfilingEnabled`: Uses `PROFILING_LIVEHEAP_ENABLED_DEFAULT` (true) instead
+  of `PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT` (false). **BEHAVIOR CHANGE.**
+
+**OpenJdkController.java**: Liveheap uses default=true, triggers "pick best backend" logic.
+Added `isOldObjectSampleAvailable()` guard for default-only path.
+
+**ProfilerFlareReporter.java**: Umbrella section shows `true` defaults instead of null.
+
+**DatadogProfilerConfigTest.java**: Liveheap default assertion changed to `assertTrue`.
+
+### All tests pass after spotlessApply
+
+### Files changed
+- `dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java`
+- `dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java`
+- `dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java`
+- `dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java`
+- `dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerConfigTest.java`
+- `dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerFlareReporter.java`


### PR DESCRIPTION
# What Does This Do

Introduces unified profiling configuration constants in `ProfilingConfig` and wires them through both the OpenJDK (JFR) and Datadog (ddprof) profiling controllers. Adds per-engine enable/disable settings for CPU, allocation, exception, live-heap, and latency profiling, with consistent naming (`dd.profiling.<engine>.enabled`) and sensible defaults. Also adds a profiler flare reporter that dumps active profiling settings for diagnostics.

# Motivation

Profiling settings were scattered and inconsistent between the JFR and ddprof backends — some engines could not be individually toggled, naming varied, and there was no single place to see all profiling knobs. This unification makes configuration predictable for users, easier to document, and simplifies support triage via the new flare reporter.

# Additional Notes

- New constants and defaults are defined in `ProfilingConfig`; existing settings (heap histogram, queueing time) are unchanged.
- `ProfilerFlareReporter` exposes active settings in profiler flare output.
- `supported-configurations.json` updated with new settings metadata.
- Unit tests added for both `OpenJdkController` and `DatadogProfilerConfig`.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROF-10633]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).