### PR TITLE
Align JDBC Oracle `testcontainers` version and close Oracle container in test cleanup.

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   testImplementation group: 'org.testcontainers', name:'mysql', version: libs.versions.testcontainers.get()
   testImplementation group: 'org.testcontainers', name:'postgresql', version: libs.versions.testcontainers.get()
   testImplementation group: 'org.testcontainers', name:'mssqlserver', version: libs.versions.testcontainers.get()
-  testImplementation group: 'org.testcontainers', name:'oracle-xe', version: '1.20.4'
+  testImplementation group: 'org.testcontainers', name:'oracle-xe', version: libs.versions.testcontainers.get()
 
   testRuntimeOnly project(':dd-java-agent:instrumentation:datadog:asm:iast-instrumenter')
 
@@ -101,4 +101,3 @@ tasks.named("latestDepJava11Test", Test) {
     minJavaVersion = JavaVersion.VERSION_11
   }
 }
-

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -223,6 +223,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     postgres?.close()
     mysql?.close()
     sqlserver?.close()
+    oracle?.close()
   }
 
   def "basic statement with #connection.getClass().getCanonicalName() on #driver generates spans"() {


### PR DESCRIPTION
# What Does This Do
Align JDBC Oracle `testcontainers` version and close Oracle container in test cleanup.

# Motivation
Green CI.

# Additional Notes
Found these issues with Oracle JDBC tests while investigating test that hanged on CI.
