### PR TITLE
Mark Kafka DSM disabled batch consume test flaky for parentId mismatch

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -835,7 +835,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     producer.close()
   }
 
-  @Flaky("Repeatedly fails with a partition set to 1 but expects 0 https://github.com/DataDog/dd-trace-java/issues/3864")
+  @Flaky("Non-deterministic ordering of batch consumer traces causes assertion failures (partition mismatch or consumer span parentId mismatch) https://github.com/DataDog/dd-trace-java/issues/3864")
   def "test spring kafka template produce and batch consume"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())


### PR DESCRIPTION
# What Does This Do

Updates the `@Flaky` annotation on `test spring kafka template produce and batch consume` in `KafkaClientTestBase` to document the consumer span `parentId` mismatch failure mode in addition to the previously documented partition ordering issue.

# Motivation

The test `KafkaClientDataStreamsDisabledForkedTest` → `test spring kafka template produce and batch consume` was observed failing in CI with:

```
assert span.parentId == parent.spanId
```

This failure occurs because the `else` branch of the `assertTraces` block (used when `hasQueueSpan()` is false) assumes a deterministic mapping between consumer trace ordering and producer span indices within trace(0). Since `SORT_TRACES_BY_ID` uses random trace IDs, the consumer-to-producer linkage is non-deterministic.

The test was already annotated `@Flaky` for a related partition-ordering issue (https://github.com/DataDog/dd-trace-java/issues/3864). This PR updates the annotation message to accurately describe all known failure modes from this same root cause.

# Additional Notes

- Failure rate: 1x in 30 days
- The root cause (non-deterministic batch consumer trace ordering) is the same as the existing `@Flaky` issue
- No functional code changes; this is a test annotation update only

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: N/A