### PR TITLE
add limits to the view name size in spring

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.util.Strings;
 import java.lang.reflect.Method;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
@@ -20,6 +21,9 @@ import org.springframework.web.servlet.mvc.Controller;
 
 public class SpringWebHttpServerDecorator
     extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse, Void> {
+  // source for limits: https://docs.datadoghq.com/tracing/troubleshooting
+  static final int VIEW_NAME_RESOURCE_LIMIT = 5_000;
+  static final int VIEW_NAME_TAG_LIMIT = 25_000;
 
   private static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
@@ -142,8 +146,8 @@ public class SpringWebHttpServerDecorator
   public AgentSpan onRender(final AgentSpan span, final ModelAndView mv) {
     final String viewName = mv.getViewName();
     if (viewName != null) {
-      span.setTag("view.name", viewName);
-      span.setResourceName(viewName);
+      span.setTag("view.name", Strings.truncate(viewName, VIEW_NAME_TAG_LIMIT));
+      span.setResourceName(Strings.truncate(viewName, VIEW_NAME_RESOURCE_LIMIT));
     }
     if (mv.getView() != null) {
       span.setTag("view.type", className(mv.getView().getClass()));

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.springweb
+
+import datadog.trace.agent.test.InstrumentationSpecification
+import org.springframework.web.servlet.ModelAndView
+
+class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
+
+  def "onRender truncates long view name for tag and resource"() {
+    given:
+    def viewName = "a" * (SpringWebHttpServerDecorator.VIEW_NAME_TAG_LIMIT + 12)
+    def modelAndView = Stub(ModelAndView) {
+      getViewName() >> viewName
+      getView() >> null
+    }
+    def span = TEST_TRACER.buildSpan("testInstrumentation", "my operation").start()
+
+    when:
+    SpringWebHttpServerDecorator.DECORATE_RENDER.onRender(span, modelAndView)
+    span.finish()
+
+    then:
+    span.getTag("view.name").toString().length() == SpringWebHttpServerDecorator.VIEW_NAME_TAG_LIMIT
+    span.getResourceName().length() == SpringWebHttpServerDecorator.VIEW_NAME_RESOURCE_LIMIT
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.util.Strings;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +24,9 @@ public class SpringWebHttpServerDecorator
 
   private static final String DD_FILTERED_SPRING_ROUTE_ALREADY_APPLIED =
       "datadog.filter.spring.route.applied";
+  // source for limits: https://docs.datadoghq.com/tracing/troubleshooting
+  static final int VIEW_NAME_RESOURCE_LIMIT = 5_000;
+  static final int VIEW_NAME_TAG_LIMIT = 25_000;
 
   private static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
@@ -149,8 +153,8 @@ public class SpringWebHttpServerDecorator
   public AgentSpan onRender(final AgentSpan span, final ModelAndView mv) {
     final String viewName = mv.getViewName();
     if (viewName != null) {
-      span.setTag("view.name", viewName);
-      span.setResourceName(viewName);
+      span.setTag("view.name", Strings.truncate(viewName, VIEW_NAME_TAG_LIMIT));
+      span.setResourceName(Strings.truncate(viewName, VIEW_NAME_RESOURCE_LIMIT));
     }
     if (mv.getView() != null) {
       span.setTag("view.type", className(mv.getView().getClass()));

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.springweb6;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.context.Context;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -27,6 +28,8 @@ public class SpringWebHttpServerDecorator
   // source for limits: https://docs.datadoghq.com/tracing/troubleshooting
   static final int VIEW_NAME_RESOURCE_LIMIT = 5_000;
   static final int VIEW_NAME_TAG_LIMIT = 25_000;
+  private static final boolean VIEW_NAME_ENABLED =
+      ConfigProvider.getInstance().getBoolean("trace.spring-web.view-name.enabled", true);
 
   private static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
@@ -151,10 +154,12 @@ public class SpringWebHttpServerDecorator
   }
 
   public AgentSpan onRender(final AgentSpan span, final ModelAndView mv) {
-    final String viewName = mv.getViewName();
-    if (viewName != null) {
-      span.setTag("view.name", Strings.truncate(viewName, VIEW_NAME_TAG_LIMIT));
-      span.setResourceName(Strings.truncate(viewName, VIEW_NAME_RESOURCE_LIMIT));
+    if (VIEW_NAME_ENABLED) {
+      final String viewName = mv.getViewName();
+      if (viewName != null) {
+        span.setTag("view.name", Strings.truncate(viewName, VIEW_NAME_TAG_LIMIT));
+        span.setResourceName(Strings.truncate(viewName, VIEW_NAME_RESOURCE_LIMIT));
+      }
     }
     if (mv.getView() != null) {
       span.setTag("view.type", className(mv.getView().getClass()));

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.springweb6
+
+import datadog.trace.agent.test.InstrumentationSpecification
+import org.springframework.web.servlet.ModelAndView
+
+class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
+
+  def "onRender truncates long view name for tag and resource"() {
+    given:
+    def viewName = "a" * (SpringWebHttpServerDecorator.VIEW_NAME_TAG_LIMIT + 12)
+    def modelAndView = Stub(ModelAndView) {
+      getViewName() >> viewName
+      getView() >> null
+    }
+    def span = TEST_TRACER.buildSpan("testInstrumentation", "my operation").start()
+
+    when:
+    SpringWebHttpServerDecorator.DECORATE_RENDER.onRender(span, modelAndView)
+    span.finish()
+
+    then:
+    span.getTag("view.name").toString().length() == SpringWebHttpServerDecorator.VIEW_NAME_TAG_LIMIT
+    span.getResourceName().length() == SpringWebHttpServerDecorator.VIEW_NAME_RESOURCE_LIMIT
+  }
+}


### PR DESCRIPTION
# What Does This Do

if view name is huge, this can cause out of memory errors. We can guard against values that are too big on set.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
