### PR TITLE
Span Creation Memory Test

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ moshi = "1.11.0"
 
 # Testing
 assertj = "3.27.7"
+jfrunit = "1.0.0.Alpha2"
 junit4 = "4.13.2"
 junit5 = "5.14.1"
 junit-platform = "1.14.1"
@@ -151,6 +152,7 @@ moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 
 # Testing
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+jfrunit = { module = "org.moditect:jfrunit", version.ref = "jfrunit" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -18,13 +18,34 @@ tasks.withType<JavaCompile>().configureEach {
   configureCompiler(8, JavaVersion.VERSION_1_8, "Need access to sun.misc.SharedSecrets")
 }
 
-fun AbstractCompile.configureCompiler(javaVersionInteger: Int, compatibilityVersion: JavaVersion? = null, unsetReleaseFlagReason: String? = null) {
+fun AbstractCompile.configureCompiler(
+  javaVersionInteger: Int,
+  compatibilityVersion: JavaVersion? = null,
+  unsetReleaseFlagReason: String? = null,
+) {
   (project.extra["configureCompiler"] as Closure<*>).call(this, javaVersionInteger, compatibilityVersion, unsetReleaseFlagReason)
+}
+
+fun addTestSuite(name: String) {
+  (project.extra["addTestSuite"] as? Closure<*>)?.call(name)
 }
 
 tasks.named<CheckForbiddenApis>("forbiddenApisMain") {
   // sun.* are accessible in JDK8, but maybe not accessible when this task is running
   failOnMissingClasses = false
+}
+
+addTestSuite("memoryTest")
+
+tasks.named<JavaCompile>("compileMemoryTestJava") {
+  configureCompiler(11, JavaVersion.VERSION_11)
+}
+
+tasks.named<Test>("memoryTest") {
+  javaLauncher =
+    javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 val minimumBranchCoverage by extra(0.7)
@@ -234,7 +255,7 @@ val excludedClassesCoverage by extra(
     "datadog.trace.bootstrap.instrumentation.api.SpanPostProcessor.NoOpSpanPostProcessor",
     "datadog.trace.util.TempLocationManager",
     "datadog.trace.util.TempLocationManager.*",
-  )
+  ),
 )
 
 val excludedClassesBranchCoverage by extra(
@@ -247,13 +268,13 @@ val excludedClassesBranchCoverage by extra(
     "datadog.trace.util.TempLocationManager.*",
     // Branches depend on RUM injector state that cannot be reliably controlled in unit tests
     "datadog.trace.api.rum.RumInjectorMetrics",
-  )
+  ),
 )
 
 val excludedClassesInstructionCoverage by extra(
   listOf(
-    "datadog.trace.util.stacktrace.StackWalkerFactory"
-  )
+    "datadog.trace.util.stacktrace.StackWalkerFactory",
+  ),
 )
 
 dependencies {
@@ -276,6 +297,7 @@ dependencies {
   testImplementation("org.junit.vintage:junit-vintage-engine:${libs.versions.junit5.get()}")
   testImplementation(libs.commons.math)
   testImplementation(libs.bundles.mockito)
+  add("memoryTestImplementation", libs.jfrunit)
 }
 
 jmh {

--- a/internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerSpanCreationMemoryTest.java
+++ b/internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerSpanCreationMemoryTest.java
@@ -23,6 +23,7 @@ import org.moditect.jfrunit.JfrEventTest;
 class AgentTracerSpanCreationMemoryTest {
   private static final String INSTRUMENTATION_NAME = "memory-test";
   private static final CharSequence SPAN_NAME = "span-creation";
+  private static final CharSequence CHILD_SPAN_NAME = "span-creation-child";
 
   @Test
   void startSpanDoesNotAllocateInNoopMode() throws Exception {
@@ -55,7 +56,15 @@ class AgentTracerSpanCreationMemoryTest {
 
   private static void createSpan() {
     AgentSpan span = AgentTracer.startSpan(INSTRUMENTATION_NAME, SPAN_NAME);
-    span.finish();
+    try (AgentScope scope = AgentTracer.activateSpan(span)) {
+      AgentSpan childSpan = AgentTracer.startSpan(INSTRUMENTATION_NAME, CHILD_SPAN_NAME);
+      try (AgentScope childScope = AgentTracer.activateSpan(childSpan)) {
+      } finally {
+        childSpan.finish();
+      }
+    } finally {
+      span.finish();
+    }
   }
 
   private static List<RecordedEvent> readEvents(Recording recording) throws Exception {

--- a/internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerSpanCreationMemoryTest.java
+++ b/internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerSpanCreationMemoryTest.java
@@ -1,0 +1,96 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.moditect.jfrunit.JfrEventTest;
+
+@JfrEventTest
+@EnabledForJreRange(min = JRE.JAVA_11)
+class AgentTracerSpanCreationMemoryTest {
+  private static final String INSTRUMENTATION_NAME = "memory-test";
+  private static final CharSequence SPAN_NAME = "span-creation";
+
+  @Test
+  void startSpanDoesNotAllocateInNoopMode() throws Exception {
+    warmupSpanCreation();
+
+    List<RecordedEvent> events = recordAllocationsWhileCreatingSpans();
+    long allocationEventsOnStartSpan = events.stream().filter(this::isStartSpanAllocation).count();
+
+    assertEquals(0L, allocationEventsOnStartSpan);
+  }
+
+  private static void warmupSpanCreation() {
+    for (int i = 0; i < 10_000; i++) {
+      createSpan();
+    }
+  }
+
+  private static List<RecordedEvent> recordAllocationsWhileCreatingSpans() throws Exception {
+    try (Recording recording = new Recording()) {
+      recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace().withThreshold(Duration.ZERO);
+      recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace().withThreshold(Duration.ZERO);
+      recording.start();
+      for (int i = 0; i < 25_000; i++) {
+        createSpan();
+      }
+      recording.stop();
+      return readEvents(recording);
+    }
+  }
+
+  private static void createSpan() {
+    AgentSpan span = AgentTracer.startSpan(INSTRUMENTATION_NAME, SPAN_NAME);
+    span.finish();
+  }
+
+  private static List<RecordedEvent> readEvents(Recording recording) throws Exception {
+    Path recordingPath = Files.createTempFile("agent-tracer-span-memory-test", ".jfr");
+    try {
+      recording.dump(recordingPath);
+      List<RecordedEvent> events = new ArrayList<>();
+      try (RecordingFile recordingFile = new RecordingFile(recordingPath)) {
+        while (recordingFile.hasMoreEvents()) {
+          events.add(recordingFile.readEvent());
+        }
+      }
+      return events;
+    } finally {
+      Files.deleteIfExists(recordingPath);
+    }
+  }
+
+  private boolean isStartSpanAllocation(RecordedEvent event) {
+    RecordedStackTrace stackTrace = event.getStackTrace();
+    if (stackTrace == null) {
+      return false;
+    }
+
+    for (RecordedFrame frame : stackTrace.getFrames()) {
+      RecordedMethod method = frame.getMethod();
+      if (method == null || method.getType() == null) {
+        continue;
+      }
+
+      if ("datadog.trace.bootstrap.instrumentation.api.AgentTracer".equals(method.getType().getName())
+          && "startSpan".equals(method.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ab48e2ea-a7c0-4972-973c-bcc650aed9ec","source":"chat","resourceId":"012201dd-a1af-4a6f-91ca-711212af62a2","workflowId":"94155f3e-f2f5-4ac3-9026-f3f4cc7c9019","codeChangeId":"94155f3e-f2f5-4ac3-9026-f3f4cc7c9019","sourceType":"chat"} -->
# What Does This Do
- Adds a dedicated `memoryTest` suite in `internal-api` that compiles and runs with Java 11.
- Adds `AgentTracerSpanCreationMemoryTest` under `internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/` to verify `AgentTracer.startSpan()` does not emit JFR allocation events in noop mode.
- Adds `jfrunit` to the version catalog and wires it into `internal-api` via `memoryTestImplementation`.

# Motivation
`APMLP-509` is focused on lowering Java tracer overhead. This change adds a regression guard in `internal-api` so span creation allocation behavior is continuously validated.

# Additional Notes
### Testing/Validation
- Ran `Lint` tool:
  - `ktlint` formatted `internal-api/build.gradle.kts`.
  - `checkstyle` ran for `internal-api/src/memoryTest/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerSpanCreationMemoryTest.java`.
- Ran `Format` tool:
  - `spotlessApply` could not run because Gradle wrapper download failed in this sandbox (`services.gradle.org` DNS resolution failure).
- Could not run Gradle tests in this environment for the same wrapper download/network limitation.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMLP-509]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/012201dd-a1af-4a6f-91ca-711212af62a2)

Comment @datadog to request changes

[APMLP-509]: https://datadoghq.atlassian.net/browse/APMLP-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ