### PR TITLE
Set Java-specific injection package size ratchet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,10 @@ variables:
     description: "Enable flaky tests"
     value: "false"
 
+  # One pipeline injection package size ratchet
+  OCI_PACKAGE_MAX_SIZE_BYTES: 40_000_000
+  LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 40_000_000
+
 # trigger new commit cancel
 workflow:
   auto_cancel:


### PR DESCRIPTION
# What Does This Do

Introduce language-specific thresholds for the injection image size ratchet through [one pipeline overrides](https://github.com/DataDog/libdatadog-build/blob/09c7352ba84397d1c5b624608c7f6cd93905d6fa/templates/one-pipeline.yml#L47-L53)

# Motivation

Due to [a change PHP-side](https://github.com/DataDog/dd-trace-php/pull/3573) libdatadog was bumped to v29. This version bump caused PHP images to blow past their previous limit. 

Simultaneously, [changes to the `datadog-package`](https://github.com/DataDog/datadog-packages/commit/2e178346124a3a88edd4e055ef5ca60d1a610b8c#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L82-R79) binary were picked up. Notably the `github.com/klauspost/compress/zstd` dependency was bumped from 1.17.4 to 1.18.1. This bump included in 1.17.5 a default value change for the compression context size, [downscaled from 32MB to 8MB](https://github.com/klauspost/compress/pull/913) (fixing compatibility with browsers like Chrome), causing drastic changes in compression results.

Unbeknownst to the second change, PHP therefore updated the global limits, attributing the size change to the libdatadog bump (which was true, but not for the whole of it):
- Container image limit [changed from 190MB to 250MB](https://github.com/DataDog/libdatadog-build/pull/186)
- OCI package limit [changed from 130MB to 160MB](https://github.com/DataDog/libdatadog-build/pull/187)

This allowed a change to slip through to other languages, where the new `datadog-package` binary caused regressions in package size _without_ change to the inputs. Due to the wildly differing sizes of packages across languages the regression is silent, rendering the size threshold ratchet moot.

To combat such silently creeping regressions, this PR introduces language-specific thresholds for the ratchet.

# Additional Notes

`datadog-package` was fixed in https://github.com/DataDog/datadog-packages/pull/64 which may take some time to trickle down.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
