### PR TITLE
Refine variant reason computation to include SPLIT and STATIC

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -122,7 +122,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
           for (final Split split : allocation.splits) {
             if (isEmpty(split.shards)) {
               return resolveVariant(
-                  target, key, defaultValue, flag, split.variationKey, allocation, context);
+                  target, key, defaultValue, flag, split.variationKey, allocation, split, context);
             } else {
               if (targetingKey == null) {
                 return error(defaultValue, ErrorCode.TARGETING_KEY_MISSING);
@@ -137,7 +137,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
               }
               if (allShardsMatch) {
                 return resolveVariant(
-                    target, key, defaultValue, flag, split.variationKey, allocation, context);
+                    target, key, defaultValue, flag, split.variationKey, allocation, split, context);
               }
             }
           }
@@ -333,6 +333,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       final Flag flag,
       final String variationKey,
       final Allocation allocation,
+      final Split split,
       final EvaluationContext context) {
     final Variant variant = flag.variations.get(variationKey);
     if (variant == null) {
@@ -377,7 +378,12 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     final ProviderEvaluation<T> result =
         ProviderEvaluation.<T>builder()
             .value(mappedValue)
-            .reason(Reason.TARGETING_MATCH.name())
+            .reason(
+                !isEmpty(allocation.rules)
+                    ? Reason.TARGETING_MATCH.name()
+                    : !isEmpty(split.shards)
+                        ? Reason.SPLIT.name()
+                        : Reason.STATIC.name())
             .variant(variant.key)
             .flagMetadata(metadataBuilder.build())
             .build();

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -137,7 +137,14 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
               }
               if (allShardsMatch) {
                 return resolveVariant(
-                    target, key, defaultValue, flag, split.variationKey, allocation, split, context);
+                    target,
+                    key,
+                    defaultValue,
+                    flag,
+                    split.variationKey,
+                    allocation,
+                    split,
+                    context);
               }
             }
           }
@@ -381,9 +388,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .reason(
                 !isEmpty(allocation.rules)
                     ? Reason.TARGETING_MATCH.name()
-                    : !isEmpty(split.shards)
-                        ? Reason.SPLIT.name()
-                        : Reason.STATIC.name())
+                    : !isEmpty(split.shards) ? Reason.SPLIT.name() : Reason.STATIC.name())
             .variant(variant.key)
             .flagMetadata(metadataBuilder.build())
             .build();

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -217,7 +217,7 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("simple-string")
             // no .targetingKey() -- null by default
-            .result(new Result<>("test-value").reason(TARGETING_MATCH.name()).variant("on")),
+            .result(new Result<>("test-value").reason(STATIC.name()).variant("on")),
         // Null targeting key on sharded flag must return TARGETING_KEY_MISSING
         new TestCase<>("default")
             .flag("shard-flag")
@@ -444,8 +444,7 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("shard-matching-flag")
             .targetingKey("specific-key-that-matches-shard")
-            .result(
-                new Result<>("shard-matched").reason(SPLIT.name()).variant("matched")),
+            .result(new Result<>("shard-matched").reason(SPLIT.name()).variant("matched")),
         new TestCase<>("default")
             .flag("future-allocation-flag")
             .targetingKey("user-123")

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -5,6 +5,8 @@ import static dev.openfeature.sdk.ErrorCode.TARGETING_KEY_MISSING;
 import static dev.openfeature.sdk.Reason.DEFAULT;
 import static dev.openfeature.sdk.Reason.DISABLED;
 import static dev.openfeature.sdk.Reason.ERROR;
+import static dev.openfeature.sdk.Reason.SPLIT;
+import static dev.openfeature.sdk.Reason.STATIC;
 import static dev.openfeature.sdk.Reason.TARGETING_MATCH;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -231,7 +233,7 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("simple-string")
             .targetingKey("")
-            .result(new Result<>("test-value").reason(TARGETING_MATCH.name()).variant("on")),
+            .result(new Result<>("test-value").reason(STATIC.name()).variant("on")),
         new TestCase<>("default")
             .flag("non-existent-flag")
             .targetingKey("user-123")
@@ -243,15 +245,15 @@ public class DDEvaluatorTest {
         new TestCase<>("default")
             .flag("simple-string")
             .targetingKey("user-123")
-            .result(new Result<>("test-value").reason(TARGETING_MATCH.name()).variant("on")),
+            .result(new Result<>("test-value").reason(STATIC.name()).variant("on")),
         new TestCase<>(false)
             .flag("boolean-flag")
             .targetingKey("user-123")
-            .result(new Result<>(true).reason(TARGETING_MATCH.name()).variant("enabled")),
+            .result(new Result<>(true).reason(STATIC.name()).variant("enabled")),
         new TestCase<>(0)
             .flag("integer-flag")
             .targetingKey("user-123")
-            .result(new Result<>(42).reason(TARGETING_MATCH.name()).variant("forty-two")),
+            .result(new Result<>(42).reason(STATIC.name()).variant("forty-two")),
         new TestCase<>("default")
             .flag("rule-based-flag")
             .targetingKey("user-premium")
@@ -261,7 +263,7 @@ public class DDEvaluatorTest {
             .flag("rule-based-flag")
             .targetingKey("user-basic")
             .context("email", "john@gmail.com")
-            .result(new Result<>("basic").reason(TARGETING_MATCH.name()).variant("basic")),
+            .result(new Result<>("basic").reason(STATIC.name()).variant("basic")),
         new TestCase<>("default")
             .flag("numeric-rule-flag")
             .targetingKey("user-vip")
@@ -287,7 +289,7 @@ public class DDEvaluatorTest {
             .result(
                 new Result<>("default")
                     // Result depends on shard calculation - either match or default
-                    .reason(TARGETING_MATCH.name(), DEFAULT.name())),
+                    .reason(SPLIT.name(), DEFAULT.name())),
         // Type mismatch: STRING flag evaluated as Integer
         new TestCase<>(0)
             .flag("string-number-flag")
@@ -369,7 +371,7 @@ public class DDEvaluatorTest {
             .targetingKey("user-123")
             .result(
                 new Result<>("tracked-value")
-                    .reason(TARGETING_MATCH.name())
+                    .reason(STATIC.name())
                     .variant("tracked")
                     .flagMetadata("allocationKey", "exposure-alloc")
                     .flagMetadata("doLog", true)),
@@ -443,7 +445,7 @@ public class DDEvaluatorTest {
             .flag("shard-matching-flag")
             .targetingKey("specific-key-that-matches-shard")
             .result(
-                new Result<>("shard-matched").reason(TARGETING_MATCH.name()).variant("matched")),
+                new Result<>("shard-matched").reason(SPLIT.name()).variant("matched")),
         new TestCase<>("default")
             .flag("future-allocation-flag")
             .targetingKey("user-123")


### PR DESCRIPTION
# What Does This Do

Computes the correct OpenFeature evaluation reason from the UFC allocation structure instead of hardcoding `TARGETING_MATCH` for all successful evaluations.

Three-way logic in `resolveVariant()`:
- `STATIC` — no rules, no shards (unconditional allocation)
- `SPLIT` — no rules, shards present (percentage-based traffic split)
- `TARGETING_MATCH` — rules present (flag matched a targeting rule)

Also fixes one test assertion that needed updating after rebasing onto #10990: a null targeting key on a static flag now correctly evaluates as `STATIC` rather than `TARGETING_MATCH`.

# Motivation

System tests `Test_FFE_Eval_Metric_Basic` (expects `reason=static`) and `Test_FFE_Eval_Reason_Split` (expects `reason=split`) were failing because the evaluator hardcoded `TARGETING_MATCH` regardless of allocation structure. This aligns Java behavior with the Python and Go SDK reference implementations.

Co-authored-by: Leo Romanovsky <leo.romanovsky@datadoghq.com> (original fix in #10971)

# Additional Notes

The `split` object is passed into `resolveVariant()` so the reason can be derived at resolution time without additional lookups.

The semantic question of whether a catch-all (no-rules, no-shards) allocation inside a multi-allocation flag should return `STATIC` vs another reason is out of scope here — that's a pre-existing behavior question tracked separately.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors