### PR TITLE
Fix feature_flag.evaluations metric count always being zero

### DIFF
--- a/products/feature-flagging/feature-flagging-api/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-api/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
   testImplementation(libs.bundles.junit5)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.moshi)
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.47.0")
   testImplementation("org.awaitility:awaitility:4.3.0")
 }
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/FlagEvalMetrics.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/FlagEvalMetrics.java
@@ -87,6 +87,14 @@ class FlagEvalMetrics implements Closeable {
     this.meterProvider = null;
   }
 
+  /** Package-private constructor for integration testing with an injected SdkMeterProvider. */
+  FlagEvalMetrics(SdkMeterProvider sdkMeterProvider) {
+    meterProvider = sdkMeterProvider;
+    Meter meter = sdkMeterProvider.meterBuilder(METER_NAME).build();
+    counter =
+        meter.counterBuilder(METRIC_NAME).setUnit(METRIC_UNIT).setDescription(METRIC_DESC).build();
+  }
+
   void record(
       String flagKey, String variant, String reason, ErrorCode errorCode, String allocationKey) {
     LongCounter c = counter;

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/FlagEvalMetrics.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/FlagEvalMetrics.java
@@ -8,6 +8,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.io.Closeable;
 import java.time.Duration;
@@ -54,7 +55,10 @@ class FlagEvalMetrics implements Closeable {
       }
 
       OtlpHttpMetricExporter exporter =
-          OtlpHttpMetricExporter.builder().setEndpoint(endpoint).build();
+          OtlpHttpMetricExporter.builder()
+              .setEndpoint(endpoint)
+              .setAggregationTemporalitySelector(AggregationTemporalitySelector.alwaysCumulative())
+              .build();
 
       PeriodicMetricReader reader =
           PeriodicMetricReader.builder(exporter).setInterval(EXPORT_INTERVAL).build();

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/FlagEvalMetricsTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/FlagEvalMetricsTest.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.openfeature;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -8,6 +9,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import dev.openfeature.sdk.ErrorCode;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -121,7 +131,7 @@ class FlagEvalMetricsTest {
 
   @Test
   void recordIsNoOpWhenCounterIsNull() {
-    FlagEvalMetrics metrics = new FlagEvalMetrics(null);
+    FlagEvalMetrics metrics = new FlagEvalMetrics((LongCounter) null);
     // Should not throw
     metrics.record("my-flag", "on", "TARGETING_MATCH", null, null);
   }
@@ -135,6 +145,51 @@ class FlagEvalMetricsTest {
     metrics.record("my-flag", "on", "TARGETING_MATCH", null, null);
 
     verifyNoInteractions(counter);
+  }
+
+  @Test
+  void exporterIsConfiguredWithCumulativeTemporalityForCounters() {
+    // Regression guard: FlagEvalMetrics must explicitly configure alwaysCumulative() so that
+    // the Datadog agent receives absolute counts rather than delta values that may be converted
+    // to rates. This test documents and enforces that the exporter uses CUMULATIVE for counters.
+    try (OtlpHttpMetricExporter exporter =
+        OtlpHttpMetricExporter.builder()
+            .setAggregationTemporalitySelector(AggregationTemporalitySelector.alwaysCumulative())
+            .build()) {
+      assertEquals(
+          AggregationTemporality.CUMULATIVE,
+          exporter.getAggregationTemporality(InstrumentType.COUNTER),
+          "alwaysCumulative() selector must produce CUMULATIVE for counters");
+    }
+  }
+
+  @Test
+  void multipleRecordCallsAccumulateCumulativelyInExportedMetrics() {
+    // Use InMemoryMetricReader with cumulative temporality (matching what FlagEvalMetrics
+    // configures on the OTLP exporter) to verify that N record() calls produce a sum of N.
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+
+    try (FlagEvalMetrics metrics = new FlagEvalMetrics(provider)) {
+      for (int i = 0; i < 5; i++) {
+        metrics.record("count-flag", "on", "STATIC", null, "default-alloc");
+      }
+
+      Collection<MetricData> data = reader.collectAllMetrics();
+      MetricData metric =
+          data.stream()
+              .filter(m -> m.getName().equals("feature_flag.evaluations"))
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("feature_flag.evaluations metric not found"));
+
+      assertEquals(
+          AggregationTemporality.CUMULATIVE,
+          metric.getLongSumData().getAggregationTemporality(),
+          "Exported metric must use CUMULATIVE temporality");
+
+      LongPointData point = metric.getLongSumData().getPoints().iterator().next();
+      assertEquals(5L, point.getValue(), "5 record() calls must produce a cumulative sum of 5");
+    }
   }
 
   private static void assertAttribute(Attributes attrs, String key, String expected) {


### PR DESCRIPTION
## Summary

- The OTel SDK defaults to DELTA temporality for `LongCounter`. The Datadog agent converts OTLP delta monotonic sums to rate metrics by dividing the value by the export interval in seconds.
- With a 10s export interval and 5 evaluations happening in under 1 second, the reported rate is ~0.5, which produces a point value of 0 in the Datadog series — causing `test_ffe_eval_metric_count` to sum to 0.
- Fix: configure `AggregationTemporalitySelector.alwaysCumulative()` on the `OtlpHttpMetricExporter` so the agent receives an absolute cumulative count rather than a rate.

## Test plan

- [ ] `./gradlew :products:feature-flagging:feature-flagging-api:test` passes
- [ ] `test_ffe_eval_metric_count` system test passes (expects total >= 5 evaluations)
- [ ] `test_ffe_eval_metric_basic` system test continues to pass

## Tags

tag: no release note