### PR TITLE
Add support for windows-style path (backslashes)

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -59,12 +59,17 @@ public class TransformerDefinitionMatcher {
       if (fileName == null) {
         continue;
       }
+      fileName = normalizeWindowsToUnixPath(fileName);
       Map<String, List<ProbeDefinition>> targetMap =
           fileName.indexOf('/') != -1
               ? definitionsByQualifiedFileNames
               : definitionsBySimpleFileNames;
       targetMap.computeIfAbsent("/" + fileName, key -> new ArrayList<>()).add(definition);
     }
+  }
+
+  private static String normalizeWindowsToUnixPath(String fileName) {
+    return fileName.replace('\\', '/');
   }
 
   private Trie buildDefinitionFileNamesTrie(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -75,6 +75,26 @@ public class TransformerDefinitionMatcherTest {
   }
 
   @Test
+  public void sourceFileWindowsStyleFileName() {
+    LogProbe probe = createProbe(PROBE_ID1, "src\\main\\java\\java\\lang\\String.java", 23);
+    TransformerDefinitionMatcher matcher = createMatcher(probe);
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(1, probeDefinitions.size());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+  }
+
+  @Test
+  public void sourceFileWindowsStyleAbsoluteFileName() {
+    LogProbe probe =
+        createProbe(
+            PROBE_ID1, "C:\\Users\\user\\project\\src\\main\\java\\java\\lang\\String.java", 23);
+    TransformerDefinitionMatcher matcher = createMatcher(probe);
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(1, probeDefinitions.size());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+  }
+
+  @Test
   public void sourceFileSimpleFileName() {
     LogProbe probe = createProbe(PROBE_ID1, "String.java", 23);
     TransformerDefinitionMatcher matcher = createMatcher(probe);


### PR DESCRIPTION
# What Does This Do
Source filename used in probe definition can have path using backslashes (Windows-style)
we normalize those paths before building the definition matcher

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5109]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5109]: https://datadoghq.atlassian.net/browse/DEBUG-5109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ