### PR TITLE
Add smoke test for websphere-jmx

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -50,7 +50,7 @@ abstract class ProcessManager extends Specification {
 
   // Here for backwards compatibility with single process case
   @Shared
-  def logFilePath = logFilePaths[0]
+  def logFilePath = logFilePaths.length > 0 ? logFilePaths[0] : null
 
   def setup() {
     testedProcesses.each {

--- a/dd-smoke-tests/websphere-jmx/build.gradle
+++ b/dd-smoke-tests/websphere-jmx/build.gradle
@@ -1,0 +1,15 @@
+apply from: "$rootDir/gradle/java.gradle"
+
+dependencies {
+  testImplementation project(':dd-smoke-tests')
+  testImplementation libs.testcontainers
+}
+
+testJvmConstraints {
+  // there is no need to run it multiple times since it runs on a container
+  maxJavaVersion = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
+++ b/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
@@ -1,0 +1,119 @@
+package datadog.smoketest
+
+
+import java.time.Duration
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.MountableFile
+import spock.lang.Shared
+
+/**
+ * Smoke test for the websphere-jmx instrumentation.
+ *
+ * Builds and starts a WebSphere traditional (tWAS) container with the dd-java-agent baked in
+ * via jvm-config.props, then verifies that jmxfetch reports WebSphere thread pool metrics
+ * via statsd UDP.
+ *
+ * Note that the websphere related metrics will only arrive if our instrumentation is applied.
+ */
+class WebSphereJmxSmokeTest extends AbstractSmokeTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WebSphereJmxSmokeTest)
+
+  @Override
+  protected int numberOfProcesses() {
+    return 0
+  }
+
+  @Shared
+  DatagramSocket statsdSocket
+
+  @Shared
+  int statsdPort
+
+  @Shared
+  BlockingQueue<String> statsdMessages = new ArrayBlockingQueue<>(256)
+
+  @Shared
+  Thread listenerThread
+
+  @Shared
+  GenericContainer websphere
+
+  def setupSpec() {
+    statsdSocket = new DatagramSocket()
+    statsdPort = statsdSocket.getLocalPort()
+    LOG.info("StatsDServer listening on UDP port {}", statsdPort)
+
+    listenerThread = Thread.start {
+      byte[] buf = new byte[2048]
+      while (!Thread.currentThread().interrupted()) {
+        try {
+          DatagramPacket packet = new DatagramPacket(buf, buf.length)
+          statsdSocket.receive(packet)
+          String msg = new String(packet.getData(), 0, packet.getLength())
+          LOG.debug("Received statsd: {}", msg)
+          statsdMessages.offer(msg, 1, TimeUnit.SECONDS)
+        } catch (Exception ignored) {
+          break
+        }
+      }
+    }
+
+    websphere = new GenericContainer("icr.io/appcafe/websphere-traditional:latest")
+      // inject wished jvm props for the server we are running
+      .withCopyFileToContainer(MountableFile.forClasspathResource("jvm-config.props"), "/work/config/")
+      // copy the agent jar
+      .withCopyFileToContainer(MountableFile.forHostPath(shadowJarPath), "/opt/dd-java-agent.jar")
+      // let it run on a macos for dev
+      .withCreateContainerCmdModifier { it.withPlatform('linux/amd64') }
+      // this is required to send back udp datagrams to us
+      .withExtraHost('host.docker.internal', 'host-gateway')
+      // set jmxfetch props
+      .withEnv('DD_JMXFETCH_STATSD_HOST', 'host.docker.internal')
+      .withEnv('DD_JMXFETCH_STATSD_PORT', String.valueOf(statsdPort))
+      .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix('websphere'))
+      // the server will restart 2 times. First to update the jvm props
+      .waitingFor(Wait.forLogMessage('.*open for e-business.*', 2))
+      // it can be long
+      .withStartupTimeout(Duration.ofMinutes(8))
+      // override the command (by default it's /work/start_server.sh)
+      .withCommand("bash", "-c", "/work/configure.sh && /work/start_server.sh")
+
+    websphere.start()
+    LOG.info("WebSphere container started")
+  }
+
+  def cleanupSpec() {
+    websphere?.stop()
+    listenerThread?.interrupt()
+    listenerThread?.join()
+    statsdSocket?.close()
+  }
+
+  def "jmxfetch reports WebSphere thread pool metrics via statsd"() {
+    when: "waiting for websphere.thread_pool metrics"
+    String metric = waitForMetric('websphere.thread_pool', Duration.ofMinutes(3))
+
+    then: "at least one thread pool metric arrives"
+    metric != null
+    metric.contains('websphere.thread_pool')
+  }
+
+  def waitForMetric(String prefix, Duration timeout) {
+    long deadline = System.currentTimeMillis() + timeout.toMillis()
+    while (System.currentTimeMillis() < deadline) {
+      String msg = statsdMessages.poll(5, TimeUnit.SECONDS)
+      if (msg?.contains(prefix)) {
+        return msg
+      }
+    }
+    return null
+  }
+}

--- a/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
+++ b/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
@@ -92,9 +92,8 @@ class WebSphereJmxSmokeTest extends AbstractSmokeTest {
 
   def cleanupSpec() {
     websphere?.stop()
-    listenerThread?.interrupt()
-    listenerThread?.join()
     statsdSocket?.close()
+    listenerThread?.join()
   }
 
   def "jmxfetch reports WebSphere thread pool metrics via statsd"() {

--- a/dd-smoke-tests/websphere-jmx/src/test/resources/jvm-config.props
+++ b/dd-smoke-tests/websphere-jmx/src/test/resources/jvm-config.props
@@ -1,0 +1,6 @@
+ResourceType=JavaVirtualMachine
+ImplementingResourceType=Server
+ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=:JavaVirtualMachine=
+AttributeInfo=jvmEntries
+
+genericJvmArguments=-javaagent:/opt/dd-java-agent.jar -Ddd.trace.debug=true -Ddd.jmxfetch.websphere.enabled=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -248,6 +248,7 @@ include(
   ":dd-smoke-tests:vertx-3.9",
   ":dd-smoke-tests:vertx-3.9-resteasy",
   ":dd-smoke-tests:vertx-4.2",
+  ":dd-smoke-tests:websphere-jmx",
   ":dd-smoke-tests:wildfly",
   ":dd-smoke-tests:appsec",
   ":dd-smoke-tests:appsec:spring-tomcat7",


### PR DESCRIPTION
# What Does This Do

Adds a smoke test for the websphere-jmx instrumentation.

It bootstraps a websphere classic via a docker container (so it's a particular smoke test) and configure its jvm to use the java agent enabling the websphere jmxfetch extension.
Then it bootstrap as well a tiny udp receiver to fetch the metrics that will be sent.

If the instrumentation applies correctly, the websphere vendored metrics will appear, otherwise not.

Note: there are some debugger tests that also spawn a udp server for the same statsd purposes. In the future, we might think about refactoring it into a common test harness.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
