### PR TITLE
Expose server.io.fs.file_write address for write file operations

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -141,6 +141,9 @@ public interface KnownAddresses {
   /** The representation of opened file on the filesystem */
   Address<String> IO_FS_FILE = new Address<>("server.io.fs.file");
 
+  /** The representation of a file being written on the filesystem */
+  Address<String> IO_FS_FILE_WRITE = new Address<>("server.io.fs.file_write");
+
   /** The database type (ex: mysql, postgresql, sqlite) */
   Address<String> DB_TYPE = new Address<>("server.db.system");
 
@@ -240,6 +243,8 @@ public interface KnownAddresses {
         return IO_NET_RESPONSE_BODY;
       case "server.io.fs.file":
         return IO_FS_FILE;
+      case "server.io.fs.file_write":
+        return IO_FS_FILE_WRITE;
       case "server.db.system":
         return DB_TYPE;
       case "server.db.statement":

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -123,6 +123,7 @@ public class GatewayBridge {
   private volatile DataSubscriberInfo httpClientRequestSubInfo;
   private volatile DataSubscriberInfo httpClientResponseSubInfo;
   private volatile DataSubscriberInfo ioFileSubInfo;
+  private volatile DataSubscriberInfo ioFileWriteSubInfo;
   private volatile DataSubscriberInfo sessionIdSubInfo;
   private volatile DataSubscriberInfo userIdSubInfo;
   private final ConcurrentHashMap<String, DataSubscriberInfo> loginEventSubInfo =
@@ -188,6 +189,7 @@ public class GatewayBridge {
     subscriptionService.registerCallback(EVENTS.httpClientRequest(), this::onHttpClientRequest);
     subscriptionService.registerCallback(EVENTS.httpClientResponse(), this::onHttpClientResponse);
     subscriptionService.registerCallback(EVENTS.fileLoaded(), this::onFileLoaded);
+    subscriptionService.registerCallback(EVENTS.fileWritten(), this::onFileWritten);
     subscriptionService.registerCallback(EVENTS.requestSession(), this::onRequestSession);
     subscriptionService.registerCallback(EVENTS.execCmd(), this::onExecCmd);
     subscriptionService.registerCallback(EVENTS.shellCmd(), this::onShellCmd);
@@ -544,6 +546,33 @@ public class GatewayBridge {
         return producerService.publishDataEvent(subInfo, ctx, bundle, gwCtx);
       } catch (ExpiredSubscriberInfoException e) {
         ioFileSubInfo = null;
+      }
+    }
+  }
+
+  private Flow<Void> onFileWritten(RequestContext ctx_, String path) {
+    AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
+    if (ctx == null) {
+      return NoopFlow.INSTANCE;
+    }
+    while (true) {
+      DataSubscriberInfo subInfo = ioFileWriteSubInfo;
+      if (subInfo == null) {
+        subInfo = producerService.getDataSubscribers(KnownAddresses.IO_FS_FILE_WRITE);
+        ioFileWriteSubInfo = subInfo;
+      }
+      if (subInfo == null || subInfo.isEmpty()) {
+        return NoopFlow.INSTANCE;
+      }
+      DataBundle bundle =
+          new MapDataBundle.Builder(CAPACITY_0_2)
+              .add(KnownAddresses.IO_FS_FILE_WRITE, path)
+              .build();
+      try {
+        GatewayContext gwCtx = new GatewayContext(true, RuleType.LFI);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, gwCtx);
+      } catch (ExpiredSubscriberInfoException e) {
+        ioFileWriteSubInfo = null;
       }
     }
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -558,7 +558,9 @@ public class GatewayBridge {
     while (true) {
       DataSubscriberInfo subInfo = ioFileWriteSubInfo;
       if (subInfo == null) {
-        subInfo = producerService.getDataSubscribers(KnownAddresses.IO_FS_FILE_WRITE);
+        subInfo =
+            producerService.getDataSubscribers(
+                KnownAddresses.IO_FS_FILE, KnownAddresses.IO_FS_FILE_WRITE);
         ioFileWriteSubInfo = subInfo;
       }
       if (subInfo == null || subInfo.isEmpty()) {
@@ -566,6 +568,7 @@ public class GatewayBridge {
       }
       DataBundle bundle =
           new MapDataBundle.Builder(CAPACITY_0_2)
+              .add(KnownAddresses.IO_FS_FILE, path)
               .add(KnownAddresses.IO_FS_FILE_WRITE, path)
               .build();
       try {

--- a/dd-java-agent/appsec/src/main/resources/default_config.json
+++ b/dd-java-agent/appsec/src/main/resources/default_config.json
@@ -5458,6 +5458,75 @@
       "transformers": []
     },
     {
+      "id": "dog-920-110",
+      "name": "Zipslip Attack - Unsafe Zip extraction",
+      "tags": {
+        "type": "http_protocol_violation",
+        "category": "attack_attempt",
+        "cwe": "502",
+        "capec": "1000/152/586",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.filenames"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x_filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x.filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-file-name"
+                ]
+              }
+            ],
+            "regex": "\\.zip$",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.fs.file_write"
+              }
+            ],
+            "regex": "(?:^|[/\\\\])\\.\\.[/\\\\]",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
       "id": "dog-931-001",
       "name": "RFI: URL Payload to well known RFI target",
       "tags": {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecificationForkedTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecificationForkedTest.groovy
@@ -49,6 +49,7 @@ class KnownAddressesSpecificationForkedTest extends Specification {
       'server.io.net.response.headers',
       'server.io.net.response.body',
       'server.io.fs.file',
+      'server.io.fs.file_write',
       'server.sys.exec.cmd',
       'server.sys.shell.cmd',
       'waf.context.processor'
@@ -57,7 +58,7 @@ class KnownAddressesSpecificationForkedTest extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 45
+    Address.instanceCount() == 46
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -1090,7 +1090,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     setup:
     final path = '/tmp/output.txt'
     eventDispatcher.getDataSubscribers({
-      KnownAddresses.IO_FS_FILE_WRITE in it
+      KnownAddresses.IO_FS_FILE in it && KnownAddresses.IO_FS_FILE_WRITE in it
     }) >> nonEmptyDsInfo
     DataBundle bundle
     GatewayContext gatewayContext
@@ -1102,6 +1102,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, _ as GatewayContext) >> {
       a, b, db, gw -> bundle = db; gatewayContext = gw; NoopFlow.INSTANCE
     }
+    bundle.get(KnownAddresses.IO_FS_FILE) == path
     bundle.get(KnownAddresses.IO_FS_FILE_WRITE) == path
     flow.result == null
     flow.action == Flow.Action.Noop.INSTANCE

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -121,6 +121,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   BiFunction<RequestContext, HttpClientResponse, Flow<Void>> httpClientResponseCB
   BiFunction<RequestContext, Long, Flow<Void>> httpClientSamplingCB
   BiFunction<RequestContext, String, Flow<Void>> fileLoadedCB
+  BiFunction<RequestContext, String, Flow<Void>> fileWrittenCB
   BiFunction<RequestContext, List<String>, Flow<Void>> requestFilesFilenamesCB
   BiFunction<RequestContext, String, Flow<Void>> requestSessionCB
   BiFunction<RequestContext, String[], Flow<Void>> execCmdCB
@@ -535,6 +536,9 @@ class GatewayBridgeSpecification extends DDSpecification {
     }
     1 * ig.registerCallback(EVENTS.fileLoaded(), _) >> {
       fileLoadedCB = it[1]; null
+    }
+    1 * ig.registerCallback(EVENTS.fileWritten(), _) >> {
+      fileWrittenCB = it[1]; null
     }
     1 * ig.registerCallback(EVENTS.requestSession(), _) >> {
       requestSessionCB = it[1]; null
@@ -1076,6 +1080,29 @@ class GatewayBridgeSpecification extends DDSpecification {
       a, b, db, gw -> bundle = db; gatewayContext = gw; NoopFlow.INSTANCE
     }
     bundle.get(KnownAddresses.IO_FS_FILE) == path
+    flow.result == null
+    flow.action == Flow.Action.Noop.INSTANCE
+    gatewayContext.isTransient == true
+    gatewayContext.isRasp == true
+  }
+
+  void 'process file written'() {
+    setup:
+    final path = '/tmp/output.txt'
+    eventDispatcher.getDataSubscribers({
+      KnownAddresses.IO_FS_FILE_WRITE in it
+    }) >> nonEmptyDsInfo
+    DataBundle bundle
+    GatewayContext gatewayContext
+
+    when:
+    Flow<?> flow = fileWrittenCB.apply(ctx, path)
+
+    then:
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, _ as GatewayContext) >> {
+      a, b, db, gw -> bundle = db; gatewayContext = gw; NoopFlow.INSTANCE
+    }
+    bundle.get(KnownAddresses.IO_FS_FILE_WRITE) == path
     flow.result == null
     flow.action == Flow.Action.Noop.INSTANCE
     gatewayContext.isTransient == true

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileCallSite.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
 @CallSite(
     spi = {IastCallSites.class, RaspCallSites.class},
-    helpers = FileLoadedRaspHelper.class)
+    helpers = FileIORaspHelper.class)
 public class FileCallSite {
 
   @CallSite.Before("void java.io.File.<init>(java.lang.String)")
@@ -101,18 +101,18 @@ public class FileCallSite {
   }
 
   private static void raspCallback(File parent, String child) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(parent, child);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(parent, child);
   }
 
   private static void raspCallback(String parent, String file) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(parent, file);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(parent, file);
   }
 
   private static void raspCallback(String s) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(s);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(s);
   }
 
   private static void raspCallback(URI uri) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(uri);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(uri);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileIORaspHelper.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileIORaspHelper.java
@@ -20,13 +20,13 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FileLoadedRaspHelper {
+public class FileIORaspHelper {
 
-  public static FileLoadedRaspHelper INSTANCE = new FileLoadedRaspHelper();
+  public static FileIORaspHelper INSTANCE = new FileIORaspHelper();
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileLoadedRaspHelper.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileIORaspHelper.class);
 
-  private FileLoadedRaspHelper() {
+  private FileIORaspHelper() {
     // prevent instantiation
   }
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
 @CallSite(
     spi = {IastCallSites.class, RaspCallSites.class},
-    helpers = FileLoadedRaspHelper.class)
+    helpers = FileIORaspHelper.class)
 public class FileInputStreamCallSite {
 
   @CallSite.Before("void java.io.FileInputStream.<init>(java.lang.String)")
@@ -35,6 +35,6 @@ public class FileInputStreamCallSite {
   }
 
   private static void raspCallback(String path) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(path);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(path);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileLoadedRaspHelper.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileLoadedRaspHelper.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.gateway.Events.EVENTS;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.EventType;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
@@ -93,16 +94,24 @@ public class FileLoadedRaspHelper {
   }
 
   public void beforeFileLoaded(@Nonnull final String path) {
+    invokeRaspCallback(EVENTS.fileLoaded(), path);
+  }
+
+  public void beforeFileWritten(@Nonnull final String path) {
+    invokeRaspCallback(EVENTS.fileWritten(), path);
+  }
+
+  private void invokeRaspCallback(
+      EventType<BiFunction<RequestContext, String, Flow<Void>>> eventType,
+      @Nonnull final String path) {
     if (!Config.get().isAppSecRaspEnabled()) {
       return;
     }
     try {
-      final BiFunction<RequestContext, String, Flow<Void>> fileLoadedCallback =
-          AgentTracer.get()
-              .getCallbackProvider(RequestContextSlot.APPSEC)
-              .getCallback(EVENTS.fileLoaded());
+      final BiFunction<RequestContext, String, Flow<Void>> callback =
+          AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC).getCallback(eventType);
 
-      if (fileLoadedCallback == null) {
+      if (callback == null) {
         return;
       }
 
@@ -116,7 +125,7 @@ public class FileLoadedRaspHelper {
         return;
       }
 
-      Flow<Void> flow = fileLoadedCallback.apply(ctx, path);
+      Flow<Void> flow = callback.apply(ctx, path);
       Flow.Action action = flow.getAction();
       if (action instanceof Flow.Action.RequestBlockingAction) {
         BlockResponseFunction brf = ctx.getBlockResponseFunction();

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
 @CallSite(
     spi = {IastCallSites.class, RaspCallSites.class},
-    helpers = FileLoadedRaspHelper.class)
+    helpers = FileIORaspHelper.class)
 public class FileOutputStreamCallSite {
 
   @CallSite.Before("void java.io.FileOutputStream.<init>(java.lang.String)")
@@ -36,6 +36,6 @@ public class FileOutputStreamCallSite {
   }
 
   private static void raspCallback(String path) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileWritten(path);
+    FileIORaspHelper.INSTANCE.beforeFileWritten(path);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -36,6 +36,6 @@ public class FileOutputStreamCallSite {
   }
 
   private static void raspCallback(String path) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(path);
+    FileLoadedRaspHelper.INSTANCE.beforeFileWritten(path);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
 @CallSite(
     spi = {IastCallSites.class, RaspCallSites.class},
-    helpers = FileLoadedRaspHelper.class)
+    helpers = FileIORaspHelper.class)
 public class PathCallSite {
 
   @CallSite.Before("java.nio.file.Path java.nio.file.Path.resolve(java.lang.String)")
@@ -36,6 +36,6 @@ public class PathCallSite {
   }
 
   private static void raspCallback(String other) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(other);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(other);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
 @CallSite(
     spi = {IastCallSites.class, RaspCallSites.class},
-    helpers = FileLoadedRaspHelper.class)
+    helpers = FileIORaspHelper.class)
 public class PathsCallSite {
 
   @CallSite.Before(
@@ -58,10 +58,10 @@ public class PathsCallSite {
   }
 
   private static void raspCallback(String first, String[] more) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(first, more);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(first, more);
   }
 
   private static void raspCallback(URI uri) {
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(uri);
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(uri);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileCallSiteTest.groovy
@@ -4,7 +4,7 @@ import datadog.trace.api.gateway.CallbackProvider
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 import foo.bar.TestFileSuite
 
 import java.util.function.BiFunction
@@ -84,8 +84,8 @@ class FileCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP new file with parent and child'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final parent = '/home/test'
     final child = 'test.txt'
 
@@ -98,8 +98,8 @@ class FileCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP new file with parent file and child'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final parent = new File('/home/test')
     final child = 'test.txt'
 
@@ -112,8 +112,8 @@ class FileCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP new file with uri'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final file = new URI('file:/test.txt')
 
     when:

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileIORaspHelperForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileIORaspHelperForkedTest.groovy
@@ -3,13 +3,13 @@ package datadog.trace.instrumentation.java.io
 import datadog.trace.api.gateway.CallbackProvider
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContextSlot
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 
 import java.util.function.BiFunction
 
 import static datadog.trace.api.gateway.Events.EVENTS
 
-class FileLoadedRaspHelperForkedTest extends BaseIoRaspCallSiteTest {
+class FileIORaspHelperForkedTest extends BaseIoRaspCallSiteTest {
 
   void 'test Helper'() {
     setup:
@@ -19,7 +19,7 @@ class FileLoadedRaspHelperForkedTest extends BaseIoRaspCallSiteTest {
     tracer.getCallbackProvider(RequestContextSlot.APPSEC) >> callbackProvider
 
     when:
-    FileLoadedRaspHelper.INSTANCE.beforeFileLoaded(*args)
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(*args)
 
     then:
     1 * callbackProvider.getCallback(EVENTS.fileLoaded()) >> listener
@@ -43,7 +43,7 @@ class FileLoadedRaspHelperForkedTest extends BaseIoRaspCallSiteTest {
     tracer.getCallbackProvider(RequestContextSlot.APPSEC) >> callbackProvider
 
     when:
-    FileLoadedRaspHelper.INSTANCE.beforeFileWritten('test.txt')
+    FileIORaspHelper.INSTANCE.beforeFileWritten('test.txt')
 
     then:
     1 * callbackProvider.getCallback(EVENTS.fileWritten()) >> listener

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 import foo.bar.TestFileInputStreamSuite
 
 class FileInputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
@@ -22,8 +22,8 @@ class FileInputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void  'test RASP new file input stream with path'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final path = newFile('test_rasp.txt').toString()
 
     when:

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileLoadedRaspHelperForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileLoadedRaspHelperForkedTest.groovy
@@ -34,4 +34,19 @@ class FileLoadedRaspHelperForkedTest extends BaseIoRaspCallSiteTest {
     ['/tmp', ['log', 'test.txt'] as String[]] | '/tmp/log/test.txt'
     ['test.txt', [] as String[]]              | 'test.txt'
   }
+
+  void 'test beforeFileWritten'() {
+    setup:
+    final callbackProvider = Mock(CallbackProvider)
+    final listener = Mock(BiFunction)
+    final flow = Mock(Flow)
+    tracer.getCallbackProvider(RequestContextSlot.APPSEC) >> callbackProvider
+
+    when:
+    FileLoadedRaspHelper.INSTANCE.beforeFileWritten('test.txt')
+
+    then:
+    1 * callbackProvider.getCallback(EVENTS.fileWritten()) >> listener
+    1 * listener.apply(reqCtx, 'test.txt') >> flow
+  }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 import foo.bar.TestFileOutputStreamSuite
 import groovy.transform.CompileDynamic
 
@@ -37,8 +37,8 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP new file input stream with path'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final path = newFile('test_rasp_1.txt').toString()
 
     when:
@@ -50,8 +50,8 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP new file input stream with path and append'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final path = newFile('test_rasp_2.txt').toString()
 
     when:

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
@@ -45,7 +45,7 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     TestFileOutputStreamSuite.newFileOutputStream(path)
 
     then:
-    1 * helper.beforeFileLoaded(path)
+    1 * helper.beforeFileWritten(path)
   }
 
   void 'test RASP new file input stream with path and append'() {
@@ -58,6 +58,6 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     TestFileOutputStreamSuite.newFileOutputStream(path, false)
 
     then:
-    1 * helper.beforeFileLoaded(path)
+    1 * helper.beforeFileWritten(path)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 import foo.bar.TestPathSuite
 
 class PathCallSiteTest extends BaseIoRaspCallSiteTest {
@@ -36,8 +36,8 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP resolve path'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final path = 'test_rasp.txt'
 
     when:
@@ -49,8 +49,8 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP resolve sibling'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final sibling = newFile('test_rasp_1.txt').toPath()
     final path = 'test_rasp_2.txt'
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
-import datadog.trace.instrumentation.java.lang.FileLoadedRaspHelper
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
 import foo.bar.TestPathsSuite
 
 class PathsCallSiteTest extends BaseIoRaspCallSiteTest {
@@ -39,8 +39,8 @@ class PathsCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP get path from strings'(final String first, final String... other) {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
 
     when:
     TestPathsSuite.get(first, other)
@@ -56,8 +56,8 @@ class PathsCallSiteTest extends BaseIoRaspCallSiteTest {
 
   void 'test RASP get path from uri'() {
     setup:
-    final helper = Mock(FileLoadedRaspHelper)
-    FileLoadedRaspHelper.INSTANCE = helper
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
     final file = new URI('file:/test.txt')
 
     when:

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -12,6 +12,7 @@ import datadog.appsec.api.blocking.BlockingException;
 import datadog.smoketest.appsec.springboot.service.AsyncService;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -187,6 +188,12 @@ public class WebController {
   @GetMapping("/lfi/path")
   public String lfiPath(@RequestParam("path") String path) {
     new File(System.getProperty("user.dir")).toPath().resolve(path);
+    return "EXECUTED";
+  }
+
+  @GetMapping("/lfi/fileoutputstream")
+  public String lfiFileOutputStream(@RequestParam("path") String path) throws IOException {
+    new FileOutputStream(path).close();
     return "EXECUTED";
   }
 

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -419,6 +419,30 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
           ],
           on_match: []
         ],
+        [
+          id          : 'rasp-930-101',
+          name        : 'Local File Inclusion write exploit',
+          enable      : 'true',
+          tags        : [
+            type      : 'lfi',
+            category  : 'vulnerability_trigger',
+            cwe       : '98',
+            capec     : '252',
+            confidence: '0',
+            module    : 'rasp'
+          ],
+          conditions  : [
+            [
+              parameters: [
+                resource: [[address: 'server.io.fs.file_write']],
+                params  : [[address: 'server.request.query']],
+              ],
+              operator  : 'lfi_detector',
+            ],
+          ],
+          transformers: [],
+          on_match    : ['block']
+        ],
       ])
   }
 
@@ -764,6 +788,39 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     'paths'    | _
     'file'    | _
     'path'    | _
+  }
+
+  void 'rasp blocks on LFI write'() {
+    when:
+    String url = "http://localhost:${httpPort}/lfi/fileoutputstream?path=." + URLEncoder.encode("../../../etc/passwd", StandardCharsets.UTF_8.name())
+    def request = new Request.Builder()
+      .url(url)
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+    def responseBodyStr = response.body().string()
+
+    then:
+    response.code() == 403
+    responseBodyStr.contains('You\'ve been blocked')
+
+    when:
+    waitForTraceCount(1)
+
+    then:
+    def rootSpan = findFirstMatchingSpan('fileoutputstream')
+    assert rootSpan != null, 'root span not found'
+    assert rootSpan.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
+    assert rootSpan.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
+    def trigger = null
+    for (t in rootSpan.triggers) {
+      if (t['rule']['id'] == 'rasp-930-101') {
+        trigger = t
+        break
+      }
+    }
+    assert trigger != null, 'test trigger not found'
+    rootSpan.span.metaStruct == null
   }
 
   def findFirstMatchingSpan(String resource) {

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -434,10 +434,11 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
           conditions  : [
             [
               parameters: [
-                resource: [[address: 'server.io.fs.file_write']],
-                params  : [[address: 'server.request.query']],
+                inputs : [[address: 'server.io.fs.file_write']],
+                regex  : '(?:^|[/\\\\])\\.\\.[/\\\\]',
+                options: [case_sensitive: true, min_length: 4],
               ],
-              operator  : 'lfi_detector',
+              operator  : 'match_regex',
             ],
           ],
           transformers: [],

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -419,30 +419,6 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
           ],
           on_match: []
         ],
-        [
-          id          : 'rasp-930-101',
-          name        : 'Local File Inclusion write exploit',
-          enable      : 'true',
-          tags        : [
-            type      : 'lfi',
-            category  : 'vulnerability_trigger',
-            cwe       : '98',
-            capec     : '252',
-            confidence: '0',
-            module    : 'rasp'
-          ],
-          conditions  : [
-            [
-              parameters: [
-                resource: [[address: 'server.io.fs.file_write']],
-                params  : [[address: 'server.request.query']],
-              ],
-              operator  : 'lfi_detector',
-            ],
-          ],
-          transformers: [],
-          on_match    : ['block']
-        ],
       ])
   }
 
@@ -814,7 +790,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     assert rootSpan.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     def trigger = null
     for (t in rootSpan.triggers) {
-      if (t['rule']['id'] == 'rasp-930-101') {
+      if (t['rule']['id'] == 'rasp-930-100') {
         trigger = t
         break
       }

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -434,11 +434,10 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
           conditions  : [
             [
               parameters: [
-                inputs : [[address: 'server.io.fs.file_write']],
-                regex  : '(?:^|[/\\\\])\\.\\.[/\\\\]',
-                options: [case_sensitive: true, min_length: 4],
+                resource: [[address: 'server.io.fs.file_write']],
+                params  : [[address: 'server.request.query']],
               ],
-              operator  : 'match_regex',
+              operator  : 'lfi_detector',
             ],
           ],
           transformers: [],

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -396,6 +396,17 @@ public final class Events<D> {
         REQUEST_FILES_FILENAMES;
   }
 
+  static final int FILE_WRITTEN_ID = 31;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType FILE_WRITTEN = new ET<>("file.written", FILE_WRITTEN_ID);
+
+  /** An I/O file written */
+  @SuppressWarnings("unchecked")
+  public EventType<BiFunction<RequestContext, String, Flow<Void>>> fileWritten() {
+    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) FILE_WRITTEN;
+  }
+
   static final int MAX_EVENTS = nextId.get();
 
   private static final class ET<T> extends EventType<T> {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.gateway.Events.DATABASE_CONNECTION_ID;
 import static datadog.trace.api.gateway.Events.DATABASE_SQL_QUERY_ID;
 import static datadog.trace.api.gateway.Events.EXEC_CMD_ID;
 import static datadog.trace.api.gateway.Events.FILE_LOADED_ID;
+import static datadog.trace.api.gateway.Events.FILE_WRITTEN_ID;
 import static datadog.trace.api.gateway.Events.GRAPHQL_SERVER_REQUEST_MESSAGE_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_METHOD_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_REQUEST_MESSAGE_ID;
@@ -447,6 +448,7 @@ public class InstrumentationGateway {
             };
       case DATABASE_SQL_QUERY_ID:
       case FILE_LOADED_ID:
+      case FILE_WRITTEN_ID:
       case SHELL_CMD_ID:
         return (C)
             new BiFunction<RequestContext, String, Flow<Void>>() {

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -240,6 +240,8 @@ public class InstrumentationGatewayTest {
     assertEquals(
         Flow.Action.Noop.INSTANCE,
         cbp.getCallback(events.requestFilesFilenames()).apply(null, null).getAction());
+    ss.registerCallback(events.fileWritten(), callback);
+    cbp.getCallback(events.fileWritten()).apply(null, null);
     assertEquals(Events.MAX_EVENTS, callback.count);
   }
 
@@ -329,6 +331,8 @@ public class InstrumentationGatewayTest {
     ss.registerCallback(events.requestFilesFilenames(), throwback);
     assertEquals(
         Flow.ResultFlow.empty(), cbp.getCallback(events.requestFilesFilenames()).apply(null, null));
+    ss.registerCallback(events.fileWritten(), throwback);
+    cbp.getCallback(events.fileWritten()).apply(null, null);
     assertEquals(Events.MAX_EVENTS, throwback.count);
   }
 


### PR DESCRIPTION
## What Does This Do

  - Adds `server.io.fs.file_write` as a new IG address, distinct from the existing `server.io.fs.file` (reads)
  - `FileOutputStream` call sites now publish both `server.io.fs.file` and `server.io.fs.file_write` via a new `fileWritten()` event; read call sites (`FileInputStream`, `File`,
  `Path`) remain on `server.io.fs.file` only
  - Adds the `dog-920-110` Zipslip detection rule (from DataDog/appsec-event-rules#282) which requires both a `.zip` upload and a path-traversal write

  ## Address behaviour per operation

  | Operation | `server.io.fs.file` | `server.io.fs.file_write` |
  |---|---|---|
  | Read (`FileInputStream`, `File`, `Path`) | ✓ | — |
  | Write (`FileOutputStream`) | ✓ (backwards compat) | ✓ (new) |

  ## Additional Notes

  Write operations continue to publish `server.io.fs.file` in addition to the new `server.io.fs.file_write`. This preserves backwards compatibility: existing rules such as
  `rasp-930-100` (LFI exploit, `lfi_detector@v2`) keep firing for write operations without any rule changes. New rules can use `server.io.fs.file_write` to target writes
  specifically.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira Ticket: [APPSEC-61874](https://datadoghq.atlassian.net/browse/APPSEC-61874)

[APPSEC-61874]: https://datadoghq.atlassian.net/browse/APPSEC-61874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ