### PR TITLE
Deprecate PROFILING_HEAP_ENABLED_DEFAULT and update metadata default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -11,7 +11,12 @@ public final class ProfilingConfig {
   public static final boolean PROFILING_ENABLED_DEFAULT = false;
   public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
   public static final String PROFILING_HEAP_ENABLED = "profiling.heap.enabled";
-  public static final boolean PROFILING_HEAP_ENABLED_DEFAULT = false;
+
+  /**
+   * @deprecated The default is now computed dynamically based on JVM capabilities.
+   */
+  @Deprecated public static final boolean PROFILING_HEAP_ENABLED_DEFAULT = false;
+
   @Deprecated // Use dd.site instead
   public static final String PROFILING_URL = "profiling.url";
   @Deprecated // Use dd.api-key instead

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -3045,7 +3045,7 @@
       {
         "version": "A",
         "type": "boolean",
-        "default": "false",
+        "default": "true",
         "aliases": []
       }
     ],


### PR DESCRIPTION
# What Does This Do

Marks `PROFILING_HEAP_ENABLED_DEFAULT` as `@Deprecated` in `ProfilingConfig` and updates the `DD_PROFILING_HEAP_ENABLED` metadata entry default from `"false"` to `"true"`.

# Motivation

The `profiling.heap.enabled` config now defaults to `isLiveHeapProfilingSafe()` — a dynamic predicate that returns `true` on JVMs where either ddprof live heap or JFR OldObjectSample is safely available (merged in #11039). As a result:

- `PROFILING_HEAP_ENABLED_DEFAULT = false` is dead code with no callers; it is a misleading artefact of the old static default. It is kept as a `@Deprecated` constant (rather than removed) to avoid a binary-incompatible change for external consumers of the `dd-trace-api` library.
- The `metadata/supported-configurations.json` entry for `DD_PROFILING_HEAP_ENABLED` still declared `"default": "false"`, misrepresenting the new effective default to tooling and documentation generators.

# Additional Notes

No behaviour changes — purely a metadata and deprecation annotation update.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROF-10633]

[PROF-10633]: https://datadoghq.atlassian.net/browse/PROF-10633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ