### PR TITLE
Bump Tomcat to `9.0.117` because `9.0.115` is no longer resolvable in GitLab CI.

### DIFF
--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -8,7 +8,7 @@ plugins {
 ext {
   serverName = 'tomcat'
   serverModule = 'tomcat-9'
-  serverVersion = '9.0.115'
+  serverVersion = '9.0.117'
   serverExtension = 'zip'
 }
 


### PR DESCRIPTION
# What Does This Do
Bump Tomcat to `9.0.117` because `9.0.115` is no longer resolvable in GitLab CI.

# Motivation
Green CI

# Additional Notes
CI started to fail as:
```
* What went wrong:
Execution failed for task ':dd-smoke-tests:springboot-tomcat:resolveAndLockAll'.
> Could not resolve all files for configuration ':dd-smoke-tests:springboot-tomcat:serverFile'.
   > Could not find tomcat:tomcat-9:9.0.115.
     Searched in the following locations:
       - file:/home/non-root-user/.m2/repository/tomcat/tomcat-9/9.0.115/tomcat-9-9.0.115.pom
       - https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/tomcat/tomcat-9/9.0.115/tomcat-9-9.0.115.pom
       - https://repo.maven.apache.org/maven2/tomcat/tomcat-9/9.0.115/tomcat-9-9.0.115.pom
       - https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.115/bin/apache-tomcat-9.0.115.zip
     Required by:
         project :dd-smoke-tests:springboot-tomcat
```

That looks like an infra issue to me.