### PR TITLE
Improve Config JUnit extension

### DIFF
--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
@@ -1,9 +1,11 @@
 package datadog.trace.junit.utils.config;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,8 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * }
  * }</pre>
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
 @Repeatable(WithConfigs.class)
 @ExtendWith(WithConfigExtension.class)
 public @interface WithConfig {

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -87,6 +87,11 @@ public class WithConfigExtension
     if (originalSystemProperties == null) {
       saveProperties();
     }
+    // Apply class-level @WithConfig so config is available before @BeforeAll methods
+    applyClassLevelConfig(context);
+    if (isConfigInstanceModifiable) {
+      rebuildConfig();
+    }
   }
 
   @Override
@@ -116,8 +121,12 @@ public class WithConfigExtension
     }
   }
 
-  private void applyDeclaredConfig(ExtensionContext context) {
-    // Class-level @WithConfig annotations
+  private static void applyDeclaredConfig(ExtensionContext context) {
+    applyClassLevelConfig(context);
+    applyMethodLevelConfig(context);
+  }
+
+  private static void applyClassLevelConfig(ExtensionContext context) {
     // Walk the entire class hierarchy so annotations on superclasses are applied
     // (topmost first, then subclass overrides)
     Class<?> testClass = context.getRequiredTestClass();
@@ -132,6 +141,9 @@ public class WithConfigExtension
         applyConfig(cfg);
       }
     }
+  }
+
+  private static void applyMethodLevelConfig(ExtensionContext context) {
     // Method-level @WithConfig annotations (supports composed/meta-annotations)
     context
         .getTestMethod()

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -19,6 +19,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,12 +110,20 @@ public class WithConfigExtension
   }
 
   private void applyDeclaredConfig(ExtensionContext context) {
-    // Class-level @WithConfig annotations (supports composed/meta-annotations)
-    List<WithConfig> classConfigs =
-        AnnotationSupport.findRepeatableAnnotations(
-            context.getRequiredTestClass(), WithConfig.class);
-    for (WithConfig cfg : classConfigs) {
-      applyConfig(cfg);
+    // Class-level @WithConfig annotations
+    // Walk the entire class hierarchy so annotations on superclasses are applied
+    // (topmost first, then subclass overrides)
+    Class<?> testClass = context.getRequiredTestClass();
+    List<Class<?>> hierarchy = new ArrayList<>();
+    for (Class<?> cls = testClass; cls != null; cls = cls.getSuperclass()) {
+      hierarchy.add(cls);
+    }
+    for (int i = hierarchy.size() - 1; i >= 0; i--) {
+      List<WithConfig> classConfigs =
+          AnnotationSupport.findRepeatableAnnotations(hierarchy.get(i), WithConfig.class);
+      for (WithConfig cfg : classConfigs) {
+        applyConfig(cfg);
+      }
     }
     // Method-level @WithConfig annotations (supports composed/meta-annotations)
     context

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -63,6 +63,7 @@ public class WithConfigExtension
   private static Field configInstanceField;
   private static Constructor<?> configConstructor;
 
+  private static volatile boolean configTransformerInstalled = false;
   private static volatile boolean isConfigInstanceModifiable = false;
   private static volatile boolean configModificationFailed = false;
 
@@ -74,9 +75,15 @@ public class WithConfigExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    installConfigTransformer();
+    if (!configTransformerInstalled) {
+      installConfigTransformer();
+      configTransformerInstalled = true;
+    }
     makeConfigInstanceModifiable();
     assertFalse(configModificationFailed, "Config class modification failed");
+    if (isConfigInstanceModifiable) {
+      checkConfigTransformation();
+    }
     if (originalSystemProperties == null) {
       saveProperties();
     }
@@ -86,10 +93,10 @@ public class WithConfigExtension
   public void beforeEach(ExtensionContext context) {
     restoreProperties();
     environmentVariables.clear();
+    applyDeclaredConfig(context);
     if (isConfigInstanceModifiable) {
       rebuildConfig();
     }
-    applyDeclaredConfig(context);
   }
 
   @Override
@@ -140,10 +147,20 @@ public class WithConfigExtension
 
   private static void applyConfig(WithConfig cfg) {
     if (cfg.env()) {
-      injectEnvConfig(cfg.key(), cfg.value(), cfg.addPrefix());
+      setEnvVariable(cfg.key(), cfg.value(), cfg.addPrefix());
     } else {
-      injectSysConfig(cfg.key(), cfg.value(), cfg.addPrefix());
+      setSysProperty(cfg.key(), cfg.value(), cfg.addPrefix());
     }
+  }
+
+  private static void setSysProperty(String name, String value, boolean addPrefix) {
+    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    System.setProperty(prefixedName, value);
+  }
+
+  private static void setEnvVariable(String name, String value, boolean addPrefix) {
+    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    environmentVariables.set(prefixedName, value);
   }
 
   // endregion
@@ -155,9 +172,7 @@ public class WithConfigExtension
   }
 
   public static void injectSysConfig(String name, String value, boolean addPrefix) {
-    checkConfigTransformation();
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
-    System.setProperty(prefixedName, value);
+    setSysProperty(name, value, addPrefix);
     rebuildConfig();
   }
 
@@ -166,7 +181,6 @@ public class WithConfigExtension
   }
 
   public static void removeSysConfig(String name, boolean addPrefix) {
-    checkConfigTransformation();
     String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
     System.clearProperty(prefixedName);
     rebuildConfig();
@@ -177,9 +191,7 @@ public class WithConfigExtension
   }
 
   public static void injectEnvConfig(String name, String value, boolean addPrefix) {
-    checkConfigTransformation();
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
-    environmentVariables.set(prefixedName, value);
+    setEnvVariable(name, value, addPrefix);
     rebuildConfig();
   }
 
@@ -188,7 +200,6 @@ public class WithConfigExtension
   }
 
   public static void removeEnvConfig(String name, boolean addPrefix) {
-    checkConfigTransformation();
     String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
     environmentVariables.removePrefixed(prefixedName);
     rebuildConfig();
@@ -254,7 +265,6 @@ public class WithConfigExtension
 
   private static void rebuildConfig() {
     synchronized (WithConfigExtension.class) {
-      checkConfigTransformation();
       try {
         Object newInstConfig = instConfigConstructor.newInstance();
         instConfigInstanceField.set(null, newInstConfig);

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -75,15 +75,24 @@ public class WithConfigExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
+    /*
+     * Patch config classes to make them modifiable.
+     */
+    // Install config transformer error listener
     if (!configTransformerInstalled) {
       installConfigTransformer();
       configTransformerInstalled = true;
     }
+    // Make config instance modifiable
     makeConfigInstanceModifiable();
+    // Verify that config class transformation succeeded
     assertFalse(configModificationFailed, "Config class modification failed");
     if (isConfigInstanceModifiable) {
       checkConfigTransformation();
     }
+    /*
+     * Back up config and apply class-level config values.
+     */
     if (originalSystemProperties == null) {
       saveProperties();
     }
@@ -127,8 +136,8 @@ public class WithConfigExtension
   }
 
   private static void applyClassLevelConfig(ExtensionContext context) {
-    // Walk the entire class hierarchy so annotations on superclasses are applied
-    // (topmost first, then subclass overrides)
+    // Walk the entire class hierarchy so annotations on superclasses and apply topmost first, then
+    // subclass overrides.
     Class<?> testClass = context.getRequiredTestClass();
     List<Class<?>> hierarchy = new ArrayList<>();
     for (Class<?> cls = testClass; cls != null; cls = cls.getSuperclass()) {
@@ -166,12 +175,12 @@ public class WithConfigExtension
   }
 
   private static void setSysProperty(String name, String value, boolean addPrefix) {
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    String prefixedName = addPrefix && !name.startsWith("dd.") ? "dd." + name : name;
     System.setProperty(prefixedName, value);
   }
 
   private static void setEnvVariable(String name, String value, boolean addPrefix) {
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    String prefixedName = addPrefix && !name.startsWith("DD_") ? "DD_" + name : name;
     environmentVariables.set(prefixedName, value);
   }
 
@@ -193,7 +202,7 @@ public class WithConfigExtension
   }
 
   public static void removeSysConfig(String name, boolean addPrefix) {
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    String prefixedName = addPrefix && !name.startsWith("dd.") ? "dd." + name : name;
     System.clearProperty(prefixedName);
     rebuildConfig();
   }
@@ -212,7 +221,7 @@ public class WithConfigExtension
   }
 
   public static void removeEnvConfig(String name, boolean addPrefix) {
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    String prefixedName = addPrefix && !name.startsWith("DD_") ? "DD_" + name : name;
     environmentVariables.removePrefixed(prefixedName);
     rebuildConfig();
   }

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigs.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigs.java
@@ -1,14 +1,16 @@
 package datadog.trace.junit.utils.config;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Container annotation for repeatable {@link WithConfig}. */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
 @ExtendWith(WithConfigExtension.class)
 public @interface WithConfigs {
   WithConfig[] value();

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/CleanConfigStateExtension.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/CleanConfigStateExtension.java
@@ -1,0 +1,80 @@
+package datadog.trace.test.util;
+
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+
+import datadog.environment.EnvironmentVariables;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Asserts that no {@code DD_*} environment variable and no {@code dd.*} system property (minus a
+ * small allowlist) is set around a test class.
+ */
+@SuppressForbidden
+public class CleanConfigStateExtension implements BeforeAllCallback, AfterAllCallback {
+
+  private static final List<String> ALLOWED_SYS_PROPS =
+      Arrays.asList(
+          "dd.appsec.enabled", "dd.iast.enabled", "dd.integration.grizzly-filterchain.enabled");
+
+  private static final Predicate<String> DATADOG_ENV_VAR_FILTER = k -> k.startsWith("DD_");
+  private static final Predicate<Object> DATADOG_SYS_PROPERTIES_FILTER =
+      o -> {
+        String key = (String) o;
+        return key.startsWith("DD_") && !ALLOWED_SYS_PROPS.contains(key);
+      };
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    assertClean("before");
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    assertClean("after");
+  }
+
+  private static void assertClean(String phase) {
+    Map<String, String> leakedEnv =
+        filterMap(EnvironmentVariables.getAll(), DATADOG_ENV_VAR_FILTER);
+    Map<Object, Object> leakedSys =
+        filterMap(System.getProperties(), DATADOG_SYS_PROPERTIES_FILTER);
+    if (!leakedEnv.isEmpty() || !leakedSys.isEmpty()) {
+      assertionFailure()
+          .message("Leaked Datadog configuration detected " + phase + " test class")
+          .reason(formatLeaks(leakedEnv, leakedSys))
+          .buildAndThrow();
+    }
+  }
+
+  private static <T> Map<T, T> filterMap(Map<T, T> map, Predicate<T> keyFilter) {
+    return map.entrySet().stream()
+        .filter(e -> keyFilter.test(e.getKey()))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, TreeMap::new));
+  }
+
+  private static String formatLeaks(Map<String, String> env, Map<Object, Object> sys) {
+    StringBuilder sb = new StringBuilder();
+    if (!env.isEmpty()) {
+      sb.append("environment variables:");
+      env.forEach((k, v) -> sb.append("\n  ").append(k).append('=').append(v));
+    }
+    if (!sys.isEmpty()) {
+      if (sb.length() > 0) {
+        sb.append('\n');
+      }
+      sb.append("system properties:");
+      sys.forEach((k, v) -> sb.append("\n  ").append(k).append('=').append(v));
+    }
+    return sb.toString();
+  }
+}

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/DDJavaSpecification.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/DDJavaSpecification.java
@@ -1,14 +1,9 @@
 package datadog.trace.test.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import datadog.environment.EnvironmentVariables;
 import datadog.trace.junit.utils.config.WithConfigExtension;
 import datadog.trace.junit.utils.context.AllowContextTestingExtension;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
@@ -16,7 +11,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({WithConfigExtension.class, AllowContextTestingExtension.class})
+@ExtendWith({
+  CleanConfigStateExtension.class,
+  WithConfigExtension.class,
+  AllowContextTestingExtension.class
+})
 @SuppressForbidden
 public class DDJavaSpecification {
 
@@ -27,13 +26,6 @@ public class DDJavaSpecification {
 
   @BeforeAll
   static void beforeAll() {
-    assertTrue(
-        EnvironmentVariables.getAll().entrySet().stream()
-            .noneMatch(e -> e.getKey().startsWith("DD_")));
-    assertTrue(
-        systemPropertiesExceptAllowed().entrySet().stream()
-            .noneMatch(e -> e.getKey().toString().startsWith("dd.")));
-
     if (getDDThreads().isEmpty()) {
       ignoreThreadCleanup = false;
     } else {
@@ -45,23 +37,7 @@ public class DDJavaSpecification {
 
   @AfterAll
   static void afterAll() {
-    assertTrue(
-        EnvironmentVariables.getAll().entrySet().stream()
-            .noneMatch(e -> e.getKey().startsWith("DD_")));
-    assertTrue(
-        systemPropertiesExceptAllowed().entrySet().stream()
-            .noneMatch(e -> e.getKey().toString().startsWith("dd.")));
-
     checkThreads();
-  }
-
-  private static Map<Object, Object> systemPropertiesExceptAllowed() {
-    List<String> allowlist =
-        Arrays.asList(
-            "dd.appsec.enabled", "dd.iast.enabled", "dd.integration.grizzly-filterchain.enabled");
-    return System.getProperties().entrySet().stream()
-        .filter(e -> !allowlist.contains(String.valueOf(e.getKey())))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @AfterEach


### PR DESCRIPTION
# What Does This Do

This PR improves the newly introduces Config JUnit extension: https://github.com/DataDog/dd-trace-java/pull/11076

* Allow to add `@WithConfig` at any class hierarchy level. Child classes can now inherit parent config and enrich it.
* Improve performance by building configuration only once per test method. It can still be rebuild if config is updated programmatically.
* Apply class level configuration (ie `@WithConfig` annotation on class element) at `@BeforeAll` level so class level configuration is accessible in static test initializers.

# Motivation

Using the extension allowed to refine both its behavior and performance.

# Additional Notes

This PR is part of some bigger improvements in stacked PRs:
* https://github.com/DataDog/dd-trace-java/pull/11094
* https://github.com/DataDog/dd-trace-java/pull/11096
* https://github.com/DataDog/dd-trace-java/pull/11097
* https://github.com/DataDog/dd-trace-java/pull/11209
* https://github.com/DataDog/dd-trace-java/pull/11081

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMLP-1247]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1247]: https://datadoghq.atlassian.net/browse/APMLP-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ