### PR TITLE
Improve instrumentation JUnit testing 

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/AbstractInstrumentationTest.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/AbstractInstrumentationTest.java
@@ -14,7 +14,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers;
 import datadog.trace.api.Config;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpan;
@@ -30,16 +30,26 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.AssertionFailedError;
 
 /**
- * This class is an experimental base to run instrumentation tests using JUnit Jupiter. It is still
- * early development, and the overall API is expected to change to leverage its extension model. The
- * current implementation is inspired and kept close to it Groovy / Spock counterpart, the {@code
- * InstrumentationSpecification}.
+ * Base class for instrumentation tests using JUnit Jupiter.
+ *
+ * <p>It is still early development, and the overall API might change to leverage its extension
+ * model. The current implementation is inspired and kept close to its Groovy / Spock counterpart,
+ * the {@code InstrumentationSpecification}.
+ *
+ * <ul>
+ *   <li>{@code @BeforeAll}: Installs the agent and creates a shared tracer
+ *   <li>{@code @BeforeEach}: Flushes and resets the writer
+ *   <li>{@code @AfterEach}: Flushes the tracer
+ *   <li>{@code @AfterAll}: Closes the tracer and removes the agent transformer
+ * </ul>
  */
 @ExtendWith({TestClassShadowingExtension.class, AllowContextTestingExtension.class})
 public abstract class AbstractInstrumentationTest {
@@ -47,31 +57,29 @@ public abstract class AbstractInstrumentationTest {
 
   static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(20);
 
-  protected AgentTracer.TracerAPI tracer;
+  protected static final InstrumentationTestConfig testConfig = new InstrumentationTestConfig();
 
-  protected ListWriter writer;
+  protected static TracerAPI tracer;
+  protected static ListWriter writer;
+  private static ClassFileTransformer activeTransformer;
+  private static ClassFileTransformerListener transformerListener;
 
-  protected ClassFileTransformer activeTransformer;
-  protected ClassFileTransformerListener transformerLister;
-
-  @BeforeEach
-  public void init() {
+  @BeforeAll
+  static void initAll() {
     // If this fails, it's likely the result of another test loading Config before it can be
     // injected into the bootstrap classpath.
-    // If one test extends AgentTestRunner in a module, all tests must extend
     assertNull(Config.class.getClassLoader(), "Config must load on the bootstrap classpath.");
 
-    // Initialize test tracer
-    this.writer = new ListWriter();
-    // Initialize test tracer
-    CoreTracer tracer =
+    // Create shared test writer and tracer
+    writer = new ListWriter();
+    CoreTracer coreTracer =
         CoreTracer.builder()
-            .writer(this.writer)
-            .idGenerationStrategy(IdGenerationStrategy.fromName(idGenerationStrategyName()))
-            .strictTraceWrites(useStrictTraceWrites())
+            .writer(writer)
+            .idGenerationStrategy(IdGenerationStrategy.fromName(testConfig.idGenerationStrategy))
+            .strictTraceWrites(testConfig.strictTraceWrites)
             .build();
-    TracerInstaller.forceInstallGlobalTracer(tracer);
-    this.tracer = tracer;
+    TracerInstaller.forceInstallGlobalTracer(coreTracer);
+    tracer = coreTracer;
 
     ClassInjector.enableClassInjection(INSTRUMENTATION);
 
@@ -85,33 +93,43 @@ public abstract class AbstractInstrumentationTest {
             .iterator()
             .hasNext(),
         "No instrumentation found");
-    this.transformerLister = new ClassFileTransformerListener();
-    this.activeTransformer =
+    transformerListener = new ClassFileTransformerListener();
+    activeTransformer =
         AgentInstaller.installBytebuddyAgent(
-            INSTRUMENTATION, true, AgentInstaller.getEnabledSystems(), this.transformerLister);
+            INSTRUMENTATION, true, AgentInstaller.getEnabledSystems(), transformerListener);
   }
 
-  protected String idGenerationStrategyName() {
-    return "SEQUENTIAL";
-  }
-
-  private boolean useStrictTraceWrites() {
-    return true;
+  @BeforeEach
+  public void init() {
+    tracer.flush();
+    writer.start();
   }
 
   @AfterEach
   public void tearDown() {
-    this.tracer.close();
-    this.writer.close();
-    if (this.activeTransformer != null) {
-      INSTRUMENTATION.removeTransformer(this.activeTransformer);
-      this.activeTransformer = null;
-    }
+    tracer.flush();
+  }
 
-    // All cleanups should happen before these assertions.
+  @AfterAll
+  static void tearDownAll() {
+    if (tracer != null) {
+      tracer.close();
+      tracer = null;
+    }
+    if (writer != null) {
+      writer.close();
+      writer = null;
+    }
+    if (activeTransformer != null) {
+      INSTRUMENTATION.removeTransformer(activeTransformer);
+      activeTransformer = null;
+    }
+    // All cleanups should happen before this verify call.
     // If not, a failing assertion may prevent cleanup
-    this.transformerLister.verify();
-    this.transformerLister = null;
+    if (transformerListener != null) {
+      transformerListener.verify();
+      transformerListener = null;
+    }
   }
 
   /**
@@ -134,11 +152,11 @@ public abstract class AbstractInstrumentationTest {
       TraceMatcher... matchers) {
     int expectedTraceCount = matchers.length;
     try {
-      this.writer.waitForTraces(expectedTraceCount);
+      writer.waitForTraces(expectedTraceCount);
     } catch (InterruptedException | TimeoutException e) {
       throw new AssertionFailedError("Timeout while waiting for traces", e);
     }
-    TraceAssertions.assertTraces(this.writer, options, matchers);
+    TraceAssertions.assertTraces(writer, options, matchers);
   }
 
   /**
@@ -149,7 +167,7 @@ public abstract class AbstractInstrumentationTest {
    */
   protected void blockUntilTracesMatch(Predicate<List<List<DDSpan>>> predicate) {
     long deadline = System.currentTimeMillis() + TIMEOUT_MILLIS;
-    while (!predicate.test(this.writer)) {
+    while (!predicate.test(writer)) {
       if (System.currentTimeMillis() > deadline) {
         throw new RuntimeException(new TimeoutException("Timed out waiting for traces/spans."));
       }
@@ -161,8 +179,8 @@ public abstract class AbstractInstrumentationTest {
     }
   }
 
-  protected void blockUntilChildSpansFinished(final int numberOfSpans) {
-    blockUntilChildSpansFinished(this.tracer.activeSpan(), numberOfSpans);
+  protected void blockUntilChildSpansFinished(int numberOfSpans) {
+    blockUntilChildSpansFinished(tracer.activeSpan(), numberOfSpans);
   }
 
   static void blockUntilChildSpansFinished(AgentSpan span, int numberOfSpans) {
@@ -188,6 +206,22 @@ public abstract class AbstractInstrumentationTest {
           Thread.currentThread().interrupt();
         }
       }
+    }
+  }
+
+  /** Configuration for {@link AbstractInstrumentationTest}. */
+  protected static class InstrumentationTestConfig {
+    private String idGenerationStrategy = "SEQUENTIAL";
+    private boolean strictTraceWrites = true;
+
+    public InstrumentationTestConfig idGenerationStrategy(String strategy) {
+      this.idGenerationStrategy = strategy;
+      return this;
+    }
+
+    public InstrumentationTestConfig strictTraceWrites(boolean strict) {
+      this.strictTraceWrites = strict;
+      return this;
     }
   }
 }

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/Matchers.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/Matchers.java
@@ -1,9 +1,10 @@
 package datadog.trace.agent.test.assertions;
 
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import org.opentest4j.AssertionFailedError;
 
 /** This class is a utility class to create generic matchers. */
 public final class Matchers {
@@ -103,12 +104,11 @@ public final class Matchers {
   static <T> void assertValue(Matcher<T> matcher, T value, String message) {
     if (matcher != null && !matcher.test(value)) {
       Optional<T> expected = matcher.expected();
-      if (expected.isPresent()) {
-        throw new AssertionFailedError(
-            message + ". " + matcher.failureReason(), expected.get(), value);
-      } else {
-        throw new AssertionFailedError(message + ": " + value + ". " + matcher.failureReason());
-      }
+      assertionFailure()
+          .message(message + ". " + matcher.failureReason())
+          .expected(expected.orElse(null))
+          .actual(value)
+          .buildAndThrow();
     }
   }
 }

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
@@ -10,6 +10,7 @@ import static datadog.trace.agent.test.assertions.Matchers.matches;
 import static datadog.trace.agent.test.assertions.Matchers.validates;
 import static datadog.trace.core.DDSpanAccessor.spanLinks;
 import static java.time.Duration.ofNanos;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
@@ -322,7 +323,7 @@ public final class SpanMatcher {
           if (matcher == null) {
             uncheckedTagNames.add(key);
           } else {
-            assertValue(matcher, value, "Unexpected " + key + " tag value.");
+            assertValue(matcher, value, "Unexpected " + key + " tag value");
           }
         });
     // Remove matchers that accept missing tags
@@ -345,9 +346,13 @@ public final class SpanMatcher {
    */
   private void assertSpanLinks(List<AgentSpanLink> links) {
     int linkCount = links == null ? 0 : links.size();
-    int expectedLinkCount = this.linkMatchers == null ? 0 : this.linkMatchers.length;
+    int expectedLinkCount = this.linkMatchers.length;
     if (linkCount != expectedLinkCount) {
-      throw new AssertionFailedError("Unexpected span link count", expectedLinkCount, linkCount);
+      assertionFailure()
+          .message("Unexpected span link count")
+          .expected(expectedLinkCount)
+          .actual(linkCount)
+          .buildAndThrow();
     }
     for (int i = 0; i < expectedLinkCount; i++) {
       SpanLinkMatcher linkMatcher = this.linkMatchers[expectedLinkCount];

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
@@ -345,6 +345,10 @@ public final class SpanMatcher {
    * It might evolve into partial link collection testing, matching links using TID/SIP.
    */
   private void assertSpanLinks(List<AgentSpanLink> links) {
+    // Check if links should be asserted at all
+    if (this.linkMatchers == null) {
+      return;
+    }
     int linkCount = links == null ? 0 : links.size();
     int expectedLinkCount = this.linkMatchers.length;
     if (linkCount != expectedLinkCount) {

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TagsMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TagsMatcher.java
@@ -3,18 +3,28 @@ package datadog.trace.agent.test.assertions;
 import static datadog.trace.agent.test.assertions.Matchers.any;
 import static datadog.trace.agent.test.assertions.Matchers.is;
 import static datadog.trace.agent.test.assertions.Matchers.isNonNull;
+import static datadog.trace.api.DDTags.BASE_SERVICE;
+import static datadog.trace.api.DDTags.DD_INTEGRATION;
+import static datadog.trace.api.DDTags.DJM_ENABLED;
+import static datadog.trace.api.DDTags.DSM_ENABLED;
 import static datadog.trace.api.DDTags.ERROR_MSG;
 import static datadog.trace.api.DDTags.ERROR_STACK;
 import static datadog.trace.api.DDTags.ERROR_TYPE;
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
+import static datadog.trace.api.DDTags.PARENT_ID;
+import static datadog.trace.api.DDTags.PID_TAG;
+import static datadog.trace.api.DDTags.PROFILING_CONTEXT_ENGINE;
+import static datadog.trace.api.DDTags.PROFILING_ENABLED;
 import static datadog.trace.api.DDTags.REQUIRED_CODE_ORIGIN_TAGS;
 import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
+import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY;
+import static datadog.trace.api.DDTags.SPAN_LINKS;
 import static datadog.trace.api.DDTags.THREAD_ID;
 import static datadog.trace.api.DDTags.THREAD_NAME;
+import static datadog.trace.api.DDTags.TRACER_HOST;
 import static datadog.trace.common.sampling.RateByServiceTraceSampler.SAMPLING_AGENT_RATE;
 import static datadog.trace.common.writer.ddagent.TraceMapper.SAMPLING_PRIORITY_KEY;
 
-import datadog.trace.api.DDTags;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,15 +44,17 @@ public final class TagsMatcher {
     tagMatchers.put(SAMPLING_AGENT_RATE, any());
     tagMatchers.put(SAMPLING_PRIORITY_KEY.toString(), any());
     tagMatchers.put("_sample_rate", any());
-    tagMatchers.put(DDTags.PID_TAG, any());
-    tagMatchers.put(DDTags.SCHEMA_VERSION_TAG_KEY, any());
-    tagMatchers.put(DDTags.PROFILING_ENABLED, any());
-    tagMatchers.put(DDTags.PROFILING_CONTEXT_ENGINE, any());
-    tagMatchers.put(DDTags.BASE_SERVICE, any());
-    tagMatchers.put(DDTags.DSM_ENABLED, any());
-    tagMatchers.put(DDTags.DJM_ENABLED, any());
-    tagMatchers.put(DDTags.PARENT_ID, any());
-    tagMatchers.put(DDTags.SPAN_LINKS, any()); // this is checked by LinksAsserter
+    tagMatchers.put(PID_TAG, any());
+    tagMatchers.put(SCHEMA_VERSION_TAG_KEY, any());
+    tagMatchers.put(PROFILING_ENABLED, any());
+    tagMatchers.put(PROFILING_CONTEXT_ENGINE, any());
+    tagMatchers.put(BASE_SERVICE, any());
+    tagMatchers.put(DSM_ENABLED, any());
+    tagMatchers.put(DJM_ENABLED, any());
+    tagMatchers.put(PARENT_ID, any());
+    tagMatchers.put(SPAN_LINKS, any()); // this is checked by LinksAsserter
+    tagMatchers.put(DD_INTEGRATION, any());
+    tagMatchers.put(TRACER_HOST, any());
 
     for (String tagName : REQUIRED_CODE_ORIGIN_TAGS) {
       tagMatchers.put(tagName, any());

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TraceAssertions.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TraceAssertions.java
@@ -1,12 +1,12 @@
 package datadog.trace.agent.test.assertions;
 
 import static java.util.function.Function.identity;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import datadog.trace.core.DDSpan;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
-import org.opentest4j.AssertionFailedError;
 
 /**
  * This class is a helper class to verify traces structure.
@@ -87,11 +87,19 @@ public final class TraceAssertions {
     int traceCount = traces.size();
     if (opts.ignoredAdditionalTraces) {
       if (traceCount < expectedTraceCount) {
-        throw new AssertionFailedError("Not enough of traces", expectedTraceCount, traceCount);
+        assertionFailure()
+            .message("Not enough of traces")
+            .expected(expectedTraceCount)
+            .actual(traceCount)
+            .buildAndThrow();
       }
     } else {
       if (traceCount != expectedTraceCount) {
-        throw new AssertionFailedError("Invalid number of traces", expectedTraceCount, traceCount);
+        assertionFailure()
+            .message("Invalid number of traces")
+            .expected(expectedTraceCount)
+            .actual(traceCount)
+            .buildAndThrow();
       }
     }
     if (opts.sorter != null) {

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
@@ -1,9 +1,11 @@
 package datadog.trace.junit.utils.config;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,8 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * }
  * }</pre>
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
 @Repeatable(WithConfigs.class)
 @ExtendWith(WithConfigExtension.class)
 public @interface WithConfig {

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -87,6 +87,11 @@ public class WithConfigExtension
     if (originalSystemProperties == null) {
       saveProperties();
     }
+    // Apply class-level @WithConfig so config is available before @BeforeAll methods
+    applyClassLevelConfig(context);
+    if (isConfigInstanceModifiable) {
+      rebuildConfig();
+    }
   }
 
   @Override
@@ -116,8 +121,12 @@ public class WithConfigExtension
     }
   }
 
-  private void applyDeclaredConfig(ExtensionContext context) {
-    // Class-level @WithConfig annotations
+  private static void applyDeclaredConfig(ExtensionContext context) {
+    applyClassLevelConfig(context);
+    applyMethodLevelConfig(context);
+  }
+
+  private static void applyClassLevelConfig(ExtensionContext context) {
     // Walk the entire class hierarchy so annotations on superclasses are applied
     // (topmost first, then subclass overrides)
     Class<?> testClass = context.getRequiredTestClass();
@@ -132,6 +141,9 @@ public class WithConfigExtension
         applyConfig(cfg);
       }
     }
+  }
+
+  private static void applyMethodLevelConfig(ExtensionContext context) {
     // Method-level @WithConfig annotations (supports composed/meta-annotations)
     context
         .getTestMethod()

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -19,6 +19,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,12 +110,20 @@ public class WithConfigExtension
   }
 
   private void applyDeclaredConfig(ExtensionContext context) {
-    // Class-level @WithConfig annotations (supports composed/meta-annotations)
-    List<WithConfig> classConfigs =
-        AnnotationSupport.findRepeatableAnnotations(
-            context.getRequiredTestClass(), WithConfig.class);
-    for (WithConfig cfg : classConfigs) {
-      applyConfig(cfg);
+    // Class-level @WithConfig annotations
+    // Walk the entire class hierarchy so annotations on superclasses are applied
+    // (topmost first, then subclass overrides)
+    Class<?> testClass = context.getRequiredTestClass();
+    List<Class<?>> hierarchy = new ArrayList<>();
+    for (Class<?> cls = testClass; cls != null; cls = cls.getSuperclass()) {
+      hierarchy.add(cls);
+    }
+    for (int i = hierarchy.size() - 1; i >= 0; i--) {
+      List<WithConfig> classConfigs =
+          AnnotationSupport.findRepeatableAnnotations(hierarchy.get(i), WithConfig.class);
+      for (WithConfig cfg : classConfigs) {
+        applyConfig(cfg);
+      }
     }
     // Method-level @WithConfig annotations (supports composed/meta-annotations)
     context

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -63,6 +63,7 @@ public class WithConfigExtension
   private static Field configInstanceField;
   private static Constructor<?> configConstructor;
 
+  private static volatile boolean configTransformerInstalled = false;
   private static volatile boolean isConfigInstanceModifiable = false;
   private static volatile boolean configModificationFailed = false;
 
@@ -74,9 +75,15 @@ public class WithConfigExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    installConfigTransformer();
+    if (!configTransformerInstalled) {
+      installConfigTransformer();
+      configTransformerInstalled = true;
+    }
     makeConfigInstanceModifiable();
     assertFalse(configModificationFailed, "Config class modification failed");
+    if (isConfigInstanceModifiable) {
+      checkConfigTransformation();
+    }
     if (originalSystemProperties == null) {
       saveProperties();
     }
@@ -86,10 +93,10 @@ public class WithConfigExtension
   public void beforeEach(ExtensionContext context) {
     restoreProperties();
     environmentVariables.clear();
+    applyDeclaredConfig(context);
     if (isConfigInstanceModifiable) {
       rebuildConfig();
     }
-    applyDeclaredConfig(context);
   }
 
   @Override
@@ -140,10 +147,20 @@ public class WithConfigExtension
 
   private static void applyConfig(WithConfig cfg) {
     if (cfg.env()) {
-      injectEnvConfig(cfg.key(), cfg.value(), cfg.addPrefix());
+      setEnvVariable(cfg.key(), cfg.value(), cfg.addPrefix());
     } else {
-      injectSysConfig(cfg.key(), cfg.value(), cfg.addPrefix());
+      setSysProperty(cfg.key(), cfg.value(), cfg.addPrefix());
     }
+  }
+
+  private static void setSysProperty(String name, String value, boolean addPrefix) {
+    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    System.setProperty(prefixedName, value);
+  }
+
+  private static void setEnvVariable(String name, String value, boolean addPrefix) {
+    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    environmentVariables.set(prefixedName, value);
   }
 
   // endregion
@@ -155,9 +172,7 @@ public class WithConfigExtension
   }
 
   public static void injectSysConfig(String name, String value, boolean addPrefix) {
-    checkConfigTransformation();
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
-    System.setProperty(prefixedName, value);
+    setSysProperty(name, value, addPrefix);
     rebuildConfig();
   }
 
@@ -166,7 +181,6 @@ public class WithConfigExtension
   }
 
   public static void removeSysConfig(String name, boolean addPrefix) {
-    checkConfigTransformation();
     String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
     System.clearProperty(prefixedName);
     rebuildConfig();
@@ -177,9 +191,7 @@ public class WithConfigExtension
   }
 
   public static void injectEnvConfig(String name, String value, boolean addPrefix) {
-    checkConfigTransformation();
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
-    environmentVariables.set(prefixedName, value);
+    setEnvVariable(name, value, addPrefix);
     rebuildConfig();
   }
 
@@ -188,7 +200,6 @@ public class WithConfigExtension
   }
 
   public static void removeEnvConfig(String name, boolean addPrefix) {
-    checkConfigTransformation();
     String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
     environmentVariables.removePrefixed(prefixedName);
     rebuildConfig();
@@ -254,7 +265,6 @@ public class WithConfigExtension
 
   private static void rebuildConfig() {
     synchronized (WithConfigExtension.class) {
-      checkConfigTransformation();
       try {
         Object newInstConfig = instConfigConstructor.newInstance();
         instConfigInstanceField.set(null, newInstConfig);

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -75,15 +75,24 @@ public class WithConfigExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
+    /*
+     * Patch config classes to make them modifiable.
+     */
+    // Install config transformer error listener
     if (!configTransformerInstalled) {
       installConfigTransformer();
       configTransformerInstalled = true;
     }
+    // Make config instance modifiable
     makeConfigInstanceModifiable();
+    // Verify that config class transformation succeeded
     assertFalse(configModificationFailed, "Config class modification failed");
     if (isConfigInstanceModifiable) {
       checkConfigTransformation();
     }
+    /*
+     * Back up config and apply class-level config values.
+     */
     if (originalSystemProperties == null) {
       saveProperties();
     }
@@ -127,8 +136,8 @@ public class WithConfigExtension
   }
 
   private static void applyClassLevelConfig(ExtensionContext context) {
-    // Walk the entire class hierarchy so annotations on superclasses are applied
-    // (topmost first, then subclass overrides)
+    // Walk the entire class hierarchy so annotations on superclasses and apply topmost first, then
+    // subclass overrides.
     Class<?> testClass = context.getRequiredTestClass();
     List<Class<?>> hierarchy = new ArrayList<>();
     for (Class<?> cls = testClass; cls != null; cls = cls.getSuperclass()) {
@@ -166,12 +175,12 @@ public class WithConfigExtension
   }
 
   private static void setSysProperty(String name, String value, boolean addPrefix) {
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    String prefixedName = addPrefix && !name.startsWith("dd.") ? "dd." + name : name;
     System.setProperty(prefixedName, value);
   }
 
   private static void setEnvVariable(String name, String value, boolean addPrefix) {
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    String prefixedName = addPrefix && !name.startsWith("DD_") ? "DD_" + name : name;
     environmentVariables.set(prefixedName, value);
   }
 
@@ -193,7 +202,7 @@ public class WithConfigExtension
   }
 
   public static void removeSysConfig(String name, boolean addPrefix) {
-    String prefixedName = name.startsWith("dd.") || !addPrefix ? name : "dd." + name;
+    String prefixedName = addPrefix && !name.startsWith("dd.") ? "dd." + name : name;
     System.clearProperty(prefixedName);
     rebuildConfig();
   }
@@ -212,7 +221,7 @@ public class WithConfigExtension
   }
 
   public static void removeEnvConfig(String name, boolean addPrefix) {
-    String prefixedName = name.startsWith("DD_") || !addPrefix ? name : "DD_" + name;
+    String prefixedName = addPrefix && !name.startsWith("DD_") ? "DD_" + name : name;
     environmentVariables.removePrefixed(prefixedName);
     rebuildConfig();
   }

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigs.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigs.java
@@ -1,14 +1,16 @@
 package datadog.trace.junit.utils.config;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Container annotation for repeatable {@link WithConfig}. */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
 @ExtendWith(WithConfigExtension.class)
 public @interface WithConfigs {
   WithConfig[] value();

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/CleanConfigStateExtension.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/CleanConfigStateExtension.java
@@ -1,0 +1,80 @@
+package datadog.trace.test.util;
+
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+
+import datadog.environment.EnvironmentVariables;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Asserts that no {@code DD_*} environment variable and no {@code dd.*} system property (minus a
+ * small allowlist) is set around a test class.
+ */
+@SuppressForbidden
+public class CleanConfigStateExtension implements BeforeAllCallback, AfterAllCallback {
+
+  private static final List<String> ALLOWED_SYS_PROPS =
+      Arrays.asList(
+          "dd.appsec.enabled", "dd.iast.enabled", "dd.integration.grizzly-filterchain.enabled");
+
+  private static final Predicate<String> DATADOG_ENV_VAR_FILTER = k -> k.startsWith("DD_");
+  private static final Predicate<Object> DATADOG_SYS_PROPERTIES_FILTER =
+      o -> {
+        String key = (String) o;
+        return key.startsWith("DD_") && !ALLOWED_SYS_PROPS.contains(key);
+      };
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    assertClean("before");
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    assertClean("after");
+  }
+
+  private static void assertClean(String phase) {
+    Map<String, String> leakedEnv =
+        filterMap(EnvironmentVariables.getAll(), DATADOG_ENV_VAR_FILTER);
+    Map<Object, Object> leakedSys =
+        filterMap(System.getProperties(), DATADOG_SYS_PROPERTIES_FILTER);
+    if (!leakedEnv.isEmpty() || !leakedSys.isEmpty()) {
+      assertionFailure()
+          .message("Leaked Datadog configuration detected " + phase + " test class")
+          .reason(formatLeaks(leakedEnv, leakedSys))
+          .buildAndThrow();
+    }
+  }
+
+  private static <T> Map<T, T> filterMap(Map<T, T> map, Predicate<T> keyFilter) {
+    return map.entrySet().stream()
+        .filter(e -> keyFilter.test(e.getKey()))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, TreeMap::new));
+  }
+
+  private static String formatLeaks(Map<String, String> env, Map<Object, Object> sys) {
+    StringBuilder sb = new StringBuilder();
+    if (!env.isEmpty()) {
+      sb.append("environment variables:");
+      env.forEach((k, v) -> sb.append("\n  ").append(k).append('=').append(v));
+    }
+    if (!sys.isEmpty()) {
+      if (sb.length() > 0) {
+        sb.append('\n');
+      }
+      sb.append("system properties:");
+      sys.forEach((k, v) -> sb.append("\n  ").append(k).append('=').append(v));
+    }
+    return sb.toString();
+  }
+}

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/DDJavaSpecification.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/DDJavaSpecification.java
@@ -1,14 +1,9 @@
 package datadog.trace.test.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import datadog.environment.EnvironmentVariables;
 import datadog.trace.junit.utils.config.WithConfigExtension;
 import datadog.trace.junit.utils.context.AllowContextTestingExtension;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
@@ -16,7 +11,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({WithConfigExtension.class, AllowContextTestingExtension.class})
+@ExtendWith({
+  CleanConfigStateExtension.class,
+  WithConfigExtension.class,
+  AllowContextTestingExtension.class
+})
 @SuppressForbidden
 public class DDJavaSpecification {
 
@@ -27,13 +26,6 @@ public class DDJavaSpecification {
 
   @BeforeAll
   static void beforeAll() {
-    assertTrue(
-        EnvironmentVariables.getAll().entrySet().stream()
-            .noneMatch(e -> e.getKey().startsWith("DD_")));
-    assertTrue(
-        systemPropertiesExceptAllowed().entrySet().stream()
-            .noneMatch(e -> e.getKey().toString().startsWith("dd.")));
-
     if (getDDThreads().isEmpty()) {
       ignoreThreadCleanup = false;
     } else {
@@ -45,23 +37,7 @@ public class DDJavaSpecification {
 
   @AfterAll
   static void afterAll() {
-    assertTrue(
-        EnvironmentVariables.getAll().entrySet().stream()
-            .noneMatch(e -> e.getKey().startsWith("DD_")));
-    assertTrue(
-        systemPropertiesExceptAllowed().entrySet().stream()
-            .noneMatch(e -> e.getKey().toString().startsWith("dd.")));
-
     checkThreads();
-  }
-
-  private static Map<Object, Object> systemPropertiesExceptAllowed() {
-    List<String> allowlist =
-        Arrays.asList(
-            "dd.appsec.enabled", "dd.iast.enabled", "dd.integration.grizzly-filterchain.enabled");
-    return System.getProperties().entrySet().stream()
-        .filter(e -> !allowlist.contains(String.valueOf(e.getKey())))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @AfterEach


### PR DESCRIPTION
# What Does This Do

This PR fixes base instrumentation tests class to initialize the tracer from per method to per class to match Spock setupSpec() / cleanUpSpec().

It introduces a `InstrumentationTestConfig` to help with configuring the tests.
As the tracer is now initialized in a static `@BeforeEach`, the instrumentation test config must be done in a static initializer block like:

```java
class MyTest extends AbstractInstrumentationTest {
    static {
        testConfig.idGenerationStrategy("RANDOM").strictTraceWrites(false);
    }
}
```

Not ideal but it could have been worse. Not many tests should changed the default configuration any way.

Additionally, it improves error reports, add missing default tags to tag assert, and fix case when span link matchers are missing.

# Motivation

This is the current behavior from the Spock specification and the per method was killing test execution performance.

# Additional Notes

This PR is part of some bigger improvements in stacked PRs:
* https://github.com/DataDog/dd-trace-java/pull/11094
* https://github.com/DataDog/dd-trace-java/pull/11096
* https://github.com/DataDog/dd-trace-java/pull/11097
* https://github.com/DataDog/dd-trace-java/pull/11209
* https://github.com/DataDog/dd-trace-java/pull/11081

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMLP-1247]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1247]: https://datadoghq.atlassian.net/browse/APMLP-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ