### PR TITLE
Fix baggage propagator flaky test

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
@@ -75,7 +75,6 @@ class BaggagePropagatorTelemetryTest {
     assertTrue(baggageMetric.tags.contains("header_style:baggage"));
   }
 
-  @Flaky
   @Test
   void shouldDirectlyIncrementAllBaggageMetrics() {
     BaggageMetrics baggageMetrics = BaggageMetrics.getInstance();

--- a/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
@@ -17,11 +17,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BaggagePropagatorTelemetryTest {
 
   private static final CarrierVisitor<Map<String, String>> MAP_VISITOR = Map::forEach;
+
+  @BeforeEach
+  void setup() {
+    // Drain any metrics accumulated by other tests
+    CoreMetricCollector.getInstance().prepareMetrics();
+    CoreMetricCollector.getInstance().drain();
+  }
 
   @Test
   void shouldDirectlyIncrementBaggageMetrics() {

--- a/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
@@ -11,7 +11,6 @@ import datadog.context.propagation.CarrierVisitor;
 import datadog.trace.api.Config;
 import datadog.trace.api.metrics.BaggageMetrics;
 import datadog.trace.api.telemetry.CoreMetricCollector;
-import datadog.trace.test.util.Flaky;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -130,7 +129,6 @@ class BaggagePropagatorTelemetryTest {
     assertEquals(1, itemsTruncatedMetric.value.longValue());
   }
 
-  @Flaky
   @Test
   void shouldNotIncrementTelemetryCounterWhenBaggageExtractionFails() {
     Config config = mock(Config.class);


### PR DESCRIPTION
# What Does This Do
drain metric collector singleton before each test

# Motivation

# Additional Notes
related to #11092 

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
