### PR TITLE
Marked test as flaky. Fixed warnings highlighted by IDEA.

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTelemetryTest.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.baggage;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -20,8 +21,7 @@ import org.junit.jupiter.api.Test;
 
 class BaggagePropagatorTelemetryTest {
 
-  private static final CarrierVisitor<Map<String, String>> MAP_VISITOR =
-      (map, consumer) -> map.forEach(consumer);
+  private static final CarrierVisitor<Map<String, String>> MAP_VISITOR = Map::forEach;
 
   @Test
   void shouldDirectlyIncrementBaggageMetrics() {
@@ -68,6 +68,7 @@ class BaggagePropagatorTelemetryTest {
     assertTrue(baggageMetric.tags.contains("header_style:baggage"));
   }
 
+  @Flaky
   @Test
   void shouldDirectlyIncrementAllBaggageMetrics() {
     BaggageMetrics baggageMetrics = BaggageMetrics.getInstance();
@@ -86,7 +87,7 @@ class BaggagePropagatorTelemetryTest {
             .findFirst()
             .orElse(null);
     assertNotNull(injectedMetric);
-    assertTrue(injectedMetric.value.longValue() == 1);
+    assertEquals(1, injectedMetric.value.longValue());
     assertTrue(injectedMetric.tags.contains("header_style:baggage"));
 
     CoreMetricCollector.CoreMetric malformedMetric =
@@ -95,7 +96,7 @@ class BaggagePropagatorTelemetryTest {
             .findFirst()
             .orElse(null);
     assertNotNull(malformedMetric);
-    assertTrue(malformedMetric.value.longValue() == 1);
+    assertEquals(1, malformedMetric.value.longValue());
     assertTrue(malformedMetric.tags.contains("header_style:baggage"));
 
     CoreMetricCollector.CoreMetric bytesTruncatedMetric =
@@ -107,7 +108,7 @@ class BaggagePropagatorTelemetryTest {
             .findFirst()
             .orElse(null);
     assertNotNull(bytesTruncatedMetric);
-    assertTrue(bytesTruncatedMetric.value.longValue() == 1);
+    assertEquals(1, bytesTruncatedMetric.value.longValue());
 
     CoreMetricCollector.CoreMetric itemsTruncatedMetric =
         metrics.stream()
@@ -118,7 +119,7 @@ class BaggagePropagatorTelemetryTest {
             .findFirst()
             .orElse(null);
     assertNotNull(itemsTruncatedMetric);
-    assertTrue(itemsTruncatedMetric.value.longValue() == 1);
+    assertEquals(1, itemsTruncatedMetric.value.longValue());
   }
 
   @Flaky


### PR DESCRIPTION
# What Does This Do
Marked test as flaky. Fixed warnings highlighted by IDEA.

# Motivation
Green CI.

# Additional Notes
Test failed on master on GitLab with:
```
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
	at app//org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
	at app//datadog.trace.core.baggage.BaggagePropagatorTelemetryTest.shouldDirectlyIncrementAllBaggageMetrics(BaggagePropagatorTelemetryTest.java:89)
	at java.base@11.0.30/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base@11.0.30/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base@11.0.30/java.util.ArrayList.forEach(ArrayList.java:1541)
```

