### PR TITLE
Update Develocity Gradle plugin to `4.4.0`.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.3.2"
+  id("com.gradle.develocity") version "4.4.0"
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
# What Does This Do
Update Develocity Gradle plugin to `4.4.0`.

https://docs.gradle.com/develocity/gradle/current/release-history/#4-4-0

# Motivation
Latest build tools.

