### PR TITLE
Update Spotbugs Gradle plugin to `6.5.0`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
   id("com.diffplug.spotless") version "8.4.0"
   id("me.champeau.gradle.japicmp") version "0.4.3"
-  id("com.github.spotbugs") version "6.4.8"
+  id("com.github.spotbugs") version "6.5.0"
   id("de.thetaphi.forbiddenapis") version "3.10"
   id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
   id("com.gradleup.shadow") version "8.3.9" apply false


### PR DESCRIPTION
# What Does This Do
Update `Spotbugs` Gradle plugin to `6.5.0`.

https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.0

# Motivation
Latest Tools.
