### PR TITLE
Add Kafka cluster ID and offset tags to producer/consumer spans

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTestBase.groovy
@@ -302,9 +302,9 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"
-        if (partitioned) {
-          "$InstrumentationTags.PARTITION" { it >= 0 }
-        }
+        "$InstrumentationTags.PARTITION" { it >= 0 }
+        "$InstrumentationTags.OFFSET" { it >= 0 }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         if (tombstone) {
           "$InstrumentationTags.TOMBSTONE" true
         }
@@ -381,6 +381,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$InstrumentationTags.OFFSET" { offset.containsWithinBounds(it as int) }
         "$InstrumentationTags.CONSUMER_GROUP" "sender"
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentationHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentationHelper.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.kafka_clients;
 
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.instrumentation.kafka_common.MetadataState;
 import org.apache.kafka.clients.Metadata;
@@ -16,7 +15,7 @@ public class KafkaConsumerInstrumentationHelper {
   public static String extractClusterId(
       KafkaConsumerInfo kafkaConsumerInfo,
       ContextStore<Metadata, MetadataState> metadataContextStore) {
-    if (Config.get().isDataStreamsEnabled() && kafkaConsumerInfo != null) {
+    if (kafkaConsumerInfo != null) {
       Metadata consumerMetadata = kafkaConsumerInfo.getClientMetadata();
       if (consumerMetadata != null) {
         MetadataState state = metadataContextStore.get(consumerMetadata);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.kafka_clients;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.CONSUMER_GROUP;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_CLUSTER_ID;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.MESSAGING_DESTINATION_NAME;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
@@ -117,6 +118,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
       final AgentSpan span,
       final ConsumerRecord record,
       String consumerGroup,
+      String clusterId,
       String bootstrapServers) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
@@ -127,7 +129,9 @@ public class KafkaDecorator extends MessagingClientDecorator {
       if (consumerGroup != null) {
         span.setTag(CONSUMER_GROUP, consumerGroup);
       }
-
+      if (clusterId != null) {
+        span.setTag(KAFKA_CLUSTER_ID, clusterId);
+      }
       if (bootstrapServers != null) {
         span.setTag(KAFKA_BOOTSTRAP_SERVERS, bootstrapServers);
       }
@@ -152,7 +156,10 @@ public class KafkaDecorator extends MessagingClientDecorator {
   }
 
   public void onProduce(
-      final AgentSpan span, final ProducerRecord record, final ProducerConfig producerConfig) {
+      final AgentSpan span,
+      final ProducerRecord record,
+      final ProducerConfig producerConfig,
+      final String clusterId) {
     if (record != null) {
       if (record.partition() != null) {
         span.setTag(PARTITION, record.partition());
@@ -162,6 +169,9 @@ public class KafkaDecorator extends MessagingClientDecorator {
             KAFKA_BOOTSTRAP_SERVERS,
             PRODUCER_BOOSTRAP_SERVERS_CACHE.computeIfAbsent(
                 producerConfig, BOOTSTRAP_SERVERS_JOINER));
+      }
+      if (clusterId != null) {
+        span.setTag(KAFKA_CLUSTER_ID, clusterId);
       }
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setResourceName(PRODUCER_RESOURCE_NAME_CACHE.computeIfAbsent(topic, PRODUCER_PREFIX));

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.kafka_clients;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.PRODUCER_DECORATE;
 
 import datadog.trace.api.datastreams.DataStreamsTags;
@@ -30,6 +32,10 @@ public class KafkaProducerCallback implements Callback {
 
   @Override
   public void onCompletion(final RecordMetadata metadata, final Exception exception) {
+    if (metadata != null) {
+      span.setTag(PARTITION, metadata.partition());
+      span.setTag(OFFSET, metadata.offset());
+    }
     PRODUCER_DECORATE.onError(span, exception);
     PRODUCER_DECORATE.beforeFinish(span);
     span.finish();

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -167,7 +167,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
         callbackParentSpan = localActiveSpan;
       }
       PRODUCER_DECORATE.afterStart(span);
-      PRODUCER_DECORATE.onProduce(span, record, producerConfig);
+      PRODUCER_DECORATE.onProduce(span, record, producerConfig, clusterId);
 
       callback = new KafkaProducerCallback(callback, callbackParentSpan, span, clusterId);
 
@@ -267,10 +267,10 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
     public static void captureConfiguration(
         @Advice.FieldValue("metadata") Metadata metadata,
         @Advice.Argument(0) ProducerConfig producerConfig) {
+      MetadataState state =
+          InstrumentationContext.get(Metadata.class, MetadataState.class)
+              .putIfAbsent(metadata, MetadataState::new);
       if (Config.get().isDataStreamsEnabled()) {
-        MetadataState state =
-            InstrumentationContext.get(Metadata.class, MetadataState.class)
-                .putIfAbsent(metadata, MetadataState::new);
         KafkaConfigHelper.storePendingProducerConfig(
             state, KafkaConfigHelper.extractProducerConfig(producerConfig));
       }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -142,7 +142,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           span.setTag(InstrumentationTags.TOMBSTONE, true);
         }
         decorator.afterStart(span);
-        decorator.onConsume(span, val, group, bootstrapServers);
+        decorator.onConsume(span, val, group, clusterId, bootstrapServers);
         if (InstrumenterConfig.get().isLegacyContextManagerEnabled()) {
           activateNext(span);
         } else {

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -1205,9 +1205,9 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"
-        if (partitioned) {
-          "$InstrumentationTags.PARTITION" { it >= 0 }
-        }
+        "$InstrumentationTags.PARTITION" { it >= 0 }
+        "$InstrumentationTags.OFFSET" { it >= 0 }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         if (tombstone) {
           "$InstrumentationTags.TOMBSTONE" true
         }
@@ -1284,6 +1284,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$InstrumentationTags.OFFSET" { offset.containsWithinBounds(it as int) }
         "$InstrumentationTags.CONSUMER_GROUP" "sender"
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaReactorForkedTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaReactorForkedTest.groovy
@@ -193,6 +193,9 @@ class KafkaReactorForkedTest extends InstrumentationSpecification {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$KafkaClientTestBase.SHARED_TOPIC"
+        "$InstrumentationTags.PARTITION" { it >= 0 }
+        "$InstrumentationTags.OFFSET" { it >= 0 }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
         defaultTags()
       }
@@ -222,6 +225,7 @@ class KafkaReactorForkedTest extends InstrumentationSpecification {
         "$InstrumentationTags.OFFSET" { Integer }
         "$InstrumentationTags.CONSUMER_GROUP" "sender"
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$KafkaClientTestBase.SHARED_TOPIC"
         defaultTags(true)

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelper.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.instrumentation.kafka_common.MetadataState;
 import org.apache.kafka.clients.Metadata;
@@ -16,7 +15,7 @@ public class KafkaConsumerInstrumentationHelper {
   public static String extractClusterId(
       KafkaConsumerInfo kafkaConsumerInfo,
       ContextStore<Metadata, MetadataState> metadataContextStore) {
-    if (Config.get().isDataStreamsEnabled() && kafkaConsumerInfo != null) {
+    if (kafkaConsumerInfo != null) {
       Metadata metadata = kafkaConsumerInfo.getmetadata().get();
       if (metadata != null) {
         MetadataState state = metadataContextStore.get(metadata);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.kafka_clients38;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.CONSUMER_GROUP;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_CLUSTER_ID;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.MESSAGING_DESTINATION_NAME;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
@@ -117,6 +118,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
       final AgentSpan span,
       final ConsumerRecord record,
       String consumerGroup,
+      String clusterId,
       String bootstrapServers) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
@@ -127,7 +129,9 @@ public class KafkaDecorator extends MessagingClientDecorator {
       if (consumerGroup != null) {
         span.setTag(CONSUMER_GROUP, consumerGroup);
       }
-
+      if (clusterId != null) {
+        span.setTag(KAFKA_CLUSTER_ID, clusterId);
+      }
       if (bootstrapServers != null) {
         span.setTag(KAFKA_BOOTSTRAP_SERVERS, bootstrapServers);
       }
@@ -152,7 +156,10 @@ public class KafkaDecorator extends MessagingClientDecorator {
   }
 
   public void onProduce(
-      final AgentSpan span, final ProducerRecord record, final ProducerConfig producerConfig) {
+      final AgentSpan span,
+      final ProducerRecord record,
+      final ProducerConfig producerConfig,
+      final String clusterId) {
     if (record != null) {
       if (record.partition() != null) {
         span.setTag(PARTITION, record.partition());
@@ -162,6 +169,9 @@ public class KafkaDecorator extends MessagingClientDecorator {
             KAFKA_BOOTSTRAP_SERVERS,
             PRODUCER_BOOSTRAP_SERVERS_CACHE.computeIfAbsent(
                 producerConfig, BOOTSTRAP_SERVERS_JOINER));
+      }
+      if (clusterId != null) {
+        span.setTag(KAFKA_CLUSTER_ID, clusterId);
       }
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setResourceName(PRODUCER_RESOURCE_NAME_CACHE.computeIfAbsent(topic, PRODUCER_PREFIX));

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.PRODUCER_DECORATE;
 
 import datadog.trace.api.datastreams.DataStreamsTags;
@@ -29,6 +31,10 @@ public class KafkaProducerCallback implements Callback {
 
   @Override
   public void onCompletion(final RecordMetadata metadata, final Exception exception) {
+    if (metadata != null) {
+      span.setTag(PARTITION, metadata.partition());
+      span.setTag(OFFSET, metadata.offset());
+    }
     PRODUCER_DECORATE.onError(span, exception);
     PRODUCER_DECORATE.beforeFinish(span);
     span.finish();

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
@@ -56,7 +56,7 @@ public class ProducerAdvice {
       callbackParentSpan = localActiveSpan;
     }
     PRODUCER_DECORATE.afterStart(span);
-    PRODUCER_DECORATE.onProduce(span, record, producerConfig);
+    PRODUCER_DECORATE.onProduce(span, record, producerConfig, clusterId);
 
     callback = new KafkaProducerCallback(callback, callbackParentSpan, span, clusterId);
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerConstructorAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerConstructorAdvice.java
@@ -14,10 +14,10 @@ public class ProducerConstructorAdvice {
   public static void captureConfiguration(
       @Advice.FieldValue("metadata") Metadata metadata,
       @Advice.Argument(0) ProducerConfig producerConfig) {
+    MetadataState state =
+        InstrumentationContext.get(Metadata.class, MetadataState.class)
+            .putIfAbsent(metadata, MetadataState::new);
     if (Config.get().isDataStreamsEnabled()) {
-      MetadataState state =
-          InstrumentationContext.get(Metadata.class, MetadataState.class)
-              .putIfAbsent(metadata, MetadataState::new);
       KafkaConfigHelper.storePendingProducerConfig(
           state, KafkaConfigHelper.extractProducerConfig(producerConfig));
     }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
@@ -141,7 +141,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           span.setTag(InstrumentationTags.TOMBSTONE, true);
         }
         decorator.afterStart(span);
-        decorator.onConsume(span, val, group, bootstrapServers);
+        decorator.onConsume(span, val, group, clusterId, bootstrapServers);
         if (InstrumenterConfig.get().isLegacyContextManagerEnabled()) {
           activateNext(span);
         } else {

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
@@ -914,9 +914,9 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"
-        if (partitioned) {
-          "$InstrumentationTags.PARTITION" { it >= 0 }
-        }
+        "$InstrumentationTags.PARTITION" { it >= 0 }
+        "$InstrumentationTags.OFFSET" { it >= 0 }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         if (tombstone) {
           "$InstrumentationTags.TOMBSTONE" true
         }
@@ -993,6 +993,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         "$InstrumentationTags.OFFSET" { offset.containsWithinBounds(it as int) }
         "$InstrumentationTags.CONSUMER_GROUP" "sender"
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$SHARED_TOPIC"

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -132,6 +132,9 @@ class KafkaStreamsTest extends InstrumentationSpecification {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PENDING"
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" { it >= 0 }
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
@@ -183,6 +186,9 @@ class KafkaStreamsTest extends InstrumentationSpecification {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PROCESSED"
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" { it >= 0 }
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
@@ -206,6 +212,7 @@ class KafkaStreamsTest extends InstrumentationSpecification {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.CONSUMER_GROUP" "sender"
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PROCESSED"
             "testing" 123

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -158,6 +158,9 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PENDING"
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" { it >= 0 }
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             if ({ isDataStreamsEnabled() }){
               "$DDTags.PATHWAY_HASH" { String }
             }
@@ -226,6 +229,9 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PROCESSED"
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" { it >= 0 }
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             if ({isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
@@ -269,6 +275,7 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.CONSUMER_GROUP" "sender"
+            "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.MESSAGING_DESTINATION_NAME" "$STREAM_PROCESSED"
             "testing" 123

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/groovy/KafkaBatchListenerCoroutineTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/groovy/KafkaBatchListenerCoroutineTest.groovy
@@ -114,6 +114,9 @@ class KafkaBatchListenerCoroutineTest extends InstrumentationSpecification {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" TOPIC
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" { String }
+        "$InstrumentationTags.PARTITION" { it >= 0 }
+        "$InstrumentationTags.OFFSET" { it >= 0 }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
         defaultTags()
       }
@@ -133,6 +136,7 @@ class KafkaBatchListenerCoroutineTest extends InstrumentationSpecification {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
         "$InstrumentationTags.MESSAGING_DESTINATION_NAME" TOPIC
         "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" { String }
+        "$InstrumentationTags.KAFKA_CLUSTER_ID" { String }
         peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
         "$InstrumentationTags.CONSUMER_GROUP" CONSUMER_GROUP
         "$InstrumentationTags.OFFSET" offset

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -102,6 +102,7 @@ public class InstrumentationTags {
   public static final String MESSAGE = "message";
   public static final String HANDLER_TYPE = "handler.type";
   public static final String KAFKA_BOOTSTRAP_SERVERS = "messaging.kafka.bootstrap.servers";
+  public static final String KAFKA_CLUSTER_ID = "messaging.kafka.cluster.id";
   public static final String MESSAGING_DESTINATION_NAME = "messaging.destination.name";
   public static final String QUARTZ_JOB_NAME = "quartz.job.name";
   public static final String QUARTZ_JOB_GROUP = "quartz.job.group";


### PR DESCRIPTION
## Summary

- Add `messaging.kafka.cluster.id` tag to both producer and consumer Kafka spans, always (not gated on Data Streams)
- Add broker-assigned `partition` and `offset` tags to producer spans via the async callback (using `RecordMetadata`)
- Consumer spans already had `partition` and `offset`; no change there
- Remove `isDataStreamsEnabled()` guard from `extractClusterId()` in `KafkaConsumerInstrumentationHelper` (both 0.11 and 3.8 modules)
- Always initialize `MetadataState` in `ProducerConstructorAdvice` so cluster ID is available at produce time regardless of DSM config

These tags enable linking a trace span directly to a specific Kafka message (cluster + topic + partition + offset).

## Notes

- Producer offset is only set when a callback is used (it's a broker-assigned value returned asynchronously); fire-and-forget usage via `Future` will not have the offset tag
- Both `kafka-clients-0.11` and `kafka-clients-3.8` modules updated in parallel

## Test plan

Used a test application to verify the tags were present on the spans.

tag: no release note
tag: ai generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)