### PR TITLE
Preload scope classes to prevent virtual thread deadlock

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -90,6 +90,7 @@ public abstract class InstrumenterModule implements Instrumenter {
   }
 
   public List<Instrumenter> typeInstrumentations() {
+    preloadClasses();
     return singletonList(this);
   }
 
@@ -214,6 +215,28 @@ public abstract class InstrumenterModule implements Instrumenter {
         .isIntegrationShortcutMatchingEnabled(singletonList(name()), defaultToShortcut);
   }
 
+  /**
+   * Force loading of classes that need to be instrumented, but are using during instrumentation.
+   */
+  @SuppressForbidden // allow this use of Class.forName()
+  protected void preloadClasses() {
+    String[] list = preloadClassNames();
+    if (list != null) {
+      for (String clazz : list) {
+        try {
+          Class.forName(clazz);
+        } catch (Throwable t) {
+          log.debug("Error force loading {} class", clazz);
+        }
+      }
+    }
+  }
+
+  /** Get classes to force load */
+  public String[] preloadClassNames() {
+    return null;
+  }
+
   /** Parent class for all tracing related instrumentations */
   public abstract static class Tracing extends InstrumenterModule {
     public Tracing(String instrumentationName, String... additionalNames) {
@@ -258,16 +281,9 @@ public abstract class InstrumenterModule implements Instrumenter {
   }
 
   /** Parent class for all IAST related instrumentations */
-  @SuppressForbidden
   public abstract static class Iast extends InstrumenterModule {
     public Iast(String instrumentationName, String... additionalNames) {
       super(instrumentationName, additionalNames);
-    }
-
-    @Override
-    public List<Instrumenter> typeInstrumentations() {
-      preloadClassNames();
-      return super.typeInstrumentations();
     }
 
     @Override
@@ -280,27 +296,6 @@ public abstract class InstrumenterModule implements Instrumenter {
         return false;
       }
       return cfg.getAppSecActivation() == ProductActivation.FULLY_ENABLED;
-    }
-
-    /**
-     * Force loading of classes that need to be instrumented, but are using during instrumentation.
-     */
-    private void preloadClassNames() {
-      String[] list = getClassNamesToBePreloaded();
-      if (list != null) {
-        for (String clazz : list) {
-          try {
-            Class.forName(clazz);
-          } catch (Throwable t) {
-            log.debug("Error force loading {} class", clazz);
-          }
-        }
-      }
-    }
-
-    /** Get classes to force load* */
-    public String[] getClassNamesToBePreloaded() {
-      return null;
     }
 
     @Override

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class InputStreamInstrumentation extends InstrumenterModule.Iast
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
 
-  private static final String[] FORCE_LOADING = {"java.io.PushbackInputStream"};
+  private static final String[] PRELOAD_CLASS_NAMES = {"java.io.PushbackInputStream"};
 
   public InputStreamInstrumentation() {
     super("inputStream");
@@ -44,8 +44,8 @@ public class InputStreamInstrumentation extends InstrumenterModule.Iast
   }
 
   @Override
-  public String[] getClassNamesToBePreloaded() {
-    return FORCE_LOADING;
+  public String[] preloadClassNames() {
+    return PRELOAD_CLASS_NAMES;
   }
 
   public static class InputStreamAdvice {

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
@@ -66,8 +66,20 @@ public final class VirtualThreadInstrumentation extends InstrumenterModule.Conte
         Instrumenter.HasMethodAdvice,
         ExcludeFilterProvider {
 
+  // Preload classes used by Context.swap() to avoid class loading on the virtual thread mount path.
+  // DatadogClassLoader loads these from a JarFile using synchronized I/O, which pins
+  // virtual thread carrier threads and can deadlock the application.
+  private static final String[] PRELOAD_CLASS_NAMES = {
+    "datadog.trace.core.scopemanager.ScopeContext", "datadog.trace.core.scopemanager.ScopeStack"
+  };
+
   public VirtualThreadInstrumentation() {
     super("java-lang", "java-lang-21", "virtual-thread");
+  }
+
+  @Override
+  public String[] preloadClassNames() {
+    return PRELOAD_CLASS_NAMES;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-21.0/src/main/java/datadog/trace/instrumentation/java/lang/jdk21/VirtualThreadInstrumentation.java
@@ -45,8 +45,8 @@ import net.bytebuddy.asm.Advice.OnMethodExit;
  *   <li>{@code unmount()}: swaps the carrier thread's original context back, saving the virtual
  *       thread's (possibly modified) context for the next mount.
  *   <li>Steps 2-3 repeat on each park/unpark cycle, potentially on different carrier threads.
- *   <li>{@code afterDone()}: cancels the help continuation, releasing the context scope to be
- *       closed.
+ *   <li>{@code afterDone()} / {@code afterTerminate()} for early VirtualThread support: cancels the
+ *       help continuation, releasing the context scope to be closed.
  * </ol>
  *
  * <p>Instrumenting the internal {@code VirtualThread.runContinuation()} method does not work as the
@@ -111,6 +111,9 @@ public final class VirtualThreadInstrumentation extends InstrumenterModule.Conte
     transformer.applyAdvice(
         isMethod().and(named("afterDone")).and(takesArguments(boolean.class)),
         getClass().getName() + "$AfterDone");
+    transformer.applyAdvice(
+        isMethod().and(named("afterTerminate")).and(takesArguments(boolean.class, boolean.class)),
+        getClass().getName() + "$AfterDone");
   }
 
   public static final class Construct {
@@ -153,7 +156,7 @@ public final class VirtualThreadInstrumentation extends InstrumenterModule.Conte
 
   public static final class AfterDone {
     @OnMethodEnter(suppress = Throwable.class)
-    public static void onTerminate(@Advice.This Object virtualThread) {
+    public static void onDone(@Advice.This Object virtualThread) {
       ContextStore<Object, VirtualThreadState> store =
           InstrumentationContext.get(VIRTUAL_THREAD_CLASS_NAME, VIRTUAL_THREAD_STATE_CLASS_NAME);
       VirtualThreadState state = store.remove(virtualThread);


### PR DESCRIPTION
# What Does This Do

This PR preloads ScopeContext and ScopeStack classes in ContinuableScopeManager constructor to avoid class loading on virtual thread mount path. DatadogClassLoader's synchronized I/O from JarFile can pin carrier threads and deadlock the application.

It additionally adds support for early versions of virtual threads internals.

# Motivation

Related to #10273 but the API (so the classes loaded on hot path) changed when re-implementing the virtual thread instrumentation in https://github.com/DataDog/dd-trace-java/pull/11009

Some versions of the JDK 21.0.1 to 21.0.4 hang, 21.0.5 crashes. 21.0.6 and above seem working fine (as CI is running with latest JDK versions, this wasn't caught in testing).

# Additional Notes

Sharing the [CI dev build](https://s3.us-east-1.amazonaws.com/dd-trace-java-builds/bbujon/virtual-threads/dd-java-agent.jar) to help with investigation

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMS-19222] [APMS-19230] 
GitHub ticket: #11103

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-19222]: https://datadoghq.atlassian.net/browse/APMS-19222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ