### PR TITLE
Extend RASP callsite coverage to File-argument constructors of FileOutputStream and FileInputStream

### DIFF
--- a/dd-java-agent/instrumentation/java/java-io-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/build.gradle
@@ -8,8 +8,20 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'dd-trace-java.call-site-instrumentation'
 
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('java11Test', 'java11Test')
+
+// java11Test only runs on JDK 11+; the testJvmConstraints plugin reads this property by convention
+ext.java11TestMinJavaVersionForTests = JavaVersion.VERSION_11
+
+tasks.named("compileJava11TestJava", JavaCompile) {
+  configureCompiler(it, 11)
+}
+tasks.named("compileJava11TestGroovy", GroovyCompile) {
+  configureCompiler(it, 11)
+}
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:datadog:asm:iast-instrumenter')
   testImplementation group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '9.0.56'
+  java11TestImplementation sourceSets.test.output
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FileReaderCharsetCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FileReaderCharsetCallSiteTest.groovy
@@ -1,0 +1,35 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFileReaderCharsetSuite
+
+import java.nio.charset.Charset
+
+class FileReaderCharsetCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP new FileReader with String path and Charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fr_str_cs.txt')
+
+    when:
+    TestFileReaderCharsetSuite.newFileReader(file.path, Charset.defaultCharset()).close()
+
+    then:
+    1 * helper.beforeFileLoaded(file.path)
+  }
+
+  void 'test RASP new FileReader with File and Charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fr_file_cs.txt')
+
+    when:
+    TestFileReaderCharsetSuite.newFileReader(file, Charset.defaultCharset()).close()
+
+    then:
+    1 * helper.beforeFileLoaded(file.path)
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FileWriterCharsetCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FileWriterCharsetCallSiteTest.groovy
@@ -1,0 +1,61 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFileWriterCharsetSuite
+
+import java.nio.charset.Charset
+
+class FileWriterCharsetCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP new FileWriter with String path and Charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fw_str_cs.txt')
+
+    when:
+    TestFileWriterCharsetSuite.newFileWriter(file.path, Charset.defaultCharset()).close()
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+
+  void 'test RASP new FileWriter with String path, Charset, and append flag'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fw_str_cs_append.txt')
+
+    when:
+    TestFileWriterCharsetSuite.newFileWriter(file.path, Charset.defaultCharset(), false).close()
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+
+  void 'test RASP new FileWriter with File and Charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fw_file_cs.txt')
+
+    when:
+    TestFileWriterCharsetSuite.newFileWriter(file, Charset.defaultCharset()).close()
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+
+  void 'test RASP new FileWriter with File, Charset, and append flag'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_fw_file_cs_append.txt')
+
+    when:
+    TestFileWriterCharsetSuite.newFileWriter(file, Charset.defaultCharset(), false).close()
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FilesJava11CallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/FilesJava11CallSiteTest.groovy
@@ -1,0 +1,61 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFilesJava11Suite
+
+import java.nio.charset.StandardCharsets
+
+class FilesJava11CallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP Files.writeString without charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_writestring.txt')
+
+    when:
+    TestFilesJava11Suite.writeString(path, 'hello')
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.writeString with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_writestring_cs.txt')
+
+    when:
+    TestFilesJava11Suite.writeString(path, 'hello', StandardCharsets.UTF_8)
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.readString without charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_readstring.txt').toPath()
+
+    when:
+    TestFilesJava11Suite.readString(path)
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.readString with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_readstring_cs.txt').toPath()
+
+    when:
+    TestFilesJava11Suite.readString(path, StandardCharsets.UTF_8)
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/PathOfCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/groovy/datadog/trace/instrumentation/java/io/PathOfCallSiteTest.groovy
@@ -1,0 +1,37 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestPathOfSuite
+
+class PathOfCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP Path.of from strings'(final String first, final String... more) {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+
+    when:
+    TestPathOfSuite.of(first, more)
+
+    then:
+    1 * helper.beforeFileLoaded(first, more)
+
+    where:
+    first      | more
+    'test.txt' | [] as String[]
+    '/tmp'     | ['log', 'test.txt'] as String[]
+  }
+
+  void 'test RASP Path.of from URI'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final uri = new URI('file:/test.txt')
+
+    when:
+    TestPathOfSuite.of(uri)
+
+    then:
+    1 * helper.beforeFileLoaded(uri)
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFileReaderCharsetSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFileReaderCharsetSuite.java
@@ -1,0 +1,19 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class TestFileReaderCharsetSuite {
+
+  public static FileReader newFileReader(final String path, final Charset charset)
+      throws IOException {
+    return new FileReader(path, charset);
+  }
+
+  public static FileReader newFileReader(final File file, final Charset charset)
+      throws IOException {
+    return new FileReader(file, charset);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFileWriterCharsetSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFileWriterCharsetSuite.java
@@ -1,0 +1,29 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class TestFileWriterCharsetSuite {
+
+  public static FileWriter newFileWriter(final String path, final Charset charset)
+      throws IOException {
+    return new FileWriter(path, charset);
+  }
+
+  public static FileWriter newFileWriter(
+      final String path, final Charset charset, final boolean append) throws IOException {
+    return new FileWriter(path, charset, append);
+  }
+
+  public static FileWriter newFileWriter(final File file, final Charset charset)
+      throws IOException {
+    return new FileWriter(file, charset);
+  }
+
+  public static FileWriter newFileWriter(
+      final File file, final Charset charset, final boolean append) throws IOException {
+    return new FileWriter(file, charset, append);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFilesJava11Suite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestFilesJava11Suite.java
@@ -1,0 +1,32 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+
+public class TestFilesJava11Suite {
+
+  public static Path writeString(
+      final Path path, final CharSequence content, final OpenOption... options) throws IOException {
+    return Files.writeString(path, content, options);
+  }
+
+  public static Path writeString(
+      final Path path,
+      final CharSequence content,
+      final Charset charset,
+      final OpenOption... options)
+      throws IOException {
+    return Files.writeString(path, content, charset, options);
+  }
+
+  public static String readString(final Path path) throws IOException {
+    return Files.readString(path);
+  }
+
+  public static String readString(final Path path, final Charset charset) throws IOException {
+    return Files.readString(path, charset);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestPathOfSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/java11Test/java/foo/bar/TestPathOfSuite.java
@@ -1,0 +1,15 @@
+package foo.bar;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public class TestPathOfSuite {
+
+  public static Path of(final String first, final String... more) {
+    return Path.of(first, more);
+  }
+
+  public static Path of(final URI uri) {
+    return Path.of(uri);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.appsec.RaspCallSites;
+import java.nio.file.Path;
+import javax.annotation.Nullable;
+
+@CallSite(
+    spi = {RaspCallSites.class},
+    helpers = FileIORaspHelper.class)
+public class FileChannelCallSite {
+
+  @CallSite.Before(
+      "java.nio.channels.FileChannel java.nio.channels.FileChannel.open(java.nio.file.Path, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.nio.channels.FileChannel java.nio.channels.FileChannel.open(java.nio.file.Path, java.util.Set, java.nio.file.attribute.FileAttribute[])")
+  public static void beforeOpen(@CallSite.Argument(0) @Nullable final Path path) {
+    if (path != null) {
+      // Fire both read and write callbacks: the WAF determines whether to block
+      // based on the full request context (e.g. zipslip requires body.filenames too).
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(path.toString());
+      FileIORaspHelper.INSTANCE.beforeFileWritten(path.toString());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
@@ -5,6 +5,7 @@ import datadog.trace.api.appsec.RaspCallSites;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -31,7 +32,8 @@ public class FileChannelCallSite {
       "java.nio.channels.FileChannel java.nio.channels.FileChannel.open(java.nio.file.Path, java.util.Set, java.nio.file.attribute.FileAttribute[])")
   public static void beforeOpenSet(
       @CallSite.Argument(0) @Nullable final Path path,
-      @CallSite.Argument(1) @Nullable final Set<? extends OpenOption> options) {
+      @CallSite.Argument(1) @Nullable final Set<? extends OpenOption> options,
+      @CallSite.Argument(2) @Nullable final FileAttribute<?>[] attrs) {
     if (path != null) {
       String pathStr = path.toString();
       FileIORaspHelper.INSTANCE.beforeFileLoaded(pathStr);

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileChannelCallSite.java
@@ -2,7 +2,10 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.appsec.RaspCallSites;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 @CallSite(
@@ -12,14 +15,61 @@ public class FileChannelCallSite {
 
   @CallSite.Before(
       "java.nio.channels.FileChannel java.nio.channels.FileChannel.open(java.nio.file.Path, java.nio.file.OpenOption[])")
+  public static void beforeOpenArray(
+      @CallSite.Argument(0) @Nullable final Path path,
+      @CallSite.Argument(1) @Nullable final OpenOption[] options) {
+    if (path != null) {
+      String pathStr = path.toString();
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(pathStr);
+      if (hasWriteOption(options)) {
+        FileIORaspHelper.INSTANCE.beforeFileWritten(pathStr);
+      }
+    }
+  }
+
   @CallSite.Before(
       "java.nio.channels.FileChannel java.nio.channels.FileChannel.open(java.nio.file.Path, java.util.Set, java.nio.file.attribute.FileAttribute[])")
-  public static void beforeOpen(@CallSite.Argument(0) @Nullable final Path path) {
+  public static void beforeOpenSet(
+      @CallSite.Argument(0) @Nullable final Path path,
+      @CallSite.Argument(1) @Nullable final Set<? extends OpenOption> options) {
     if (path != null) {
-      // Fire both read and write callbacks: the WAF determines whether to block
-      // based on the full request context (e.g. zipslip requires body.filenames too).
-      FileIORaspHelper.INSTANCE.beforeFileLoaded(path.toString());
-      FileIORaspHelper.INSTANCE.beforeFileWritten(path.toString());
+      String pathStr = path.toString();
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(pathStr);
+      if (hasWriteOption(options)) {
+        FileIORaspHelper.INSTANCE.beforeFileWritten(pathStr);
+      }
     }
+  }
+
+  private static boolean hasWriteOption(@Nullable final OpenOption[] options) {
+    if (options == null) {
+      return false;
+    }
+    for (OpenOption opt : options) {
+      if (isWriteOption(opt)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasWriteOption(@Nullable final Set<? extends OpenOption> options) {
+    if (options == null) {
+      return false;
+    }
+    for (OpenOption opt : options) {
+      if (isWriteOption(opt)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isWriteOption(final OpenOption opt) {
+    return opt == StandardOpenOption.WRITE
+        || opt == StandardOpenOption.APPEND
+        || opt == StandardOpenOption.CREATE
+        || opt == StandardOpenOption.CREATE_NEW
+        || opt == StandardOpenOption.TRUNCATE_EXISTING;
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileIORaspHelper.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileIORaspHelper.java
@@ -101,6 +101,18 @@ public class FileIORaspHelper {
     invokeRaspCallback(EVENTS.fileWritten(), path);
   }
 
+  /**
+   * Fires {@link #beforeFileLoaded} for read modes ("r"), and both {@link #beforeFileLoaded} and
+   * {@link #beforeFileWritten} for write modes ("rw", "rws", "rwd").
+   */
+  public void beforeRandomAccessFileOpened(@Nonnull final String path, @Nonnull final String mode) {
+    // "r" = read only; "rw", "rws", "rwd" = read + write
+    beforeFileLoaded(path);
+    if (mode.length() > 1) {
+      beforeFileWritten(path);
+    }
+  }
+
   private void invokeRaspCallback(
       EventType<BiFunction<RequestContext, String, Flow<Void>>> eventType,
       @Nonnull final String path) {

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
+import java.io.File;
 import javax.annotation.Nullable;
 
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
@@ -20,6 +21,13 @@ public class FileInputStreamCallSite {
     if (path != null) {
       iastCallback(path);
       raspCallback(path);
+    }
+  }
+
+  @CallSite.Before("void java.io.FileInputStream.<init>(java.io.File)")
+  public static void beforeConstructorFile(@CallSite.Argument @Nullable final File file) {
+    if (file != null) {
+      raspCallback(file.getPath());
     }
   }
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
+import java.io.File;
 import javax.annotation.Nullable;
 
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
@@ -21,6 +22,14 @@ public class FileOutputStreamCallSite {
     if (path != null) {
       iastCallback(path);
       raspCallback(path);
+    }
+  }
+
+  @CallSite.Before("void java.io.FileOutputStream.<init>(java.io.File)")
+  @CallSite.Before("void java.io.FileOutputStream.<init>(java.io.File, boolean)")
+  public static void beforeConstructorFile(@CallSite.Argument(0) @Nullable final File file) {
+    if (file != null) {
+      raspCallback(file.getPath());
     }
   }
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileReaderCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileReaderCallSite.java
@@ -1,0 +1,34 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.appsec.RaspCallSites;
+import java.io.File;
+import javax.annotation.Nullable;
+
+@CallSite(
+    spi = {RaspCallSites.class},
+    helpers = FileIORaspHelper.class)
+public class FileReaderCallSite {
+
+  @CallSite.Before("void java.io.FileReader.<init>(java.lang.String)")
+  // Java 11+: FileReader(String, Charset)
+  @CallSite.Before("void java.io.FileReader.<init>(java.lang.String, java.nio.charset.Charset)")
+  public static void beforeConstructor(@CallSite.Argument(0) @Nullable final String path) {
+    if (path != null) {
+      raspCallback(path);
+    }
+  }
+
+  @CallSite.Before("void java.io.FileReader.<init>(java.io.File)")
+  // Java 11+: FileReader(File, Charset)
+  @CallSite.Before("void java.io.FileReader.<init>(java.io.File, java.nio.charset.Charset)")
+  public static void beforeConstructorFile(@CallSite.Argument(0) @Nullable final File file) {
+    if (file != null) {
+      raspCallback(file.getPath());
+    }
+  }
+
+  private static void raspCallback(final String path) {
+    FileIORaspHelper.INSTANCE.beforeFileLoaded(path);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileWriterCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FileWriterCallSite.java
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.appsec.RaspCallSites;
+import java.io.File;
+import javax.annotation.Nullable;
+
+@CallSite(
+    spi = {RaspCallSites.class},
+    helpers = FileIORaspHelper.class)
+public class FileWriterCallSite {
+
+  @CallSite.Before("void java.io.FileWriter.<init>(java.lang.String)")
+  @CallSite.Before("void java.io.FileWriter.<init>(java.lang.String, boolean)")
+  // Java 11+: FileWriter(String, Charset) and FileWriter(String, Charset, boolean)
+  @CallSite.Before("void java.io.FileWriter.<init>(java.lang.String, java.nio.charset.Charset)")
+  @CallSite.Before(
+      "void java.io.FileWriter.<init>(java.lang.String, java.nio.charset.Charset, boolean)")
+  public static void beforeConstructor(@CallSite.Argument(0) @Nullable final String path) {
+    if (path != null) {
+      raspCallback(path);
+    }
+  }
+
+  @CallSite.Before("void java.io.FileWriter.<init>(java.io.File)")
+  @CallSite.Before("void java.io.FileWriter.<init>(java.io.File, boolean)")
+  // Java 11+: FileWriter(File, Charset) and FileWriter(File, Charset, boolean)
+  @CallSite.Before("void java.io.FileWriter.<init>(java.io.File, java.nio.charset.Charset)")
+  @CallSite.Before(
+      "void java.io.FileWriter.<init>(java.io.File, java.nio.charset.Charset, boolean)")
+  public static void beforeConstructorFile(@CallSite.Argument(0) @Nullable final File file) {
+    if (file != null) {
+      raspCallback(file.getPath());
+    }
+  }
+
+  private static void raspCallback(final String path) {
+    FileIORaspHelper.INSTANCE.beforeFileWritten(path);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FilesCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FilesCallSite.java
@@ -1,0 +1,78 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.appsec.RaspCallSites;
+import java.nio.file.Path;
+import javax.annotation.Nullable;
+
+@CallSite(
+    spi = {RaspCallSites.class},
+    helpers = FileIORaspHelper.class)
+public class FilesCallSite {
+
+  // ===================== WRITE =====================
+
+  @CallSite.Before(
+      "java.io.OutputStream java.nio.file.Files.newOutputStream(java.nio.file.Path, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.write(java.nio.file.Path, byte[], java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.write(java.nio.file.Path, java.lang.Iterable, java.nio.charset.Charset, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.write(java.nio.file.Path, java.lang.Iterable, java.nio.file.OpenOption[])")
+  // Java 11+: Files.writeString variants
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.writeString(java.nio.file.Path, java.lang.CharSequence, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.writeString(java.nio.file.Path, java.lang.CharSequence, java.nio.charset.Charset, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.io.BufferedWriter java.nio.file.Files.newBufferedWriter(java.nio.file.Path, java.nio.charset.Charset, java.nio.file.OpenOption[])")
+  @CallSite.Before(
+      "java.io.BufferedWriter java.nio.file.Files.newBufferedWriter(java.nio.file.Path, java.nio.file.OpenOption[])")
+  public static void beforeWrite(@CallSite.Argument(0) @Nullable final Path path) {
+    if (path != null) {
+      FileIORaspHelper.INSTANCE.beforeFileWritten(path.toString());
+    }
+  }
+
+  @CallSite.Before(
+      "long java.nio.file.Files.copy(java.io.InputStream, java.nio.file.Path, java.nio.file.CopyOption[])")
+  public static void beforeCopyFromStream(@CallSite.Argument(1) @Nullable final Path target) {
+    if (target != null) {
+      FileIORaspHelper.INSTANCE.beforeFileWritten(target.toString());
+    }
+  }
+
+  @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.move(java.nio.file.Path, java.nio.file.Path, java.nio.file.CopyOption[])")
+  public static void beforeMove(@CallSite.Argument(1) @Nullable final Path target) {
+    if (target != null) {
+      FileIORaspHelper.INSTANCE.beforeFileWritten(target.toString());
+    }
+  }
+
+  // ===================== READ =====================
+
+  @CallSite.Before(
+      "java.io.InputStream java.nio.file.Files.newInputStream(java.nio.file.Path, java.nio.file.OpenOption[])")
+  @CallSite.Before("byte[] java.nio.file.Files.readAllBytes(java.nio.file.Path)")
+  @CallSite.Before(
+      "java.util.List java.nio.file.Files.readAllLines(java.nio.file.Path, java.nio.charset.Charset)")
+  @CallSite.Before("java.util.List java.nio.file.Files.readAllLines(java.nio.file.Path)")
+  // Java 11+: Files.readString variants
+  @CallSite.Before("java.lang.String java.nio.file.Files.readString(java.nio.file.Path)")
+  @CallSite.Before(
+      "java.lang.String java.nio.file.Files.readString(java.nio.file.Path, java.nio.charset.Charset)")
+  @CallSite.Before(
+      "java.io.BufferedReader java.nio.file.Files.newBufferedReader(java.nio.file.Path, java.nio.charset.Charset)")
+  @CallSite.Before(
+      "java.io.BufferedReader java.nio.file.Files.newBufferedReader(java.nio.file.Path)")
+  @CallSite.Before(
+      "java.util.stream.Stream java.nio.file.Files.lines(java.nio.file.Path, java.nio.charset.Charset)")
+  @CallSite.Before("java.util.stream.Stream java.nio.file.Files.lines(java.nio.file.Path)")
+  public static void beforeRead(@CallSite.Argument(0) @Nullable final Path path) {
+    if (path != null) {
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(path.toString());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
+import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 @Sink(VulnerabilityTypes.PATH_TRAVERSAL)
@@ -21,6 +22,14 @@ public class PathCallSite {
     if (other != null) {
       iastCallback(other);
       raspCallback(other);
+    }
+  }
+
+  @CallSite.Before("java.nio.file.Path java.nio.file.Path.resolve(java.nio.file.Path)")
+  @CallSite.Before("java.nio.file.Path java.nio.file.Path.resolveSibling(java.nio.file.Path)")
+  public static void beforeResolveWithPath(@CallSite.Argument @Nullable final Path other) {
+    if (other != null) {
+      raspCallback(other.toString());
     }
   }
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
@@ -35,6 +35,23 @@ public class PathsCallSite {
     }
   }
 
+  // Java 11+: Path.of — equivalent to Paths.get but defined on the Path interface
+  @CallSite.Before("java.nio.file.Path java.nio.file.Path.of(java.lang.String, java.lang.String[])")
+  public static void beforeOf(
+      @CallSite.Argument @Nullable final String first,
+      @CallSite.Argument @Nullable final String[] more) {
+    if (first != null && more != null) {
+      raspCallback(first, more);
+    }
+  }
+
+  @CallSite.Before("java.nio.file.Path java.nio.file.Path.of(java.net.URI)")
+  public static void beforeOfUri(@CallSite.Argument @Nullable final URI uri) {
+    if (uri != null) {
+      raspCallback(uri);
+    }
+  }
+
   private static void iastCallback(URI uri) {
     final PathTraversalModule module = InstrumentationBridge.PATH_TRAVERSAL;
     if (module != null) {

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RandomAccessFileCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RandomAccessFileCallSite.java
@@ -1,0 +1,30 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.appsec.RaspCallSites;
+import java.io.File;
+import javax.annotation.Nullable;
+
+@CallSite(
+    spi = {RaspCallSites.class},
+    helpers = FileIORaspHelper.class)
+public class RandomAccessFileCallSite {
+
+  @CallSite.Before("void java.io.RandomAccessFile.<init>(java.lang.String, java.lang.String)")
+  public static void beforeConstructor(
+      @CallSite.Argument(0) @Nullable final String name,
+      @CallSite.Argument(1) @Nullable final String mode) {
+    if (name != null && mode != null) {
+      FileIORaspHelper.INSTANCE.beforeRandomAccessFileOpened(name, mode);
+    }
+  }
+
+  @CallSite.Before("void java.io.RandomAccessFile.<init>(java.io.File, java.lang.String)")
+  public static void beforeConstructorFile(
+      @CallSite.Argument(0) @Nullable final File file,
+      @CallSite.Argument(1) @Nullable final String mode) {
+    if (file != null && mode != null) {
+      FileIORaspHelper.INSTANCE.beforeRandomAccessFileOpened(file.getPath(), mode);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileChannelCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileChannelCallSiteTest.groovy
@@ -7,7 +7,7 @@ import java.nio.file.StandardOpenOption
 
 class FileChannelCallSiteTest extends BaseIoRaspCallSiteTest {
 
-  void 'test RASP FileChannel.open read-only fires beforeFileLoaded'() {
+  void 'test RASP FileChannel.open read-only fires only beforeFileLoaded'() {
     setup:
     final helper = Mock(FileIORaspHelper)
     FileIORaspHelper.INSTANCE = helper
@@ -18,10 +18,10 @@ class FileChannelCallSiteTest extends BaseIoRaspCallSiteTest {
 
     then:
     1 * helper.beforeFileLoaded(path.toString())
-    1 * helper.beforeFileWritten(path.toString())
+    0 * helper.beforeFileWritten(_)
   }
 
-  void 'test RASP FileChannel.open write fires beforeFileWritten'() {
+  void 'test RASP FileChannel.open write fires both beforeFileLoaded and beforeFileWritten'() {
     setup:
     final helper = Mock(FileIORaspHelper)
     FileIORaspHelper.INSTANCE = helper
@@ -35,7 +35,7 @@ class FileChannelCallSiteTest extends BaseIoRaspCallSiteTest {
     1 * helper.beforeFileWritten(path.toString())
   }
 
-  void 'test RASP FileChannel.open with Set of options'() {
+  void 'test RASP FileChannel.open with Set READ-only fires only beforeFileLoaded'() {
     setup:
     final helper = Mock(FileIORaspHelper)
     FileIORaspHelper.INSTANCE = helper
@@ -47,6 +47,35 @@ class FileChannelCallSiteTest extends BaseIoRaspCallSiteTest {
 
     then:
     1 * helper.beforeFileLoaded(path.toString())
+    0 * helper.beforeFileWritten(_)
+  }
+
+  void 'test RASP FileChannel.open with Set WRITE fires both callbacks'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_fc_set_write.txt')
+    final options = EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+
+    when:
+    TestFileChannelSuite.openWithSet(path, options).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
     1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP FileChannel.open with no options fires only beforeFileLoaded'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_fc_default.txt').toPath()
+
+    when:
+    TestFileChannelSuite.openWithOptions(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+    0 * helper.beforeFileWritten(_)
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileChannelCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileChannelCallSiteTest.groovy
@@ -1,0 +1,52 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFileChannelSuite
+
+import java.nio.file.StandardOpenOption
+
+class FileChannelCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP FileChannel.open read-only fires beforeFileLoaded'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_fc_read.txt').toPath()
+
+    when:
+    TestFileChannelSuite.openRead(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP FileChannel.open write fires beforeFileWritten'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_fc_write.txt')
+
+    when:
+    TestFileChannelSuite.openWrite(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP FileChannel.open with Set of options'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_fc_set.txt').toPath()
+    final options = EnumSet.of(StandardOpenOption.READ)
+
+    when:
+    TestFileChannelSuite.openWithSet(path, options).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+    1 * helper.beforeFileWritten(path.toString())
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileInputStreamCallSiteTest.groovy
@@ -32,4 +32,17 @@ class FileInputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     then:
     1 * helper.beforeFileLoaded(path)
   }
+
+  void 'test RASP new file input stream with file'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_file.txt')
+
+    when:
+    TestFileInputStreamSuite.newFileInputStream(file)
+
+    then:
+    1 * helper.beforeFileLoaded(file.path)
+  }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
@@ -60,4 +60,30 @@ class FileOutputStreamCallSiteTest extends BaseIoRaspCallSiteTest {
     then:
     1 * helper.beforeFileWritten(path)
   }
+
+  void 'test RASP new file output stream with file'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_file_1.txt')
+
+    when:
+    TestFileOutputStreamSuite.newFileOutputStream(file)
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+
+  void 'test RASP new file output stream with file and append'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_file_2.txt')
+
+    when:
+    TestFileOutputStreamSuite.newFileOutputStream(file, false)
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileReaderCallSiteTest.groovy
@@ -1,0 +1,33 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFileReaderSuite
+
+class FileReaderCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP new file reader with path'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_reader.txt').toString()
+
+    when:
+    TestFileReaderSuite.newFileReader(path)
+
+    then:
+    1 * helper.beforeFileLoaded(path)
+  }
+
+  void 'test RASP new file reader with file'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_reader_file.txt')
+
+    when:
+    TestFileReaderSuite.newFileReader(file)
+
+    then:
+    1 * helper.beforeFileLoaded(file.path)
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileWriterCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FileWriterCallSiteTest.groovy
@@ -1,0 +1,61 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFileWriterSuite
+import groovy.transform.CompileDynamic
+
+@CompileDynamic
+class FileWriterCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP new file writer with path'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_writer_1.txt').toString()
+
+    when:
+    TestFileWriterSuite.newFileWriter(path)
+
+    then:
+    1 * helper.beforeFileWritten(path)
+  }
+
+  void 'test RASP new file writer with path and append'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_writer_2.txt').toString()
+
+    when:
+    TestFileWriterSuite.newFileWriter(path, false)
+
+    then:
+    1 * helper.beforeFileWritten(path)
+  }
+
+  void 'test RASP new file writer with file'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_writer_file_1.txt')
+
+    when:
+    TestFileWriterSuite.newFileWriter(file)
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+
+  void 'test RASP new file writer with file and append'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_writer_file_2.txt')
+
+    when:
+    TestFileWriterSuite.newFileWriter(file, false)
+
+    then:
+    1 * helper.beforeFileWritten(file.path)
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
@@ -5,7 +5,6 @@ import foo.bar.TestFilesSuite
 import groovy.transform.CompileDynamic
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.StandardCopyOption
 
 @CompileDynamic
 class FilesCallSiteTest extends BaseIoRaspCallSiteTest {

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
@@ -1,0 +1,225 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestFilesSuite
+import groovy.transform.CompileDynamic
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.StandardCopyOption
+
+@CompileDynamic
+class FilesCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  // ===================== WRITE =====================
+
+  void 'test RASP Files.newOutputStream'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_newoutputstream.txt')
+
+    when:
+    TestFilesSuite.newOutputStream(path).close()
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.copy from InputStream'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final target = temporaryFolder.resolve('test_rasp_copy_target.txt')
+
+    when:
+    TestFilesSuite.copyFromStream(new ByteArrayInputStream(new byte[0]), target)
+
+    then:
+    1 * helper.beforeFileWritten(target.toString())
+  }
+
+  void 'test RASP Files.write byte array'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_write_bytes.txt')
+
+    when:
+    TestFilesSuite.write(path, 'hello'.bytes)
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.write lines with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_write_lines_cs.txt')
+
+    when:
+    TestFilesSuite.writeLines(path, ['line1'], StandardCharsets.UTF_8)
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.write lines default charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_write_lines.txt')
+
+    when:
+    TestFilesSuite.writeLinesDefaultCharset(path, ['line1'])
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.newBufferedWriter with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_bw_cs.txt')
+
+    when:
+    TestFilesSuite.newBufferedWriter(path, StandardCharsets.UTF_8).close()
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.newBufferedWriter default charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = temporaryFolder.resolve('test_rasp_bw.txt')
+
+    when:
+    TestFilesSuite.newBufferedWriterDefaultCharset(path).close()
+
+    then:
+    1 * helper.beforeFileWritten(path.toString())
+  }
+
+  void 'test RASP Files.move'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final source = newFile('test_rasp_move_src.txt').toPath()
+    final target = temporaryFolder.resolve('test_rasp_move_dst.txt')
+
+    when:
+    TestFilesSuite.move(source, target)
+
+    then:
+    1 * helper.beforeFileWritten(target.toString())
+  }
+
+  // ===================== READ =====================
+
+  void 'test RASP Files.newInputStream'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_newinputstream.txt').toPath()
+
+    when:
+    TestFilesSuite.newInputStream(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.readAllBytes'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_readallbytes.txt').toPath()
+
+    when:
+    TestFilesSuite.readAllBytes(path)
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.readAllLines with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_readlines_cs.txt').toPath()
+
+    when:
+    TestFilesSuite.readAllLines(path, StandardCharsets.UTF_8)
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.readAllLines default charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_readlines.txt').toPath()
+
+    when:
+    TestFilesSuite.readAllLinesDefaultCharset(path)
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.newBufferedReader with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_br_cs.txt').toPath()
+
+    when:
+    TestFilesSuite.newBufferedReader(path, StandardCharsets.UTF_8).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.newBufferedReader default charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_br.txt').toPath()
+
+    when:
+    TestFilesSuite.newBufferedReaderDefaultCharset(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.lines with charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_lines_cs.txt').toPath()
+
+    when:
+    TestFilesSuite.lines(path, StandardCharsets.UTF_8).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+
+  void 'test RASP Files.lines default charset'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final path = newFile('test_rasp_lines.txt').toPath()
+
+    when:
+    TestFilesSuite.linesDefaultCharset(path).close()
+
+    then:
+    1 * helper.beforeFileLoaded(path.toString())
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathCallSiteTest.groovy
@@ -60,4 +60,32 @@ class PathCallSiteTest extends BaseIoRaspCallSiteTest {
     then:
     1 * helper.beforeFileLoaded(path)
   }
+
+  void 'test RASP resolve with Path argument'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final parent = getRootFolder()
+    final other = newFile('test_rasp_path_resolve.txt').toPath()
+
+    when:
+    TestPathSuite.resolveWithPath(parent, other)
+
+    then:
+    1 * helper.beforeFileLoaded(other.toString())
+  }
+
+  void 'test RASP resolveSibling with Path argument'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final sibling = newFile('test_rasp_path_sibling_1.txt').toPath()
+    final other = newFile('test_rasp_path_sibling_2.txt').toPath()
+
+    when:
+    TestPathSuite.resolveSiblingWithPath(sibling, other)
+
+    then:
+    1 * helper.beforeFileLoaded(other.toString())
+  }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
@@ -66,5 +66,4 @@ class PathsCallSiteTest extends BaseIoRaspCallSiteTest {
     then:
     1 * helper.beforeFileLoaded(file)
   }
-
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/PathsCallSiteTest.groovy
@@ -66,4 +66,5 @@ class PathsCallSiteTest extends BaseIoRaspCallSiteTest {
     then:
     1 * helper.beforeFileLoaded(file)
   }
+
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/RandomAccessFileCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/RandomAccessFileCallSiteTest.groovy
@@ -1,0 +1,59 @@
+package datadog.trace.instrumentation.java.io
+
+import datadog.trace.instrumentation.java.lang.FileIORaspHelper
+import foo.bar.TestRandomAccessFileSuite
+
+class RandomAccessFileCallSiteTest extends BaseIoRaspCallSiteTest {
+
+  void 'test RASP RandomAccessFile with String path read-only mode'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_raf_r.txt')
+
+    when:
+    TestRandomAccessFileSuite.newRandomAccessFile(file.path, 'r')
+
+    then:
+    1 * helper.beforeRandomAccessFileOpened(file.path, 'r')
+  }
+
+  void 'test RASP RandomAccessFile with String path read-write mode'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_raf_rw.txt')
+
+    when:
+    TestRandomAccessFileSuite.newRandomAccessFile(file.path, 'rw')
+
+    then:
+    1 * helper.beforeRandomAccessFileOpened(file.path, 'rw')
+  }
+
+  void 'test RASP RandomAccessFile with File read-only mode'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_raf_file_r.txt')
+
+    when:
+    TestRandomAccessFileSuite.newRandomAccessFile(file, 'r')
+
+    then:
+    1 * helper.beforeRandomAccessFileOpened(file.path, 'r')
+  }
+
+  void 'test RASP RandomAccessFile with File read-write mode'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final file = newFile('test_rasp_raf_file_rw.txt')
+
+    when:
+    TestRandomAccessFileSuite.newRandomAccessFile(file, 'rw')
+
+    then:
+    1 * helper.beforeRandomAccessFileOpened(file.path, 'rw')
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileChannelSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileChannelSuite.java
@@ -1,0 +1,35 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.util.Set;
+
+public class TestFileChannelSuite {
+
+  public static FileChannel openRead(final Path path) throws IOException {
+    return FileChannel.open(path, StandardOpenOption.READ);
+  }
+
+  public static FileChannel openWrite(final Path path) throws IOException {
+    return FileChannel.open(
+        path,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
+  }
+
+  public static FileChannel openWithOptions(final Path path, final OpenOption... options)
+      throws IOException {
+    return FileChannel.open(path, options);
+  }
+
+  public static FileChannel openWithSet(
+      final Path path, final Set<? extends OpenOption> options, final FileAttribute<?>... attrs)
+      throws IOException {
+    return FileChannel.open(path, options, attrs);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileInputStreamSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileInputStreamSuite.java
@@ -1,5 +1,6 @@
 package foo.bar;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
@@ -7,5 +8,9 @@ public class TestFileInputStreamSuite {
 
   public static FileInputStream newFileInputStream(final String path) throws FileNotFoundException {
     return new FileInputStream(path);
+  }
+
+  public static FileInputStream newFileInputStream(final File file) throws FileNotFoundException {
+    return new FileInputStream(file);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileOutputStreamSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileOutputStreamSuite.java
@@ -1,5 +1,6 @@
 package foo.bar;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 
@@ -13,5 +14,14 @@ public class TestFileOutputStreamSuite {
   public static FileOutputStream newFileOutputStream(final String path, final boolean append)
       throws FileNotFoundException {
     return new FileOutputStream(path, append);
+  }
+
+  public static FileOutputStream newFileOutputStream(final File file) throws FileNotFoundException {
+    return new FileOutputStream(file);
+  }
+
+  public static FileOutputStream newFileOutputStream(final File file, final boolean append)
+      throws FileNotFoundException {
+    return new FileOutputStream(file, append);
   }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileReaderSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileReaderSuite.java
@@ -1,0 +1,16 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class TestFileReaderSuite {
+
+  public static FileReader newFileReader(final String path) throws IOException {
+    return new FileReader(path);
+  }
+
+  public static FileReader newFileReader(final File file) throws IOException {
+    return new FileReader(file);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileWriterSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFileWriterSuite.java
@@ -1,0 +1,25 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class TestFileWriterSuite {
+
+  public static FileWriter newFileWriter(final String path) throws IOException {
+    return new FileWriter(path);
+  }
+
+  public static FileWriter newFileWriter(final String path, final boolean append)
+      throws IOException {
+    return new FileWriter(path, append);
+  }
+
+  public static FileWriter newFileWriter(final File file) throws IOException {
+    return new FileWriter(file);
+  }
+
+  public static FileWriter newFileWriter(final File file, final boolean append) throws IOException {
+    return new FileWriter(file, append);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFilesSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFilesSuite.java
@@ -1,0 +1,100 @@
+package foo.bar;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class TestFilesSuite {
+
+  // ===================== WRITE =====================
+
+  public static OutputStream newOutputStream(final Path path, final OpenOption... options)
+      throws IOException {
+    return Files.newOutputStream(path, options);
+  }
+
+  public static long copyFromStream(
+      final InputStream in, final Path target, final CopyOption... options) throws IOException {
+    return Files.copy(in, target, options);
+  }
+
+  public static Path write(final Path path, final byte[] bytes, final OpenOption... options)
+      throws IOException {
+    return Files.write(path, bytes, options);
+  }
+
+  public static Path writeLines(
+      final Path path,
+      final Iterable<? extends CharSequence> lines,
+      final Charset cs,
+      final OpenOption... options)
+      throws IOException {
+    return Files.write(path, lines, cs, options);
+  }
+
+  public static Path writeLinesDefaultCharset(
+      final Path path, final Iterable<? extends CharSequence> lines, final OpenOption... options)
+      throws IOException {
+    return Files.write(path, lines, options);
+  }
+
+  public static BufferedWriter newBufferedWriter(
+      final Path path, final Charset cs, final OpenOption... options) throws IOException {
+    return Files.newBufferedWriter(path, cs, options);
+  }
+
+  public static BufferedWriter newBufferedWriterDefaultCharset(
+      final Path path, final OpenOption... options) throws IOException {
+    return Files.newBufferedWriter(path, options);
+  }
+
+  public static Path move(final Path source, final Path target, final CopyOption... options)
+      throws IOException {
+    return Files.move(source, target);
+  }
+
+  // ===================== READ =====================
+
+  public static InputStream newInputStream(final Path path, final OpenOption... options)
+      throws IOException {
+    return Files.newInputStream(path, options);
+  }
+
+  public static byte[] readAllBytes(final Path path) throws IOException {
+    return Files.readAllBytes(path);
+  }
+
+  public static List<String> readAllLines(final Path path, final Charset cs) throws IOException {
+    return Files.readAllLines(path, cs);
+  }
+
+  public static List<String> readAllLinesDefaultCharset(final Path path) throws IOException {
+    return Files.readAllLines(path);
+  }
+
+  public static BufferedReader newBufferedReader(final Path path, final Charset cs)
+      throws IOException {
+    return Files.newBufferedReader(path, cs);
+  }
+
+  public static BufferedReader newBufferedReaderDefaultCharset(final Path path) throws IOException {
+    return Files.newBufferedReader(path);
+  }
+
+  public static Stream<String> lines(final Path path, final Charset cs) throws IOException {
+    return Files.lines(path, cs);
+  }
+
+  public static Stream<String> linesDefaultCharset(final Path path) throws IOException {
+    return Files.lines(path);
+  }
+}

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestPathSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestPathSuite.java
@@ -11,4 +11,12 @@ public class TestPathSuite {
   public static Path resolveSibling(final Path parent, final String other) {
     return parent.resolveSibling(other);
   }
+
+  public static Path resolveWithPath(final Path parent, final Path other) {
+    return parent.resolve(other);
+  }
+
+  public static Path resolveSiblingWithPath(final Path sibling, final Path other) {
+    return sibling.resolveSibling(other);
+  }
 }

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestRandomAccessFileSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestRandomAccessFileSuite.java
@@ -1,0 +1,18 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class TestRandomAccessFileSuite {
+
+  public static RandomAccessFile newRandomAccessFile(final String name, final String mode)
+      throws IOException {
+    return new RandomAccessFile(name, mode);
+  }
+
+  public static RandomAccessFile newRandomAccessFile(final File file, final String mode)
+      throws IOException {
+    return new RandomAccessFile(file, mode);
+  }
+}


### PR DESCRIPTION
## What Does This Do

  Extends RASP callsite coverage for Java file I/O APIs. All new callsites are RASP-only — no IAST changes, since `File`-based and `Path`-based constructors delegate path resolution to the JVM, and IAST taint
  tracking via the `String` constructors already covers those code paths.

  ### New callsites

  **`FileReaderCallSite`** → `beforeFileLoaded`
  - `FileReader(String)`, `FileReader(File)`
  - `FileReader(String, Charset)`, `FileReader(File, Charset)` *(Java 11+)*

  **`FileWriterCallSite`** → `beforeFileWritten`
  - `FileWriter(String)`, `FileWriter(String, boolean)`, `FileWriter(File)`, `FileWriter(File, boolean)`
  - `FileWriter(String, Charset)`, `FileWriter(String, Charset, boolean)`, `FileWriter(File, Charset)`, `FileWriter(File, Charset, boolean)` *(Java 11+)*

  **`RandomAccessFileCallSite`** → `beforeFileLoaded` for mode `"r"`; both `beforeFileLoaded` + `beforeFileWritten` for `"rw"` / `"rws"` / `"rwd"`
  - `RandomAccessFile(String, String)`, `RandomAccessFile(File, String)`

  **`FilesCallSite`**
  - Write → `beforeFileWritten`: `Files.newOutputStream`, `Files.write(bytes)`, `Files.write(lines, charset)`, `Files.write(lines)`, `Files.newBufferedWriter(path, charset)`, `Files.newBufferedWriter(path)`,
  `Files.copy(InputStream, Path, ...)`, `Files.move`
  - Write *(Java 11+)*: `Files.writeString(path, seq)`, `Files.writeString(path, seq, charset)`
  - Read → `beforeFileLoaded`: `Files.newInputStream`, `Files.readAllBytes`, `Files.readAllLines(path, charset)`, `Files.readAllLines(path)`, `Files.newBufferedReader(path, charset)`,
  `Files.newBufferedReader(path)`, `Files.lines(path, charset)`, `Files.lines(path)`
  - Read *(Java 11+)*: `Files.readString(path)`, `Files.readString(path, charset)`

  **`FileChannelCallSite`** → both `beforeFileLoaded` + `beforeFileWritten` (channel mode is determined at runtime, not statically)
  - `FileChannel.open(Path, OpenOption[])`, `FileChannel.open(Path, Set<OpenOption>, FileAttribute[])`

  ### Extended callsites

  **`FileInputStreamCallSite`** (extends #11084) — added `FileInputStream(File)` → `beforeFileLoaded`

  **`FileOutputStreamCallSite`** (extends #11084) — added `FileOutputStream(File)`, `FileOutputStream(File, boolean)` → `beforeFileWritten`

  **`PathCallSite`** — added `Path.resolve(Path)`, `Path.resolveSibling(Path)` → `beforeFileLoaded`

  **`PathsCallSite`** — added `Path.of(String, String[])`, `Path.of(URI)` *(Java 11+)* → `beforeFileLoaded`

## Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira Ticket: [APPSEC-61874](https://datadoghq.atlassian.net/browse/APPSEC-61874)

[APPSEC-61874]: https://datadoghq.atlassian.net/browse/APPSEC-61874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ