### PR TITLE
Added logic to mute noisy env vars.

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -77,8 +77,10 @@ abstract class ProcessManager extends Specification {
     (0..<numberOfProcesses).each { idx ->
       ProcessBuilder processBuilder = createProcessBuilder(idx)
 
-      processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
-      processBuilder.environment().put("DD_API_KEY", apiKey())
+      Map<String, String> env = processBuilder.environment()
+      env.put("JAVA_HOME", System.getProperty("java.home"))
+      env.put("DD_API_KEY", apiKey())
+      muteNoisyEnvironmentVariables(env)
 
       processBuilder.redirectErrorStream(true)
 
@@ -189,6 +191,21 @@ abstract class ProcessManager extends Specification {
 
     return line.contains("ERROR") || line.contains("ASSERTION FAILED")
     || line.contains("Failed to handle exception in instrumentation")
+  }
+
+  /**
+   * @return Set of noisy variables to remove.
+   */
+  protected Set<String> noisyEnvironmentVariables() {
+    return ['CI_COMMIT_MESSAGE'] as Set
+  }
+
+  /**
+   * Some variable can be printed in smoke application logs and result into false-positive test result.
+   * @param env environment variables to process.
+   */
+  void muteNoisyEnvironmentVariables(Map<String, String> env) {
+    noisyEnvironmentVariables().each { String envVar -> env.remove(envVar) }
   }
 
   /**

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -1,5 +1,6 @@
 package datadog.smoketest
 
+import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.utils.PortUtils
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -15,6 +16,7 @@ abstract class ProcessManager extends Specification {
   public static final String SERVICE_NAME = "smoke-test-java-app"
   public static final String ENV = "smoketest"
   public static final String VERSION = "99"
+  public static final Set<String> NOISY_ENVIRONMENT_VARIABLES = ImmutableSet.of('CI_COMMIT_MESSAGE')
 
   @Shared
   protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
@@ -194,18 +196,11 @@ abstract class ProcessManager extends Specification {
   }
 
   /**
-   * @return Set of noisy variables to remove.
-   */
-  protected Set<String> noisyEnvironmentVariables() {
-    return ['CI_COMMIT_MESSAGE'] as Set
-  }
-
-  /**
    * Some variable can be printed in smoke application logs and result into false-positive test result.
    * @param env environment variables to process.
    */
   void muteNoisyEnvironmentVariables(Map<String, String> env) {
-    noisyEnvironmentVariables().each { String envVar -> env.remove(envVar) }
+    env.keySet().removeAll(NOISY_ENVIRONMENT_VARIABLES)
   }
 
   /**


### PR DESCRIPTION
# What Does This Do
On GitLab CI Spring Boot smoke apps can print `CI_COMMIT_MESSAGE` into app logs.
If commit message contains `ERROR` substring that will result into `false-positive` failure on CI.
Added method that allows to mute such noisy env vars.

# Motivation
Green CI.
