### PR TITLE
Align test agent version with one we have for GitLab CI.

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
@@ -116,7 +116,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
 
   def startTestAgentContainer() {
     //noinspection GrDeprecatedAPIUsage Use FixedHostPortGenericContainer against deprecation because we need to know the exposed to configure the tracer at start
-    def agentContainer = new FixedHostPortGenericContainer("ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.27.1")
+    def agentContainer = new FixedHostPortGenericContainer("registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.44.0")
       .withFixedExposedPort(agentContainerPort, DEFAULT_TRACE_AGENT_PORT)
       .withEnv("ENABLED_CHECKS", "trace_count_header,meta_tracer_version_header,trace_content_length")
       .waitingFor(Wait.forHttp("/test/traces"))


### PR DESCRIPTION
# What Does This Do
Align test agent version with one we have for GitLab CI.
in #10982 we updated GitLab CI config, but missed this test.

# Motivation
Consistent configuration.

