### PR TITLE
Integrate parallel macrobenchmarks from apm-sdks-benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ include:
   - local: ".gitlab/ci-visibility-tests.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-spring-petclinic-parallel.yml'
-    ref: 'fayssal/integrate'
+    ref: 'main'
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ include:
 stages:
   - build
   - publish
+  # These benchmarks are intended to replace the legacy benchmarks in the future
   - java-spring-petclinic-parallel
   - java-spring-petclinic-parallel-slo
   - shared-pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,15 @@ include:
   - local: ".gitlab/macrobenchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-java-spring-petclinic-parallel.yml'
+    ref: 'fayssal/integrate'
 
 stages:
   - build
   - publish
+  - java-spring-petclinic-parallel
+  - java-spring-petclinic-parallel-slo
   - shared-pipeline
   - benchmarks
   - macrobenchmarks


### PR DESCRIPTION
# What Does This Do
Integrates new parallel macrobenchmarks from the `DataDog/apm-reliability/apm-sdks-benchmarks` repository into the GitLab CI pipeline via `include: project:`. Both old and new benchmark stages run together during a transition period before switching over completely.
# Motivation
The `apm-sdks-benchmarks` repository will be the single source for all macrobenchmark configurations across APM SDKs. This integration enables centralized benchmark management while maintaining stability during the migration.
# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
