### PR TITLE
🍒 11091 - Bump Tomcat to `9.0.117` because `9.0.115` is no longer resolvable in GitLab CI.

### DIFF
--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -8,7 +8,7 @@ plugins {
 ext {
   serverName = 'tomcat'
   serverModule = 'tomcat-9'
-  serverVersion = '9.0.115'
+  serverVersion = '9.0.117'
   serverExtension = 'zip'
 }
 


### PR DESCRIPTION
Backport #11091 to release/v1.61.x