### PR TITLE
Abort on IBMJ9's `keytool` 

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -258,11 +258,8 @@ public final class AgentBootstrap {
     String command = SystemProperties.get("sun.java.command");
     if (null != command && !command.isEmpty()) {
       // substring on first space
-      String mainClass = command;
       int firstSpace = command.indexOf(' ');
-      if (firstSpace != -1) {
-        mainClass = command.substring(0, firstSpace);
-      }
+      String mainClass = firstSpace > 0 ? command.substring(0, firstSpace) : command;
       switch (mainClass) {
         // IBM J9 JDK 8 specific tool main classes
         case "com.ibm.crypto.tools.KeyTool": // keytool

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -294,6 +294,22 @@ public final class AgentBootstrap {
         case "com.sun.tools.script.shell.Main": // jrunscript
         case "sun.tools.jconsole.JConsole": // jconsole
         case "sun.applet.Main": // appletviewer
+        case "com.sun.corba.se.impl.naming.cosnaming.TransientNameServer": // tnameserv
+        // (Oracle/OpenJDK 8)
+        case "com.sun.tools.corba.se.idl.toJavaPortable.Compile": // idlj (Oracle/OpenJDK 8)
+        case "com.sun.corba.se.impl.activation.ORBD": // orbd
+        case "com.sun.corba.se.impl.activation.ServerTool": // servertool
+        case "sun.tools.jps.Jps": // jps
+        case "sun.tools.jstack.JStack": // jstack
+        case "sun.tools.jmap.JMap": // jmap
+        case "sun.tools.jinfo.JInfo": // jinfo
+        case "com.sun.tools.hat.Main": // jhat
+        case "sun.tools.jstat.Jstat": // jstat
+        case "sun.tools.jstatd.Jstatd": // jstatd
+        case "sun.tools.jcmd.JCmd": // jcmd
+        case "jdk.jfr.internal.tool.Main": // jfr, backported to OpenJDK 8 in 8u262 (JEP 328
+        // backport, July 2020)
+        case "sun.jvm.hotspot.jdi.SADebugServer": // jsadebugd
           return true;
       }
     }

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -261,7 +261,7 @@ public final class AgentBootstrap {
       String mainClass = command;
       int firstSpace = command.indexOf(' ');
       if (firstSpace != -1) {
-        mainClass = command.subSequence(0, firstSpace).toString();
+        mainClass = command.substring(0, firstSpace);
       }
       switch (mainClass) {
         // IBM J9 JDK 8 specific tool main classes

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -253,6 +253,20 @@ public final class AgentBootstrap {
           return true;
       }
     }
+    // Handles IBMJ9 tools
+    String command = SystemProperties.get("sun.java.command");
+    if (null != command && !command.isEmpty()) {
+      // substring on first space
+      String mainClass = command;
+      int firstSpace = command.indexOf(' ');
+      if (firstSpace != -1) {
+        mainClass = command.subSequence(0, firstSpace).toString();
+      }
+      switch (mainClass) {
+        case "com.ibm.crypto.tools.KeyTool": // keytool
+          return true;
+      }
+    }
     return false;
   }
 

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -216,7 +216,7 @@ public final class AgentBootstrap {
     return false;
   }
 
-  private static boolean isJdkTool() {
+  static boolean isJdkTool() {
     String moduleMain = SystemProperties.get("jdk.module.main");
     if (null != moduleMain && !moduleMain.isEmpty() && moduleMain.charAt(0) == 'j') {
       switch (moduleMain) {
@@ -253,7 +253,8 @@ public final class AgentBootstrap {
           return true;
       }
     }
-    // Handles IBMJ9 tools
+    // Handles JDK 8 tools (IBM J9 and standard JDK 8 vendors)
+    // jdk.module.main is only set for JDK 9+ module-based tools (already handled above)
     String command = SystemProperties.get("sun.java.command");
     if (null != command && !command.isEmpty()) {
       // substring on first space
@@ -263,7 +264,39 @@ public final class AgentBootstrap {
         mainClass = command.subSequence(0, firstSpace).toString();
       }
       switch (mainClass) {
+        // IBM J9 JDK 8 specific tool main classes
         case "com.ibm.crypto.tools.KeyTool": // keytool
+        case "com.ibm.security.krb5.internal.tools.Kinit": // kinit
+        case "com.ibm.security.krb5.internal.tools.Klist": // klist
+        case "com.ibm.security.krb5.internal.tools.Ktab": // ktab
+        case "com.ibm.jvm.dtfjview.DTFJView": // jdmpview
+        case "com.ibm.gsk.ikeyman.ikeycmd": // ikeycmd
+        case "com.ibm.CosNaming.TransientNameServer": // tnameserv
+        case "com.ibm.idl.toJavaPortable.Compile": // idlj
+        // Standard JDK 8 tool main classes (shared by IBM J9 and Oracle/OpenJDK 8)
+        case "sun.tools.jar.Main": // jar
+        case "com.sun.tools.javac.Main": // javac
+        case "com.sun.tools.javadoc.Main": // javadoc
+        case "com.sun.tools.javap.Main": // javap
+        case "com.sun.tools.javah.Main": // javah
+        case "sun.security.tools.keytool.Main": // keytool (Oracle/OpenJDK 8)
+        case "sun.security.tools.jarsigner.Main": // jarsigner
+        case "sun.security.tools.policytool.PolicyTool": // policytool
+        case "com.sun.tools.example.debug.tty.TTY": // jdb
+        case "com.sun.tools.jdeps.Main": // jdeps
+        case "sun.rmi.rmic.Main": // rmic
+        case "sun.rmi.registry.RegistryImpl": // rmiregistry
+        case "sun.rmi.server.Activation": // rmid
+        case "com.sun.tools.extcheck.Main": // extcheck
+        case "sun.tools.serialver.SerialVer": // serialver
+        case "sun.tools.native2ascii.Main": // native2ascii
+        case "com.sun.tools.internal.ws.WsGen": // wsgen
+        case "com.sun.tools.internal.ws.WsImport": // wsimport
+        case "com.sun.tools.internal.xjc.Driver": // xjc
+        case "com.sun.tools.internal.jxc.SchemaGenerator": // schemagen
+        case "com.sun.tools.script.shell.Main": // jrunscript
+        case "sun.tools.jconsole.JConsole": // jconsole
+        case "sun.applet.Main": // appletviewer
           return true;
       }
     }


### PR DESCRIPTION
# What Does This Do

The JVM agent should not activate on JDK tools. The JVM agent already did that for JVM having modules. This PR extends that check to older commercial IBMJ9. To avoid faulty behavior.

Note tests are in #11134

# Motivation

First, the java agent should not activate on JDK tools. In particular when these JDK tools are invoked as a subprocess of the main app, they might inherit the `JAVA_TOOL_OPTIONS` that contain the `-java-agent` flag.

It was observed that IBMJ9 synchronizes `JarFile` and `SignerInfo`, on `keytool`, the agent bstartup thread and the main thread are dead-locking while loading security providers. 

The #10714 prevented a code path for this to happen, but another code path was discovered with `Strings.sha256` using `MessageDigest` (loading under the hood the providers).

Preventing keytool from being instrumented should fully solve the issue.

# Additional Notes

Since other Java 8 tools might be impacted, I added them.

This PR extends the JDK tool check introduced in #6096

----

I collected the various tools using this approach:

I created a simple agent capturing the `sun.java.command` system property

```java
import java.lang.instrument.*;
public class ReadToolCommand {
    public static void premain(String a, Instrumentation i) {
        System.err.println("CMD=" + System.getProperty("sun.java.command"));
    }
}
```

```
mkdir -p /tmp/agentsrc /tmp/agentclasses
javac -d /tmp/agentclasses /tmp/agentsrc/ReadToolCommand.java
printf "Premain-Class: ReadToolCommand\n\n" > /tmp/meta.txt
cd /tmp/agentclasses && jar cfm /tmp/read-tool-command.jar /tmp/meta.txt ReadToolCommand.class
```

Then grab the output for each tool with this agent

```
# JRE tools
for tool in keytool rmiregistry rmid tnameserv kinit klist ktab jdmpview ikeycmd; do
  echo "$tool: $(timeout 3 /opt/ibm/java/jre/bin/$tool -J-javaagent:/tmp/read-tool-command.jar 2>&1 | grep CMD)"
done

# SDK tools
for tool in jar javac javadoc javap javah jarsigner jdb jdeps rmic extcheck \
            serialver native2ascii wsgen wsimport xjc schemagen jrunscript idlj jconsole; do
  echo "$tool: $(timeout 3 /opt/ibm/java/bin/$tool -J-javaagent:/tmp/read-tool-command.jar 2>&1 | grep CMD)"
done
```

However, some tool didn't accept `-J` prefix, in this case I used the class in the `rt.jar` (`sun/security/tools/policytool/PolicyTool.class` and `sun/applet/Main.class`)

This was done on the docker image `ibmjava:8-sdk`. I did the same on a local Hotspot based JDK 8.

