### PR TITLE
test(propagation): verify formatKnuthSamplingRate is locale-independent

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/PTagsFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/PTagsFactoryTest.groovy
@@ -1,0 +1,24 @@
+package datadog.trace.core.propagation.ptags
+
+import datadog.trace.core.test.DDCoreSpecification
+
+class PTagsFactoryTest extends DDCoreSpecification {
+
+  def 'formatKnuthSamplingRate is locale-independent'() {
+    setup:
+    def originalLocale = Locale.getDefault()
+
+    when:
+    Locale.setDefault(Locale.GERMANY)
+
+    then:
+    PTagsFactory.PTags.formatKnuthSamplingRate(0.3d)      == "0.3"
+    PTagsFactory.PTags.formatKnuthSamplingRate(1.0d)      == "1"
+    PTagsFactory.PTags.formatKnuthSamplingRate(0.000001d) == "0.000001"
+    PTagsFactory.PTags.formatKnuthSamplingRate(0.0d)      == "0"
+    PTagsFactory.PTags.formatKnuthSamplingRate(0.5d)      == "0.5"
+
+    cleanup:
+    Locale.setDefault(originalLocale)
+  }
+}


### PR DESCRIPTION
# What Does This Do

Adds a unit test to verify that `PTagsFactory.PTags.formatKnuthSamplingRate` produces locale-independent output (e.g., uses `.` as the decimal separator regardless of the JVM's default locale).

# Motivation

Locales like `Locale.GERMANY` use `,` as the decimal separator. If `formatKnuthSamplingRate` ever regresses to use locale-sensitive formatting, propagation tags would be malformed. This test sets the JVM locale to `Locale.GERMANY` and asserts the output uses `.` for all cases (zero, one, fractional, and very small values).

# Additional Notes

The method under test uses char-array arithmetic and is already locale-safe. This test locks in that behavior as a regression guard.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors