### PR TITLE
Add an immediate try at maven deployment check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1017,11 +1017,12 @@ verify_maven_central_deployment:
         "https://repo1.maven.org/maven2/com/datadoghq/dd-trace-api/${VERSION}/dd-trace-api-${VERSION}.jar"
         "https://repo1.maven.org/maven2/com/datadoghq/dd-trace-ot/${VERSION}/dd-trace-ot-${VERSION}.jar"
       )
-      # Wait 5 mins initially, then try 5 times with a minute delay between each retry to see if the release artifacts are available
-      sleep 300
+      # Try once immediately (fast path on job retry), then wait 5 mins for initial propagation,
+      # then try 4 more times with a minute delay between each retry.
       TRY=0
-      MAX_TRIES=5
-      DELAY=60
+      MAX_TRIES=6
+      INITIAL_DELAY=300
+      RETRY_DELAY=60
       while [ $TRY -lt $MAX_TRIES ]; do
         ARTIFACTS_AVAILABLE=true
         for URL in "${ARTIFACT_URLS[@]}"; do
@@ -1038,7 +1039,11 @@ verify_maven_central_deployment:
           echo "The release was not available after 10 mins. Manually re-run the job to try again."
           exit 1
         fi
-        sleep $DELAY
+        if [ $TRY -eq 1 ]; then
+          sleep $INITIAL_DELAY
+        else
+          sleep $RETRY_DELAY
+        fi
       done
 
 publishing-gate:


### PR DESCRIPTION
# What Does This Do

This PR adds an immediate try at the maven deployment check.

# Motivation

When the job is retried, we don’t want to wait for 5m before the first try.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
