### PR TITLE
Lazily allocate HashMap in PathMatchingHttpServletRequestWrapper

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/PathMatchingHttpServletRequestWrapper.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/PathMatchingHttpServletRequestWrapper.java
@@ -6,7 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
 class PathMatchingHttpServletRequestWrapper extends HttpServletRequestWrapper {
-  private final Map<String, Object> localAttributes = new HashMap<>();
+  private Map<String, Object> localAttributes;
 
   public PathMatchingHttpServletRequestWrapper(HttpServletRequest request) {
     super(request);
@@ -14,20 +14,27 @@ class PathMatchingHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
   @Override
   public Object getAttribute(String name) {
-    final Object ret = localAttributes.get(name);
-    if (ret == null) {
-      return super.getAttribute(name);
+    if (localAttributes != null) {
+      final Object ret = localAttributes.get(name);
+      if (ret != null) {
+        return ret;
+      }
     }
-    return ret;
+    return super.getAttribute(name);
   }
 
   @Override
   public void setAttribute(String name, Object o) {
+    if (localAttributes == null) {
+      localAttributes = new HashMap<>();
+    }
     localAttributes.put(name, o);
   }
 
   @Override
   public void removeAttribute(String name) {
-    localAttributes.remove(name);
+    if (localAttributes != null) {
+      localAttributes.remove(name);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/PathMatchingHttpServletRequestWrapper.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/PathMatchingHttpServletRequestWrapper.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class PathMatchingHttpServletRequestWrapper extends HttpServletRequestWrapper {
-  private final Map<String, Object> localAttributes = new HashMap<>();
+  private Map<String, Object> localAttributes;
 
   public PathMatchingHttpServletRequestWrapper(HttpServletRequest request) {
     super(request);
@@ -14,20 +14,27 @@ class PathMatchingHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
   @Override
   public Object getAttribute(String name) {
-    final Object ret = localAttributes.get(name);
-    if (ret == null) {
-      return super.getAttribute(name);
+    if (localAttributes != null) {
+      final Object ret = localAttributes.get(name);
+      if (ret != null) {
+        return ret;
+      }
     }
-    return ret;
+    return super.getAttribute(name);
   }
 
   @Override
   public void setAttribute(String name, Object o) {
+    if (localAttributes == null) {
+      localAttributes = new HashMap<>();
+    }
     localAttributes.put(name, o);
   }
 
   @Override
   public void removeAttribute(String name) {
-    localAttributes.remove(name);
+    if (localAttributes != null) {
+      localAttributes.remove(name);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Makes the `localAttributes` HashMap in `PathMatchingHttpServletRequestWrapper` lazily initialized — only allocated on first `setAttribute()` call
- For requests that don't match any handler mapping, Spring's `getHandler()` returns null without calling `setAttribute`, so the HashMap is never allocated
- Applied to both 3.1 and 6.0 wrapper implementations

**Motivation:** `HandlerMappingResourceNameFilter` creates a `PathMatchingHttpServletRequestWrapper` (with an internal `HashMap` + 16-entry `Node[]` array) on every request before checking if a matching handler exists. For non-matching requests, the allocation is wasted.

### Files changed
- `PathMatchingHttpServletRequestWrapper.java` (3.1) — lazy init
- `PathMatchingHttpServletRequestWrapper.java` (6.0) — lazy init

## Test plan
- [x] All spring-webmvc-3.1 tests pass (including forked)
- [x] All spring-webmvc-5.3 tests pass
- [x] All spring-webmvc-6.0 tests pass
- [ ] Run full CI suite

tag: no release note
tag: ai generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)