### PR TITLE
Run test jobs on non default jvms via commit message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -589,15 +589,19 @@ muzzle-dep-report:
     TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: "registry.ddbuild.io/images/mirror/"
     JETTY_AVAILABLE_PROCESSORS: 4 # Jetty incorrectly calculates processor count in containers
   rules:
-    - if: $testJvm =~ $DEFAULT_TEST_JVMS
-      when: on_success
-    - if: $NON_DEFAULT_JVMS == "true"
-      when: on_success
-    - if: $CI_COMMIT_BRANCH == "master"
+    # Protected branches (master/mq/gh-readonly): all JVMs run unconditionally
+    - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success
     - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: on_success
+    # Enable for default test JVMs or for NON_DEFAULT_JVMS
+    - if: '$NON_DEFAULT_JVMS == "true"'
+      when: on_success
+    - if: '$CI_COMMIT_MESSAGE =~ /\[ci: NON_DEFAULT_JVMS\]/'
+      when: on_success
+    - if: '$testJvm =~ $DEFAULT_TEST_JVMS'
       when: on_success
   script:
     - *gitlab_base_ref_params


### PR DESCRIPTION
# What Does This Do

Allow to request non default jvms to run in the pipeline by adding this line in the commit message:

```
[ci: NON_DEFAULT_JVMS]
```

# Motivation

Previously the only way to run a CI job on a non default JVM was to trigger it via the CI pipeline interface which is cumbersome.

# Additional information

I was also able to run a single jvm, but this proved a tad verbose in the rules (1 rule per test jvm) because Gitlab workflow rules is bit limited/constrained in that area. So I reverted those changes to keep something simple.
