### PR TITLE
🪞 10671 - Fix platform-dependent String.getBytes() calls to use explicit UTF-8 charset

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/buildid/ElfBuildIdExtractor.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/buildid/ElfBuildIdExtractor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.slf4j.Logger;
@@ -31,7 +32,7 @@ public class ElfBuildIdExtractor implements BuildIdExtractor {
 
   // Note header constants
   private static final int NT_GNU_BUILD_ID = 3;
-  private static final byte[] GNU_NOTE_NAME = "GNU\0".getBytes();
+  private static final byte[] GNU_NOTE_NAME = "GNU\0".getBytes(StandardCharsets.UTF_8);
 
   @Override
   public String extractBuildId(Path file) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.exception;
 import static com.datadog.debugger.util.ExceptionHelper.getInnerMostThrowable;
 
 import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ public class Fingerprinter {
       return null;
     }
     String typeName = clazz.getTypeName();
-    digest.update(typeName.getBytes());
+    digest.update(typeName.getBytes(StandardCharsets.UTF_8));
     StackTraceElement[] stackTrace = t.getStackTrace();
     if (stackTrace != null) {
       for (StackTraceElement stackTraceElement : stackTrace) {
@@ -38,7 +39,7 @@ public class Fingerprinter {
         if (classNameFiltering.isExcluded(className)) {
           continue;
         }
-        digest.update(stackTraceElement.toString().getBytes());
+        digest.update(stackTraceElement.toString().getBytes(StandardCharsets.UTF_8));
       }
     }
     return bytesToHex(digest.digest());
@@ -47,7 +48,7 @@ public class Fingerprinter {
   public static String fingerprint(StackTraceElement element) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      digest.update(element.toString().getBytes());
+      digest.update(element.toString().getBytes(StandardCharsets.UTF_8));
       return bytesToHex(digest.digest());
     } catch (NoSuchAlgorithmException e) {
       LOGGER.debug("Unable to find digest algorithm SHA-256", e);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.iast.telemetry.IastMetric;
 import datadog.trace.api.iast.telemetry.IastMetricCollector;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,7 @@ public class VulnerabilityEncoding {
   public static String toJson(final VulnerabilityBatch value) {
     try {
       String json = BATCH_ADAPTER.toJson(value);
-      return json.getBytes().length > MAX_SPAN_TAG_SIZE
+      return json.getBytes(StandardCharsets.UTF_8).length > MAX_SPAN_TAG_SIZE
           ? getExceededTagSizeJson(new TruncatedVulnerabilities(value.getVulnerabilities()))
           : json;
     } catch (Exception ex) {

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.environment.EnvironmentVariables;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.Closeable;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -319,7 +320,7 @@ public abstract class BootstrapInitializationTelemetry {
 
       // Run forwarder and mute tracing for subprocesses executed in by dd-java-agent.
       try (final Closeable ignored = muteTracing()) {
-        byte[] payload = telemetry.toString().getBytes();
+        byte[] payload = telemetry.toString().getBytes(StandardCharsets.UTF_8);
 
         Process process = builder.start();
         try (OutputStream out = process.getOutputStream()) {

--- a/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
+++ b/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 
 /** Special lightweight pre-main class that skips installation on incompatible JVMs. */
 public class AgentPreCheck {
@@ -189,7 +190,7 @@ public class AgentPreCheck {
         OutputStream out = null;
         try {
           out = process.getOutputStream();
-          out.write(payload.getBytes());
+          out.write(payload.getBytes(StandardCharsets.UTF_8));
         } finally {
           if (out != null) {
             out.close();

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2.java
@@ -189,7 +189,7 @@ public class CiTestCovMapperV2 implements RemoteMapper {
 
     // backend requires _some_ JSON to be present
     private static final RequestBody DUMMY_JSON_BODY =
-        jsonRequestBodyOf("{\"dummy\":true}".getBytes());
+        jsonRequestBodyOf("{\"dummy\":true}".getBytes(StandardCharsets.UTF_8));
 
     private final boolean compressionEnabled;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JsonStreamParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JsonStreamParser.java
@@ -5,6 +5,7 @@ import datadog.trace.util.json.PathCursor;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import okio.BufferedSource;
 import okio.Okio;
 
@@ -60,7 +61,7 @@ public class JsonStreamParser {
    */
   public static boolean tryToParse(String raw, Visitor visitor, PathCursor pathCursor) {
     if (raw.startsWith("{") && raw.endsWith("}") || raw.startsWith("[") && raw.endsWith("]")) {
-      try (InputStream is = new ByteArrayInputStream(raw.getBytes())) {
+      try (InputStream is = new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8))) {
         return tryToParse(is, visitor, pathCursor.copy());
       } catch (Exception e) {
         visitor.expandValueFailed(pathCursor, e);

--- a/gradle/forbiddenApiFilters/main.txt
+++ b/gradle/forbiddenApiFilters/main.txt
@@ -7,6 +7,9 @@ java.lang.String#split(java.lang.String,int)
 java.lang.String#replaceAll(java.lang.String,java.lang.String)
 java.lang.String#replaceFirst(java.lang.String,java.lang.String)
 
+# uses the platform's default charset, which may not be UTF-8
+java.lang.String#getBytes()
+
 # can initialize java.util.logging when ACCP is installed, prefer RandomUtils instead
 java.util.UUID#randomUUID()
 

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -36,6 +36,7 @@ import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -374,12 +375,13 @@ public class AppSecEventTracker extends EventTracker implements UserService, Eve
     }
     MessageDigest digest;
     try {
-      // TODO avoid lookup a new instance every time
+      // A new instance is needed each time for thread safety.
+      // Per micro-benchmarks, the overhead of getInstance() is negligible.
       digest = MessageDigest.getInstance("SHA-256");
     } catch (NoSuchAlgorithmException e) {
       return null;
     }
-    digest.update(userId.getBytes());
+    digest.update(userId.getBytes(StandardCharsets.UTF_8));
     byte[] hash = digest.digest();
     if (hash.length > HASH_SIZE_BYTES) {
       byte[] temp = new byte[HASH_SIZE_BYTES];

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/TransactionInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/TransactionInfo.java
@@ -2,6 +2,7 @@ package datadog.trace.api.datastreams;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,7 +39,7 @@ public final class TransactionInfo implements InboxItem {
     int id = ID_COUNTER.getAndIncrement();
 
     // update cache bytes
-    byte[] checkpointBytes = checkpoint.getBytes();
+    byte[] checkpointBytes = checkpoint.getBytes(StandardCharsets.UTF_8);
     byte[] bytesToAdd = new byte[checkpointBytes.length + 2];
     bytesToAdd[0] = (byte) id;
     bytesToAdd[1] = (byte) checkpointBytes.length;
@@ -56,7 +57,7 @@ public final class TransactionInfo implements InboxItem {
   }
 
   public byte[] getBytes() {
-    byte[] idBytes = id.getBytes();
+    byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
 
     // long ids will be truncated
     int idLen = Math.min(idBytes.length, MAX_ID_SIZE);

--- a/internal-api/src/main/java/datadog/trace/api/git/RawParseUtils.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/RawParseUtils.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -17,8 +18,8 @@ public final class RawParseUtils {
 
   private RawParseUtils() {}
 
-  public static final byte[] COMMITTER = "committer ".getBytes();
-  public static final byte[] AUTHOR = "author ".getBytes();
+  public static final byte[] COMMITTER = "committer ".getBytes(StandardCharsets.UTF_8);
+  public static final byte[] AUTHOR = "author ".getBytes(StandardCharsets.UTF_8);
 
   private static final byte[] digits10;
 

--- a/internal-api/src/main/java/datadog/trace/util/FNV64Hash.java
+++ b/internal-api/src/main/java/datadog/trace/util/FNV64Hash.java
@@ -1,5 +1,7 @@
 package datadog.trace.util;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Calculates the FNV 64 bit hash. Longs should be treated as though they were unsigned
  *
@@ -15,11 +17,11 @@ public class FNV64Hash {
   }
 
   public static long generateHash(String data, Version version) {
-    return generateHash(data.getBytes(), version);
+    return generateHash(data.getBytes(StandardCharsets.UTF_8), version);
   }
 
   public static long continueHash(long currentHash, String data, Version version) {
-    return continueHash(currentHash, data.getBytes(), version);
+    return continueHash(currentHash, data.getBytes(StandardCharsets.UTF_8), version);
   }
 
   public static long generateHash(byte[] data, Version version) {


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/10671
**Original Author:** @saravadeo
**Original Branch:** saravadeo/dd-trace-java:fix/explicit-charset-in-getbytes-calls

Closes #10671

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*