### PR TITLE
Cache SQL normalization results for ad-hoc JDBC statements

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -14,10 +14,12 @@ public final class DBQueryInfo {
   private static final ToIntFunction<DBQueryInfo> SQL_WEIGHER = DBQueryInfo::weight;
   private static final DDCache<String, DBQueryInfo> CACHED_PREPARED_STATEMENTS =
       DDCaches.newFixedSizeWeightedCache(512, SQL_WEIGHER, COMBINED_SQL_LIMIT);
+  private static final DDCache<String, DBQueryInfo> CACHED_STATEMENTS =
+      DDCaches.newFixedSizeWeightedCache(512, SQL_WEIGHER, COMBINED_SQL_LIMIT);
   private static final Function<String, DBQueryInfo> NORMALIZE = DBQueryInfo::new;
 
   public static DBQueryInfo ofStatement(String sql) {
-    return NORMALIZE.apply(sql);
+    return CACHED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);
   }
 
   public static DBQueryInfo ofPreparedStatement(String sql) {


### PR DESCRIPTION
## Summary
- Adds a `CACHED_STATEMENTS` weighted DDCache to `DBQueryInfo.ofStatement()`, matching the existing `CACHED_PREPARED_STATEMENTS` pattern
- Changes `ofStatement(sql)` from `NORMALIZE.apply(sql)` (no caching) to `CACHED_STATEMENTS.computeIfAbsent(sql, NORMALIZE)`
- Uses the same 512-slot / 2MB weighted limit as prepared statements

**Motivation:** `DBQueryInfo.ofStatement(String sql)` called `SQLNormalizer.normalize()` on every ad-hoc statement execution without any caching. Each call allocated `byte[]` (via `getBytes(UTF_8)`), `BitSet`, and `UTF8BytesString`. Repeated queries like `SELECT 1` health checks or ORM-generated SQL paid the full normalization cost every time. `ofPreparedStatement()` already had caching via `DDCache` — ad-hoc statements had none.

## Test plan
- [x] All JDBC tests pass (317/318, 1 pre-existing Docker infra failure)
- [x] DBQueryInfoTest passes
- [ ] Run full CI suite

tag: no release note
tag: ai generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)