### PR TITLE
Fix flaky test spring kafka template produce and batch consume

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -17,7 +17,6 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpan
 import datadog.trace.core.datastreams.StatsGroup
-import datadog.trace.test.util.Flaky
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -43,7 +42,6 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
-import spock.lang.RepeatUntilFailure
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
@@ -862,9 +860,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     producer.close()
   }
 
-  // TODO remove both annotations before ,erge
-  @Flaky("Repeatedly fails with a partition set to 1 but expects 0 https://github.com/DataDog/dd-trace-java/issues/3864")
-  @RepeatUntilFailure(maxAttempts = 100)
   def "test spring kafka template produce and batch consume"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -43,6 +43,7 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
+import spock.lang.RepeatUntilFailure
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
@@ -102,6 +103,32 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
           return 1
       }
     }
+  }
+
+  private static class SortBatchKafkaTraces implements Comparator<List<DDSpan>> {
+    @Override
+    int compare(List<DDSpan> o1, List<DDSpan> o2) {
+      return Long.compare(batchSortKey(o1), batchSortKey(o2))
+    }
+  }
+
+  private static long batchSortKey(List<DDSpan> trace) {
+    assert !trace.isEmpty()
+    if (trace.get(0).localRootSpan.operationName.toString() == "parent") {
+      return Long.MIN_VALUE
+    }
+    def deliverSpan = trace.find { it.operationName.toString() == "kafka.deliver" }
+    return deliverSpan ? deliverSpan.parentId : trace.get(0).parentId
+  }
+
+  private static List<DDSpan> producerSpans(List<List<DDSpan>> traces) {
+    def producerTrace = traces.find { trace ->
+      !trace.isEmpty() && trace.get(0).localRootSpan.operationName.toString() == "parent"
+    }
+    assert producerTrace != null
+    return producerTrace
+      .findAll { it.getTag(Tags.SPAN_KIND) == Tags.SPAN_KIND_PRODUCER }
+      .sort { it.spanId }
   }
 
 
@@ -835,7 +862,9 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     producer.close()
   }
 
+  // TODO remove both annotations before ,erge
   @Flaky("Repeatedly fails with a partition set to 1 but expects 0 https://github.com/DataDog/dd-trace-java/issues/3864")
+  @RepeatUntilFailure(maxAttempts = 100)
   def "test spring kafka template produce and batch consume"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())
@@ -857,14 +886,14 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     def container = new KafkaMessageListenerContainer<>(consumerFactory, containerProperties)
     def records = new LinkedBlockingQueue<ConsumerRecord<String, String>>()
     container.setupMessageListener(new BatchMessageListener<String, String>() {
-        @Override
-        void onMessage(List<ConsumerRecord<String, String>> consumerRecords) {
-          TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
-          consumerRecords.each {
-            records.add(it)
-          }
+      @Override
+      void onMessage(List<ConsumerRecord<String, String>> consumerRecords) {
+        TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
+        consumerRecords.each {
+          records.add(it)
         }
-      })
+      }
+    })
     container.start()
     ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic())
 
@@ -874,7 +903,8 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       for (g in greetings) {
         kafkaTemplate.send(SHARED_TOPIC, g).addCallback({
           runUnderTrace("producer callback") {}
-        }, { ex ->
+        }, {
+          ex ->
           runUnderTrace("producer exception: " + ex) {}
         })
       }
@@ -888,17 +918,31 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     then:
     def receivedSet = greetings.toSet()
-    greetings.eachWithIndex { g, i ->
+    def receivedRecords = []
+    greetings.eachWithIndex {
+      g, i ->
       def received = records.poll(5, TimeUnit.SECONDS)
       receivedSet.remove(received.value()) //maybe received out of order in case several partitions
       assert received.key() == null
 
       def headers = received.headers()
       assert headers.iterator().hasNext()
+      receivedRecords.add(received)
     }
     assert receivedSet.isEmpty()
 
-    assertTraces(4, SORT_TRACES_BY_ID) {
+    TEST_WRITER.waitForTraces(4)
+    def traces = Arrays.asList(TEST_WRITER.toArray()) as List<List<DDSpan>>
+    def produceSpans = producerSpans(traces)
+    def spanIdToRecord = receivedRecords.collectEntries {
+      record ->
+      def header = record.headers().headers("x-datadog-parent-id").iterator()
+      assert header.hasNext()
+      [(Long.parseLong(new String(header.next().value(), StandardCharsets.UTF_8))): record]
+    }
+
+    // Batch listener delivery order can vary; match each consumer trace to its producer via the propagated parent ID.
+    assertTraces(4, new SortBatchKafkaTraces()) {
       trace(7) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
@@ -910,46 +954,44 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       }
 
       if (hasQueueSpan()) {
-        trace(2) {
-          consumerSpan(it, consumerProperties, trace(1)[1], 0..0)
-          queueSpan(it, trace(0)[6])
-        }
-        trace(2) {
-          consumerSpan(it, consumerProperties, trace(2)[1], 0..1)
-          queueSpan(it, trace(0)[4])
-        }
-        trace(2) {
-          consumerSpan(it, consumerProperties, trace(3)[1], 0..1)
-          queueSpan(it, trace(0)[2])
+        [0, 1, 2].each {
+          i ->
+          def expectedOffset = spanIdToRecord[produceSpans[i].spanId].offset()
+          trace(2) {
+            consumerSpan(it, consumerProperties, span(1), expectedOffset..expectedOffset)
+            queueSpan(it, produceSpans[i])
+          }
         }
       } else {
-        trace(1) {
-          consumerSpan(it, consumerProperties, trace(0)[6], 0..0)
-        }
-        trace(1) {
-          consumerSpan(it, consumerProperties, trace(0)[4], 0..1)
-        }
-        trace(1) {
-          consumerSpan(it, consumerProperties, trace(0)[2], 0..1)
+        [0, 1, 2].each {
+          i ->
+          def expectedOffset = spanIdToRecord[produceSpans[i].spanId].offset()
+          trace(1) {
+            consumerSpan(it, consumerProperties, produceSpans[i], expectedOffset..expectedOffset)
+          }
         }
       }
     }
 
     if (isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find {
+        it.parentHash == 0
+      }
       verifyAll(first) {
         tags.hasAllTags("direction:out", "kafka_cluster_id:$clusterId", "topic:$SHARED_TOPIC".toString(), "type:kafka")
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find {
+        it.parentHash == first.hash
+      }
       verifyAll(second) {
         tags.hasAllTags(
-          "direction:in",
-          "group:sender",
-          "kafka_cluster_id:$clusterId",
-          "topic:$SHARED_TOPIC".toString(),
-          "type:kafka"
-          )
+        "direction:in",
+        "group:sender",
+        "kafka_cluster_id:$clusterId",
+        "topic:$SHARED_TOPIC".toString(),
+        "type:kafka"
+        )
       }
     }
 
@@ -981,16 +1023,16 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     // setup a Kafka message listener
     container.setupMessageListener(new MessageListener<String, String>() {
-        @Override
-        void onMessage(ConsumerRecord<String, String> record) {
-          TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
-          records.add(record)
-          if (isDataStreamsEnabled()) {
-            // even if header propagation is disabled, we want data streams to work.
-            TEST_DATA_STREAMS_WRITER.waitForGroups(2)
-          }
+      @Override
+      void onMessage(ConsumerRecord<String, String> record) {
+        TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
+        records.add(record)
+        if (isDataStreamsEnabled()) {
+          // even if header propagation is disabled, we want data streams to work.
+          TEST_DATA_STREAMS_WRITER.waitForGroups(2)
         }
-      })
+      }
+    })
 
     // start the container and underlying message listener
     container.start()
@@ -1028,9 +1070,9 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     def existingSpanId = 9876543210987654L
     def headers = new RecordHeaders()
     headers.add(new RecordHeader("x-datadog-trace-id",
-      String.valueOf(existingTraceId).getBytes(StandardCharsets.UTF_8)))
+    String.valueOf(existingTraceId).getBytes(StandardCharsets.UTF_8)))
     headers.add(new RecordHeader("x-datadog-parent-id",
-      String.valueOf(existingSpanId).getBytes(StandardCharsets.UTF_8)))
+    String.valueOf(existingSpanId).getBytes(StandardCharsets.UTF_8)))
 
     when:
     def record = new ProducerRecord(SHARED_TOPIC, 0, null, "test-context-extraction", headers)
@@ -1063,16 +1105,16 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     def oldExtractorsByType = extractorsByTypeField.get(TEST_DATA_STREAMS_MONITORING)
 
     def extractor = new DataStreamsTransactionExtractor() {
-        String getName() {
-          return "kafka-produce-test"
-        }
-        DataStreamsTransactionExtractor.Type getType() {
-          return DataStreamsTransactionExtractor.Type.KAFKA_PRODUCE_HEADERS
-        }
-        String getValue() {
-          return "x-transaction-id"
-        }
+      String getName() {
+        return "kafka-produce-test"
       }
+      DataStreamsTransactionExtractor.Type getType() {
+        return DataStreamsTransactionExtractor.Type.KAFKA_PRODUCE_HEADERS
+      }
+      String getValue() {
+        return "x-transaction-id"
+      }
+    }
     def extractorsByType = new EnumMap<>(DataStreamsTransactionExtractor.Type)
     extractorsByType.put(DataStreamsTransactionExtractor.Type.KAFKA_PRODUCE_HEADERS, [extractor])
     extractorsByTypeField.set(TEST_DATA_STREAMS_MONITORING, extractorsByType)


### PR DESCRIPTION
# What Does This Do

Fix `test spring kafka template produce and batch consume`

Sort both sides by the same key - producer span ID, so the correspondence is derived from the data rather than assumed by arrival order. Extract the three produce spans and sort them by spanId. Sort the consumer trace groups by the parentId of their kafka.deliver span, which equals the produce span ID of the message they consumed. By construction `produceSpans[i].spanId == sortedConsumerTraces[i].queueSpan.parentId`, making the assertion stable regardless of partition assignment or async callback interleaving. Offsets are then verified per-span by reading them from the actual `ConsumerRecord` linked via the `x-datadog-parent-id` header, preserving exact coverage without hardcoding.

# Motivation

The test hardcodes a fixed mapping between consumer trace group positions (`trace[1]` → first in sort order) and producer span positions (`trace(0)[6]` → 3rd produce span). These two orderings are independent. Most of the time they happen to align, but ~1% of the time they diverge, causing the childOf assertion to find the wrong parent span.

# Additional Notes

`test spring kafka template produce and batch consume` sends 3 messages to a 2-partition topic and asserts the three kafka.deliver queue spans are children of specific kafka.produce spans using hardcoded indices into the sorted trace (trace(0)[2], [4], [6]). Because partition assignment is non-deterministic, the consumer trace groups arrive in the ListWriter in a different order run-to-run, so the hardcoded index-to-parent mapping is wrong whenever the partition distribution changes.

Both the passing run and the failing run emitted exactly the same span structure: one 7-span producer trace and three 2-span consumer/queue traces. What differed was the pairing order.

Passing run — consumer queue spans arrived in parent order 1396, 1395, 1397, which happened to match the test's assumed order:

```
  s_id=1399 → p_id=1396   offset=0 partition=1
  s_id=1405 → p_id=1395   offset=0 partition=0
  s_id=1409 → p_id=1397   offset=1 partition=0
```

Failing run — partition 1 received two messages (offsets 0 and 1), partition 0 received one (offset 0), so the consumer queue spans arrived in parent order 1417, 1419, 1418 instead:

```
  s_id=1423 → p_id=1417   offset=0 partition=1
  s_id=1427 → p_id=1419   offset=1 partition=1   ← test expected p_id=1418 here
  s_id=1429 → p_id=1418   offset=0 partition=0
```
  
The assertion `span.parentId(1419) == parent.spanId(1418)` failed.

Log fragment:

```text
15:33:24.676 [Test worker] Started span: DDSpan [ t_id=1416, s_id=1417, p_id=1415 ] trace=.../kafka.produce/...
15:33:24.679 [Test worker] Started span: DDSpan [ t_id=1416, s_id=1418, p_id=1415 ] trace=.../kafka.produce/...
15:33:24.680 [Test worker] Started span: DDSpan [ t_id=1416, s_id=1419, p_id=1415 ] trace=.../kafka.produce/...

15:33:24.682 [-C-1] Started span: DDSpan [ t_id=1416, s_id=1423, p_id=1417 ] trace=.../kafka.deliver/...
15:33:24.684 [-C-1] Started span: DDSpan [ t_id=1416, s_id=1427, p_id=1419 ] trace=.../kafka.deliver/...
15:33:24.684 [-C-1] Started span: DDSpan [ t_id=1416, s_id=1429, p_id=1418 ] trace=.../kafka.deliver/...

assert span.parentId == parent.spanId
       |    1419     |        1418
       DDSpan [ t_id=1416, s_id=1427, p_id=1419 ]  // queue span
       DDSpan [ t_id=1416, s_id=1418, p_id=1415 ]  // expected produce span
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [IDMPL-375]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

[IDMPL-375]: https://datadoghq.atlassian.net/browse/IDMPL-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ