### PR TITLE
Add server.request.body.filenames AppSec address for Akka HTTP

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -75,6 +75,11 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
   }
 
   @Override
+  boolean testBodyFilenames() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }
@@ -224,6 +229,11 @@ abstract class AkkaHttpServerInstrumentationSyncTest extends AkkaHttpServerInstr
   }
 
   @Override
+  boolean testBodyFilenames() {
+    false
+  }
+
+  @Override
   boolean testBodyJson() {
     false
   }
@@ -284,6 +294,11 @@ class AkkaHttpServerInstrumentationBindAndHandleTest extends AkkaHttpServerInstr
   }
 
   @Override
+  boolean testBodyFilenames() {
+    akkaHttpVersion != '10.0.10'
+  }
+
+  @Override
   boolean testBodyUrlencoded() {
     akkaHttpVersion != '10.0.10'
   }
@@ -306,6 +321,11 @@ class AkkaHttpServerInstrumentationBindAndHandleAsyncWithRouteAsyncHandlerTest e
 
   @Override
   boolean testBodyMultipart() {
+    akkaHttpVersion != '10.0.10'
+  }
+
+  @Override
+  boolean testBodyFilenames() {
     akkaHttpVersion != '10.0.10'
   }
 

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/latestDepTest/groovy/AkkaHttp102ServerInstrumentationTests.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/latestDepTest/groovy/AkkaHttp102ServerInstrumentationTests.groovy
@@ -37,6 +37,11 @@ class AkkaHttp102ServerInstrumentationBindSyncTest extends AkkaHttpServerInstrum
   }
 
   @Override
+  boolean testBodyFilenames() {
+    false
+  }
+
+  @Override
   boolean testBodyJson() {
     false
   }

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/UnmarshallerHelpers.java
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/UnmarshallerHelpers.java
@@ -125,18 +125,10 @@ public class UnmarshallerHelpers {
     Flow<Void> flow = callback.apply(reqCtx, conv);
     Flow.Action action = flow.getAction();
     if (action instanceof Flow.Action.RequestBlockingAction) {
-      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
-      BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
-      if (blockResponseFunction != null) {
-        boolean success =
-            blockResponseFunction.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
-        if (success) {
-          if (blockResponseFunction instanceof AkkaBlockResponseFunction) {
-            AkkaBlockResponseFunction abrf = (AkkaBlockResponseFunction) blockResponseFunction;
-            abrf.setUnmarshallBlock(true);
-          }
-          throw new BlockingException("Blocked request (for " + details + ")");
-        }
+      BlockingException e =
+          tryBlock(reqCtx, (Flow.Action.RequestBlockingAction) action, "for " + details);
+      if (e != null) {
+        throw e;
       }
     }
   }
@@ -211,10 +203,10 @@ public class UnmarshallerHelpers {
     java.lang.Iterable<akka.http.javadsl.model.Multipart.FormData.BodyPart.Strict> strictParts =
         st.getStrictParts();
     Map<String, List<String>> conv = new HashMap<>();
-    List<String> filenames = new ArrayList<>();
+    List<String> filenames = filenamesCallback != null ? new ArrayList<>() : null;
     for (akka.http.javadsl.model.Multipart.FormData.BodyPart.Strict part : strictParts) {
       Optional<String> filenameOpt = part.getFilename();
-      if (filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
+      if (filenames != null && filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
         filenames.add(filenameOpt.get());
       }
 
@@ -244,26 +236,32 @@ public class UnmarshallerHelpers {
       curStrings.add(s);
     }
 
+    BlockingException pendingBlock = null;
     if (bodyCallback != null) {
-      executeCallback(reqCtx, bodyCallback, conv, "multipartFormDataUnmarshaller");
+      Flow<Void> flow = bodyCallback.apply(reqCtx, conv);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        pendingBlock =
+            tryBlock(
+                reqCtx,
+                (Flow.Action.RequestBlockingAction) action,
+                "multipartFormDataUnmarshaller");
+      }
     }
 
-    if (filenamesCallback != null && !filenames.isEmpty()) {
-      Flow<Void> filenamesFlow = filenamesCallback.apply(reqCtx, filenames);
-      Flow.Action filenamesAction = filenamesFlow.getAction();
-      if (filenamesAction instanceof Flow.Action.RequestBlockingAction) {
-        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) filenamesAction;
-        BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
-        if (brf != null) {
-          boolean success = brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
-          if (success) {
-            if (brf instanceof AkkaBlockResponseFunction) {
-              ((AkkaBlockResponseFunction) brf).setUnmarshallBlock(true);
-            }
-            throw new BlockingException("Blocked request (multipart file upload)");
-          }
+    if (filenamesCallback != null && filenames != null && !filenames.isEmpty()) {
+      Flow<Void> flow = filenamesCallback.apply(reqCtx, filenames);
+      if (pendingBlock == null) {
+        Flow.Action action = flow.getAction();
+        if (action instanceof Flow.Action.RequestBlockingAction) {
+          pendingBlock =
+              tryBlock(reqCtx, (Flow.Action.RequestBlockingAction) action, "multipart file upload");
         }
       }
+    }
+
+    if (pendingBlock != null) {
+      throw pendingBlock;
     }
   }
 
@@ -418,9 +416,13 @@ public class UnmarshallerHelpers {
   }
 
   private static void handleStrictFormData(StrictForm sf) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
+        cbp.getCallback(EVENTS.requestFilesFilenames());
+
     Iterator<Tuple2<String, StrictForm.Field>> iterator = sf.fields().iterator();
     Map<String, List<String>> conv = new HashMap<>();
-    List<String> filenames = new ArrayList<>();
+    List<String> filenames = filenamesCb != null ? new ArrayList<>() : null;
     while (iterator.hasNext()) {
       Tuple2<String, StrictForm.Field> next = iterator.next();
       String fieldName = next._1();
@@ -447,9 +449,11 @@ public class UnmarshallerHelpers {
           instanceof akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict) {
         akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict bodyPart =
             (akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict) strictFieldValue;
-        Optional<String> filenameOpt = bodyPart.getFilename();
-        if (filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
-          filenames.add(filenameOpt.get());
+        if (filenames != null) {
+          Optional<String> filenameOpt = bodyPart.getFilename();
+          if (filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
+            filenames.add(filenameOpt.get());
+          }
         }
         HttpEntity.Strict sentity = bodyPart.entity();
         String s =
@@ -461,36 +465,33 @@ public class UnmarshallerHelpers {
       }
     }
 
-    handleArbitraryPostData(conv, "HttpEntity -> StrictForm unmarshaller");
+    BlockingException pendingBlock = null;
+    try {
+      handleArbitraryPostData(conv, "HttpEntity -> StrictForm unmarshaller");
+    } catch (BlockingException e) {
+      pendingBlock = e;
+    }
 
-    if (!filenames.isEmpty()) {
+    if (filenamesCb != null && filenames != null && !filenames.isEmpty()) {
       AgentSpan span = activeSpan();
       RequestContext reqCtx;
       if (span != null
           && (reqCtx = span.getRequestContext()) != null
           && reqCtx.getData(RequestContextSlot.APPSEC) != null) {
-        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-        BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
-            cbp.getCallback(EVENTS.requestFilesFilenames());
-        if (filenamesCb != null) {
-          Flow<Void> filenamesFlow = filenamesCb.apply(reqCtx, filenames);
-          Flow.Action filenamesAction = filenamesFlow.getAction();
-          if (filenamesAction instanceof Flow.Action.RequestBlockingAction) {
-            Flow.Action.RequestBlockingAction rba =
-                (Flow.Action.RequestBlockingAction) filenamesAction;
-            BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
-            if (brf != null) {
-              boolean success = brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
-              if (success) {
-                if (brf instanceof AkkaBlockResponseFunction) {
-                  ((AkkaBlockResponseFunction) brf).setUnmarshallBlock(true);
-                }
-                throw new BlockingException("Blocked request (multipart file upload)");
-              }
-            }
+        Flow<Void> flow = filenamesCb.apply(reqCtx, filenames);
+        if (pendingBlock == null) {
+          Flow.Action action = flow.getAction();
+          if (action instanceof Flow.Action.RequestBlockingAction) {
+            pendingBlock =
+                tryBlock(
+                    reqCtx, (Flow.Action.RequestBlockingAction) action, "multipart file upload");
           }
         }
       }
+    }
+
+    if (pendingBlock != null) {
+      throw pendingBlock;
     }
   }
 
@@ -537,6 +538,22 @@ public class UnmarshallerHelpers {
 
     // callback execution
     executeCallback(reqCtx, callback, o, source);
+  }
+
+  private static BlockingException tryBlock(
+      RequestContext reqCtx, Flow.Action.RequestBlockingAction rba, String details) {
+    BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+    if (brf == null) {
+      return null;
+    }
+    boolean success = brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
+    if (!success) {
+      return null;
+    }
+    if (brf instanceof AkkaBlockResponseFunction) {
+      ((AkkaBlockResponseFunction) brf).setUnmarshallBlock(true);
+    }
+    return new BlockingException("Blocked request (" + details + ")");
   }
 
   private static void handleException(Exception e, String logMessage) {

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/UnmarshallerHelpers.java
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/UnmarshallerHelpers.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.function.BiFunction;
 import org.slf4j.Logger;
@@ -199,17 +200,28 @@ public class UnmarshallerHelpers {
     }
 
     CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-    BiFunction<RequestContext, Object, Flow<Void>> callback =
+    BiFunction<RequestContext, Object, Flow<Void>> bodyCallback =
         cbp.getCallback(EVENTS.requestBodyProcessed());
-    if (callback == null) {
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCallback =
+        cbp.getCallback(EVENTS.requestFilesFilenames());
+    if (bodyCallback == null && filenamesCallback == null) {
       return;
     }
 
-    // conversion to map string -> list of string
     java.lang.Iterable<akka.http.javadsl.model.Multipart.FormData.BodyPart.Strict> strictParts =
         st.getStrictParts();
     Map<String, List<String>> conv = new HashMap<>();
+    List<String> filenames = new ArrayList<>();
     for (akka.http.javadsl.model.Multipart.FormData.BodyPart.Strict part : strictParts) {
+      Optional<String> filenameOpt = part.getFilename();
+      if (filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
+        filenames.add(filenameOpt.get());
+      }
+
+      if (bodyCallback == null) {
+        continue;
+      }
+
       akka.http.javadsl.model.HttpEntity.Strict entity = part.getEntity();
       if (!(entity instanceof HttpEntity.Strict)) {
         continue;
@@ -232,8 +244,27 @@ public class UnmarshallerHelpers {
       curStrings.add(s);
     }
 
-    // callback execution
-    executeCallback(reqCtx, callback, conv, "multipartFormDataUnmarshaller");
+    if (bodyCallback != null) {
+      executeCallback(reqCtx, bodyCallback, conv, "multipartFormDataUnmarshaller");
+    }
+
+    if (filenamesCallback != null && !filenames.isEmpty()) {
+      Flow<Void> filenamesFlow = filenamesCallback.apply(reqCtx, filenames);
+      Flow.Action filenamesAction = filenamesFlow.getAction();
+      if (filenamesAction instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) filenamesAction;
+        BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+        if (brf != null) {
+          boolean success = brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
+          if (success) {
+            if (brf instanceof AkkaBlockResponseFunction) {
+              ((AkkaBlockResponseFunction) brf).setUnmarshallBlock(true);
+            }
+            throw new BlockingException("Blocked request (multipart file upload)");
+          }
+        }
+      }
+    }
   }
 
   public static Unmarshaller<HttpEntity, String> transformStringUnmarshaller(
@@ -389,6 +420,7 @@ public class UnmarshallerHelpers {
   private static void handleStrictFormData(StrictForm sf) {
     Iterator<Tuple2<String, StrictForm.Field>> iterator = sf.fields().iterator();
     Map<String, List<String>> conv = new HashMap<>();
+    List<String> filenames = new ArrayList<>();
     while (iterator.hasNext()) {
       Tuple2<String, StrictForm.Field> next = iterator.next();
       String fieldName = next._1();
@@ -413,9 +445,13 @@ public class UnmarshallerHelpers {
         strings.add((String) strictFieldValue);
       } else if (strictFieldValue
           instanceof akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict) {
-        HttpEntity.Strict sentity =
-            ((akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict) strictFieldValue)
-                .entity();
+        akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict bodyPart =
+            (akka.http.scaladsl.model.Multipart$FormData$BodyPart$Strict) strictFieldValue;
+        Optional<String> filenameOpt = bodyPart.getFilename();
+        if (filenameOpt.isPresent() && !filenameOpt.get().isEmpty()) {
+          filenames.add(filenameOpt.get());
+        }
+        HttpEntity.Strict sentity = bodyPart.entity();
         String s =
             sentity
                 .getData()
@@ -426,6 +462,36 @@ public class UnmarshallerHelpers {
     }
 
     handleArbitraryPostData(conv, "HttpEntity -> StrictForm unmarshaller");
+
+    if (!filenames.isEmpty()) {
+      AgentSpan span = activeSpan();
+      RequestContext reqCtx;
+      if (span != null
+          && (reqCtx = span.getRequestContext()) != null
+          && reqCtx.getData(RequestContextSlot.APPSEC) != null) {
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
+            cbp.getCallback(EVENTS.requestFilesFilenames());
+        if (filenamesCb != null) {
+          Flow<Void> filenamesFlow = filenamesCb.apply(reqCtx, filenames);
+          Flow.Action filenamesAction = filenamesFlow.getAction();
+          if (filenamesAction instanceof Flow.Action.RequestBlockingAction) {
+            Flow.Action.RequestBlockingAction rba =
+                (Flow.Action.RequestBlockingAction) filenamesAction;
+            BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+            if (brf != null) {
+              boolean success = brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba);
+              if (success) {
+                if (brf instanceof AkkaBlockResponseFunction) {
+                  ((AkkaBlockResponseFunction) brf).setUnmarshallBlock(true);
+                }
+                throw new BlockingException("Blocked request (multipart file upload)");
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   private static Object tryConvertingScalaContainers(Object obj, int depth) {

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/test/groovy/AkkaHttp102ServerInstrumentationTests.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/test/groovy/AkkaHttp102ServerInstrumentationTests.groovy
@@ -37,6 +37,11 @@ class AkkaHttp102ServerInstrumentationBindSyncTest extends AkkaHttpServerInstrum
   }
 
   @Override
+  boolean testBodyFilenames() {
+    false
+  }
+
+  @Override
   boolean testBodyJson() {
     false
   }

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -76,6 +76,11 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
   }
 
   @Override
+  boolean testBodyFilenames() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }
@@ -224,6 +229,11 @@ abstract class AkkaHttpServerInstrumentationSyncTest extends AkkaHttpServerInstr
   }
 
   @Override
+  boolean testBodyFilenames() {
+    false
+  }
+
+  @Override
   boolean testBodyJson() {
     false
   }
@@ -280,6 +290,11 @@ class AkkaHttpServerInstrumentationBindAndHandleTest extends AkkaHttpServerInstr
   }
 
   @Override
+  boolean testBodyFilenames() {
+    true
+  }
+
+  @Override
   boolean testBodyUrlencoded() {
     true
   }
@@ -302,6 +317,11 @@ class AkkaHttpServerInstrumentationBindAndHandleAsyncWithRouteAsyncHandlerTest e
 
   @Override
   boolean testBodyMultipart() {
+    true
+  }
+
+  @Override
+  boolean testBodyFilenames() {
     true
   }
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/test/boot/SpringBootBasedTest.groovy
@@ -110,6 +110,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
+  boolean testBodyFilenames() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -120,6 +120,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
+  boolean testBodyFilenames() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }


### PR DESCRIPTION
# What Does This Do

## Akka HTTP 10.0 / 10.6 — `UnmarshallerHelpers`

- **`handleMultipartStrictFormData()`**: extracts filenames from `Multipart.FormData.BodyPart.Strict` via `getFilename()` and fires the `requestFilesFilenames` IG callback. Both `requestBodyProcessed` and `requestFilesFilenames` are fetched upfront; the early return only triggers when both are null. Uses the `pendingBlock` pattern: body and filenames callbacks always fire regardless of which triggers blocking — the first blocking action wins, the exception is deferred until after both callbacks have run.
- **`handleStrictFormData()`**: same filename extraction for the `formFieldMultiMap` path (which goes through `StrictFormCompanionInstrumentation` and was not previously reaching `handleMultipartStrictFormData`). Wraps `handleArbitraryPostData()` in try/catch to capture a potential `BlockingException`, then fires the filenames callback unconditionally before re-throwing.
- **`tryBlock()` helper** (private, module-local): encapsulates `tryCommitBlockingResponse()` + `AkkaBlockResponseFunction.setUnmarshallBlock(true)` + `BlockingException` construction. Returns the exception rather than throwing, enabling callers to defer the throw. Shared only within this module — not across server integrations.
- **Conditional `filenames` list**: `new ArrayList<>()` is only allocated when `filenamesCallback != null`, avoiding unnecessary allocation when no WAF rules target the address.
- **`executeCallback()` refactored** to delegate the blocking logic to `tryBlock()`.

## Spring Boot

- `testBodyFilenames()` enabled in `SpringBootBasedTest` (Spring Boot defaults to Tomcat, whose `ParsePartsInstrumentation` already fires `requestFilesFilenames`).

# Motivation

Implements the `server.request.body.filenames` WAF address for Akka HTTP.

Jira ticket: [APPSEC-61873](https://datadoghq.atlassian.net/browse/APPSEC-61873)

# Additional Notes

`requestBodyProcessed` and `requestFilesFilenames` are registered as independent callbacks in `GatewayBridge.DATA_DEPENDENCIES` — a deployment with filename-only WAF rules will have `requestBodyProcessed == null` but `requestFilesFilenames != null`. Returning early when only one is null would silently skip filename detection in that case.

The `pendingBlock` pattern (fire both, defer throw) follows the canonical precedent established in PR #10973 (Tomcat `ParsePartsInstrumentation`). The blocking helper `tryBlock()` cannot be shared across server modules because each server has its own `BlockResponseFunction` subclass and server-specific state flags (e.g. `setUnmarshallBlock` is Akka-specific).

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

[APPSEC-61873]: https://datadoghq.atlassian.net/browse/APPSEC-61873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ