### PR TITLE
Add RASP instrumentation for Files.copy(Path,Path) and Files.copy(Path,OutputStream)

### DIFF
--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FilesCallSite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/main/java/datadog/trace/instrumentation/java/lang/FilesCallSite.java
@@ -44,10 +44,30 @@ public class FilesCallSite {
   }
 
   @CallSite.Before(
+      "java.nio.file.Path java.nio.file.Files.copy(java.nio.file.Path, java.nio.file.Path, java.nio.file.CopyOption[])")
+  public static void beforeCopyPathToPath(
+      @CallSite.Argument(0) @Nullable final Path source,
+      @CallSite.Argument(1) @Nullable final Path target) {
+    if (source != null) {
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(source.toString());
+    }
+    if (target != null) {
+      FileIORaspHelper.INSTANCE.beforeFileWritten(target.toString());
+    }
+  }
+
+  @CallSite.Before(
       "java.nio.file.Path java.nio.file.Files.move(java.nio.file.Path, java.nio.file.Path, java.nio.file.CopyOption[])")
   public static void beforeMove(@CallSite.Argument(1) @Nullable final Path target) {
     if (target != null) {
       FileIORaspHelper.INSTANCE.beforeFileWritten(target.toString());
+    }
+  }
+
+  @CallSite.Before("long java.nio.file.Files.copy(java.nio.file.Path, java.io.OutputStream)")
+  public static void beforeCopyToStream(@CallSite.Argument(0) @Nullable final Path source) {
+    if (source != null) {
+      FileIORaspHelper.INSTANCE.beforeFileLoaded(source.toString());
     }
   }
 

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/groovy/datadog/trace/instrumentation/java/io/FilesCallSiteTest.groovy
@@ -102,6 +102,35 @@ class FilesCallSiteTest extends BaseIoRaspCallSiteTest {
     1 * helper.beforeFileWritten(path.toString())
   }
 
+  void 'test RASP Files.copy path to path fires beforeFileLoaded on source and beforeFileWritten on target'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final source = newFile('test_rasp_copy_src.txt').toPath()
+    final target = temporaryFolder.resolve('test_rasp_copy_path_dst.txt')
+
+    when:
+    TestFilesSuite.copyPathToPath(source, target)
+
+    then:
+    1 * helper.beforeFileLoaded(source.toString())
+    1 * helper.beforeFileWritten(target.toString())
+  }
+
+  void 'test RASP Files.copy path to OutputStream fires beforeFileLoaded on source'() {
+    setup:
+    final helper = Mock(FileIORaspHelper)
+    FileIORaspHelper.INSTANCE = helper
+    final source = newFile('test_rasp_copy_stream_src.txt').toPath()
+
+    when:
+    TestFilesSuite.copyToStream(source, new ByteArrayOutputStream())
+
+    then:
+    1 * helper.beforeFileLoaded(source.toString())
+    0 * helper.beforeFileWritten(_)
+  }
+
   void 'test RASP Files.move'() {
     setup:
     final helper = Mock(FileIORaspHelper)

--- a/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFilesSuite.java
+++ b/dd-java-agent/instrumentation/java/java-io-1.8/src/test/java/foo/bar/TestFilesSuite.java
@@ -57,6 +57,15 @@ public class TestFilesSuite {
     return Files.newBufferedWriter(path, options);
   }
 
+  public static Path copyPathToPath(
+      final Path source, final Path target, final CopyOption... options) throws IOException {
+    return Files.copy(source, target, options);
+  }
+
+  public static long copyToStream(final Path source, final OutputStream out) throws IOException {
+    return Files.copy(source, out);
+  }
+
   public static Path move(final Path source, final Path target, final CopyOption... options)
       throws IOException {
     return Files.move(source, target);


### PR DESCRIPTION
# What Does This Do

- Instruments `Files.copy(Path source, Path target, CopyOption[])` in `FilesCallSite`: fires `beforeFileLoaded(source)` for LFI detection and `beforeFileWritten(target)` for write detection
- Instruments `Files.copy(Path source, OutputStream out)` in `FilesCallSite`: fires `beforeFileLoaded(source)` for LFI detection
- Adds `copyPathToPath` and `copyToStream` helpers in `TestFilesSuite` and corresponding Spock tests in `FilesCallSiteTest`

# Motivation

`FilesCallSite` was introduced in #11113 but omitted the `Files.copy(Path, Path, CopyOption[])` and `Files.copy(Path, OutputStream)` overloads. Both are common file-management APIs: the source path is an LFI attack vector and the target path (in the path-to-path variant) is a path-traversal write vector. This PR closes that gap.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APPSEC-61874](https://datadoghq.atlassian.net/browse/APPSEC-61874)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

[APPSEC-61874]: https://datadoghq.atlassian.net/browse/APPSEC-61874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ