### PR TITLE
Added missing `CI_COMMIT_DESCRIPTION` to the list of noisy env vars.

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -16,7 +16,7 @@ abstract class ProcessManager extends Specification {
   public static final String SERVICE_NAME = "smoke-test-java-app"
   public static final String ENV = "smoketest"
   public static final String VERSION = "99"
-  public static final Set<String> NOISY_ENVIRONMENT_VARIABLES = ImmutableSet.of('CI_COMMIT_MESSAGE')
+  public static final Set<String> NOISY_ENVIRONMENT_VARIABLES = ImmutableSet.of('CI_COMMIT_MESSAGE', 'CI_COMMIT_DESCRIPTION')
 
   @Shared
   protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")


### PR DESCRIPTION
# What Does This Do
Added missing `CI_COMMIT_DESCRIPTION` to the list of noisy env vars.

# Motivation
Green CI.

# Additional Notes
In #11115 I added `CI_COMMIT_MESSAGE` but overlooked `CI_COMMIT_DESCRIPTION`.
