### PR TITLE
Remove deprecated startSpan and use integration name for telemetry

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -166,7 +166,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
    * @return A new context bundling the span, child of the given parent context.
    */
   public Context startSpan(REQUEST_CARRIER carrier, Context parentContext) {
-    String instrumentationName = primaryInstrumentationName();
+    String instrumentationName = component().toString();
     AgentSpanContext extracted = getExtractedSpanContext(parentContext);
     // Call IG callbacks
     extracted = callIGCallbackStart(extracted);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -16,7 +16,7 @@ public class HttpUrlState {
   private volatile boolean finished = false;
 
   public AgentSpan start(final HttpURLConnection connection) {
-    span = startSpan(DECORATE.operationName());
+    span = startSpan("httpurlconnection", DECORATE.operationName());
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, connection);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.httpurlconnection;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator.DECORATE;
+import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator.HTTP_URL_CONNECTION;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -16,7 +17,7 @@ public class HttpUrlState {
   private volatile boolean finished = false;
 
   public AgentSpan start(final HttpURLConnection connection) {
-    span = startSpan("httpurlconnection", DECORATE.operationName());
+    span = startSpan(HTTP_URL_CONNECTION.toString(), DECORATE.operationName());
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, connection);

--- a/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/AbstractBenchmark.java
+++ b/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/AbstractBenchmark.java
@@ -63,7 +63,7 @@ public abstract class AbstractBenchmark<C extends AbstractBenchmark.BenchmarkCon
     if (Config.get().getIastActivation() == ProductActivation.FULLY_ENABLED) {
       tagContext.withRequestContextDataIast(context.getIastContext());
     }
-    span = AgentTracer.startSpan("benchmark", tagContext);
+    span = AgentTracer.startSpan("iast", "benchmark", tagContext);
     scope = AgentTracer.activateSpan(span);
   }
 

--- a/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -65,7 +65,7 @@ public final class AgentCLI {
 
     int numTraces = 0;
     while (++numTraces <= count || count < 0) {
-      AgentSpan span = AgentTracer.startSpan("sample");
+      AgentSpan span = AgentTracer.startSpan("datadog", "sample");
       try {
         Thread.sleep(Math.max((long) (1000.0 * interval), 1L));
       } catch (InterruptedException ignore) {

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -33,6 +33,7 @@ import datadog.metrics.impl.MonitoringImpl
 import datadog.metrics.api.statsd.StatsDClient
 import datadog.instrument.classinject.ClassInjector
 import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.asserts.TagsAssert
 import datadog.trace.agent.test.datastreams.MockFeaturesDiscovery
 import datadog.trace.agent.test.datastreams.RecordingDatastreamsPayloadWriter
 import datadog.trace.agent.tooling.AgentInstaller
@@ -405,8 +406,11 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
 
     boolean enabledFinishTimingChecks = this.enabledFinishTimingChecks()
-    TEST_TRACER.startSpan(*_) >> {
+    TEST_TRACER.startSpan(*_) >> { Object[] args ->
       AgentSpan agentSpan = callRealMethod()
+      if (args.length > 0 && args[0] instanceof String) {
+        TagsAssert.INSTRUMENTATION_NAMES[agentSpan.spanId] = (String) args[0]
+      }
       if (!enabledFinishTimingChecks) {
         return agentSpan
       }

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -56,6 +56,7 @@ import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.bootstrap.InstrumentationErrors
 import datadog.trace.bootstrap.debugger.DebuggerContext
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.metrics.EventListener
 import datadog.trace.common.metrics.Sink
@@ -406,18 +407,17 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
 
     boolean enabledFinishTimingChecks = this.enabledFinishTimingChecks()
-    TEST_TRACER.startSpan(*_) >> { Object[] args ->
-      AgentSpan agentSpan = callRealMethod()
-      if (args.length > 0 && args[0] instanceof String) {
-        TagsAssert.INSTRUMENTATION_NAMES[agentSpan.spanId] = (String) args[0]
-      }
-      if (!enabledFinishTimingChecks) {
-        return agentSpan
-      }
-
-      def trackingSpan = new TrackingSpanDecorator(agentSpan, spanFinishLocations, originalToTrackingSpan, useStrictTraceWrites())
-      originalToTrackingSpan[agentSpan] = trackingSpan
-      return trackingSpan
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence) >> { String instrName, CharSequence spanName ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as Long) >> { String instrName, CharSequence spanName, long micros ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext) >> { String instrName, CharSequence spanName, AgentSpanContext ctx ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext, _ as Long) >> { String instrName, CharSequence spanName, AgentSpanContext ctx, long micros ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
     }
 
     ClassInjector.enableClassInjection(INSTRUMENTATION)
@@ -573,6 +573,16 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
 
   boolean useStrictTraceWrites() {
     return true
+  }
+
+  protected AgentSpan trackStartSpan(AgentSpan span, String instrName, boolean enabledFinishTimingChecks) {
+    TagsAssert.INSTRUMENTATION_NAMES[span.spanId] = instrName
+    if (!enabledFinishTimingChecks) {
+      return span
+    }
+    def trackingSpan = new TrackingSpanDecorator(span, spanFinishLocations, originalToTrackingSpan, useStrictTraceWrites())
+    originalToTrackingSpan[span] = trackingSpan
+    return trackingSpan
   }
 
   void assertTraces(

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -56,7 +56,6 @@ import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.bootstrap.InstrumentationErrors
 import datadog.trace.bootstrap.debugger.DebuggerContext
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.metrics.EventListener
 import datadog.trace.common.metrics.Sink
@@ -409,17 +408,8 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
 
     boolean enabledFinishTimingChecks = this.enabledFinishTimingChecks()
-    TEST_TRACER.startSpan(_ as String, _ as CharSequence) >> { String instrName, CharSequence spanName ->
-      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
-    }
-    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as Long) >> { String instrName, CharSequence spanName, long micros ->
-      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
-    }
-    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext) >> { String instrName, CharSequence spanName, AgentSpanContext ctx ->
-      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
-    }
-    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext, _ as Long) >> { String instrName, CharSequence spanName, AgentSpanContext ctx, long micros ->
-      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    TEST_TRACER.startSpan(*_) >> { args ->
+      trackStartSpan(callRealMethod(), args[0] as String, enabledFinishTimingChecks)
     }
 
     ClassInjector.enableClassInjection(INSTRUMENTATION)

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -56,6 +56,7 @@ import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.bootstrap.InstrumentationErrors
 import datadog.trace.bootstrap.debugger.DebuggerContext
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.metrics.EventListener
 import datadog.trace.common.metrics.Sink
@@ -408,18 +409,17 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
 
     boolean enabledFinishTimingChecks = this.enabledFinishTimingChecks()
-    TEST_TRACER.startSpan(*_) >> { Object[] args ->
-      AgentSpan agentSpan = callRealMethod()
-      if (args.length > 0 && args[0] instanceof String) {
-        TagsAssert.INSTRUMENTATION_NAMES[agentSpan.spanId] = (String) args[0]
-      }
-      if (!enabledFinishTimingChecks) {
-        return agentSpan
-      }
-
-      def trackingSpan = new TrackingSpanDecorator(agentSpan, spanFinishLocations, originalToTrackingSpan, useStrictTraceWrites())
-      originalToTrackingSpan[agentSpan] = trackingSpan
-      return trackingSpan
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence) >> { String instrName, CharSequence spanName ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as Long) >> { String instrName, CharSequence spanName, long micros ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext) >> { String instrName, CharSequence spanName, AgentSpanContext ctx ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
+    }
+    TEST_TRACER.startSpan(_ as String, _ as CharSequence, _ as AgentSpanContext, _ as Long) >> { String instrName, CharSequence spanName, AgentSpanContext ctx, long micros ->
+      trackStartSpan(callRealMethod(), instrName, enabledFinishTimingChecks)
     }
 
     ClassInjector.enableClassInjection(INSTRUMENTATION)
@@ -575,6 +575,16 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
 
   boolean useStrictTraceWrites() {
     return true
+  }
+
+  protected AgentSpan trackStartSpan(AgentSpan span, String instrName, boolean enabledFinishTimingChecks) {
+    TagsAssert.INSTRUMENTATION_NAMES[span.spanId] = instrName
+    if (!enabledFinishTimingChecks) {
+      return span
+    }
+    def trackingSpan = new TrackingSpanDecorator(span, spanFinishLocations, originalToTrackingSpan, useStrictTraceWrites())
+    originalToTrackingSpan[span] = trackingSpan
+    return trackingSpan
   }
 
   void assertTraces(

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -33,6 +33,7 @@ import datadog.metrics.api.statsd.StatsDClient
 import datadog.metrics.impl.DDSketchHistograms
 import datadog.metrics.impl.MonitoringImpl
 import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.asserts.TagsAssert
 import datadog.trace.agent.test.datastreams.MockFeaturesDiscovery
 import datadog.trace.agent.test.datastreams.RecordingDatastreamsPayloadWriter
 import datadog.trace.agent.tooling.AgentInstaller
@@ -407,8 +408,11 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
 
     boolean enabledFinishTimingChecks = this.enabledFinishTimingChecks()
-    TEST_TRACER.startSpan(*_) >> {
+    TEST_TRACER.startSpan(*_) >> { Object[] args ->
       AgentSpan agentSpan = callRealMethod()
+      if (args.length > 0 && args[0] instanceof String) {
+        TagsAssert.INSTRUMENTATION_NAMES[agentSpan.spanId] = (String) args[0]
+      }
       if (!enabledFinishTimingChecks) {
         return agentSpan
       }

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -41,7 +41,7 @@ abstract class LogContextInjectionTestBase extends InstrumentationSpecification 
   def "Log context shows trace and span ids for active scope"() {
     when:
     put("foo", "bar")
-    AgentSpan rootSpan = startSpan("root")
+    AgentSpan rootSpan = startSpan("test", "root")
     AgentScope rootScope = activateSpan(rootSpan)
 
     then:
@@ -50,7 +50,7 @@ abstract class LogContextInjectionTestBase extends InstrumentationSpecification 
     get("foo") == "bar"
 
     when:
-    AgentSpan childSpan = startSpan("child")
+    AgentSpan childSpan = startSpan("test", "child")
     AgentScope childScope = activateSpan(childSpan)
 
     then:
@@ -93,7 +93,7 @@ abstract class LogContextInjectionTestBase extends InstrumentationSpecification 
         @Override
         void run() {
           // other trace in scope
-          final AgentSpan thread2Span = startSpan("root2")
+          final AgentSpan thread2Span = startSpan("test", "root2")
           final AgentScope thread2Scope = activateSpan(thread2Span)
           try {
             thread2TraceId.set(get(CorrelationIdentifier.getTraceIdKey()))
@@ -104,7 +104,7 @@ abstract class LogContextInjectionTestBase extends InstrumentationSpecification 
         }
       }
 
-    final AgentSpan mainSpan = startSpan("root")
+    final AgentSpan mainSpan = startSpan("test", "root")
     final AgentScope mainScope = activateSpan(mainSpan)
     thread1.start()
     thread2.start()

--- a/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -94,7 +94,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   public AgentSpan startAerospikeSpan(final String methodName) {
-    final AgentSpan span = startSpan("aerospike", OPERATION_NAME);
+    final AgentSpan span = startSpan(JAVA_AEROSPIKE.toString(), OPERATION_NAME);
     afterStart(span);
     withMethod(span, methodName);
     return span;

--- a/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -94,7 +94,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   public AgentSpan startAerospikeSpan(final String methodName) {
-    final AgentSpan span = startSpan(OPERATION_NAME);
+    final AgentSpan span = startSpan("aerospike", OPERATION_NAME);
     afterStart(span);
     withMethod(span, methodName);
     return span;

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
@@ -133,7 +133,7 @@ class Greeter(message: String, receiverActor: ActorRef) extends Actor {
     case Greet =>
       receiverActor ! Greeting(greeting)
     case Leak(leak) =>
-      val span = startSpan(greeting)
+      val span = startSpan("test", greeting)
       span.setResourceName(leak)
       activateSpan(span)
       span.finish()

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/test/java/LinearTask.java
@@ -31,7 +31,7 @@ public class LinearTask extends RecursiveTask<Integer> {
       return parent;
     } else {
       int next = parent + 1;
-      AgentSpan span = startSpan(Integer.toString(next));
+      AgentSpan span = startSpan("test", Integer.toString(next));
       try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST;
+import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.AKKA_HTTP_CLIENT;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientHelpers.AkkaHttpHeaders;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientHelpers.OnCompleteHandler;
@@ -77,7 +78,7 @@ public final class AkkaHttpSingleRequestInstrumentation extends InstrumenterModu
         return null;
       }
 
-      final AgentSpan span = startSpan("akka-http", AKKA_CLIENT_REQUEST);
+      final AgentSpan span = startSpan(AKKA_HTTP_CLIENT.toString(), AKKA_CLIENT_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.6/src/main/java11/datadog/trace/instrumentation/akkahttp106/SingleRequestAdvice.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.akkahttp106;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.akkahttp106.AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST;
+import static datadog.trace.instrumentation.akkahttp106.AkkaHttpClientDecorator.AKKA_HTTP_CLIENT;
 import static datadog.trace.instrumentation.akkahttp106.AkkaHttpClientDecorator.DECORATE;
 
 import akka.http.scaladsl.HttpExt;
@@ -22,7 +23,7 @@ public class SingleRequestAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan("akka-http", AKKA_CLIENT_REQUEST);
+    final AgentSpan span = startSpan(AKKA_HTTP_CLIENT.toString(), AKKA_CLIENT_REQUEST);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
     return activateSpan(span);

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpasyncclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpasyncclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -102,7 +102,7 @@ public class ApacheHttpAsyncClientInstrumentation
       }
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan("httpasyncclient", HTTP_REQUEST);
       DECORATE.afterStart(clientSpan);
       ((DelegatingRequestProducer) requestProducer).setSpan(clientSpan);
       futureCallback =

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpasyncclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpasyncclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.APACHE_HTTPASYNCCLIENT;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.HTTP_REQUEST;
 import static java.util.Arrays.asList;
@@ -102,7 +103,7 @@ public class ApacheHttpAsyncClientInstrumentation
       }
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan("httpasyncclient", HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan(APACHE_HTTPASYNCCLIENT.toString(), HTTP_REQUEST);
       DECORATE.afterStart(clientSpan);
       ((DelegatingRequestProducer) requestProducer).setSpan(clientSpan);
       futureCallback =

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -35,7 +35,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpUriRequest request) {
-    final AgentSpan span = startSpan(HTTP_REQUEST);
+    final AgentSpan span = startSpan("httpclient", HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.APACHE_HTTP_CLIENT;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
@@ -35,7 +36,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpUriRequest request) {
-    final AgentSpan span = startSpan("httpclient", HTTP_REQUEST);
+    final AgentSpan span = startSpan(APACHE_HTTP_CLIENT.toString(), HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.APACHE_HTTP_CLIENT;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -113,7 +114,7 @@ public class ApacheHttpAsyncClientInstrumentation extends InstrumenterModule.Tra
         @Advice.Argument(value = 4, readOnly = false) FutureCallback<?> futureCallback) {
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan("httpasyncclient5", HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan(APACHE_HTTP_CLIENT.toString(), HTTP_REQUEST);
       final AgentScope clientScope = activateSpan(clientSpan);
       DECORATE.afterStart(clientSpan);
 

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -113,7 +113,7 @@ public class ApacheHttpAsyncClientInstrumentation extends InstrumenterModule.Tra
         @Advice.Argument(value = 4, readOnly = false) FutureCallback<?> futureCallback) {
 
       final AgentScope.Continuation parentContinuation = captureActiveSpan();
-      final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
+      final AgentSpan clientSpan = startSpan("httpasyncclient5", HTTP_REQUEST);
       final AgentScope clientScope = activateSpan(clientSpan);
       DECORATE.afterStart(clientSpan);
 

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.apachehttpclient5;
 import static datadog.context.Context.current;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.APACHE_HTTP_CLIENT;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
@@ -35,7 +36,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpRequest request) {
-    final AgentSpan span = startSpan("httpclient5", HTTP_REQUEST);
+    final AgentSpan span = startSpan(APACHE_HTTP_CLIENT.toString(), HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient/apache-httpclient-5.0/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -35,7 +35,7 @@ public class HelperMethods {
   }
 
   private static AgentScope activateHttpSpan(final HttpRequest request) {
-    final AgentSpan span = startSpan(HTTP_REQUEST);
+    final AgentSpan span = startSpan("httpclient5", HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.armeria.grpc.client.GrpcClientDecorator.OPERATION_NAME;
@@ -211,7 +212,7 @@ public final class ClientCallImplInstrumentation
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan("armeria-grpc-client", GRPC_MESSAGE)
+            startSpan(COMPONENT_NAME.toString(), GRPC_MESSAGE)
                 .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/ClientCallImplInstrumentation.java
@@ -211,7 +211,8 @@ public final class ClientCallImplInstrumentation
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan(GRPC_MESSAGE).setTag("message.type", clientSpan.getTag("response.type"));
+            startSpan("armeria-grpc-client", GRPC_MESSAGE)
+                .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);
       }

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -95,7 +95,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return AgentTracer.blackholeSpan();
     }
     AgentSpan span =
-        startSpan("grpc", OPERATION_NAME)
+        startSpan(COMPONENT_NAME.toString(), OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions

--- a/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -93,9 +93,9 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
       AgentSpanContext lambdaContext = AgentTracer.get().notifyLambdaStart(in, lambdaRequestId);
       final AgentSpan span;
       if (null == lambdaContext) {
-        span = startSpan("aws-sdk", INVOCATION_SPAN_NAME);
+        span = startSpan("java-aws-sdk", INVOCATION_SPAN_NAME);
       } else {
-        span = startSpan("aws-sdk", INVOCATION_SPAN_NAME, lambdaContext);
+        span = startSpan("java-aws-sdk", INVOCATION_SPAN_NAME, lambdaContext);
       }
       span.setSpanType(InternalSpanTypes.SERVERLESS);
       span.setTag("request_id", lambdaRequestId);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -93,9 +93,9 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
       AgentSpanContext lambdaContext = AgentTracer.get().notifyLambdaStart(in, lambdaRequestId);
       final AgentSpan span;
       if (null == lambdaContext) {
-        span = startSpan(INVOCATION_SPAN_NAME);
+        span = startSpan("aws-sdk", INVOCATION_SPAN_NAME);
       } else {
-        span = startSpan(INVOCATION_SPAN_NAME, lambdaContext);
+        span = startSpan("aws-sdk", INVOCATION_SPAN_NAME, lambdaContext);
       }
       span.setSpanType(InternalSpanTypes.SERVERLESS);
       span.setTag("request_id", lambdaRequestId);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -65,7 +65,7 @@ public class TracingRequestHandler extends RequestHandler2 {
         span.setOperationName(AwsNameCache.spanName(request));
       } else {
         // this is the most common code path
-        span = startSpan("aws-sdk", AwsNameCache.spanName(request));
+        span = startSpan("java-aws-sdk", AwsNameCache.spanName(request));
         context = span; // TODO If DSM is enabled, add DSM context here too
       }
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -10,6 +10,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.AWS_LEGACY_TRACING;
+import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.DECORATE;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -65,7 +66,7 @@ public class TracingRequestHandler extends RequestHandler2 {
         span.setOperationName(AwsNameCache.spanName(request));
       } else {
         // this is the most common code path
-        span = startSpan("java-aws-sdk", AwsNameCache.spanName(request));
+        span = startSpan(COMPONENT_NAME.toString(), AwsNameCache.spanName(request));
         context = span; // TODO If DSM is enabled, add DSM context here too
       }
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.blackholeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_LEGACY_TRACING;
+import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
 import datadog.context.Context;
@@ -54,7 +55,8 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       return; // SQS messages spans are created by aws-java-sqs-2.0
     }
 
-    final AgentSpan span = startSpan("java-aws-sdk", DECORATE.spanName(executionAttributes));
+    final AgentSpan span =
+        startSpan(COMPONENT_NAME.toString(), DECORATE.spanName(executionAttributes));
     // TODO If DSM is enabled, add DSM context here too
     DECORATE.afterStart(span);
     executionAttributes.putAttribute(CONTEXT_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -54,7 +54,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       return; // SQS messages spans are created by aws-java-sqs-2.0
     }
 
-    final AgentSpan span = startSpan("aws-sdk", DECORATE.spanName(executionAttributes));
+    final AgentSpan span = startSpan("java-aws-sdk", DECORATE.spanName(executionAttributes));
     // TODO If DSM is enabled, add DSM context here too
     DECORATE.afterStart(span);
     executionAttributes.putAttribute(CONTEXT_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -109,7 +109,7 @@ public class SnsInterceptor extends RequestHandler2 {
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {
-    final AgentSpan span = AgentTracer.startSpan("aws-sdk", "aws.sns.send");
+    final AgentSpan span = AgentTracer.startSpan("java-aws-sdk", "aws.sns.send");
     // pass the span to TracingRequestHandler in the sdk instrumentation where it'll be enriched &
     // activated
     // TODO If DSM is enabled, add DSM context here too

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -109,7 +109,7 @@ public class SnsInterceptor extends RequestHandler2 {
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {
-    final AgentSpan span = AgentTracer.startSpan("aws.sns.send");
+    final AgentSpan span = AgentTracer.startSpan("aws-sdk", "aws.sns.send");
     // pass the span to TracingRequestHandler in the sdk instrumentation where it'll be enriched &
     // activated
     // TODO If DSM is enabled, add DSM context here too

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
@@ -88,7 +88,7 @@ public class SqsInterceptor extends RequestHandler2 {
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {
-    final AgentSpan span = startSpan(SqsDecorator.COMPONENT_NAME.toString(), "aws.sqs.send");
+    final AgentSpan span = startSpan("java-aws-sdk", "aws.sqs.send");
     // pass the span to TracingRequestHandler in the sdk instrumentation where it'll be enriched &
     // activated
     // TODO If DSM is enabled, add DSM context here too

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
@@ -88,7 +88,7 @@ public class SqsInterceptor extends RequestHandler2 {
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {
-    final AgentSpan span = startSpan("sqs", "aws.sqs.send");
+    final AgentSpan span = startSpan(SqsDecorator.COMPONENT_NAME.toString(), "aws.sqs.send");
     // pass the span to TracingRequestHandler in the sdk instrumentation where it'll be enriched &
     // activated
     // TODO If DSM is enabled, add DSM context here too

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.sp
 import static datadog.trace.bootstrap.instrumentation.api.URIUtils.urlFileName;
 import static datadog.trace.instrumentation.aws.v1.sqs.MessageExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.BROKER_DECORATE;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_INBOUND_OPERATION;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_TIME_IN_QUEUE_OPERATION;
@@ -103,7 +104,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan("java-aws-sdk", SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan(COMPONENT_NAME.toString(), SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -89,6 +89,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
             if (timeInQueueStart > 0) {
               queueSpan =
                   startSpan(
+                      "aws-sdk",
                       SQS_TIME_IN_QUEUE_OPERATION,
                       spanContext,
                       MILLISECONDS.toMicros(timeInQueueStart));
@@ -102,7 +103,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan(SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan("aws-sdk", SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -103,7 +103,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan("aws-sdk", SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan("java-aws-sdk", SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -90,7 +90,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
             if (timeInQueueStart > 0) {
               queueSpan =
                   startSpan(
-                      "aws-sdk",
+                      COMPONENT_NAME.toString(),
                       SQS_TIME_IN_QUEUE_OPERATION,
                       spanContext,
                       MILLISECONDS.toMicros(timeInQueueStart));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -91,6 +91,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
             if (timeInQueueStart > 0) {
               queueSpan =
                   startSpan(
+                      "aws-sdk",
                       SQS_TIME_IN_QUEUE_OPERATION,
                       spanContext,
                       MILLISECONDS.toMicros(timeInQueueStart));
@@ -104,7 +105,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan(SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan("aws-sdk", SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -105,7 +105,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan("aws-sdk", SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan("java-aws-sdk", SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.sp
 import static datadog.trace.bootstrap.instrumentation.api.URIUtils.urlFileName;
 import static datadog.trace.instrumentation.aws.v2.sqs.MessageExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.BROKER_DECORATE;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_INBOUND_OPERATION;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_TIME_IN_QUEUE_OPERATION;
@@ -105,7 +106,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           // re-use this context for any other messages received in this batch
           batchContext = spanContext;
         }
-        AgentSpan span = startSpan("java-aws-sdk", SQS_INBOUND_OPERATION, batchContext);
+        AgentSpan span = startSpan(COMPONENT_NAME.toString(), SQS_INBOUND_OPERATION, batchContext);
 
         DataStreamsTags tags = create("sqs", INBOUND, urlFileName(queueUrl));
         AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, create(tags, 0, 0));

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -92,7 +92,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
             if (timeInQueueStart > 0) {
               queueSpan =
                   startSpan(
-                      "aws-sdk",
+                      COMPONENT_NAME.toString(),
                       SQS_TIME_IN_QUEUE_OPERATION,
                       spanContext,
                       MILLISECONDS.toMicros(timeInQueueStart));

--- a/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisEngineInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisEngineInstrumentation.java
@@ -53,7 +53,7 @@ public final class AxisEngineInstrumentation
         @Advice.Argument(0) final MessageContext message) {
       // only create a span if the message has a clear action and there's a surrounding request
       if (DECORATE.shouldTrace(message)) {
-        AgentSpan span = startSpan(AXIS2_MESSAGE);
+        AgentSpan span = startSpan("axis2", AXIS2_MESSAGE);
         DECORATE.afterStart(span);
         DECORATE.onMessage(span, message);
         return activateSpan(span);
@@ -88,7 +88,7 @@ public final class AxisEngineInstrumentation
         message.removeSelfManagedData(Tracer.class, AXIS2_CONTINUATION_KEY);
         // resuming is a distinct operation, so create a new span under the original request
         try (AgentScope parentScope = ((AgentScope.Continuation) continuation).activate()) {
-          AgentSpan span = startSpan(AXIS2_MESSAGE);
+          AgentSpan span = startSpan("axis2", AXIS2_MESSAGE);
           DECORATE.afterStart(span);
           DECORATE.onMessage(span, message);
           return activateSpan(span);

--- a/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
@@ -54,7 +54,7 @@ public final class AxisTransportInstrumentation
     public static AgentScope beginTransport(@Advice.Argument(0) final MessageContext message) {
       // only create a span if the message has a clear action and there's a surrounding request
       if (DECORATE.shouldTrace(message)) {
-        AgentSpan span = startSpan(AXIS2_TRANSPORT);
+        AgentSpan span = startSpan("axis2", AXIS2_TRANSPORT);
         DECORATE.afterStart(span);
         DECORATE.onTransport(span, message);
         DECORATE.onMessage(span, message);

--- a/dd-java-agent/instrumentation/axis2-1.3/src/test/groovy/datadog/trace/instrumentation/axis2/AxisEngineTest.groovy
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/test/groovy/datadog/trace/instrumentation/axis2/AxisEngineTest.groovy
@@ -143,7 +143,7 @@ class AxisEngineTest extends InstrumentationSpecification {
 
   def "test send"() {
     when:
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       def message1 = testMessage()
@@ -170,7 +170,7 @@ class AxisEngineTest extends InstrumentationSpecification {
     when:
     def message = testMessage()
     message.setProperty(TRIGGER_PAUSE, true)
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       AxisEngine.send(message)
@@ -201,7 +201,7 @@ class AxisEngineTest extends InstrumentationSpecification {
     when:
     def message = testMessage()
     message.setProperty(TRIGGER_FAIL, true)
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       try {
@@ -224,7 +224,7 @@ class AxisEngineTest extends InstrumentationSpecification {
 
   def "test sendFault"() {
     when:
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     def faultMessage = createFaultMessageContext(testMessage(), new Exception('internal error'))
     activateSpan(span0).withCloseable {
@@ -243,7 +243,7 @@ class AxisEngineTest extends InstrumentationSpecification {
 
   def "test receive"() {
     when:
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       def message1 = testMessage()
@@ -271,7 +271,7 @@ class AxisEngineTest extends InstrumentationSpecification {
     injectSysConfig("trace.axis.promote.resource-name", "true")
     when:
     // emulates AxisServlet behaviour
-    AgentSpan span0 = startSpan("servlet.request")
+    AgentSpan span0 = startSpan("test", "servlet.request")
     span0.setServiceName("testSpan")
     span0.setResourceName("POST /some/context/services/TestService")
     activateSpan(span0).withCloseable {
@@ -306,7 +306,7 @@ class AxisEngineTest extends InstrumentationSpecification {
     when:
     def message = testMessage()
     message.setProperty(TRIGGER_PAUSE, true)
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       AxisEngine.receive(message)
@@ -337,7 +337,7 @@ class AxisEngineTest extends InstrumentationSpecification {
     when:
     def message = testMessage()
     message.setProperty(TRIGGER_FAIL, true)
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       try {

--- a/dd-java-agent/instrumentation/axis2-1.3/src/test/groovy/datadog/trace/instrumentation/axis2/AxisTransportForkedTest.groovy
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/test/groovy/datadog/trace/instrumentation/axis2/AxisTransportForkedTest.groovy
@@ -83,7 +83,7 @@ class AxisTransportForkedTest extends InstrumentationSpecification {
     message1.setProperty("TRANSPORT_HEADERS", ["foo":"bar"] as HashMap)
     def message2 = testMessage()
     // no action, expect span to use testDestination
-    AgentSpan span0 = startSpan('test')
+    AgentSpan span0 = startSpan('test', 'test')
     span0.setServiceName('testSpan')
     activateSpan(span0).withCloseable {
       AxisEngine.send(message1)

--- a/dd-java-agent/instrumentation/axway-api-7.5/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
+++ b/dd-java-agent/instrumentation/axway-api-7.5/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
@@ -17,7 +17,7 @@ public class HTTPPluginAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static ContextScope onEnter(@Advice.Argument(value = 2) final Object serverTransaction) {
-    final AgentSpan span = startSpan("axway-api", DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("axway-http", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     // serverTransaction is like request + connection in one object:
     DECORATE.onRequest(span, serverTransaction, serverTransaction, getRootContext());

--- a/dd-java-agent/instrumentation/axway-api-7.5/src/main/java/datadog/trace/instrumentation/axway/StateAdvice.java
+++ b/dd-java-agent/instrumentation/axway-api-7.5/src/main/java/datadog/trace/instrumentation/axway/StateAdvice.java
@@ -20,7 +20,7 @@ import net.bytebuddy.asm.Advice;
 public class StateAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.This final Object stateInstance) {
-    final AgentSpan span = startSpan(AXWAY_TRY_TRANSACTION);
+    final AgentSpan span = startSpan("axway-http", AXWAY_TRY_TRANSACTION);
     final AgentScope scope = activateSpan(span);
     span.setMeasured(true);
     DECORATE.onTransaction(span, stateInstance);

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/ECIInteractionInstrumentation.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/ECIInteractionInstrumentation.java
@@ -36,7 +36,7 @@ public final class ECIInteractionInstrumentation
         return null;
       }
 
-      AgentSpan span = startSpan(ECI_EXECUTE_OPERATION);
+      AgentSpan span = startSpan("cics", ECI_EXECUTE_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onECIInteraction(span, (ECIInteractionSpec) spec);
 

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/ECIInteractionInstrumentation.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/ECIInteractionInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.cics;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.cics.CicsDecorator.CICS_CLIENT;
 import static datadog.trace.instrumentation.cics.CicsDecorator.DECORATE;
 import static datadog.trace.instrumentation.cics.CicsDecorator.ECI_EXECUTE_OPERATION;
 
@@ -36,7 +37,7 @@ public final class ECIInteractionInstrumentation
         return null;
       }
 
-      AgentSpan span = startSpan("cics", ECI_EXECUTE_OPERATION);
+      AgentSpan span = startSpan(CICS_CLIENT.toString(), ECI_EXECUTE_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onECIInteraction(span, (ECIInteractionSpec) spec);
 

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/JavaGatewayInterfaceInstrumentation.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/JavaGatewayInterfaceInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.cics.CicsDecorator.CICS_CLIENT;
 import static datadog.trace.instrumentation.cics.CicsDecorator.DECORATE;
 import static datadog.trace.instrumentation.cics.CicsDecorator.GATEWAY_FLOW_OPERATION;
 
@@ -53,7 +54,7 @@ public final class JavaGatewayInterfaceInstrumentation
       }
 
       // Not inside execute() - create a new span
-      final AgentSpan span = startSpan("cics", GATEWAY_FLOW_OPERATION);
+      final AgentSpan span = startSpan(CICS_CLIENT.toString(), GATEWAY_FLOW_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, strAddress, port, ipGateway);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/JavaGatewayInterfaceInstrumentation.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/JavaGatewayInterfaceInstrumentation.java
@@ -53,7 +53,7 @@ public final class JavaGatewayInterfaceInstrumentation
       }
 
       // Not inside execute() - create a new span
-      final AgentSpan span = startSpan(GATEWAY_FLOW_OPERATION);
+      final AgentSpan span = startSpan("cics", GATEWAY_FLOW_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, strAddress, port, ipGateway);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/commons-httpclient-2.0/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2.0/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -65,7 +65,7 @@ public class CommonsHttpClientInstrumentation extends InstrumenterModule.Tracing
           return null;
         }
 
-        final AgentSpan span = startSpan(HTTP_REQUEST);
+        final AgentSpan span = startSpan("commons-http-client", HTTP_REQUEST);
         final AgentScope scope = activateSpan(span);
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
@@ -39,6 +39,11 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   }
 
   @Override
+  protected String instrumentationName() {
+    return "couchbase-client";
+  }
+
+  @Override
   protected void afterStart(final AgentSpan span) {
     super.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 
 public class TraceDecorator extends AsyncResultDecorator {
   public static TraceDecorator DECORATE = new TraceDecorator();
-  private static final String INSTRUMENTATION_NAME = "trace-annotation";
+  private static final String INSTRUMENTATION_NAME = "trace";
 
   private static final boolean USE_LEGACY_OPERATION_NAME =
       InstrumenterConfig.get().isLegacyInstrumentationEnabled(true, "trace.annotations");

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DATANUCLEUS_FIND_OBJECT;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DECORATE;
+import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.JAVA_DATANUCLEUS;
 import static java.util.Collections.singleton;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -78,7 +79,7 @@ public class ExecutionContextInstrumentation
         @Advice.This final ExecutionContext executionContext,
         @Advice.Origin("datanucleus.#m") final String operationName) {
 
-      final AgentSpan span = startSpan("datanucleus", operationName);
+      final AgentSpan span = startSpan(JAVA_DATANUCLEUS.toString(), operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -111,7 +112,7 @@ public class ExecutionContextInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan("datanucleus", operationName);
+      final AgentSpan span = startSpan(JAVA_DATANUCLEUS.toString(), operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -141,7 +142,7 @@ public class ExecutionContextInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan(JAVA_DATANUCLEUS.toString(), DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -172,7 +173,7 @@ public class ExecutionContextInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan(JAVA_DATANUCLEUS.toString(), DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
@@ -78,7 +78,7 @@ public class ExecutionContextInstrumentation
         @Advice.This final ExecutionContext executionContext,
         @Advice.Origin("datanucleus.#m") final String operationName) {
 
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -111,7 +111,7 @@ public class ExecutionContextInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -141,7 +141,7 @@ public class ExecutionContextInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan(DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);
@@ -172,7 +172,7 @@ public class ExecutionContextInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope startMethod() {
 
-      final AgentSpan span = startSpan(DATANUCLEUS_FIND_OBJECT);
+      final AgentSpan span = startSpan("datanucleus", DATANUCLEUS_FIND_OBJECT);
       DECORATE.afterStart(span);
 
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DATANUCLEUS_QUERY_DELETE;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DATANUCLEUS_QUERY_EXECUTE;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DECORATE;
+import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.JAVA_DATANUCLEUS;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import datadog.trace.agent.tooling.Instrumenter;
@@ -56,8 +57,8 @@ public class JDOQueryInstrumentation
 
       final AgentSpan span =
           methodName.startsWith("execute")
-              ? startSpan("datanucleus", DATANUCLEUS_QUERY_EXECUTE)
-              : startSpan("datanucleus", DATANUCLEUS_QUERY_DELETE);
+              ? startSpan(JAVA_DATANUCLEUS.toString(), DATANUCLEUS_QUERY_EXECUTE)
+              : startSpan(JAVA_DATANUCLEUS.toString(), DATANUCLEUS_QUERY_DELETE);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOQueryInstrumentation.java
@@ -56,8 +56,8 @@ public class JDOQueryInstrumentation
 
       final AgentSpan span =
           methodName.startsWith("execute")
-              ? startSpan(DATANUCLEUS_QUERY_EXECUTE)
-              : startSpan(DATANUCLEUS_QUERY_DELETE);
+              ? startSpan("datanucleus", DATANUCLEUS_QUERY_EXECUTE)
+              : startSpan("datanucleus", DATANUCLEUS_QUERY_DELETE);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
@@ -30,7 +30,7 @@ public class JDOTransactionInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope start(
         @Advice.Origin("datanucleus.transaction.#m") final String operationName) {
-      final AgentSpan span = startSpan(operationName);
+      final AgentSpan span = startSpan("datanucleus", operationName);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/JDOTransactionInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.DECORATE;
+import static datadog.trace.instrumentation.datanucleus.DatanucleusDecorator.JAVA_DATANUCLEUS;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import datadog.trace.agent.tooling.Instrumenter;
@@ -30,7 +31,7 @@ public class JDOTransactionInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope start(
         @Advice.Origin("datanucleus.transaction.#m") final String operationName) {
-      final AgentSpan span = startSpan("datanucleus", operationName);
+      final AgentSpan span = startSpan(JAVA_DATANUCLEUS.toString(), operationName);
 
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -252,7 +252,7 @@ public class TracingSession implements Session {
   }
 
   private AgentScope startSpanWithScope(final String query) {
-    final AgentSpan span = startSpan(OPERATION_NAME);
+    final AgentSpan span = startSpan("cassandra", OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, session);
     DECORATE.onStatement(span, query);

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -4,6 +4,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.datastax.cassandra.CassandraClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.datastax.cassandra.CassandraClientDecorator.JAVA_CASSANDRA;
 import static datadog.trace.instrumentation.datastax.cassandra.CassandraClientDecorator.OPERATION_NAME;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACE_CASSANDRA_ASYNC_SESSION;
 
@@ -252,7 +253,7 @@ public class TracingSession implements Session {
   }
 
   private AgentScope startSpanWithScope(final String query) {
-    final AgentSpan span = startSpan("cassandra", OPERATION_NAME);
+    final AgentSpan span = startSpan(JAVA_CASSANDRA.toString(), OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, session);
     DECORATE.onStatement(span, query);

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
@@ -54,7 +54,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private ResultSet wrapSyncRequest(Statement request) {
-    AgentSpan span = startSpan(OPERATION_NAME);
+    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());
@@ -78,7 +78,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private CompletionStage<AsyncResultSet> wrapAsyncRequest(Statement request) {
-    AgentSpan span = startSpan(OPERATION_NAME);
+    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.datastax.cassandra4;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.datastax.cassandra4.CassandraClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.datastax.cassandra4.CassandraClientDecorator.JAVA_CASSANDRA;
 import static datadog.trace.instrumentation.datastax.cassandra4.CassandraClientDecorator.OPERATION_NAME;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACE_CASSANDRA_ASYNC_SESSION;
 
@@ -54,7 +55,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private ResultSet wrapSyncRequest(Statement request) {
-    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
+    AgentSpan span = startSpan(JAVA_CASSANDRA.toString(), OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());
@@ -78,7 +79,7 @@ public class TracingSession extends SessionWrapper implements CqlSession {
   }
 
   private CompletionStage<AsyncResultSet> wrapAsyncRequest(Statement request) {
-    AgentSpan span = startSpan("cassandra", OPERATION_NAME);
+    AgentSpan span = startSpan(JAVA_CASSANDRA.toString(), OPERATION_NAME);
 
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, getDelegate());

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views-0.7/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views-0.7/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -69,7 +69,8 @@ public final class DropwizardViewInstrumentation extends InstrumenterModule.Trac
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span = startSpan("view.render").setTag(Tags.COMPONENT, "dropwizard-view");
+      final AgentSpan span =
+          startSpan("dropwizard-view", "view.render").setTag(Tags.COMPONENT, "dropwizard-view");
       span.context().setIntegrationName("dropwizard-view");
       span.setResourceName("View " + view.getTemplateName());
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -59,7 +59,7 @@ public class Elasticsearch5RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(1) final String endpoint,
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, method, endpoint, null, null);
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -59,7 +60,7 @@ public class Elasticsearch5RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(1) final String endpoint,
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, method, endpoint, null, null);
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -57,7 +57,7 @@ public class Elasticsearch6RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -57,7 +58,7 @@ public class Elasticsearch6RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-7.0/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-7.0/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
@@ -74,7 +74,7 @@ public class Elasticsearch7RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-7.0/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-rest/elasticsearch-rest-7.0/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -74,7 +75,7 @@ public class Elasticsearch7RestClientInstrumentation extends InstrumenterModule.
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-2.0/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-2.0/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -63,7 +63,7 @@ public class Elasticsearch2TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-2.0/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-2.0/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -63,7 +64,7 @@ public class Elasticsearch2TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -63,7 +63,7 @@ public class Elasticsearch5TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.0/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -63,7 +64,7 @@ public class Elasticsearch5TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -64,7 +64,7 @@ public class Elasticsearch53TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -64,7 +65,7 @@ public class Elasticsearch53TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-6.0/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-6.0/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -67,7 +67,7 @@ public class Elasticsearch6TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-6.0/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-6.0/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -67,7 +68,7 @@ public class Elasticsearch6TransportClientInstrumentation extends InstrumenterMo
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
@@ -74,7 +74,7 @@ public class Elasticsearch73TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_JAVA;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -74,7 +75,7 @@ public class Elasticsearch73TransportClientInstrumentation extends InstrumenterM
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("elasticsearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(ELASTICSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -75,7 +75,7 @@ public class FinatraInstrumentation extends InstrumenterModule.Tracing
         parent.setSpanName(DECORATE.spanName());
       }
 
-      final AgentSpan span = startSpan(FINATRA_CONTROLLER);
+      final AgentSpan span = startSpan("finatra", FINATRA_CONTROLLER);
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.className(clazz));
 

--- a/dd-java-agent/instrumentation/google-http-client-1.19/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client-1.19/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -80,7 +80,8 @@ public class GoogleHttpClientInstrumentation extends InstrumenterModule.Tracing
           return null;
         }
       }
-      return activateSpan(DECORATE.prepareSpan(startSpan(HTTP_REQUEST), request));
+      return activateSpan(
+          DECORATE.prepareSpan(startSpan("google-http-client", HTTP_REQUEST), request));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -108,7 +109,8 @@ public class GoogleHttpClientInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope methodEnter(@Advice.This HttpRequest request) {
-      return activateSpan(DECORATE.prepareSpan(startSpan(HTTP_REQUEST), request));
+      return activateSpan(
+          DECORATE.prepareSpan(startSpan("google-http-client", HTTP_REQUEST), request));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
@@ -124,7 +124,7 @@ public class PubSubDecorator extends MessagingClientDecorator {
   public AgentSpan onConsume(final PubsubMessage message, final String subscription) {
     final AgentSpanContext spanContext =
         extractContextAndGetSpanContext(message, TextMapExtractAdapter.GETTER);
-    final AgentSpan span = startSpan(PUBSUB_CONSUME, spanContext);
+    final AgentSpan span = startSpan("google-pubsub", PUBSUB_CONSUME, spanContext);
     final CharSequence parsedSubscription = extractSubscription(subscription);
     DataStreamsTags tags =
         createWithSubscription("google-pubsub", INBOUND, parsedSubscription.toString());

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
@@ -124,7 +124,7 @@ public class PubSubDecorator extends MessagingClientDecorator {
   public AgentSpan onConsume(final PubsubMessage message, final String subscription) {
     final AgentSpanContext spanContext =
         extractContextAndGetSpanContext(message, TextMapExtractAdapter.GETTER);
-    final AgentSpan span = startSpan("google-pubsub", PUBSUB_CONSUME, spanContext);
+    final AgentSpan span = startSpan(JAVA_PUBSUB.toString(), PUBSUB_CONSUME, spanContext);
     final CharSequence parsedSubscription = extractSubscription(subscription);
     DataStreamsTags tags =
         createWithSubscription("google-pubsub", INBOUND, parsedSubscription.toString());

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
@@ -42,7 +42,7 @@ public final class PublisherInstrumentation
   public static final class Wrap {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope before(@Advice.This Publisher publisher) {
-      final AgentSpan span = startSpan(PUBSUB_PRODUCE);
+      final AgentSpan span = startSpan("google-pubsub", PUBSUB_PRODUCE);
 
       final CharSequence topicName = PRODUCER_DECORATE.extractTopic(publisher.getTopicNameString());
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
@@ -8,6 +8,7 @@ import static datadog.trace.api.datastreams.DataStreamsTags.create;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.JAVA_PUBSUB;
 import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.PRODUCER_DECORATE;
 import static datadog.trace.instrumentation.googlepubsub.PubSubDecorator.PUBSUB_PRODUCE;
 import static datadog.trace.instrumentation.googlepubsub.TextMapInjectAdapter.SETTER;
@@ -42,7 +43,7 @@ public final class PublisherInstrumentation
   public static final class Wrap {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope before(@Advice.This Publisher publisher) {
-      final AgentSpan span = startSpan("google-pubsub", PUBSUB_PRODUCE);
+      final AgentSpan span = startSpan(JAVA_PUBSUB.toString(), PUBSUB_PRODUCE);
 
       final CharSequence topicName = PRODUCER_DECORATE.extractTopic(publisher.getTopicNameString());
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
@@ -61,7 +61,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
   @Override
   public InstrumentationContext<ExecutionResult> beginExecution(
       InstrumentationExecutionParameters parameters) {
-    final AgentSpan requestSpan = startSpan(GRAPHQL_REQUEST);
+    final AgentSpan requestSpan = startSpan("graphql", GRAPHQL_REQUEST);
     DECORATE.afterStart(requestSpan);
 
     State state = parameters.getInstrumentationState();
@@ -100,7 +100,8 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
   public InstrumentationContext<Document> beginParse(
       InstrumentationExecutionParameters parameters) {
     State state = parameters.getInstrumentationState();
-    final AgentSpan parsingSpan = startSpan(GRAPHQL_PARSING, state.getRequestSpan().context());
+    final AgentSpan parsingSpan =
+        startSpan("graphql", GRAPHQL_PARSING, state.getRequestSpan().context());
     DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -111,7 +112,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
     State state = parameters.getInstrumentationState();
 
     final AgentSpan validationSpan =
-        startSpan(GRAPHQL_VALIDATION, state.getRequestSpan().context());
+        startSpan("graphql", GRAPHQL_VALIDATION, state.getRequestSpan().context());
     DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava14/GraphQLInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.graphqljava14;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.DECORATE;
+import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.GRAPHQL_JAVA;
 import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.GRAPHQL_PARSING;
 import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.GRAPHQL_REQUEST;
 import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.GRAPHQL_VALIDATION;
@@ -61,7 +62,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
   @Override
   public InstrumentationContext<ExecutionResult> beginExecution(
       InstrumentationExecutionParameters parameters) {
-    final AgentSpan requestSpan = startSpan("graphql", GRAPHQL_REQUEST);
+    final AgentSpan requestSpan = startSpan(GRAPHQL_JAVA.toString(), GRAPHQL_REQUEST);
     DECORATE.afterStart(requestSpan);
 
     State state = parameters.getInstrumentationState();
@@ -101,7 +102,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
       InstrumentationExecutionParameters parameters) {
     State state = parameters.getInstrumentationState();
     final AgentSpan parsingSpan =
-        startSpan("graphql", GRAPHQL_PARSING, state.getRequestSpan().context());
+        startSpan(GRAPHQL_JAVA.toString(), GRAPHQL_PARSING, state.getRequestSpan().context());
     DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -112,7 +113,7 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
     State state = parameters.getInstrumentationState();
 
     final AgentSpan validationSpan =
-        startSpan("graphql", GRAPHQL_VALIDATION, state.getRequestSpan().context());
+        startSpan(GRAPHQL_JAVA.toString(), GRAPHQL_VALIDATION, state.getRequestSpan().context());
     DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
@@ -65,7 +65,7 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
       return super.beginExecution(parameters, instrumentationState);
     }
     final State state = (State) instrumentationState;
-    final AgentSpan requestSpan = startSpan(GraphQLDecorator.GRAPHQL_REQUEST);
+    final AgentSpan requestSpan = startSpan("graphql", GraphQLDecorator.GRAPHQL_REQUEST);
     GraphQLDecorator.DECORATE.afterStart(requestSpan);
 
     state.setRequestSpan(requestSpan);
@@ -116,7 +116,8 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
     }
     final State state = (State) instrumentationState;
     final AgentSpan parsingSpan =
-        AgentTracer.startSpan(GraphQLDecorator.GRAPHQL_PARSING, state.getRequestSpan().context());
+        AgentTracer.startSpan(
+            "graphql", GraphQLDecorator.GRAPHQL_PARSING, state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -131,7 +132,7 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
 
     final AgentSpan validationSpan =
         AgentTracer.startSpan(
-            GraphQLDecorator.GRAPHQL_VALIDATION, state.getRequestSpan().context());
+            "graphql", GraphQLDecorator.GRAPHQL_VALIDATION, state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-20.0/src/main/java/datadog/trace/instrumentation/graphqljava20/GraphQLInstrumentation.java
@@ -65,7 +65,8 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
       return super.beginExecution(parameters, instrumentationState);
     }
     final State state = (State) instrumentationState;
-    final AgentSpan requestSpan = startSpan("graphql", GraphQLDecorator.GRAPHQL_REQUEST);
+    final AgentSpan requestSpan =
+        startSpan(GraphQLDecorator.GRAPHQL_JAVA.toString(), GraphQLDecorator.GRAPHQL_REQUEST);
     GraphQLDecorator.DECORATE.afterStart(requestSpan);
 
     state.setRequestSpan(requestSpan);
@@ -117,7 +118,9 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
     final State state = (State) instrumentationState;
     final AgentSpan parsingSpan =
         AgentTracer.startSpan(
-            "graphql", GraphQLDecorator.GRAPHQL_PARSING, state.getRequestSpan().context());
+            GraphQLDecorator.GRAPHQL_JAVA.toString(),
+            GraphQLDecorator.GRAPHQL_PARSING,
+            state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(parsingSpan);
     return new ParsingInstrumentationContext(parsingSpan, state, parameters.getQuery());
   }
@@ -132,7 +135,9 @@ public final class GraphQLInstrumentation extends SimplePerformantInstrumentatio
 
     final AgentSpan validationSpan =
         AgentTracer.startSpan(
-            "graphql", GraphQLDecorator.GRAPHQL_VALIDATION, state.getRequestSpan().context());
+            GraphQLDecorator.GRAPHQL_JAVA.toString(),
+            GraphQLDecorator.GRAPHQL_VALIDATION,
+            state.getRequestSpan().context());
     GraphQLDecorator.DECORATE.afterStart(validationSpan);
     return new ValidationInstrumentationContext(validationSpan);
   }

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
@@ -34,7 +34,7 @@ public class InstrumentedDataFetcher implements DataFetcher<Object> {
         return dataFetcher.get(environment);
       }
     } else {
-      final AgentSpan fieldSpan = startSpan("graphql.field", this.requestSpan.context());
+      final AgentSpan fieldSpan = startSpan("graphql", "graphql.field", this.requestSpan.context());
       DECORATE.afterStart(fieldSpan);
       String parentType = GraphQLTypeUtil.simplePrint(environment.getParentType());
       String fieldName = environment.getField().getName();

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/InstrumentedDataFetcher.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.graphqljava;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.DECORATE;
+import static datadog.trace.instrumentation.graphqljava.GraphQLDecorator.GRAPHQL_JAVA;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -34,7 +35,8 @@ public class InstrumentedDataFetcher implements DataFetcher<Object> {
         return dataFetcher.get(environment);
       }
     } else {
-      final AgentSpan fieldSpan = startSpan("graphql", "graphql.field", this.requestSpan.context());
+      final AgentSpan fieldSpan =
+          startSpan(GRAPHQL_JAVA.toString(), "graphql.field", this.requestSpan.context());
       DECORATE.afterStart(fieldSpan);
       String parentType = GraphQLTypeUtil.simplePrint(environment.getParentType());
       String fieldName = environment.getField().getName();

--- a/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -46,7 +46,7 @@ public final class AsyncHttpClientInstrumentation
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler<?> handler) {
       AgentSpan parentSpan = activeSpan();
-      AgentSpan span = startSpan("grizzly-client", HTTP_REQUEST);
+      AgentSpan span = startSpan("grizzly-http-async-client", HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       handler = new AsyncHandlerAdapter<>(span, parentSpan, handler);

--- a/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -46,7 +46,7 @@ public final class AsyncHttpClientInstrumentation
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler<?> handler) {
       AgentSpan parentSpan = activeSpan();
-      AgentSpan span = startSpan(HTTP_REQUEST);
+      AgentSpan span = startSpan("grizzly-client", HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       handler = new AsyncHandlerAdapter<>(span, parentSpan, handler);

--- a/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class GrizzlyByteBodyInstrumentationTest extends InstrumentationSpecification {
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
     TagContext ctx = new TagContext().withRequestContextDataAppSec(new Object())
-    def agentSpan = AgentTracer.startSpan('test-span', ctx)
+    def agentSpan = AgentTracer.startSpan('test', 'test-span', ctx)
     this.scope = AgentTracer.activateSpan(agentSpan)
 
     ss.registerCallback(EVENTS.requestBodyStart(), { RequestContext reqContext, StoredBodySupplier sup ->

--- a/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
@@ -34,7 +34,7 @@ class GrizzlyCharBodyInstrumentationTest extends InstrumentationSpecification {
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
     TagContext ctx = new TagContext().withRequestContextDataAppSec(new Object())
-    def agentSpan = AgentTracer.startSpan('test-span', ctx)
+    def agentSpan = AgentTracer.startSpan('test', 'test-span', ctx)
     this.scope = AgentTracer.activateSpan(agentSpan)
 
     ss.registerCallback(EVENTS.requestBodyStart(), { RequestContext reqContext, StoredBodySupplier sup ->

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -98,7 +98,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return AgentTracer.blackholeSpan();
     }
     AgentSpan span =
-        startSpan("grpc", OPERATION_NAME)
+        startSpan(COMPONENT_NAME.toString(), OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -98,7 +98,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return AgentTracer.blackholeSpan();
     }
     AgentSpan span =
-        startSpan(OPERATION_NAME)
+        startSpan("grpc", OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method))
             // method.getServiceName() may not be available on some grpc versions

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.OPERATION_NAME;
@@ -55,7 +56,7 @@ public final class MessagesAvailableInstrumentation
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan("grpc", GRPC_MESSAGE)
+            startSpan(COMPONENT_NAME.toString(), GRPC_MESSAGE)
                 .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
@@ -55,7 +55,8 @@ public final class MessagesAvailableInstrumentation
       AgentSpan clientSpan = activeSpan();
       if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
-            startSpan(GRPC_MESSAGE).setTag("message.type", clientSpan.getTag("response.type"));
+            startSpan("grpc", GRPC_MESSAGE)
+                .setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);
         return activateSpan(messageSpan);
       }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -67,7 +67,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     spanContext = callIGCallbackRequestStarted(tracer, spanContext);
 
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
-    final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
+    final AgentSpan span = startSpan("grpc", GRPC_SERVER, spanContext).setMeasured(true);
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
@@ -143,7 +143,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onMessage(final ReqT message) {
       final AgentSpan msgSpan =
-          startSpan(GRPC_MESSAGE, this.span.context())
+          startSpan("grpc", GRPC_MESSAGE, this.span.context())
               .setTag("message.type", message.getClass().getName());
       DECORATE.afterStart(msgSpan);
       try (AgentScope scope = activateSpan(msgSpan)) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.grpc.server.GrpcExtractAdapter.GETTER;
+import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.GRPC_SERVER;
@@ -67,7 +68,8 @@ public class TracingServerInterceptor implements ServerInterceptor {
     spanContext = callIGCallbackRequestStarted(tracer, spanContext);
 
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
-    final AgentSpan span = startSpan("grpc", GRPC_SERVER, spanContext).setMeasured(true);
+    final AgentSpan span =
+        startSpan(COMPONENT_NAME.toString(), GRPC_SERVER, spanContext).setMeasured(true);
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
@@ -143,7 +145,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onMessage(final ReqT message) {
       final AgentSpan msgSpan =
-          startSpan("grpc", GRPC_MESSAGE, this.span.context())
+          startSpan(COMPONENT_NAME.toString(), GRPC_MESSAGE, this.span.context())
               .setTag("message.type", message.getClass().getName());
       DECORATE.afterStart(msgSpan);
       try (AgentScope scope = activateSpan(msgSpan)) {

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hazelcast36.DistributedObjectDecorator.DECORATE;
+import static datadog.trace.instrumentation.hazelcast36.HazelcastConstants.COMPONENT_NAME;
 import static datadog.trace.instrumentation.hazelcast36.HazelcastConstants.SPAN_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -197,7 +198,7 @@ public final class DistributedObjectInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
+      final AgentSpan span = startSpan(COMPONENT_NAME.toString(), SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
@@ -256,7 +257,7 @@ public final class DistributedObjectInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
+      final AgentSpan span = startSpan(COMPONENT_NAME.toString(), SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectInstrumentation.java
@@ -197,7 +197,7 @@ public final class DistributedObjectInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
@@ -256,7 +256,7 @@ public final class DistributedObjectInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
@@ -68,7 +68,7 @@ public final class ClientInvocationInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
       DECORATE.onHazelcastInstance(
           span, InstrumentationContext.get(ClientInvocation.class, String.class).get(that));
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hazelcast39.ClientInvocationDecorator.DECORATE;
+import static datadog.trace.instrumentation.hazelcast39.HazelcastConstants.COMPONENT_NAME;
 import static datadog.trace.instrumentation.hazelcast39.HazelcastConstants.SPAN_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -68,7 +69,7 @@ public final class ClientInvocationInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
+      final AgentSpan span = startSpan(COMPONENT_NAME.toString(), SPAN_NAME);
       DECORATE.onHazelcastInstance(
           span, InstrumentationContext.get(ClientInvocation.class, String.class).get(that));
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
@@ -59,7 +59,7 @@ public final class ClientListenerInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan(SPAN_NAME);
+      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, operationName, null, correlationId);
 

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/ClientListenerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.hazelcast4;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.COMPONENT_NAME;
 import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.SPAN_NAME;
 import static datadog.trace.instrumentation.hazelcast4.HazelcastDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -59,7 +60,7 @@ public final class ClientListenerInstrumentation
         return null;
       }
 
-      final AgentSpan span = startSpan("hazelcast-sdk", SPAN_NAME);
+      final AgentSpan span = startSpan(COMPONENT_NAME.toString(), SPAN_NAME);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, operationName, null, correlationId);
 

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.hazelcast4;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.COMPONENT_NAME;
 import static datadog.trace.instrumentation.hazelcast4.HazelcastDecorator.DECORATE;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -36,7 +37,7 @@ public class InvocationAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan("hazelcast-sdk", HazelcastConstants.SPAN_NAME);
+    final AgentSpan span = startSpan(COMPONENT_NAME.toString(), HazelcastConstants.SPAN_NAME);
 
     span.setTag(
         HazelcastConstants.HAZELCAST_INSTANCE,

--- a/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
+++ b/dd-java-agent/instrumentation/hazelcast/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/InvocationAdvice.java
@@ -36,7 +36,7 @@ public class InvocationAdvice {
       return null;
     }
 
-    final AgentSpan span = startSpan(HazelcastConstants.SPAN_NAME);
+    final AgentSpan span = startSpan("hazelcast-sdk", HazelcastConstants.SPAN_NAME);
 
     span.setTag(
         HazelcastConstants.HAZELCAST_INSTANCE,

--- a/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -41,7 +41,8 @@ public class SessionMethodUtils {
 
     final AgentScope scope;
     if (createSpan) {
-      final AgentSpan span = startSpan(operationName, sessionState.getSessionSpan().context());
+      final AgentSpan span =
+          startSpan("hibernate-core", operationName, sessionState.getSessionSpan().context());
       DECORATOR.afterStart(span);
       DECORATOR.onOperation(span, entity);
       scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -42,7 +42,7 @@ public class SessionMethodUtils {
     final AgentScope scope;
     if (createSpan) {
       final AgentSpan span =
-          startSpan("hibernate-core", operationName, sessionState.getSessionSpan().context());
+          startSpan("java-hibernate", operationName, sessionState.getSessionSpan().context());
       DECORATOR.afterStart(span);
       DECORATOR.onOperation(span, entity);
       scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -57,7 +57,7 @@ public final class SessionFactoryInstrumentation extends AbstractHibernateInstru
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan("hibernate-core", HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -57,7 +57,7 @@ public final class SessionFactoryInstrumentation extends AbstractHibernateInstru
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final AgentSpan span = startSpan("hibernate-core", HIBERNATE_SESSION);
+      final AgentSpan span = startSpan("java-hibernate", HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/test/groovy/SessionTest.groovy
@@ -540,7 +540,7 @@ class SessionTest extends AbstractHibernateTest {
 
 
   def "test hibernate overlapping Sessions"() {
-    AgentScope scope = activateSpan(startSpan("overlapping Sessions"))
+    AgentScope scope = activateSpan(startSpan("test", "overlapping Sessions"))
 
     def session1 = sessionFactory.openSession()
     session1.beginTransaction()

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -51,7 +51,7 @@ public final class SessionFactoryInstrumentation extends AbstractHibernateInstru
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final AgentSpan span = startSpan("hibernate-core", HIBERNATE_SESSION);
+      final AgentSpan span = startSpan("java-hibernate", HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -51,7 +51,7 @@ public final class SessionFactoryInstrumentation extends AbstractHibernateInstru
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan("hibernate-core", HIBERNATE_SESSION);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/test/groovy/SessionTest.groovy
@@ -466,7 +466,7 @@ class SessionTest extends AbstractHibernateTest {
   def "test hibernate overlapping Sessions"() {
     setup:
 
-    AgentScope scope = activateSpan(startSpan("overlapping Sessions"))
+    AgentScope scope = activateSpan(startSpan("test", "overlapping Sessions"))
 
     def session1 = sessionFactory.openSession()
     session1.beginTransaction()

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixOnSubscribe.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixOnSubscribe.java
@@ -24,6 +24,11 @@ public class HystrixOnSubscribe extends TracedOnSubscribe {
   }
 
   @Override
+  protected String instrumentationName() {
+    return "hystrix";
+  }
+
+  @Override
   protected void afterStart(final AgentSpan span) {
     super.afterStart(span);
 

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
@@ -68,7 +68,7 @@ public final class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheIn
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -124,7 +124,7 @@ public final class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheIn
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
@@ -68,7 +68,7 @@ public final class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheIn
         return null;
       }
 
-      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite-cache", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -124,7 +124,7 @@ public final class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheIn
         return null;
       }
 
-      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite-cache", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
@@ -81,7 +81,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -122,7 +122,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -162,7 +162,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan(IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheSyncInstrumentation.java
@@ -81,7 +81,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite-cache", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -122,7 +122,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite-cache", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
@@ -162,7 +162,7 @@ public final class IgniteCacheSyncInstrumentation extends AbstractIgniteCacheIns
         return null;
       }
 
-      final AgentSpan span = startSpan("ignite", IgniteCacheDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("ignite-cache", IgniteCacheDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onIgnite(
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
@@ -25,7 +25,7 @@ public class RecursiveThreadPoolExecution implements Runnable {
     if (depth == maxDepth) {
       return;
     }
-    AgentSpan span = startSpan(String.valueOf(depth));
+    AgentSpan span = startSpan("test", String.valueOf(depth));
     try (AgentScope scope = activateSpan(span)) {
       executor.execute(new RecursiveThreadPoolExecution(executor, maxDepth, depth + 1));
     } finally {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
@@ -26,7 +26,7 @@ public class RecursiveThreadPoolMixedSubmissionAndExecution implements Runnable 
     if (depth == maxDepth) {
       return;
     }
-    AgentSpan span = startSpan(String.valueOf(depth));
+    AgentSpan span = startSpan("test", String.valueOf(depth));
     try (AgentScope scope = activateSpan(span)) {
       if (depth % 2 == 0) {
         executor.submit(

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
@@ -25,7 +25,7 @@ public class RecursiveThreadPoolSubmission implements Runnable {
     if (depth == maxDepth) {
       return;
     }
-    AgentSpan span = startSpan(String.valueOf(depth));
+    AgentSpan span = startSpan("test", String.valueOf(depth));
     try (AgentScope scope = activateSpan(span)) {
       executor.submit(new RecursiveThreadPoolSubmission(executor, maxDepth, depth + 1));
     } finally {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/forkjoin/LinearTask.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/forkjoin/LinearTask.java
@@ -33,7 +33,7 @@ public class LinearTask extends RecursiveTask<Integer> {
       return parent;
     } else {
       int next = parent + 1;
-      AgentSpan span = startSpan(Integer.toString(next));
+      AgentSpan span = startSpan("test", Integer.toString(next));
       try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/runnable/Descendant.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/runnable/Descendant.java
@@ -16,7 +16,7 @@ public final class Descendant implements Runnable {
 
   @Override
   public void run() {
-    AgentSpan span = startSpan(parent + "-child");
+    AgentSpan span = startSpan("test", parent + "-child");
     try (AgentScope scope = activateSpan(span)) {
 
     } finally {

--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -25,7 +25,7 @@ class ProcessImplStartAdvice {
       return null;
     }
 
-    final AgentSpan span = AgentTracer.startSpan("appsec", "command_execution");
+    final AgentSpan span = AgentTracer.startSpan("subprocess", "command_execution");
     span.setSpanType("system");
     span.setResourceName(ProcessImplInstrumentationHelpers.determineResource(command));
     span.setTag("component", "subprocess");

--- a/dd-java-agent/instrumentation/java/java-net/java-net-1.8/src/main/java/datadog/trace/instrumentation/java/net/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-1.8/src/main/java/datadog/trace/instrumentation/java/net/UrlInstrumentation.java
@@ -53,7 +53,7 @@ public class UrlInstrumentation extends InstrumenterModule.Tracing
         String protocol = url.getProtocol();
         protocol = protocol != null ? protocol : "url";
 
-        final AgentSpan span = startSpan(DECORATE.operationName(protocol));
+        final AgentSpan span = startSpan("urlconnection", DECORATE.operationName(protocol));
 
         try (final AgentScope scope = activateSpan(span)) {
           DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/java/java-net/java-net-1.8/src/main/java/datadog/trace/instrumentation/java/net/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-1.8/src/main/java/datadog/trace/instrumentation/java/net/UrlInstrumentation.java
@@ -53,7 +53,7 @@ public class UrlInstrumentation extends InstrumenterModule.Tracing
         String protocol = url.getProtocol();
         protocol = protocol != null ? protocol : "url";
 
-        final AgentSpan span = startSpan("urlconnection", DECORATE.operationName(protocol));
+        final AgentSpan span = startSpan("UrlConnection", DECORATE.operationName(protocol));
 
         try (final AgentScope scope = activateSpan(span)) {
           DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -56,7 +56,7 @@ public final class RmiClientInstrumentation extends InstrumenterModule.Tracing
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span = startSpan(RMI_INVOKE);
+      final AgentSpan span = startSpan("rmi", RMI_INVOKE);
       DECORATE.afterStart(span);
       DECORATE.onMethodInvocation(span, method);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.rmi.RmiClientDecorator.DECORATE;
+import static datadog.trace.bootstrap.instrumentation.rmi.RmiClientDecorator.RMI_CLIENT;
 import static datadog.trace.bootstrap.instrumentation.rmi.RmiClientDecorator.RMI_INVOKE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -56,7 +57,7 @@ public final class RmiClientInstrumentation extends InstrumenterModule.Tracing
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span = startSpan("rmi", RMI_INVOKE);
+      final AgentSpan span = startSpan(RMI_CLIENT.toString(), RMI_INVOKE);
       DECORATE.afterStart(span);
       DECORATE.onMethodInvocation(span, method);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -57,9 +57,9 @@ public final class RmiServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span;
       if (context == null) {
-        span = startSpan(RMI_REQUEST);
+        span = startSpan("rmi", RMI_REQUEST);
       } else {
-        span = startSpan(RMI_REQUEST, context);
+        span = startSpan("rmi", RMI_REQUEST, context);
       }
 
       span.setResourceName(DECORATE.spanNameForMethod(method));

--- a/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-rmi-1.1/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.rmi.RmiServerDecorator.DECORATE;
 import static datadog.trace.bootstrap.instrumentation.rmi.RmiServerDecorator.RMI_REQUEST;
+import static datadog.trace.bootstrap.instrumentation.rmi.RmiServerDecorator.RMI_SERVER;
 import static datadog.trace.bootstrap.instrumentation.rmi.ThreadLocalContext.THREAD_LOCAL_CONTEXT;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -57,9 +58,9 @@ public final class RmiServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span;
       if (context == null) {
-        span = startSpan("rmi", RMI_REQUEST);
+        span = startSpan(RMI_SERVER.toString(), RMI_REQUEST);
       } else {
-        span = startSpan("rmi", RMI_REQUEST, context);
+        span = startSpan(RMI_SERVER.toString(), RMI_REQUEST, context);
       }
 
       span.setResourceName(DECORATE.spanNameForMethod(method));

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -89,16 +89,16 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
-            span = startSpan("jdbc", DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
             DECORATE.setApplicationName(span, connection);
           } else if (DECORATE.isOracle(dbInfo)) {
-            span = startSpan("jdbc", DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan("jdbc", DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
           }
         } else {
-          span = startSpan("jdbc", DATABASE_QUERY);
+          span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
         }
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -89,16 +89,16 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan("jdbc", DATABASE_QUERY);
             DECORATE.setApplicationName(span, connection);
           } else if (DECORATE.isOracle(dbInfo)) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan("jdbc", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan("jdbc", DATABASE_QUERY);
           }
         } else {
-          span = startSpan(DATABASE_QUERY);
+          span = startSpan("jdbc", DATABASE_QUERY);
         }
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DBM_TRACE_PREPARED_STATEMENTS;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
-import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JAVA_JDBC;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logMissingQueryInfo;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logSQLException;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -90,16 +89,16 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
-            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
             DECORATE.setApplicationName(span, connection);
           } else if (DECORATE.isOracle(dbInfo)) {
-            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
           }
         } else {
-          span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+          span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
         }
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -8,6 +8,7 @@ import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DBM_TRACE_PREPARED_STATEMENTS;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JAVA_JDBC;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logMissingQueryInfo;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.logSQLException;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -89,16 +90,16 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
-            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
+            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
             DECORATE.setApplicationName(span, connection);
           } else if (DECORATE.isOracle(dbInfo)) {
-            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
+            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
+            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
           }
         } else {
-          span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);
+          span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
         }
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.DATABASE_CONNECTION;
 import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.DECORATE;
+import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.JAVA_JDBC_CONNECTION;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -64,7 +65,7 @@ public final class DataSourceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan("jdbc-datasource", DATABASE_CONNECTION);
+      final AgentSpan span = startSpan(JAVA_JDBC_CONNECTION.toString(), DATABASE_CONNECTION);
       DECORATE.afterStart(span);
 
       span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -64,7 +64,7 @@ public final class DataSourceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(DATABASE_CONNECTION);
+      final AgentSpan span = startSpan("jdbc-datasource", DATABASE_CONNECTION);
       DECORATE.afterStart(span);
 
       span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/Dbcp2LinkedBlockingDequeInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/Dbcp2LinkedBlockingDequeInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jdbc;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.DECORATE;
+import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.JAVA_JDBC_POOL_WAITING;
 import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.POOL_WAITING;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -51,7 +52,7 @@ public final class Dbcp2LinkedBlockingDequeInstrumentation extends InstrumenterM
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentSpan onEnter() {
       if (CallDepthThreadLocalMap.getCallDepth(PoolWaitingDecorator.class) > 0) {
-        AgentSpan span = startSpan("jdbc", POOL_WAITING);
+        AgentSpan span = startSpan(JAVA_JDBC_POOL_WAITING.toString(), POOL_WAITING);
         DECORATE.afterStart(span);
         span.setResourceName("dbcp2.waiting");
         return span;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/Dbcp2LinkedBlockingDequeInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/Dbcp2LinkedBlockingDequeInstrumentation.java
@@ -51,7 +51,7 @@ public final class Dbcp2LinkedBlockingDequeInstrumentation extends InstrumenterM
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentSpan onEnter() {
       if (CallDepthThreadLocalMap.getCallDepth(PoolWaitingDecorator.class) > 0) {
-        AgentSpan span = startSpan(POOL_WAITING);
+        AgentSpan span = startSpan("jdbc", POOL_WAITING);
         DECORATE.afterStart(span);
         span.setResourceName("dbcp2.waiting");
         return span;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagInstrumentation.java
@@ -88,7 +88,7 @@ public final class HikariConcurrentBagInstrumentation extends InstrumenterModule
         @Advice.Thrown final Throwable throwable) {
       if (HikariBlockedTracker.wasBlocked()) {
         final AgentSpan span =
-            startSpan(POOL_WAITING, TimeUnit.MILLISECONDS.toMicros(startTimeMillis));
+            startSpan("jdbc", POOL_WAITING, TimeUnit.MILLISECONDS.toMicros(startTimeMillis));
         DECORATE.afterStart(span);
         DECORATE.onError(span, throwable);
         span.setResourceName("hikari.waiting");

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/HikariConcurrentBagInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_POOL_NAME;
 import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.DECORATE;
+import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.JAVA_JDBC_POOL_WAITING;
 import static datadog.trace.instrumentation.jdbc.PoolWaitingDecorator.POOL_WAITING;
 import static java.util.Collections.singletonMap;
 
@@ -88,7 +89,10 @@ public final class HikariConcurrentBagInstrumentation extends InstrumenterModule
         @Advice.Thrown final Throwable throwable) {
       if (HikariBlockedTracker.wasBlocked()) {
         final AgentSpan span =
-            startSpan("jdbc", POOL_WAITING, TimeUnit.MILLISECONDS.toMicros(startTimeMillis));
+            startSpan(
+                JAVA_JDBC_POOL_WAITING.toString(),
+                POOL_WAITING,
+                TimeUnit.MILLISECONDS.toMicros(startTimeMillis));
         DECORATE.afterStart(span);
         DECORATE.onError(span, throwable);
         span.setResourceName("hikari.waiting");

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -100,13 +100,13 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // we then force that pre-determined span ID for the span covering the actual query
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
           } else if (isOracle) {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan("jdbc", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(DATABASE_QUERY);
+            span = startSpan("jdbc", DATABASE_QUERY);
           }
         } else {
-          span = startSpan(DATABASE_QUERY);
+          span = startSpan("jdbc", DATABASE_QUERY);
         }
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -100,13 +100,13 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // we then force that pre-determined span ID for the span covering the actual query
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
           } else if (isOracle) {
-            span = startSpan("jdbc", DATABASE_QUERY);
+            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan("jdbc", DATABASE_QUERY);
+            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
           }
         } else {
-          span = startSpan("jdbc", DATABASE_QUERY);
+          span = startSpan("java-jdbc-statement", DATABASE_QUERY);
         }
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -10,7 +10,6 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DB
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
-import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JAVA_JDBC;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -101,13 +100,13 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // we then force that pre-determined span ID for the span covering the actual query
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
           } else if (isOracle) {
-            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
           }
         } else {
-          span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
+          span = startSpan("java-jdbc-statement", DATABASE_QUERY);
         }
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -10,6 +10,7 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DB
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.JAVA_JDBC;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -100,13 +101,13 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // we then force that pre-determined span ID for the span covering the actual query
             span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
           } else if (isOracle) {
-            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
+            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
             DECORATE.setAction(span, connection);
           } else {
-            span = startSpan("java-jdbc-statement", DATABASE_QUERY);
+            span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
           }
         } else {
-          span = startSpan("java-jdbc-statement", DATABASE_QUERY);
+          span = startSpan(JAVA_JDBC.toString(), DATABASE_QUERY);
         }
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jedis.JedisClientDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.jedis.JedisClientDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -64,7 +65,8 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span =
+          startSpan(COMPONENT_NAME.toString(), JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
       DECORATE.onStatement(span, command.name());

--- a/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -64,7 +64,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
       DECORATE.onStatement(span, command.name());

--- a/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
@@ -56,7 +56,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
@@ -56,7 +56,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
       if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
@@ -56,7 +56,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope onEnter(
         @Advice.Argument(0) final CommandObject<?> commandObject,
         @Advice.This final Connection thiz) {
-      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
@@ -56,7 +56,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope onEnter(
         @Advice.Argument(0) final CommandObject<?> commandObject,
         @Advice.This final Connection thiz) {
-      final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("jedis", JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
+++ b/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
@@ -44,12 +44,13 @@ public class DatadogMessageListener implements MessageListener {
     }
     long startMillis = GETTER.extractTimeInQueueStart(message);
     if (startMillis == 0 || !TIME_IN_QUEUE_ENABLED) {
-      span = startSpan(JMS_CONSUME, propagatedContext);
+      span = startSpan("jms", JMS_CONSUME, propagatedContext);
     } else {
       long batchId = GETTER.extractMessageBatchId(message);
       AgentSpan timeInQueue = consumerState.getTimeInQueueSpan(batchId);
       if (null == timeInQueue) {
-        timeInQueue = startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
+        timeInQueue =
+            startSpan("jms", JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
         BROKER_DECORATE.afterStart(timeInQueue);
         BROKER_DECORATE.onTimeInQueue(
             timeInQueue,
@@ -57,7 +58,7 @@ public class DatadogMessageListener implements MessageListener {
             consumerState.getBrokerServiceName());
         consumerState.setTimeInQueueSpan(batchId, timeInQueue);
       }
-      span = startSpan(JMS_CONSUME, timeInQueue.context());
+      span = startSpan("jms", JMS_CONSUME, timeInQueue.context());
     }
     CONSUMER_DECORATE.afterStart(span);
     CONSUMER_DECORATE.onConsume(span, message, consumerState.getConsumerResourceName());

--- a/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -142,13 +142,13 @@ public final class JMSMessageConsumerInstrumentation
       }
       long startMillis = GETTER.extractTimeInQueueStart(message);
       if (startMillis == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan(JMS_CONSUME, propagatedContext);
+        span = startSpan("jms", JMS_CONSUME, propagatedContext);
       } else {
         long batchId = GETTER.extractMessageBatchId(message);
         AgentSpan timeInQueue = consumerState.getTimeInQueueSpan(batchId);
         if (null == timeInQueue) {
           timeInQueue =
-              startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
+              startSpan("jms", JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
           BROKER_DECORATE.afterStart(timeInQueue);
           BROKER_DECORATE.onTimeInQueue(
               timeInQueue,
@@ -156,7 +156,7 @@ public final class JMSMessageConsumerInstrumentation
               consumerState.getBrokerServiceName());
           consumerState.setTimeInQueueSpan(batchId, timeInQueue);
         }
-        span = startSpan(JMS_CONSUME, timeInQueue.context());
+        span = startSpan("jms", JMS_CONSUME, timeInQueue.context());
       }
 
       CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -103,7 +103,7 @@ public final class JMSMessageProducerInstrumentation
         destinationName = "";
       }
 
-      final AgentSpan span = startSpan(JMS_PRODUCE);
+      final AgentSpan span = startSpan("jms", JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
 
@@ -173,7 +173,7 @@ public final class JMSMessageProducerInstrumentation
       String destinationName = PRODUCER_DECORATE.getDestinationName(destination);
       CharSequence resourceName = PRODUCER_DECORATE.toResourceName(destinationName, isQueue);
 
-      final AgentSpan span = startSpan(JMS_PRODUCE);
+      final AgentSpan span = startSpan("jms", JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
 

--- a/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/MDBMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/javax-jms-1.1/src/main/java/datadog/trace/instrumentation/jms/MDBMessageConsumerInstrumentation.java
@@ -85,7 +85,7 @@ public final class MDBMessageConsumerInstrumentation
       if (CallDepthThreadLocalMap.incrementCallDepth(MessageListener.class) > 0) {
         return null;
       }
-      AgentSpan span = startSpan(JMS_CONSUME);
+      AgentSpan span = startSpan("jms", JMS_CONSUME);
       CONSUMER_DECORATE.afterStart(span);
       CharSequence consumerResourceName;
       try {

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -59,7 +59,8 @@ public final class JSPInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(
         @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
-      final AgentSpan span = startSpan(JSP_RENDER).setTag("servlet.context", req.getContextPath());
+      final AgentSpan span =
+          startSpan("jsp", JSP_RENDER).setTag("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);
       DECORATE.onRender(span, req);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jsp.JSPDecorator.DECORATE;
+import static datadog.trace.instrumentation.jsp.JSPDecorator.JSP_HTTP_SERVLET;
 import static datadog.trace.instrumentation.jsp.JSPDecorator.JSP_RENDER;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -60,7 +61,8 @@ public final class JSPInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope onEnter(
         @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
       final AgentSpan span =
-          startSpan("jsp", JSP_RENDER).setTag("servlet.context", req.getContextPath());
+          startSpan(JSP_HTTP_SERVLET.toString(), JSP_RENDER)
+              .setTag("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);
       DECORATE.onRender(span, req);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -48,7 +48,7 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter() {
-      final AgentSpan span = startSpan(JSP_COMPILE);
+      final AgentSpan span = startSpan("jsp", JSP_COMPILE);
       DECORATE.afterStart(span);
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jsp.JSPDecorator.DECORATE;
 import static datadog.trace.instrumentation.jsp.JSPDecorator.JSP_COMPILE;
+import static datadog.trace.instrumentation.jsp.JSPDecorator.JSP_HTTP_SERVLET;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -48,7 +49,7 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter() {
-      final AgentSpan span = startSpan("jsp", JSP_COMPILE);
+      final AgentSpan span = startSpan(JSP_HTTP_SERVLET.toString(), JSP_COMPILE);
       DECORATE.afterStart(span);
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
@@ -251,7 +251,7 @@ public final class KafkaConsumerInfoInstrumentation extends InstrumenterModule.T
       }
 
       if (traceConfig().isDataStreamsEnabled()) {
-        final AgentSpan span = startSpan(KAFKA_POLL);
+        final AgentSpan span = startSpan("kafka", KAFKA_POLL);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfoInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_RECORDS_COUNT;
+import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_POLL;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -251,7 +252,7 @@ public final class KafkaConsumerInfoInstrumentation extends InstrumenterModule.T
       }
 
       if (traceConfig().isDataStreamsEnabled()) {
-        final AgentSpan span = startSpan("kafka", KAFKA_POLL);
+        final AgentSpan span = startSpan(JAVA_KAFKA.toString(), KAFKA_POLL);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -160,10 +160,10 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
       final AgentSpan callbackParentSpan;
 
       if (extractedContext != null) {
-        span = startSpan(KAFKA_PRODUCE, extractedContext);
+        span = startSpan("kafka", KAFKA_PRODUCE, extractedContext);
         callbackParentSpan = span;
       } else {
-        span = startSpan(KAFKA_PRODUCE);
+        span = startSpan("kafka", KAFKA_PRODUCE);
         callbackParentSpan = localActiveSpan;
       }
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.PRODUCER_DECORATE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.TIME_IN_QUEUE_ENABLED;
@@ -160,10 +161,10 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
       final AgentSpan callbackParentSpan;
 
       if (extractedContext != null) {
-        span = startSpan("kafka", KAFKA_PRODUCE, extractedContext);
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_PRODUCE, extractedContext);
         callbackParentSpan = span;
       } else {
-        span = startSpan("kafka", KAFKA_PRODUCE);
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_PRODUCE);
         callbackParentSpan = localActiveSpan;
       }
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -104,13 +104,14 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
               extractContextAndGetSpanContext(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
           if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-            span = startSpan(operationName, spanContext);
+            span = startSpan("kafka", operationName, spanContext);
           } else {
             queueSpan =
-                startSpan(KAFKA_DELIVER, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
+                startSpan(
+                    "kafka", KAFKA_DELIVER, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
             BROKER_DECORATE.afterStart(queueSpan);
             BROKER_DECORATE.onTimeInQueue(queueSpan, val);
-            span = startSpan(operationName, queueSpan.context());
+            span = startSpan("kafka", operationName, queueSpan.context());
             BROKER_DECORATE.beforeFinish(queueSpan);
             // The queueSpan will be finished after inner span has been activated to ensure that
             // spans are written out together by TraceStructureWriter when running in strict mode
@@ -136,7 +137,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
             }
           }
         } else {
-          span = startSpan(operationName, null);
+          span = startSpan("kafka", operationName, null);
         }
         if (val.value() == null) {
           span.setTag(InstrumentationTags.TOMBSTONE, true);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfi
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.BROKER_DECORATE;
+import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_DELIVER;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter.GETTER;
@@ -104,14 +105,17 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
               extractContextAndGetSpanContext(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
           if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-            span = startSpan("kafka", operationName, spanContext);
+            span = startSpan(JAVA_KAFKA.toString(), operationName, spanContext);
           } else {
             queueSpan =
                 startSpan(
-                    "kafka", KAFKA_DELIVER, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
+                    JAVA_KAFKA.toString(),
+                    KAFKA_DELIVER,
+                    spanContext,
+                    MILLISECONDS.toMicros(timeInQueueStart));
             BROKER_DECORATE.afterStart(queueSpan);
             BROKER_DECORATE.onTimeInQueue(queueSpan, val);
-            span = startSpan("kafka", operationName, queueSpan.context());
+            span = startSpan(JAVA_KAFKA.toString(), operationName, queueSpan.context());
             BROKER_DECORATE.beforeFinish(queueSpan);
             // The queueSpan will be finished after inner span has been activated to ensure that
             // spans are written out together by TraceStructureWriter when running in strict mode
@@ -137,7 +141,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
             }
           }
         } else {
-          span = startSpan("kafka", operationName, null);
+          span = startSpan(JAVA_KAFKA.toString(), operationName, null);
         }
         if (val.value() == null) {
           span.setTag(InstrumentationTags.TOMBSTONE, true);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -239,7 +239,7 @@ class KafkaClientCustomPropagationConfigTest extends InstrumentationSpecificatio
     when:
     Headers header = new RecordHeaders()
 
-    AgentSpan span = startSpan(KAFKA_PRODUCE)
+    AgentSpan span = startSpan("kafka", KAFKA_PRODUCE)
     activateSpan(span).withCloseable {
       for (String topic : SHARED_TOPIC) {
         ProducerRecord record = new ProducerRecord<>(

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
@@ -49,10 +49,10 @@ public class ProducerAdvice {
     final AgentSpan callbackParentSpan;
 
     if (extractedContext != null) {
-      span = startSpan(KAFKA_PRODUCE, extractedContext);
+      span = startSpan("kafka", KAFKA_PRODUCE, extractedContext);
       callbackParentSpan = span;
     } else {
-      span = startSpan(KAFKA_PRODUCE);
+      span = startSpan("kafka", KAFKA_PRODUCE);
       callbackParentSpan = localActiveSpan;
     }
     PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/ProducerAdvice.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extra
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.KAFKA_PRODUCE;
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.PRODUCER_DECORATE;
 
@@ -49,10 +50,10 @@ public class ProducerAdvice {
     final AgentSpan callbackParentSpan;
 
     if (extractedContext != null) {
-      span = startSpan("kafka", KAFKA_PRODUCE, extractedContext);
+      span = startSpan(JAVA_KAFKA.toString(), KAFKA_PRODUCE, extractedContext);
       callbackParentSpan = span;
     } else {
-      span = startSpan("kafka", KAFKA_PRODUCE);
+      span = startSpan(JAVA_KAFKA.toString(), KAFKA_PRODUCE);
       callbackParentSpan = localActiveSpan;
     }
     PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.KAFKA_RECORDS_COUNT;
+import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.KAFKA_POLL;
 
 import datadog.trace.api.Config;
@@ -38,7 +39,7 @@ public class RecordsAdvice {
     }
 
     if (traceConfig().isDataStreamsEnabled()) {
-      final AgentSpan span = startSpan("kafka", KAFKA_POLL);
+      final AgentSpan span = startSpan(JAVA_KAFKA.toString(), KAFKA_POLL);
       return activateSpan(span);
     }
     return null;

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/RecordsAdvice.java
@@ -38,7 +38,7 @@ public class RecordsAdvice {
     }
 
     if (traceConfig().isDataStreamsEnabled()) {
-      final AgentSpan span = startSpan(KAFKA_POLL);
+      final AgentSpan span = startSpan("kafka", KAFKA_POLL);
       return activateSpan(span);
     }
     return null;

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
@@ -11,6 +11,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
+import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_clients38.TextMapExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.kafka_clients38.TextMapInjectAdapter.SETTER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -100,17 +101,17 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
               extractContextAndGetSpanContext(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
           if (timeInQueueStart == 0 || !KafkaDecorator.TIME_IN_QUEUE_ENABLED) {
-            span = startSpan("kafka", operationName, spanContext);
+            span = startSpan(JAVA_KAFKA.toString(), operationName, spanContext);
           } else {
             queueSpan =
                 startSpan(
-                    "kafka",
+                    JAVA_KAFKA.toString(),
                     KafkaDecorator.KAFKA_DELIVER,
                     spanContext,
                     MILLISECONDS.toMicros(timeInQueueStart));
             KafkaDecorator.BROKER_DECORATE.afterStart(queueSpan);
             KafkaDecorator.BROKER_DECORATE.onTimeInQueue(queueSpan, val);
-            span = startSpan("kafka", operationName, queueSpan.context());
+            span = startSpan(JAVA_KAFKA.toString(), operationName, queueSpan.context());
             KafkaDecorator.BROKER_DECORATE.beforeFinish(queueSpan);
             // The queueSpan will be finished after inner span has been activated to ensure that
             // spans are written out together by TraceStructureWriter when running in strict mode
@@ -136,7 +137,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
             }
           }
         } else {
-          span = startSpan("kafka", operationName, null);
+          span = startSpan(JAVA_KAFKA.toString(), operationName, null);
         }
         if (val.value() == null) {
           span.setTag(InstrumentationTags.TOMBSTONE, true);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TracingIterator.java
@@ -100,16 +100,17 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
               extractContextAndGetSpanContext(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
           if (timeInQueueStart == 0 || !KafkaDecorator.TIME_IN_QUEUE_ENABLED) {
-            span = startSpan(operationName, spanContext);
+            span = startSpan("kafka", operationName, spanContext);
           } else {
             queueSpan =
                 startSpan(
+                    "kafka",
                     KafkaDecorator.KAFKA_DELIVER,
                     spanContext,
                     MILLISECONDS.toMicros(timeInQueueStart));
             KafkaDecorator.BROKER_DECORATE.afterStart(queueSpan);
             KafkaDecorator.BROKER_DECORATE.onTimeInQueue(queueSpan, val);
-            span = startSpan(operationName, queueSpan.context());
+            span = startSpan("kafka", operationName, queueSpan.context());
             KafkaDecorator.BROKER_DECORATE.beforeFinish(queueSpan);
             // The queueSpan will be finished after inner span has been activated to ensure that
             // spans are written out together by TraceStructureWriter when running in strict mode
@@ -135,7 +136,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
             }
           }
         } else {
-          span = startSpan(operationName, null);
+          span = startSpan("kafka", operationName, null);
         }
         if (val.value() == null) {
           span.setTag(InstrumentationTags.TOMBSTONE, true);

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -249,7 +249,7 @@ class KafkaClientCustomPropagationConfigTest extends InstrumentationSpecificatio
     when:
     Headers header = new RecordHeaders()
 
-    AgentSpan span = startSpan(KAFKA_PRODUCE)
+    AgentSpan span = startSpan("kafka", KAFKA_PRODUCE)
     activateSpan(span).withCloseable {
       for (String topic : SHARED_TOPIC) {
         ProducerRecord record = new ProducerRecord<>(

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -280,12 +280,13 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
           InstrumentationContext.get(StreamTask.class, StreamTaskContext.class).get(task);
       long timeInQueueStart = SR_GETTER.extractTimeInQueueStart(record);
       if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan(KAFKA_CONSUME);
+        span = startSpan("kafka-streams", KAFKA_CONSUME);
       } else {
-        queueSpan = startSpan(KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
+        queueSpan =
+            startSpan("kafka-streams", KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
         BROKER_DECORATE.afterStart(queueSpan);
         BROKER_DECORATE.onTimeInQueue(queueSpan, record);
-        span = startSpan(KAFKA_CONSUME, queueSpan.context());
+        span = startSpan("kafka-streams", KAFKA_CONSUME, queueSpan.context());
         BROKER_DECORATE.beforeFinish(queueSpan);
         // The queueSpan will be finished after inner span has been activated to ensure that
         // spans are written out together by TraceStructureWriter when running in strict mode
@@ -344,12 +345,13 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
           InstrumentationContext.get(StreamTask.class, StreamTaskContext.class).get(task);
       long timeInQueueStart = PR_GETTER.extractTimeInQueueStart(record);
       if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan(KAFKA_CONSUME);
+        span = startSpan("kafka-streams", KAFKA_CONSUME);
       } else {
-        queueSpan = startSpan(KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
+        queueSpan =
+            startSpan("kafka-streams", KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
         BROKER_DECORATE.afterStart(queueSpan);
         BROKER_DECORATE.onTimeInQueue(queueSpan, record);
-        span = startSpan(KAFKA_CONSUME, queueSpan.context());
+        span = startSpan("kafka-streams", KAFKA_CONSUME, queueSpan.context());
         BROKER_DECORATE.beforeFinish(queueSpan);
         // The queueSpan will be finished after inner span has been activated to ensure that
         // spans are written out together by TraceStructureWriter when running in strict mode

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -15,6 +15,7 @@ import static datadog.trace.instrumentation.kafka_common.StreamingContext.STREAM
 import static datadog.trace.instrumentation.kafka_common.Utils.computePayloadSizeBytes;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.JAVA_KAFKA;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_CONSUME;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_DELIVER;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.TIME_IN_QUEUE_ENABLED;
@@ -280,13 +281,14 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
           InstrumentationContext.get(StreamTask.class, StreamTaskContext.class).get(task);
       long timeInQueueStart = SR_GETTER.extractTimeInQueueStart(record);
       if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan("kafka-streams", KAFKA_CONSUME);
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_CONSUME);
       } else {
         queueSpan =
-            startSpan("kafka-streams", KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
+            startSpan(
+                JAVA_KAFKA.toString(), KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
         BROKER_DECORATE.afterStart(queueSpan);
         BROKER_DECORATE.onTimeInQueue(queueSpan, record);
-        span = startSpan("kafka-streams", KAFKA_CONSUME, queueSpan.context());
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_CONSUME, queueSpan.context());
         BROKER_DECORATE.beforeFinish(queueSpan);
         // The queueSpan will be finished after inner span has been activated to ensure that
         // spans are written out together by TraceStructureWriter when running in strict mode
@@ -345,13 +347,14 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
           InstrumentationContext.get(StreamTask.class, StreamTaskContext.class).get(task);
       long timeInQueueStart = PR_GETTER.extractTimeInQueueStart(record);
       if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
-        span = startSpan("kafka-streams", KAFKA_CONSUME);
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_CONSUME);
       } else {
         queueSpan =
-            startSpan("kafka-streams", KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
+            startSpan(
+                JAVA_KAFKA.toString(), KAFKA_DELIVER, MILLISECONDS.toMicros(timeInQueueStart));
         BROKER_DECORATE.afterStart(queueSpan);
         BROKER_DECORATE.onTimeInQueue(queueSpan, record);
-        span = startSpan("kafka-streams", KAFKA_CONSUME, queueSpan.context());
+        span = startSpan(JAVA_KAFKA.toString(), KAFKA_CONSUME, queueSpan.context());
         BROKER_DECORATE.beforeFinish(queueSpan);
         // The queueSpan will be finished after inner span has been activated to ensure that
         // spans are written out together by TraceStructureWriter when running in strict mode

--- a/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
@@ -34,7 +34,7 @@ public final class InstrumentationPoints {
 
   public static AgentScope beforeCommand(
       final RedisCommand<?, ?, ?> command, final RedisURI redisURI) {
-    final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
     DECORATE.onCommand(span, command);
@@ -73,7 +73,7 @@ public final class InstrumentationPoints {
   }
 
   public static AgentScope beforeConnect(final RedisURI redisURI) {
-    final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
     span.setResourceName(DECORATE.resourceNameForConnection(redisURI));

--- a/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
@@ -11,6 +11,7 @@ import static com.lambdaworks.redis.protocol.CommandType.SHUTDOWN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce4.LettuceClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.lettuce4.LettuceClientDecorator.REDIS_CLIENT;
 
 import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.protocol.AsyncCommand;
@@ -34,7 +35,8 @@ public final class InstrumentationPoints {
 
   public static AgentScope beforeCommand(
       final RedisCommand<?, ?, ?> command, final RedisURI redisURI) {
-    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span =
+        startSpan(REDIS_CLIENT.toString(), LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
     DECORATE.onCommand(span, command);
@@ -73,7 +75,8 @@ public final class InstrumentationPoints {
   }
 
   public static AgentScope beforeConnect(final RedisURI redisURI) {
-    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span =
+        startSpan(REDIS_CLIENT.toString(), LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
     span.setResourceName(DECORATE.resourceNameForConnection(redisURI));

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
@@ -15,7 +15,7 @@ import net.bytebuddy.asm.Advice;
 public class ConnectionFutureAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Argument(1) final RedisURI redisUri) {
-    final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     span.setResourceName(DECORATE.resourceNameForConnection(redisUri));
     DECORATE.onConnection(span, redisUri);

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
@@ -15,7 +15,9 @@ import net.bytebuddy.asm.Advice;
 public class ConnectionFutureAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Argument(1) final RedisURI redisUri) {
-    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span =
+        startSpan(
+            LettuceClientDecorator.REDIS_CLIENT.toString(), LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     span.setResourceName(DECORATE.resourceNameForConnection(redisUri));
     DECORATE.onConnection(span, redisUri);

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
@@ -22,7 +22,7 @@ public class LettuceAsyncCommandsAdvice {
       @Advice.Argument(0) final RedisCommand command,
       @Advice.This final AbstractRedisAsyncCommands thiz) {
 
-    final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(
         span,

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
@@ -22,7 +22,9 @@ public class LettuceAsyncCommandsAdvice {
       @Advice.Argument(0) final RedisCommand command,
       @Advice.This final AbstractRedisAsyncCommands thiz) {
 
-    final AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
+    final AgentSpan span =
+        startSpan(
+            LettuceClientDecorator.REDIS_CLIENT.toString(), LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(
         span,

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
@@ -43,7 +43,9 @@ public class RedisSubscriptionSubscribeAdvice {
     if (parentSpan != null) {
       parentScope = activateSpan(parentSpan);
     }
-    AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
+    AgentSpan span =
+        startSpan(
+            LettuceClientDecorator.REDIS_CLIENT.toString(), LettuceClientDecorator.OPERATION_NAME);
     InstrumentationContext.get(RedisCommand.class, AgentSpan.class).put(subscriptionCommand, span);
     DECORATE.afterStart(span);
     if (state != null && state.connection != null) {

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
@@ -43,7 +43,7 @@ public class RedisSubscriptionSubscribeAdvice {
     if (parentSpan != null) {
       parentScope = activateSpan(parentSpan);
     }
-    AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
+    AgentSpan span = startSpan("lettuce", LettuceClientDecorator.OPERATION_NAME);
     InstrumentationContext.get(RedisCommand.class, AgentSpan.class).put(subscriptionCommand, span);
     DECORATE.afterStart(span);
     if (state != null && state.connection != null) {

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice.java
@@ -21,7 +21,7 @@ public class ChannelAcceptAdvice {
     if (request == null || nettySpan == null) {
       return null;
     }
-    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice.java
@@ -21,7 +21,7 @@ public class ChannelAcceptAdvice {
     if (request == null || nettySpan == null) {
       return null;
     }
-    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut-controller", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice2.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice2.java
@@ -20,7 +20,7 @@ public class ChannelAcceptAdvice2 {
     if (request == null || nettySpan == null) {
       return null;
     }
-    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice2.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-4.0/src/main/java17/datadog/trace/instrumentation/micronaut/v4_0/ChannelAcceptAdvice2.java
@@ -20,7 +20,7 @@ public class ChannelAcceptAdvice2 {
     if (request == null || nettySpan == null) {
       return null;
     }
-    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut-controller", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-common/src/main/java/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-common/src/main/java/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
@@ -20,7 +20,7 @@ public class ChannelRead0Advice {
       // Micronaut-netty uses Netty so there needs to be a Netty span
       return null;
     }
-    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut-controller", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-common/src/main/java/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
+++ b/dd-java-agent/instrumentation/micronaut/micronaut-http-server-netty/micronaut-http-server-netty-common/src/main/java/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
@@ -20,7 +20,7 @@ public class ChannelRead0Advice {
       // Micronaut-netty uses Netty so there needs to be a Netty span
       return null;
     }
-    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("micronaut", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);

--- a/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
@@ -129,7 +129,7 @@ public final class MongoCommandListener implements CommandListener {
     AgentSpan span = activeSpan();
     boolean shouldForceCloseSpanScope = true;
     if (span == null || span.getSpanName() != MongoDecorator.OPERATION_NAME) {
-      span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
+      span = startSpan("java-mongo", MongoDecorator.OPERATION_NAME);
       shouldForceCloseSpanScope = false;
     }
 

--- a/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
@@ -129,7 +129,7 @@ public final class MongoCommandListener implements CommandListener {
     AgentSpan span = activeSpan();
     boolean shouldForceCloseSpanScope = true;
     if (span == null || span.getSpanName() != MongoDecorator.OPERATION_NAME) {
-      span = startSpan(MongoDecorator.OPERATION_NAME);
+      span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
       shouldForceCloseSpanScope = false;
     }
 

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.6/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection36Instrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.6/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection36Instrumentation.java
@@ -70,7 +70,7 @@ public class DefaultServerConnection36Instrumentation extends InstrumenterModule
         return;
       }
 
-      AgentSpan span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
+      AgentSpan span = startSpan("java-mongo", MongoDecorator.OPERATION_NAME);
       // scope is going to be closed by the MongoCommandListener
       activateSpanWithoutScope(span);
 

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.6/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection36Instrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.6/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection36Instrumentation.java
@@ -70,7 +70,7 @@ public class DefaultServerConnection36Instrumentation extends InstrumenterModule
         return;
       }
 
-      AgentSpan span = startSpan(MongoDecorator.OPERATION_NAME);
+      AgentSpan span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
       // scope is going to be closed by the MongoCommandListener
       activateSpanWithoutScope(span);
 

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.8/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection38Instrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.8/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection38Instrumentation.java
@@ -70,7 +70,7 @@ public class DefaultServerConnection38Instrumentation extends InstrumenterModule
         return;
       }
 
-      AgentSpan span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
+      AgentSpan span = startSpan("java-mongo", MongoDecorator.OPERATION_NAME);
       // scope is going to be closed by the MongoCommandListener
       activateSpanWithoutScope(span);
 

--- a/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.8/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection38Instrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-driver/mongo-driver-3/mongo-driver-3.8/src/main/java/datadog/trace/instrumentation/mongo/DefaultServerConnection38Instrumentation.java
@@ -70,7 +70,7 @@ public class DefaultServerConnection38Instrumentation extends InstrumenterModule
         return;
       }
 
-      AgentSpan span = startSpan(MongoDecorator.OPERATION_NAME);
+      AgentSpan span = startSpan("mongo", MongoDecorator.OPERATION_NAME);
       // scope is going to be closed by the MongoCommandListener
       activateSpanWithoutScope(span);
 

--- a/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
+++ b/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
@@ -68,9 +68,9 @@ public class MuleDecorator extends BaseDecorator {
     }
     final AgentSpan span;
     if (parentSpan == null) {
-      span = startSpan(OPERATION_NAME);
+      span = startSpan("mule", OPERATION_NAME);
     } else {
-      span = startSpan(OPERATION_NAME, parentSpan.context());
+      span = startSpan("mule", OPERATION_NAME, parentSpan.context());
     }
     // here we have to use the forEachAttribute since each specialized InitialSpanInfo class can add
     // different things through this method. Using the map version is not the same.

--- a/dd-java-agent/instrumentation/netty/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -108,7 +108,7 @@ public class ChannelFutureListenerInstrumentation extends InstrumenterModule.Tra
       }
       final AgentScope parentScope = continuation.activate();
 
-      final AgentSpan errorSpan = startSpan(NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
+      final AgentSpan errorSpan = startSpan("netty", NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
       errorSpan.context().setIntegrationName(NETTY);
       try (final ContextScope scope = getCurrentContext().with(errorSpan).attach()) {
         DECORATE.onError(errorSpan, cause);

--- a/dd-java-agent/instrumentation/netty/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.DECORATE_SECURE;
+import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.NETTY_CLIENT;
 import static datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty38.client.NettyResponseInjectAdapter.SETTER;
 
@@ -54,7 +55,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     boolean isSecure = ctx.getPipeline().get("sslHandler") != null;
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
-    final AgentSpan span = startSpan("netty", NETTY_CLIENT_REQUEST);
+    final AgentSpan span = startSpan(NETTY_CLIENT.toString(), NETTY_CLIENT_REQUEST);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);
       decorate.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -93,7 +93,7 @@ public class ChannelFutureListenerInstrumentation extends InstrumenterModule.Tra
       }
       final AgentScope parentScope = continuation.activate();
 
-      final AgentSpan errorSpan = startSpan(NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
+      final AgentSpan errorSpan = startSpan("netty", NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
       errorSpan.context().setIntegrationName(NETTY);
       try (final ContextScope scope = getCurrentContext().with(errorSpan).attach()) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);

--- a/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -10,6 +10,7 @@ import static datadog.trace.instrumentation.netty40.AttributeKeys.CONNECT_PARENT
 import static datadog.trace.instrumentation.netty40.AttributeKeys.CONTEXT_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.DECORATE_SECURE;
+import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.NETTY_CLIENT;
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAdapter.SETTER;
 
@@ -77,7 +78,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     boolean isSecure = SSL_HANDLER != null && ctx.pipeline().get(SSL_HANDLER) != null;
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
-    final AgentSpan span = startSpan("netty", NETTY_CLIENT_REQUEST);
+    final AgentSpan span = startSpan(NETTY_CLIENT.toString(), NETTY_CLIENT_REQUEST);
     final Context context = getCurrentContext().with(span);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
@@ -93,7 +93,7 @@ public class ChannelFutureListenerInstrumentation extends InstrumenterModule.Tra
       }
       final AgentScope parentScope = continuation.activate();
 
-      final AgentSpan errorSpan = startSpan(NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
+      final AgentSpan errorSpan = startSpan("netty", NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
       errorSpan.context().setIntegrationName(NETTY);
       try (final ContextScope scope = getCurrentContext().with(errorSpan).attach()) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -10,6 +10,7 @@ import static datadog.trace.instrumentation.netty41.AttributeKeys.CONNECT_PARENT
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CONTEXT_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.DECORATE_SECURE;
+import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.NETTY_CLIENT;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.NETTY_CLIENT_REQUEST;
 import static datadog.trace.instrumentation.netty41.client.NettyResponseInjectAdapter.SETTER;
 
@@ -78,7 +79,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     boolean isSecure = SSL_HANDLER != null && ctx.pipeline().get(SSL_HANDLER) != null;
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
-    final AgentSpan span = startSpan("netty", NETTY_CLIENT_REQUEST);
+    final AgentSpan span = startSpan(NETTY_CLIENT.toString(), NETTY_CLIENT_REQUEST);
     final Context context = getCurrentContext().with(span);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);

--- a/dd-java-agent/instrumentation/ognl-appsec-3.3.2/src/main/java/datadog/trace/instrumentation/ognl/OgnlInstrumentation.java
+++ b/dd-java-agent/instrumentation/ognl-appsec-3.3.2/src/main/java/datadog/trace/instrumentation/ognl/OgnlInstrumentation.java
@@ -41,7 +41,7 @@ public class OgnlInstrumentation extends InstrumenterModule.AppSec
         return;
       }
 
-      AgentSpan agentSpan = startSpan("ognl.parse", parentSpan.context());
+      AgentSpan agentSpan = startSpan("ognl", "ognl.parse", parentSpan.context());
       agentSpan.setTag("ognl.expression", expression);
       agentSpan.finish();
     }

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -42,7 +42,7 @@ public class OpenAiDecorator extends ClientDecorator {
   private final WellKnownTags wellKnownTags = Config.get().getWellKnownTags();
 
   public AgentSpan startSpan(ClientOptions clientOptions) {
-    AgentSpan span = AgentTracer.startSpan(INSTRUMENTATION_NAME, SPAN_NAME);
+    AgentSpan span = AgentTracer.startSpan(INTEGRATION, SPAN_NAME);
     afterStart(span);
     String baseUrl = clientOptions.baseUrl();
     span.setTag(CommonTags.OPENAI_API_BASE, baseUrl);

--- a/dd-java-agent/instrumentation/opensearch/opensearch-rest-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-rest-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientInstrumentation.java
@@ -66,7 +66,7 @@ public class OpensearchRestClientInstrumentation extends InstrumenterModule.Trac
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("opensearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/opensearch/opensearch-rest-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-rest-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.opensearch.OpensearchRestClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.opensearch.OpensearchRestClientDecorator.OPENSEARCH_JAVA;
 import static datadog.trace.instrumentation.opensearch.OpensearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -66,7 +67,7 @@ public class OpensearchRestClientInstrumentation extends InstrumenterModule.Trac
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan("opensearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(OPENSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(
           span,

--- a/dd-java-agent/instrumentation/opensearch/opensearch-transport-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-transport-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
@@ -70,7 +70,7 @@ public class OpensearchTransportClientInstrumentation extends InstrumenterModule
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(OPERATION_NAME);
+      final AgentSpan span = startSpan("opensearch", OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/opensearch/opensearch-transport-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-transport-1.0/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.opensearch.OpensearchTransportClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.opensearch.OpensearchTransportClientDecorator.OPENSEARCH_JAVA;
 import static datadog.trace.instrumentation.opensearch.OpensearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -70,7 +71,7 @@ public class OpensearchTransportClientInstrumentation extends InstrumenterModule
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan("opensearch", OPERATION_NAME);
+      final AgentSpan span = startSpan(OPENSEARCH_JAVA.toString(), OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/scala/PekkoActors.scala
+++ b/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/scala/PekkoActors.scala
@@ -137,7 +137,7 @@ class Greeter(message: String, receiverActor: ActorRef) extends Actor {
     case Greet =>
       receiverActor ! Greeting(greeting)
     case Leak(leak) =>
-      val span = startSpan(greeting)
+      val span = startSpan("test", greeting)
       span.setResourceName(leak)
       activateSpan(span)
       span.finish()

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.PEKKO_CLIENT_REQUEST;
+import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator.PEKKO_HTTP_CLIENT;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientHelpers.OnCompleteHandler;
 import static datadog.trace.instrumentation.pekkohttp.PekkoHttpClientHelpers.PekkoHttpHeaders;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -79,7 +80,7 @@ public final class PekkoHttpSingleRequestInstrumentation extends InstrumenterMod
         return null;
       }
 
-      final AgentSpan span = startSpan("pekko-http", PEKKO_CLIENT_REQUEST);
+      final AgentSpan span = startSpan(PEKKO_HTTP_CLIENT.toString(), PEKKO_CLIENT_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_ACTION;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_REQUEST;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -32,7 +33,7 @@ public class PlayAdvice {
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
-      span = startSpan("play", PLAY_REQUEST);
+      span = startSpan(PLAY_ACTION.toString(), PLAY_REQUEST);
       span.setMeasured(true);
       scope = span.attachWithCurrent();
     }

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_ACTION;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_REQUEST;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -38,7 +39,7 @@ public class PlayAdvice {
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
-      span = startSpan("play", PLAY_REQUEST);
+      span = startSpan(PLAY_ACTION.toString(), PLAY_REQUEST);
       span.setMeasured(true);
       scope = span.attachWithCurrent();
     }

--- a/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.PLAY_ACTION;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.PLAY_REQUEST;
 
 import datadog.context.Context;
@@ -40,7 +41,7 @@ public class PlayAdvice {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
       parentContext = getRootContext();
-      span = startSpan("play", PLAY_REQUEST);
+      span = startSpan(PLAY_ACTION.toString(), PLAY_REQUEST);
       scope = span.attachWithCurrent();
     }
 

--- a/dd-java-agent/instrumentation/quartz-2.0/src/main/java/datadog/trace/instrumentation/quartz/QuartzSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/quartz-2.0/src/main/java/datadog/trace/instrumentation/quartz/QuartzSchedulingInstrumentation.java
@@ -57,7 +57,7 @@ public final class QuartzSchedulingInstrumentation extends InstrumenterModule.Tr
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope enter(@Advice.Argument(0) JobExecutionContext context) {
       // create a new trace for every job
-      final AgentSpan span = startSpan(SCHEDULED_CALL, null);
+      final AgentSpan span = startSpan("quartz", SCHEDULED_CALL, null);
       DECORATE.afterStart(span);
       DECORATE.onExecute(span, context);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -18,6 +18,7 @@ import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.CONSUM
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_COMMAND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_OUTBOUND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.RABBITMQ_AMQP;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TextMapInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.canThrow;
@@ -129,7 +130,7 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan("rabbitmq", OPERATION_AMQP_COMMAND);
+      final AgentSpan span = startSpan(RABBITMQ_AMQP.toString(), OPERATION_AMQP_COMMAND);
       span.setResourceName(method);
       CLIENT_DECORATE.setPeerPort(span, connection.getPort());
       CLIENT_DECORATE.afterStart(span);
@@ -166,7 +167,7 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan("rabbitmq", OPERATION_AMQP_OUTBOUND);
+      final AgentSpan span = startSpan(RABBITMQ_AMQP.toString(), OPERATION_AMQP_OUTBOUND);
       PRODUCER_DECORATE.setPeerPort(span, connection.getPort());
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onPeerConnection(span, connection.getAddress());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -129,7 +129,7 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan(OPERATION_AMQP_COMMAND);
+      final AgentSpan span = startSpan("rabbitmq", OPERATION_AMQP_COMMAND);
       span.setResourceName(method);
       CLIENT_DECORATE.setPeerPort(span, connection.getPort());
       CLIENT_DECORATE.afterStart(span);
@@ -166,7 +166,7 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan(OPERATION_AMQP_OUTBOUND);
+      final AgentSpan span = startSpan("rabbitmq", OPERATION_AMQP_OUTBOUND);
       PRODUCER_DECORATE.setPeerPort(span, connection.getPort());
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onPeerConnection(span, connection.getAddress());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -224,7 +224,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       queueStartMillis = Math.min(spanStartMillis, queueStartMillis);
       queueSpan =
           startSpan(
-              "rabbitmq",
+              RABBITMQ_AMQP.toString(),
               OPERATION_AMQP_DELIVER,
               parentContext,
               TimeUnit.MILLISECONDS.toMicros(queueStartMillis));
@@ -236,7 +236,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       // spans are written out together by the TraceStructureWriter when running in strict mode
     }
     final AgentSpan span =
-        startSpan("rabbitmq", OPERATION_AMQP_INBOUND, parentContext, spanStartMicros);
+        startSpan(RABBITMQ_AMQP.toString(), OPERATION_AMQP_INBOUND, parentContext, spanStartMicros);
 
     if (null != body) {
       span.setTag("message.size", body.length);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -224,6 +224,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       queueStartMillis = Math.min(spanStartMillis, queueStartMillis);
       queueSpan =
           startSpan(
+              "rabbitmq",
               OPERATION_AMQP_DELIVER,
               parentContext,
               TimeUnit.MILLISECONDS.toMicros(queueStartMillis));
@@ -234,7 +235,8 @@ public class RabbitDecorator extends MessagingClientDecorator {
       // The queueSpan will be finished after the inner span has been activated to ensure that the
       // spans are written out together by the TraceStructureWriter when running in strict mode
     }
-    final AgentSpan span = startSpan(OPERATION_AMQP_INBOUND, parentContext, spanStartMicros);
+    final AgentSpan span =
+        startSpan("rabbitmq", OPERATION_AMQP_INBOUND, parentContext, spanStartMicros);
 
     if (null != body) {
       span.setTag("message.size", body.length);

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -38,7 +38,7 @@ public final class TracingHandler implements Handler {
     final AgentSpan nettySpan = nettyContext != null ? fromContext(nettyContext) : null;
 
     // Relying on executor instrumentation to assume the netty span is in context as the parent.
-    final AgentSpan ratpackSpan = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan ratpackSpan = startSpan("ratpack", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(ratpackSpan);
     DECORATE.onRequest(ratpackSpan, request, request, root());
     ctx.getExecution().add(ratpackSpan);

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -303,7 +303,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
       // The "add one" operations in the publisher created here should be children of the publisher-parent
       Publisher<Integer> publisher = publisherSupplier()
 
-      AgentSpan intermediate = startSpan("intermediate")
+      AgentSpan intermediate = startSpan("test", "intermediate")
       AgentScope scope = activateSpan(intermediate)
       try {
         if (publisher instanceof Mono) {
@@ -497,7 +497,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def assemblePublisherUnderTrace(def publisherSupplier) {
-    def span = startSpan("publisher-parent")
+    def span = startSpan("test", "publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
     def scope = activateSpan(span)
 
@@ -519,7 +519,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
-    final AgentSpan span = startSpan("publisher-parent")
+    final AgentSpan span = startSpan("test", "publisher-parent")
     AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/SubscriptionTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/SubscriptionTest.groovy
@@ -118,7 +118,7 @@ class SubscriptionTest extends InstrumentationSpecification {
 
   static class Connection {
     static int query() {
-      def span = AgentTracer.startSpan("Connection.query")
+      def span = AgentTracer.startSpan("test", "Connection.query")
       span.finish()
       return new Random().nextInt()
     }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -303,7 +303,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
       // The "add one" operations in the publisher created here should be children of the publisher-parent
       Publisher<Integer> publisher = publisherSupplier()
 
-      AgentSpan intermediate = startSpan("intermediate")
+      AgentSpan intermediate = startSpan("test", "intermediate")
       AgentScope scope = activateSpan(intermediate)
       try {
         if (publisher instanceof Mono) {
@@ -497,7 +497,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def assemblePublisherUnderTrace(def publisherSupplier) {
-    def span = startSpan("publisher-parent")
+    def span = startSpan("test", "publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
     def scope = activateSpan(span)
 
@@ -519,7 +519,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
-    final AgentSpan span = startSpan("publisher-parent")
+    final AgentSpan span = startSpan("test", "publisher-parent")
     AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/SubscriptionTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/SubscriptionTest.groovy
@@ -206,7 +206,7 @@ class SubscriptionTest extends InstrumentationSpecification {
 
   static class Connection {
     static int query() {
-      def span = AgentTracer.startSpan("Connection.query")
+      def span = AgentTracer.startSpan("test", "Connection.query")
       span.finish()
       return new Random().nextInt()
     }

--- a/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -84,7 +84,7 @@ public final class RediscalaInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(@Advice.Argument(0) final RedisCommand cmd) {
-      final AgentSpan span = startSpan(RediscalaClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("rediscala", RediscalaClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onStatement(span, DECORATE.className(cmd.getClass()));
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -84,7 +84,7 @@ public final class RediscalaInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(@Advice.Argument(0) final RedisCommand cmd) {
-      final AgentSpan span = startSpan("rediscala", RediscalaClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RediscalaClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onStatement(span, DECORATE.className(cmd.getClass()));
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
@@ -66,7 +66,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (command.getPromise() == null) {
         return null;
       }
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       DECORATE.onStatement(span, command.getCommand().getName());
@@ -91,7 +91,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
@@ -66,7 +66,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (command.getPromise() == null) {
         return null;
       }
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       DECORATE.onStatement(span, command.getCommand().getName());
@@ -91,7 +91,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
@@ -66,7 +66,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (command.getPromise() == null) {
         return null;
       }
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
@@ -92,7 +92,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
@@ -66,7 +66,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (command.getPromise() == null) {
         return null;
       }
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
@@ -92,7 +92,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -71,7 +71,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (promise == null) {
         return null;
       }
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
@@ -102,7 +102,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (promise == null) {
         return null;
       }
-      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redis-command", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -71,7 +71,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (promise == null) {
         return null;
       }
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
@@ -102,7 +102,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       if (promise == null) {
         return null;
       }
-      final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("redisson", RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
       RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
 

--- a/dd-java-agent/instrumentation/renaissance-0.7/src/main/java/datadog/trace/instrumentation/renaissance/RenaissanceInstrumentation.java
+++ b/dd-java-agent/instrumentation/renaissance-0.7/src/main/java/datadog/trace/instrumentation/renaissance/RenaissanceInstrumentation.java
@@ -45,7 +45,8 @@ public class RenaissanceInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(
         @Advice.Argument(0) int index, @Advice.FieldValue("benchmarkName") String benchmarkName) {
-      AgentSpan span = startSpan("renaissance.benchmark").setResourceName(benchmarkName);
+      AgentSpan span =
+          startSpan("renaissance", "renaissance.benchmark").setResourceName(benchmarkName);
       return activateSpan(span);
     }
 

--- a/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/ResourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/ResourceInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.restlet.ResourceDecorator.DECORATE;
+import static datadog.trace.instrumentation.restlet.ResourceDecorator.RESTLET_CONTROLLER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -62,7 +63,7 @@ public final class ResourceInstrumentation extends InstrumenterModule.Tracing
         @Advice.Argument(0) final AnnotationInfo annotationInfo) {
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan("restlet-http", RESTLET_HTTP_OPERATION_NAME);
+      final AgentSpan span = startSpan(RESTLET_CONTROLLER.toString(), RESTLET_HTTP_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onRestletSpan(span, parent, serverResource, annotationInfo.getJavaMethod());
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/ResourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/ResourceInstrumentation.java
@@ -62,7 +62,7 @@ public final class ResourceInstrumentation extends InstrumenterModule.Tracing
         @Advice.Argument(0) final AnnotationInfo annotationInfo) {
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(RESTLET_HTTP_OPERATION_NAME);
+      final AgentSpan span = startSpan("restlet-http", RESTLET_HTTP_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onRestletSpan(span, parent, serverResource, annotationInfo.getJavaMethod());
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
@@ -31,7 +31,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JakartaRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan(JAKARTA_RS_REQUEST_ABORT);
+        final AgentSpan span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JakartaRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.JAKARTA_RS_CONTROLLER;
 import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.JAKARTA_RS_REQUEST_ABORT;
 
 import com.google.auto.service.AutoService;
@@ -31,7 +32,8 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JakartaRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
+        final AgentSpan span =
+            startSpan(JAKARTA_RS_CONTROLLER.toString(), JAKARTA_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JakartaRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -11,6 +11,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.JAKARTA_RS_CONTROLLER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -116,7 +117,8 @@ public final class JakartaRsAnnotationsInstrumentation extends InstrumenterModul
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan("jakarta-rs", JAKARTA_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span =
+          startSpan(JAKARTA_RS_CONTROLLER.toString(), JAKARTA_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJakartaRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -116,7 +116,7 @@ public final class JakartaRsAnnotationsInstrumentation extends InstrumenterModul
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAKARTA_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jakarta-rs", JAKARTA_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJakartaRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
@@ -26,7 +26,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan(JAKARTA_RS_REQUEST_ABORT);
+        span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.JAKARTA_RS_CONTROLLER;
 import static datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator.JAKARTA_RS_REQUEST_ABORT;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -26,7 +27,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan("jakarta-rs", JAKARTA_RS_REQUEST_ABORT);
+        span = startSpan(JAKARTA_RS_CONTROLLER.toString(), JAKARTA_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -93,7 +93,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs1.JaxRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs1.JaxRsAnnotationsDecorator.JAX_RS_CONTROLLER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -93,7 +94,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan(JAX_RS_CONTROLLER.toString(), JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -31,7 +31,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan(JAX_RS_REQUEST_ABORT);
+        final AgentSpan span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JaxRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_CONTROLLER;
 import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_REQUEST_ABORT;
 
 import com.google.auto.service.AutoService;
@@ -31,7 +32,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
 
       if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null) {
         final AgentSpan parent = activeSpan();
-        final AgentSpan span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
+        final AgentSpan span = startSpan(JAX_RS_CONTROLLER.toString(), JAX_RS_REQUEST_ABORT);
 
         // Save spans so a more specific instrumentation can run later
         context.setProperty(JaxRsAnnotationsDecorator.ABORT_PARENT, parent);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -124,7 +124,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan(JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -12,6 +12,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_CONTROLLER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -124,7 +125,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       // Rename the parent span according to the path represented by these annotations.
       final AgentSpan parent = activeSpan();
 
-      final AgentSpan span = startSpan("jax-rs", JAX_ENDPOINT_OPERATION_NAME);
+      final AgentSpan span = startSpan(JAX_RS_CONTROLLER.toString(), JAX_ENDPOINT_OPERATION_NAME);
       span.setMeasured(true);
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -25,7 +25,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan(JAX_RS_REQUEST_ABORT);
+        span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_CONTROLLER;
 import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_REQUEST_ABORT;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -25,7 +26,7 @@ public class RequestFilterHelper {
 
       if (span == null) {
         parent = activeSpan();
-        span = startSpan("jax-rs", JAX_RS_REQUEST_ABORT);
+        span = startSpan(JAX_RS_CONTROLLER.toString(), JAX_RS_REQUEST_ABORT);
 
         final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -72,7 +72,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
       // WARNING: this might be a chain...so we only have to trace the first in the chain.
       final boolean isRootClientHandler = null == request.getProperties().get(DD_CONTEXT_ATTRIBUTE);
       if (isRootClientHandler) {
-        final AgentSpan span = startSpan(JAX_RS_CLIENT_CALL);
+        final AgentSpan span = startSpan("jax-rs", JAX_RS_CLIENT_CALL);
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_CONTEXT_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -10,6 +10,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.ge
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_CONTEXT_ATTRIBUTE;
 import static datadog.trace.instrumentation.jaxrs.v1.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator.JAX_RS_CLIENT;
 import static datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator.JAX_RS_CLIENT_CALL;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -72,7 +73,7 @@ public final class JaxRsClientV1Instrumentation extends InstrumenterModule.Traci
       // WARNING: this might be a chain...so we only have to trace the first in the chain.
       final boolean isRootClientHandler = null == request.getProperties().get(DD_CONTEXT_ATTRIBUTE);
       if (isRootClientHandler) {
-        final AgentSpan span = startSpan("jax-rs", JAX_RS_CLIENT_CALL);
+        final AgentSpan span = startSpan(JAX_RS_CLIENT.toString(), JAX_RS_CLIENT_CALL);
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_CONTEXT_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-client/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jaxrs.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.JAX_RS_CLIENT;
 import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.JAX_RS_CLIENT_CALL;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -22,7 +23,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
 
   @Override
   public void filter(final ClientRequestContext requestContext) {
-    final AgentSpan span = startSpan("jax-rs", JAX_RS_CLIENT_CALL);
+    final AgentSpan span = startSpan(JAX_RS_CLIENT.toString(), JAX_RS_CLIENT_CALL);
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);

--- a/dd-java-agent/instrumentation/rxjava/rxjava-1.0/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-1.0/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -30,7 +30,8 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
 
   @Override
   public void call(final Subscriber<? super T> subscriber) {
-    final AgentSpan span = startSpan(operationName, parent != null ? parent.context() : null);
+    final AgentSpan span =
+        startSpan("rxjava", operationName, parent != null ? parent.context() : null);
     afterStart(span);
 
     try (final AgentScope scope = activateSpan(span)) {

--- a/dd-java-agent/instrumentation/rxjava/rxjava-1.0/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-1.0/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -28,10 +28,14 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
     this.parent = activeSpan();
   }
 
+  protected String instrumentationName() {
+    return "rxjava";
+  }
+
   @Override
   public void call(final Subscriber<? super T> subscriber) {
     final AgentSpan span =
-        startSpan("rxjava", operationName, parent != null ? parent.context() : null);
+        startSpan(instrumentationName(), operationName, parent != null ? parent.context() : null);
     afterStart(span);
 
     try (final AgentScope scope = activateSpan(span)) {

--- a/dd-java-agent/instrumentation/rxjava/rxjava-2.0/src/test/groovy/RxJava2Test.groovy
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-2.0/src/test/groovy/RxJava2Test.groovy
@@ -300,7 +300,7 @@ class RxJava2Test extends InstrumentationSpecification {
       // The "add one" operations in the publisher created here should be children of the publisher-parent
       def publisher = publisherSupplier()
 
-      AgentSpan intermediate = startSpan("intermediate")
+      AgentSpan intermediate = startSpan("test", "intermediate")
       AgentScope scope = activateSpan(intermediate)
       try {
         if (publisher instanceof Maybe) {
@@ -382,7 +382,7 @@ class RxJava2Test extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def assemblePublisherUnderTrace(def publisherSupplier) {
-    def span = startSpan("publisher-parent")
+    def span = startSpan("test", "publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
     def scope = activateSpan(span)
 
@@ -404,7 +404,7 @@ class RxJava2Test extends InstrumentationSpecification {
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
-    final AgentSpan span = startSpan("publisher-parent")
+    final AgentSpan span = startSpan("test", "publisher-parent")
     AgentScope scope = activateSpan(span)
 
     def publisher = publisherSupplier()

--- a/dd-java-agent/instrumentation/rxjava/rxjava-2.0/src/test/groovy/SubscriptionTest.groovy
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-2.0/src/test/groovy/SubscriptionTest.groovy
@@ -34,7 +34,7 @@ class SubscriptionTest extends InstrumentationSpecification {
 
   static class Connection {
     static int query() {
-      def span = AgentTracer.startSpan("Connection.query")
+      def span = AgentTracer.startSpan("test", "Connection.query")
       span.finish()
       return new Random().nextInt()
     }

--- a/dd-java-agent/instrumentation/scala/scala-concurrent-2.8/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/scala/scala-concurrent-2.8/src/test/java/LinearTask.java
@@ -31,7 +31,7 @@ public class LinearTask extends RecursiveTask<Integer> {
       return parent;
     } else {
       int next = parent + 1;
-      AgentSpan span = startSpan(Integer.toString(next));
+      AgentSpan span = startSpan("test", Integer.toString(next));
       try (AgentScope scope = activateSpan(span)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -96,7 +96,7 @@ public final class AsyncContextInstrumentation extends InstrumenterModule.Tracin
         return true;
       }
 
-      final AgentSpan span = startSpan(SERVLET_DISPATCH, parent.context());
+      final AgentSpan span = startSpan("servlet", SERVLET_DISPATCH, parent.context());
       // This span should get finished by Servlet3Advice
       // However, when using Jetty without servlets (directly org.eclipse.jetty.server.Handler),
       // that's not the case (see jetty's HandleAdvice)

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -10,6 +10,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.sp
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_CONTEXT_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator.DECORATE;
+import static datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator.JAVA_WEB_SERVLET_DISPATCHER;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DD_CONTEXT_PATH_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DD_SERVLET_PATH_ATTRIBUTE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -96,7 +97,8 @@ public final class AsyncContextInstrumentation extends InstrumenterModule.Tracin
         return true;
       }
 
-      final AgentSpan span = startSpan("servlet", SERVLET_DISPATCH, parent.context());
+      final AgentSpan span =
+          startSpan(JAVA_WEB_SERVLET_DISPATCHER.toString(), SERVLET_DISPATCH, parent.context());
       // This span should get finished by Servlet3Advice
       // However, when using Jetty without servlets (directly org.eclipse.jetty.server.Handler),
       // that's not the case (see jetty's HandleAdvice)

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -16,6 +16,7 @@ import static datadog.trace.instrumentation.servlet.SpanNameCache.SPAN_NAME_CACH
 import static datadog.trace.instrumentation.servlet.dispatcher.RequestDispatcherDecorator.DD_CONTEXT_PATH_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet.dispatcher.RequestDispatcherDecorator.DD_SERVLET_PATH_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet.dispatcher.RequestDispatcherDecorator.DECORATE;
+import static datadog.trace.instrumentation.servlet.dispatcher.RequestDispatcherDecorator.JAVA_WEB_SERVLET_DISPATCHER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -110,7 +111,10 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       }
 
       final AgentSpan span =
-          startSpan("servlet", SPAN_NAME_CACHE.computeIfAbsent(method, SERVLET_PREFIX), parent);
+          startSpan(
+              JAVA_WEB_SERVLET_DISPATCHER.toString(),
+              SPAN_NAME_CACHE.computeIfAbsent(method, SERVLET_PREFIX),
+              parent);
       DECORATE.afterStart(span);
       span.setTag(SERVLET_CONTEXT, request.getAttribute(DD_CONTEXT_PATH_ATTRIBUTE));
       span.setTag(SERVLET_PATH, request.getAttribute(DD_SERVLET_PATH_ATTRIBUTE));

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -68,7 +68,7 @@ public final class FilterInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(SERVLET_FILTER);
+      final AgentSpan span = startSpan("servlet", SERVLET_FILTER);
       DECORATE.afterStart(span);
 
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.servlet.filter.FilterDecorator.DECORATE;
+import static datadog.trace.instrumentation.servlet.filter.FilterDecorator.JAVA_WEB_SERVLET_FILTER;
 import static datadog.trace.instrumentation.servlet.filter.FilterDecorator.SERVLET_FILTER;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -68,7 +69,7 @@ public final class FilterInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan("servlet", SERVLET_FILTER);
+      final AgentSpan span = startSpan(JAVA_WEB_SERVLET_FILTER.toString(), SERVLET_FILTER);
       DECORATE.afterStart(span);
 
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -78,7 +78,8 @@ public final class HttpServletInstrumentation extends InstrumenterModule.Tracing
       }
 
       final AgentSpan span =
-          startSpan(SPAN_NAME_CACHE.computeIfAbsent(method.getName(), SERVLET_PREFIX));
+          startSpan(
+              "servlet-service", SPAN_NAME_CACHE.computeIfAbsent(method.getName(), SERVLET_PREFIX));
       DECORATE.afterStart(span);
 
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -79,7 +79,8 @@ public final class HttpServletInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span =
           startSpan(
-              "servlet-service", SPAN_NAME_CACHE.computeIfAbsent(method.getName(), SERVLET_PREFIX));
+              HttpServletDecorator.JAVA_WEB_SERVLET_SERVICE.toString(),
+              SPAN_NAME_CACHE.computeIfAbsent(method.getName(), SERVLET_PREFIX));
       DECORATE.afterStart(span);
 
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator.DECORATE;
+import static datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator.JAVA_WEB_SERVLET_RESPONSE;
 import static datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator.SERVLET_RESPONSE;
 
 import com.google.auto.service.AutoService;
@@ -67,7 +68,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
         return null;
       }
 
-      final AgentSpan span = startSpan("servlet", SERVLET_RESPONSE);
+      final AgentSpan span = startSpan(JAVA_WEB_SERVLET_RESPONSE.toString(), SERVLET_RESPONSE);
       DECORATE.afterStart(span);
 
       span.setResourceName(DECORATE.spanNameForMethod(HttpServletResponse.class, method));

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -67,7 +67,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
         return null;
       }
 
-      final AgentSpan span = startSpan(SERVLET_RESPONSE);
+      final AgentSpan span = startSpan("servlet", SERVLET_RESPONSE);
       DECORATE.afterStart(span);
 
       span.setResourceName(DECORATE.spanNameForMethod(HttpServletResponse.class, method));

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/AbstractClusterInstrumentation.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/AbstractClusterInstrumentation.java
@@ -44,7 +44,7 @@ public class AbstractClusterInstrumentation
         @Advice.This AbstractCluster self, @Advice.Argument(0) SofaRequest request) {
       ConsumerConfig config = self.getConsumerConfig();
       String protocol = config != null ? config.getProtocol() : null;
-      AgentSpan span = startSpan(SOFA_RPC_CLIENT);
+      AgentSpan span = startSpan("sofarpc", SOFA_RPC_CLIENT);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       if (protocol != null) {

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/AbstractClusterInstrumentation.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/AbstractClusterInstrumentation.java
@@ -44,7 +44,7 @@ public class AbstractClusterInstrumentation
         @Advice.This AbstractCluster self, @Advice.Argument(0) SofaRequest request) {
       ConsumerConfig config = self.getConsumerConfig();
       String protocol = config != null ? config.getProtocol() : null;
-      AgentSpan span = startSpan("sofarpc", SOFA_RPC_CLIENT);
+      AgentSpan span = startSpan("sofarpc-client", SOFA_RPC_CLIENT);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       if (protocol != null) {

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/ProviderProxyInvokerInstrumentation.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/ProviderProxyInvokerInstrumentation.java
@@ -53,8 +53,8 @@ public class ProviderProxyInvokerInstrumentation
       AgentSpanContext parentContext = extractContextAndGetSpanContext(request, GETTER);
       AgentSpan span =
           parentContext != null
-              ? startSpan(SOFA_RPC_SERVER, parentContext)
-              : startSpan(SOFA_RPC_SERVER);
+              ? startSpan("sofarpc", SOFA_RPC_SERVER, parentContext)
+              : startSpan("sofarpc", SOFA_RPC_SERVER);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       span.setTag("sofarpc.protocol", protocol);

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/ProviderProxyInvokerInstrumentation.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/ProviderProxyInvokerInstrumentation.java
@@ -53,8 +53,8 @@ public class ProviderProxyInvokerInstrumentation
       AgentSpanContext parentContext = extractContextAndGetSpanContext(request, GETTER);
       AgentSpan span =
           parentContext != null
-              ? startSpan("sofarpc", SOFA_RPC_SERVER, parentContext)
-              : startSpan("sofarpc", SOFA_RPC_SERVER);
+              ? startSpan("sofarpc-server", SOFA_RPC_SERVER, parentContext)
+              : startSpan("sofarpc-server", SOFA_RPC_SERVER);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       span.setTag("sofarpc.protocol", protocol);

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcRestTest.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcRestTest.java
@@ -79,7 +79,7 @@ public class SofaRpcRestTest extends AbstractInstrumentationTest {
   void clientAndServerSpansForRestCall() throws InterruptedException, TimeoutException {
     String serviceUniqueName = RestGreeterService.class.getName() + ":1.0";
 
-    AgentSpan callerSpan = startSpan("caller");
+    AgentSpan callerSpan = startSpan("test", "caller");
     AgentScope callerScope = activateSpan(callerSpan);
     String reply;
     try {

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcTest.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcTest.java
@@ -93,7 +93,7 @@ public class SofaRpcTest extends AbstractInstrumentationTest {
   void clientAndServerSpansForBoltCall() throws InterruptedException, TimeoutException {
     String serviceUniqueName = GreeterService.class.getName() + ":1.0";
 
-    AgentSpan callerSpan = startSpan("caller");
+    AgentSpan callerSpan = startSpan("test", "caller");
     AgentScope callerScope = activateSpan(callerSpan);
     String reply;
     try {

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcTripleWithGrpcForkedTest.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/test/java/datadog/trace/instrumentation/sofarpc/SofaRpcTripleWithGrpcForkedTest.java
@@ -98,7 +98,7 @@ public class SofaRpcTripleWithGrpcForkedTest extends AbstractInstrumentationTest
 
   @Test
   void tripleServerSpanIsNestedUnderGrpcServer() throws InterruptedException, TimeoutException {
-    AgentSpan callerSpan = startSpan("caller");
+    AgentSpan callerSpan = startSpan("test", "caller");
     AgentScope callerScope = activateSpan(callerSpan);
     String reply;
     try {

--- a/dd-java-agent/instrumentation/spark/spark-executor-common/src/main/java/datadog/trace/instrumentation/spark/SparkExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/spark-executor-common/src/main/java/datadog/trace/instrumentation/spark/SparkExecutorInstrumentation.java
@@ -53,7 +53,7 @@ public class SparkExecutorInstrumentation extends InstrumenterModule.Tracing
   public static final class RunAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope enter(@Advice.This Executor.TaskRunner taskRunner) {
-      final AgentSpan span = startSpan("spark-executor", SPARK_TASK);
+      final AgentSpan span = startSpan("spark", SPARK_TASK);
 
       DECORATE.afterStart(span);
       DECORATE.onTaskStart(span, taskRunner);

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.SPRAY_HTTP_SERVER;
 
 import datadog.context.Context;
 import datadog.context.ContextScope;
@@ -29,7 +30,7 @@ public class SprayHttpServerRunSealedRouteAdvice {
       span = spanFromContext(context);
     } else {
       parentContext = getRootContext();
-      span = startSpan("spray", DECORATE.spanName());
+      span = startSpan(SPRAY_HTTP_SERVER.toString(), DECORATE.spanName());
       context = span;
     }
 

--- a/dd-java-agent/instrumentation/spring/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
+++ b/dd-java-agent/instrumentation/spring/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
@@ -31,7 +31,7 @@ final class RepositoryInterceptor implements MethodInterceptor {
       return methodInvocation.proceed();
     }
 
-    final AgentSpan span = startSpan(REPOSITORY_OPERATION);
+    final AgentSpan span = startSpan("spring-data", REPOSITORY_OPERATION);
     DECORATOR.afterStart(span);
     DECORATOR.onOperation(span, invokedMethod, repositoryInterface);
 

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageHandlerInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getRootContext;
+import static datadog.trace.instrumentation.springmessaging.SpringMessageDecorator.COMPONENT_NAME;
 import static datadog.trace.instrumentation.springmessaging.SpringMessageDecorator.DECORATE;
 import static datadog.trace.instrumentation.springmessaging.SpringMessageDecorator.SPRING_INBOUND;
 import static datadog.trace.instrumentation.springmessaging.SpringMessageExtractAdapter.GETTER;
@@ -80,7 +81,7 @@ public final class SpringMessageHandlerInstrumentation extends InstrumenterModul
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(@Advice.This InvocableHandlerMethod thiz) {
-      AgentSpan span = startSpan("spring-messaging", SPRING_INBOUND);
+      AgentSpan span = startSpan(COMPONENT_NAME.toString(), SPRING_INBOUND);
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.spanNameForMethod(thiz.getMethod()));
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageHandlerInstrumentation.java
@@ -80,7 +80,7 @@ public final class SpringMessageHandlerInstrumentation extends InstrumenterModul
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(@Advice.This InvocableHandlerMethod thiz) {
-      AgentSpan span = startSpan(SPRING_INBOUND);
+      AgentSpan span = startSpan("spring-messaging", SPRING_INBOUND);
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.spanNameForMethod(thiz.getMethod()));
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/groovy/listener/TestListener.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/groovy/listener/TestListener.groovy
@@ -24,7 +24,7 @@ class TestListener extends AsyncObservationSupport {
       markAsyncStarted()
       awaitAsyncRelease()
       // Asserting spring.consume root span is active during async execution
-      def childSpan = startSpan("async.child")
+      def childSpan = startSpan("test", "async.child")
       def childScope = activateSpan(childSpan)
       childScope.close()
       childSpan.finish()

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/kotlin/KafkaBatchCoroutineConfig.kt
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/test/kotlin/KafkaBatchCoroutineConfig.kt
@@ -89,7 +89,7 @@ class KafkaBatchCoroutineListener : AsyncObservationSupport() {
     }
     // Create a child span inside the coroutine body.
     // It should be linked to spring.consume, which should be linked to kafka.consume.
-    val childSpan = startSpan("child.work")
+    val childSpan = startSpan("test", "child.work")
     records.forEach { receivedValues.add(it.value()) }
     childSpan.finish()
     latch.countDown()

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
@@ -72,7 +72,7 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
           AgentScope.Continuation continuation = state.getAndResetContinuation();
           if (null != continuation) {
             try (AgentScope scope = continuation.activate()) {
-              AgentSpan span = startSpan("amqp", AMQP_CONSUME);
+              AgentSpan span = startSpan("rabbitmq-amqp", AMQP_CONSUME);
               span.setMeasured(true);
               DECORATE.afterStart(span);
               DECORATE.onConsume(span, message.getMessageProperties().getConsumerQueue());

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
@@ -72,7 +72,7 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
           AgentScope.Continuation continuation = state.getAndResetContinuation();
           if (null != continuation) {
             try (AgentScope scope = continuation.activate()) {
-              AgentSpan span = startSpan(AMQP_CONSUME);
+              AgentSpan span = startSpan("amqp", AMQP_CONSUME);
               span.setMeasured(true);
               DECORATE.afterStart(span);
               DECORATE.onConsume(span, message.getMessageProperties().getConsumerQueue());

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -48,7 +48,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
   }
 
   private Object invokeWithSpan(CharSequence spanName) throws Throwable {
-    AgentSpan span = startSpan(spanName);
+    AgentSpan span = startSpan("spring-scheduling", spanName);
     try (AgentScope scope = activateSpan(span)) {
       return delegate.proceed();
     } finally {

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -55,7 +55,9 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
   @Override
   public void run() {
     final AgentSpan span =
-        LEGACY_TRACING ? startSpan(SCHEDULED_CALL) : startSpan(SCHEDULED_CALL, null);
+        LEGACY_TRACING
+            ? startSpan("spring-scheduling", SCHEDULED_CALL)
+            : startSpan("spring-scheduling", SCHEDULED_CALL, null);
     DECORATE.afterStart(span);
 
     try (final AgentScope scope = activateSpan(span)) {

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
@@ -50,7 +50,7 @@ public class WebClientTracingFilter implements ExchangeFilterFunction {
 
     @Override
     public void subscribe(final CoreSubscriber<? super ClientResponse> subscriber) {
-      AgentSpan span = startSpan(HTTP_REQUEST);
+      AgentSpan span = startSpan("spring-webflux", HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       AgentSpan parent = activeSpan();

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
@@ -50,7 +50,7 @@ public class WebClientTracingFilter implements ExchangeFilterFunction {
 
     @Override
     public void subscribe(final CoreSubscriber<? super ClientResponse> subscriber) {
-      AgentSpan span = startSpan("spring-webflux", HTTP_REQUEST);
+      AgentSpan span = startSpan("spring-webflux-client", HTTP_REQUEST);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       AgentSpan parent = activeSpan();

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -33,7 +33,7 @@ public class DispatcherHandlerAdvice {
       exchange.getAttributes().put(AdviceUtils.PARENT_SPAN_ATTRIBUTE, parentSpan);
     }
 
-    final AgentSpan span = startSpan("spring-webflux", DISPATCHER_HANDLE_HANDLER);
+    final AgentSpan span = startSpan("spring-webflux-controller", DISPATCHER_HANDLE_HANDLER);
     span.setMeasured(true);
     DECORATE.afterStart(span);
     exchange.getAttributes().put(AdviceUtils.SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -33,7 +33,7 @@ public class DispatcherHandlerAdvice {
       exchange.getAttributes().put(AdviceUtils.PARENT_SPAN_ATTRIBUTE, parentSpan);
     }
 
-    final AgentSpan span = startSpan(DISPATCHER_HANDLE_HANDLER);
+    final AgentSpan span = startSpan("spring-webflux", DISPATCHER_HANDLE_HANDLER);
     span.setMeasured(true);
     DECORATE.afterStart(span);
     exchange.getAttributes().put(AdviceUtils.SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -97,7 +97,7 @@ public final class DispatcherServletInstrumentation extends InstrumenterModule.T
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-      final AgentSpan span = startSpan("spring-web", RESPONSE_RENDER);
+      final AgentSpan span = startSpan("spring-webmvc", RESPONSE_RENDER);
       DECORATE_RENDER.afterStart(span);
       DECORATE_RENDER.onRender(span, mv);
       return getCurrentContext().with(span).attach();

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -97,7 +97,7 @@ public final class DispatcherServletInstrumentation extends InstrumenterModule.T
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-      final AgentSpan span = startSpan(RESPONSE_RENDER);
+      final AgentSpan span = startSpan("spring-web", RESPONSE_RENDER);
       DECORATE_RENDER.afterStart(span);
       DECORATE_RENDER.onRender(span, mv);
       return getCurrentContext().with(span).attach();

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -104,7 +104,7 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
         return ((Context) existingContext).attach();
       }
 
-      final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+      final AgentSpan span = startSpan("spring-web", DECORATE.spanName()).setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -104,7 +104,8 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
         return ((Context) existingContext).attach();
       }
 
-      final AgentSpan span = startSpan("spring-web", DECORATE.spanName()).setMeasured(true);
+      final AgentSpan span =
+          startSpan("spring-web-controller", DECORATE.spanName()).setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentationTest.groovy
@@ -27,7 +27,7 @@ class HttpMessageConverterInstrumentationTest extends InstrumentationSpecificati
   def setup() {
     publishedBodies.clear()
     TagContext ctx = new TagContext().withRequestContextDataAppSec(new Object())
-    def span = AgentTracer.startSpan('test-span', ctx)
+    def span = AgentTracer.startSpan('test', 'test-span', ctx)
     scope = AgentTracer.activateSpan(span)
 
     ss.registerCallback(EVENTS.requestBodyProcessed(), { RequestContext reqCtx, Object body ->

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
@@ -55,7 +55,7 @@ public class ControllerAdvice {
       return ((Context) existingContext).attach();
     }
 
-    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span = startSpan("spring-web", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     DECORATE.onHandle(span, handler);
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
@@ -55,7 +55,8 @@ public class ControllerAdvice {
       return ((Context) existingContext).attach();
     }
 
-    final AgentSpan span = startSpan("spring-web", DECORATE.spanName()).setMeasured(true);
+    final AgentSpan span =
+        startSpan("spring-web-controller", DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     DECORATE.onHandle(span, handler);
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/RenderAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/RenderAdvice.java
@@ -13,7 +13,7 @@ public class RenderAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static ContextScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-    final AgentSpan span = startSpan("spring-web", SpringWebHttpServerDecorator.RESPONSE_RENDER);
+    final AgentSpan span = startSpan("spring-webmvc", SpringWebHttpServerDecorator.RESPONSE_RENDER);
     SpringWebHttpServerDecorator.DECORATE_RENDER.afterStart(span);
     SpringWebHttpServerDecorator.DECORATE_RENDER.onRender(span, mv);
     return getCurrentContext().with(span).attach();

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/RenderAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/RenderAdvice.java
@@ -13,7 +13,7 @@ public class RenderAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static ContextScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-    final AgentSpan span = startSpan(SpringWebHttpServerDecorator.RESPONSE_RENDER);
+    final AgentSpan span = startSpan("spring-web", SpringWebHttpServerDecorator.RESPONSE_RENDER);
     SpringWebHttpServerDecorator.DECORATE_RENDER.afterStart(span);
     SpringWebHttpServerDecorator.DECORATE_RENDER.onRender(span, mv);
     return getCurrentContext().with(span).attach();

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
@@ -78,7 +78,7 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan(MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -107,7 +107,7 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan(MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -136,7 +136,7 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan(MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -165,7 +165,7 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan(MemcacheClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME);
       return new SyncCompletionListener(span, methodName);
     }
 

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.spymemcached.MemcacheClientDecorator.COMPONENT_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -78,7 +79,8 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(
+          startSpan(COMPONENT_NAME.toString(), MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -107,7 +109,8 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(
+          startSpan(COMPONENT_NAME.toString(), MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -136,7 +139,8 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      return activateSpan(startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME));
+      return activateSpan(
+          startSpan(COMPONENT_NAME.toString(), MemcacheClientDecorator.OPERATION_NAME));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -165,7 +169,8 @@ public final class MemcachedClientInstrumentation extends InstrumenterModule.Tra
       if (CallDepthThreadLocalMap.incrementCallDepth(MemcachedClient.class) > 0) {
         return null;
       }
-      final AgentSpan span = startSpan("spymemcached", MemcacheClientDecorator.OPERATION_NAME);
+      final AgentSpan span =
+          startSpan(COMPONENT_NAME.toString(), MemcacheClientDecorator.OPERATION_NAME);
       return new SyncCompletionListener(span, methodName);
     }
 

--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
@@ -9,6 +9,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.getCurrentContext;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.SYNAPSE_CLIENT;
 import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.SYNAPSE_CONTEXT_KEY;
 import static datadog.trace.instrumentation.synapse3.SynapseClientDecorator.SYNAPSE_REQUEST;
 import static datadog.trace.instrumentation.synapse3.TargetRequestInjectAdapter.SETTER;
@@ -86,9 +87,9 @@ public final class SynapseClientInstrumentation extends InstrumenterModule.Traci
 
       AgentSpan span;
       if (null != parentSpan) {
-        span = startSpan("synapse3-client", SYNAPSE_REQUEST, parentSpan.context());
+        span = startSpan(SYNAPSE_CLIENT.toString(), SYNAPSE_REQUEST, parentSpan.context());
       } else {
-        span = startSpan("synapse3-client", SYNAPSE_REQUEST);
+        span = startSpan(SYNAPSE_CLIENT.toString(), SYNAPSE_REQUEST);
       }
 
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
@@ -86,9 +86,9 @@ public final class SynapseClientInstrumentation extends InstrumenterModule.Traci
 
       AgentSpan span;
       if (null != parentSpan) {
-        span = startSpan(SYNAPSE_REQUEST, parentSpan.context());
+        span = startSpan("synapse3-client", SYNAPSE_REQUEST, parentSpan.context());
       } else {
-        span = startSpan(SYNAPSE_REQUEST);
+        span = startSpan("synapse3-client", SYNAPSE_REQUEST);
       }
 
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobInstrumentation.java
@@ -38,7 +38,7 @@ public class JobInstrumentation extends AbstractTibcoInstrumentation
       if (suffixIdx > 0) {
         workflowName = workflowName.substring(0, suffixIdx);
       }
-      AgentSpan span = startSpan(TIBCO_PROCESS_OPERATION);
+      AgentSpan span = startSpan("tibco_bw", TIBCO_PROCESS_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onProcessStart(span, workflowName);
       Map<String, AgentSpan> map =

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
@@ -48,7 +48,7 @@ public class JobPoolInstrumentation extends AbstractTibcoInstrumentation
       if (suffixIdx > 0) {
         workflowName = workflowName.substring(0, suffixIdx);
       }
-      AgentSpan span = startSpan(TIBCO_PROCESS_OPERATION);
+      AgentSpan span = startSpan("tibco_bw", TIBCO_PROCESS_OPERATION);
       DECORATE.afterStart(span);
       DECORATE.onProcessStart(span, workflowName);
       Map<String, AgentSpan> map = new HashMap<>();

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TaskInstrumentation.java
@@ -66,7 +66,9 @@ public class TaskInstrumentation extends AbstractTibcoInstrumentation
       AgentSpan span = map.get(ddActivityInfo.id);
       if (span == null) {
         AgentSpan parent = map.getOrDefault(ddActivityInfo.parent, activeSpan());
-        span = startSpan(TIBCO_ACTIVITY_OPERATION, parent != null ? parent.context() : null);
+        span =
+            startSpan(
+                "tibco_bw", TIBCO_ACTIVITY_OPERATION, parent != null ? parent.context() : null);
         DECORATE.afterStart(span);
         DECORATE.onActivityStart(span, ddActivityInfo.name);
         map.put(ddActivityInfo.id, span);

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/BehaviorInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/BehaviorInstrumentation.java
@@ -91,6 +91,7 @@ public class BehaviorInstrumentation extends AbstractTibcoInstrumentation
       }
       AgentSpan span =
           startSpan(
+              "tibco_bw",
               TibcoDecorator.TIBCO_ACTIVITY_OPERATION,
               parentSpan != null ? parentSpan.context() : null);
       TibcoDecorator.DECORATE.afterStart(span);
@@ -141,6 +142,7 @@ public class BehaviorInstrumentation extends AbstractTibcoInstrumentation
         }
         AgentSpan span =
             startSpan(
+                "tibco_bw",
                 TibcoDecorator.TIBCO_PROCESS_OPERATION,
                 parent != null ? parentSpan.context() : null);
         TibcoDecorator.DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/ProcessInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/ProcessInstrumentation.java
@@ -66,7 +66,7 @@ public class ProcessInstrumentation extends AbstractTibcoInstrumentation
         }
       }
       try (AgentScope maybeScope = parentSpan != null ? activateSpan(parentSpan) : null) {
-        AgentSpan span = startSpan(TibcoDecorator.TIBCO_PROCESS_OPERATION);
+        AgentSpan span = startSpan("tibco_bw", TibcoDecorator.TIBCO_PROCESS_OPERATION);
         TibcoDecorator.DECORATE.afterStart(span);
         if (appName != null) {
           AgentSpan root = span.getLocalRootSpan();

--- a/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -102,7 +102,7 @@ public class TwilioAsyncInstrumentation extends InstrumenterModule.Tracing
       }
 
       // Don't automatically close the span with the scope if we're executing an async method
-      final AgentSpan span = startSpan(TWILIO_SDK);
+      final AgentSpan span = startSpan("twilio-sdk", TWILIO_SDK);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 

--- a/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -85,7 +85,7 @@ public class TwilioSyncInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      final AgentSpan span = startSpan(TWILIO_SDK);
+      final AgentSpan span = startSpan("twilio-sdk", TWILIO_SDK);
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 

--- a/dd-java-agent/instrumentation/valkey-java-5.3/src/main/java/datadog/trace/instrumentation/valkey/ValkeyInstrumentation.java
+++ b/dd-java-agent/instrumentation/valkey-java-5.3/src/main/java/datadog/trace/instrumentation/valkey/ValkeyInstrumentation.java
@@ -56,7 +56,7 @@ public final class ValkeyInstrumentation extends InstrumenterModule.Tracing
     public static AgentScope onEnter(
         @Advice.Argument(0) final CommandObject<?> commandObject,
         @Advice.This final Connection thiz) {
-      final AgentSpan span = startSpan("valkey", ValkeyClientDecorator.OPERATION_NAME);
+      final AgentSpan span = startSpan("valkey-command", ValkeyClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, thiz);
 

--- a/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -81,7 +81,7 @@ public class VertxRedisClientDecorator
   }
 
   private AgentSpan innerStartAndDecorateSpan(UTF8BytesString command) {
-    final AgentSpan span = startSpan("vertx", REDIS_COMMAND);
+    final AgentSpan span = startSpan("redis-command", REDIS_COMMAND);
     DECORATE.afterStart(span);
     DECORATE.onStatement(span, command);
     return span;

--- a/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -81,7 +81,7 @@ public class VertxRedisClientDecorator
   }
 
   private AgentSpan innerStartAndDecorateSpan(UTF8BytesString command) {
-    final AgentSpan span = startSpan(REDIS_COMMAND);
+    final AgentSpan span = startSpan("vertx", REDIS_COMMAND);
     DECORATE.afterStart(span);
     DECORATE.onStatement(span, command);
     return span;

--- a/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
@@ -75,7 +75,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   public <T> AgentSpan startAndDecorateSpanForStatement(
       T query, ContextStore<T, Pair> contextStore, boolean prepared) {
     CharSequence component = prepared ? VERTX_PREPARED_STATEMENT : VERTX_STATEMENT;
-    AgentSpan span = startSpan(DATABASE_QUERY);
+    AgentSpan span = startSpan("vertx", DATABASE_QUERY);
     if (null == span) {
       return null;
     }

--- a/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
@@ -75,7 +75,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   public <T> AgentSpan startAndDecorateSpanForStatement(
       T query, ContextStore<T, Pair> contextStore, boolean prepared) {
     CharSequence component = prepared ? VERTX_PREPARED_STATEMENT : VERTX_STATEMENT;
-    AgentSpan span = startSpan("vertx", DATABASE_QUERY);
+    AgentSpan span = startSpan("vertx-sql", DATABASE_QUERY);
     if (null == span) {
       return null;
     }

--- a/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
@@ -75,7 +75,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   public <T> AgentSpan startAndDecorateSpanForStatement(
       T query, ContextStore<T, Pair> contextStore, boolean prepared) {
     CharSequence component = prepared ? VERTX_PREPARED_STATEMENT : VERTX_STATEMENT;
-    AgentSpan span = startSpan("vertx-sql", DATABASE_QUERY);
+    AgentSpan span = startSpan(component.toString(), DATABASE_QUERY);
     if (null == span) {
       return null;
     }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
@@ -44,7 +44,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
         AgentSpan parentSpan = activeSpan();
         routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
 
-        span = startSpan(INSTRUMENTATION_NAME);
+        span = startSpan("vertx", INSTRUMENTATION_NAME);
         routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
 
         routingContext.response().endHandler(new EndHandlerWrapper(routingContext));

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -40,7 +40,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
         AgentSpan parentSpan = activeSpan();
         routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
 
-        span = startSpan(INSTRUMENTATION_NAME);
+        span = startSpan("vertx", INSTRUMENTATION_NAME);
         routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
 
         routingContext.response().endHandler(new EndHandlerWrapper(routingContext));

--- a/dd-java-agent/instrumentation/ws/jakarta-ws-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jakarta-ws-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
@@ -75,7 +75,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan(JAKARTA_WS_REQUEST);
+      AgentSpan span = startSpan("jakarta-ws", JAKARTA_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJakartaWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ws/jakarta-ws-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jakarta-ws-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakartaws/WebServiceInstrumentation.java
@@ -75,7 +75,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan("jakarta-ws", JAKARTA_WS_REQUEST);
+      AgentSpan span = startSpan("jakarta-ws-endpoint", JAKARTA_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJakartaWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-1.1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-1.1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
@@ -75,7 +75,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws-endpoint", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-1.1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-1.1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
@@ -75,7 +75,7 @@ public final class WebServiceInstrumentation extends InstrumenterModule.Tracing
         return null;
       }
 
-      AgentSpan span = startSpan(JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
@@ -69,7 +69,7 @@ public final class WebServiceProviderInstrumentation extends InstrumenterModule.
         return null;
       }
 
-      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws-endpoint", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
@@ -69,7 +69,7 @@ public final class WebServiceProviderInstrumentation extends InstrumenterModule.
         return null;
       }
 
-      AgentSpan span = startSpan(JAX_WS_REQUEST);
+      AgentSpan span = startSpan("jax-ws", JAX_WS_REQUEST);
       span.setMeasured(true);
       DECORATE.onJaxWsSpan(span, thiz.getClass(), method);
       DECORATE.afterStart(span);

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -11,16 +11,22 @@ import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
 
 class TagsAssert {
+  // Populated by the InstrumentationSpecification spy; keyed by span ID.
+  static final Map<Long, String> INSTRUMENTATION_NAMES = new ConcurrentHashMap<>()
+
   private final long spanParentId
+  private final long spanId
   private final Map<String, Object> tags
   private final String serviceName
   private final Set<String> assertedTags = new TreeSet<>()
 
   private TagsAssert(DDSpan span) {
     this.spanParentId = span.parentId
+    this.spanId = span.spanId
     this.tags = span.tags
     this.serviceName = span.getServiceName()
   }
@@ -106,6 +112,11 @@ class TagsAssert {
     }
     if (assertedTags.add(DDTags.DD_INTEGRATION) && tags[Tags.COMPONENT] != null) {
       assert tags[Tags.COMPONENT].toString() == tags[DDTags.DD_INTEGRATION].toString()
+    }
+    String capturedInstrumentationName = INSTRUMENTATION_NAMES.remove(spanId)
+    if (capturedInstrumentationName != null && capturedInstrumentationName != "test" && tags[DDTags.DD_INTEGRATION] != null) {
+      assert tags[DDTags.DD_INTEGRATION].toString() == capturedInstrumentationName :
+      "DD_INTEGRATION '${tags[DDTags.DD_INTEGRATION]}' != instrumentationName '${capturedInstrumentationName}' passed to startSpan()"
     }
 
     assert tags["thread.name"] != null

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -114,6 +114,7 @@ class TagsAssert {
       assert tags[Tags.COMPONENT].toString() == tags[DDTags.DD_INTEGRATION].toString()
     }
     String capturedInstrumentationName = INSTRUMENTATION_NAMES.remove(spanId)
+    System.err.println("CAPTURED $capturedInstrumentationName")
     if (capturedInstrumentationName != null && capturedInstrumentationName != "test" && tags[DDTags.DD_INTEGRATION] != null) {
       assert tags[DDTags.DD_INTEGRATION].toString() == capturedInstrumentationName :
       "DD_INTEGRATION '${tags[DDTags.DD_INTEGRATION]}' != instrumentationName '${capturedInstrumentationName}' passed to startSpan()"

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -114,7 +114,6 @@ class TagsAssert {
       assert tags[Tags.COMPONENT].toString() == tags[DDTags.DD_INTEGRATION].toString()
     }
     String capturedInstrumentationName = INSTRUMENTATION_NAMES.remove(spanId)
-    System.err.println("CAPTURED $capturedInstrumentationName")
     if (capturedInstrumentationName != null && capturedInstrumentationName != "test" && tags[DDTags.DD_INTEGRATION] != null) {
       assert tags[DDTags.DD_INTEGRATION].toString() == capturedInstrumentationName :
       "DD_INTEGRATION '${tags[DDTags.DD_INTEGRATION]}' != instrumentationName '${capturedInstrumentationName}' passed to startSpan()"

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -3,6 +3,7 @@ package datadog.trace.agent.test.utils
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator
 import datadog.trace.core.DDSpan
 
@@ -44,7 +45,7 @@ class TraceUtils {
   }
 
   static <T> T runUnderTrace(final String rootOperationName, final boolean inheritCurrent, final boolean async, final Callable<T> r) {
-    final AgentSpan span = inheritCurrent ? startSpan(rootOperationName) : startSpan(rootOperationName, null)
+    final AgentSpan span = inheritCurrent ? startSpan("test", rootOperationName) : startSpan("test", rootOperationName, (AgentSpanContext) null)
     DECORATOR.afterStart(span)
 
     AgentScope scope = activateSpan(span)

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -25,27 +25,12 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 public class AgentTracer {
-  private static final String DEFAULT_INSTRUMENTATION_NAME = "datadog";
-
-  // Implicit parent
-  /** Deprecated. Use {@link #startSpan(String, CharSequence)} instead. */
-  @Deprecated
-  public static AgentSpan startSpan(final CharSequence spanName) {
-    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName);
-  }
 
   /**
    * @see TracerAPI#startSpan(String, CharSequence)
    */
   public static AgentSpan startSpan(final String instrumentationName, final CharSequence spanName) {
     return get().startSpan(instrumentationName, spanName);
-  }
-
-  // Implicit parent
-  /** Deprecated. Use {@link #startSpan(String, CharSequence, long)} instead. */
-  @Deprecated
-  public static AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, startTimeMicros);
   }
 
   /**
@@ -56,13 +41,6 @@ public class AgentTracer {
     return get().startSpan(instrumentationName, spanName, startTimeMicros);
   }
 
-  // Explicit parent
-  /** Deprecated. Use {@link #startSpan(String, CharSequence, AgentSpanContext)} instead. */
-  @Deprecated
-  public static AgentSpan startSpan(final CharSequence spanName, final AgentSpanContext parent) {
-    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, parent);
-  }
-
   /**
    * @see TracerAPI#startSpan(String, CharSequence, AgentSpanContext)
    */
@@ -71,14 +49,6 @@ public class AgentTracer {
       final CharSequence spanName,
       final AgentSpanContext parent) {
     return get().startSpan(instrumentationName, spanName, parent);
-  }
-
-  // Explicit parent
-  /** Deprecated. Use {@link #startSpan(String, CharSequence, AgentSpanContext, long)} instead. */
-  @Deprecated
-  public static AgentSpan startSpan(
-      final CharSequence spanName, final AgentSpanContext parent, final long startTimeMicros) {
-    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, parent, startTimeMicros);
   }
 
   /**
@@ -379,12 +349,12 @@ public class AgentTracer {
     /** Deprecated. Use {@link #buildSpan(String, CharSequence)} instead. */
     @Deprecated
     default SpanBuilder buildSpan(CharSequence spanName) {
-      return buildSpan(DEFAULT_INSTRUMENTATION_NAME, spanName);
+      return buildSpan("datadog", spanName);
     }
 
     @Deprecated
     default SpanBuilder singleSpanBuilder(CharSequence spanName) {
-      return singleSpanBuilder(DEFAULT_INSTRUMENTATION_NAME, spanName);
+      return singleSpanBuilder("datadog", spanName);
     }
 
     /**


### PR DESCRIPTION
# What Does This Do

Removes the 4 deprecated `startSpan` overloads from `AgentTracer` that accepted a `CharSequence` span name as the only/first argument and defaulted to `"datadog"` as the instrumentation name:

```java
// removed:
startSpan(CharSequence spanName)
startSpan(CharSequence spanName, long startTimeMicros)
startSpan(CharSequence spanName, AgentSpanContext parent)
startSpan(CharSequence spanName, AgentSpanContext parent, long startTimeMicros)
```

All call sites have been migrated to the non-deprecated form that explicitly passes the integration's own name as the first `String` argument.

The instrumentation name used is the same as `component()` already used on `_dd.integration` tag. A check on `TagAssertion` is making sure that both are coherent that ensures the correctness of this PR

The private `DEFAULT_INSTRUMENTATION_NAME = "datadog"` constant in `AgentTracer` is also removed; the two remaining deprecated methods in `TracerAPI` (`buildSpan(CharSequence)` and `singleSpanBuilder(CharSequence)`) now inline the `"datadog"` literal directly.

**No behaviour change** — this is a pure refactor. The instrumentation name passed to the tracer now matches what each integration already declared as its own name.

## Recap of changes

| Module                                                   | File(s)                                                                                                     | instrName (resolved)                                       |
| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| aerospike-4.0                                            | AerospikeClientDecorator                                                                                    | `"java-aerospike"`                                         |
| akka/akka-http/akka-http-10.0                            | AkkaHttpSingleRequestInstrumentation                                                                        | `"akka-http-client"`                                       |
| akka/akka-http/akka-http-10.6                            | SingleRequestAdvice                                                                                         | `"akka-http-client"`                                       |
| apache-httpclient/apache-httpasyncclient-4.0             | ApacheHttpAsyncClientInstrumentation                                                                        | `"apache-httpasyncclient"`                                 |
| apache-httpclient/apache-httpclient-4.0                  | HelperMethods                                                                                               | `"apache-httpclient"`                                      |
| apache-httpclient/apache-httpclient-5.0                  | HelperMethods, ApacheHttpAsyncClientInstrumentation                                                         | `"apache-httpclient"`                                      |
| aws-java/aws-java-lambda-handler-1.2                     | LambdaHandlerInstrumentation                                                                                | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sdk-1.11                               | TracingRequestHandler                                                                                       | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sns-1.0                                | SnsInterceptor                                                                                              | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sqs-1.0                                | SqsInterceptor                                                                                              | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sqs-1.0                                | TracingIterator (consumer span)                                                                             | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sqs-1.0                                | TracingIterator (time-in-queue)                                                                             | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sqs-2.0                                | TracingIterator (consumer span)                                                                             | `"java-aws-sdk"`                                           |
| aws-java/aws-java-sqs-2.0                                | TracingIterator (time-in-queue)                                                                             | `"java-aws-sdk"`                                           |
| axis2-1.3                                                | AxisTransportInstrumentation, AxisEngineInstrumentation                                                     | `"axis2"`                                                  |
| axway-api-7.5                                            | StateAdvice, HTTPPluginAdvice                                                                               | `"axway-http"`                                             |
| cics-9.1                                                 | JavaGatewayInterfaceInstrumentation, ECIInteractionInstrumentation                                          | `"cics-client"`                                            |
| commons-httpclient-2.0                                   | CommonsHttpClientInstrumentation                                                                            | `"commons-http-client"`                                    |
| cucumber-5.4                                             | CucumberStepDecorator                                                                                       | `"cucumber"`                                               |
| datanucleus-4.0.5                                        | ExecutionContextInstrumentation (×4), JDOTransactionInstrumentation                                         | `"java-datanucleus"`                                       |
| datastax-cassandra/datastax-cassandra-3.0                | TracingSession                                                                                              | `"java-cassandra"`                                         |
| datastax-cassandra/datastax-cassandra-4.0                | TracingSession (×2)                                                                                         | `"java-cassandra"`                                         |
| dropwizard/dropwizard-views-0.7                          | DropwizardViewInstrumentation                                                                               | `"dropwizard-view"`                                        |
| elasticsearch/elasticsearch-rest/* (×3)                  | Elasticsearch*RestClientInstrumentation                                                                     | `"elasticsearch-java"`                                     |
| elasticsearch/elasticsearch-transport/* (×5)             | Elasticsearch*TransportClientInstrumentation                                                                | `"elasticsearch-java"`                                     |
| finatra-2.9                                              | FinatraInstrumentation                                                                                      | `"finatra"`                                                |
| google-http-client-1.19                                  | GoogleHttpClientInstrumentation                                                                             | `"google-http-client"`                                     |
| google-pubsub-1.116                                      | PubSubDecorator, PublisherInstrumentation                                                                   | `"java-google-pubsub"`                                     |
| graphql-java/graphql-java-14.0                           | GraphQLInstrumentation                                                                                      | `"graphql-java"`                                           |
| grizzly/grizzly-client-1.9                               | AsyncHttpClientInstrumentation                                                                              | `"grizzly-http-async-client"`                              |
| hazelcast/hazelcast-3.6                                  | DistributedObjectInstrumentation (×2)                                                                       | `"hazelcast-sdk"`                                          |
| hazelcast/hazelcast-3.9                                  | ClientInvocationInstrumentation                                                                             | `"hazelcast-sdk"`                                          |
| hazelcast/hazelcast-4.0                                  | ClientListenerInstrumentation, InvocationAdvice                                                             | `"hazelcast-sdk"`                                          |
| hibernate/hibernate-core-3.3, 4.0                        | SessionFactoryInstrumentation                                                                               | `"java-hibernate"`                                         |
| ignite-2.0                                               | IgniteCacheAsyncInstrumentation (×2), IgniteCacheSyncInstrumentation (×3)                                   | `"ignite-cache"`                                           |
| java/java-lang/java-lang-1.8                             | ProcessImplStartAdvice                                                                                      | `"subprocess"`                                             |
| java/java-net/java-net-1.8                               | UrlInstrumentation                                                                                          | `"UrlConnection"`                                          |
| java/java-net/java-net-11.0                              | SendAdvice, SendAsyncAdvice                                                                                 | `"java-http-client"`                                       |
| java/java-rmi-1.1                                        | RmiServerInstrumentation (×2)                                                                               | `"rmi-server"`                                             |
| java/java-rmi-1.1                                        | RmiClientInstrumentation                                                                                    | `"rmi-client"`                                             |
| jdbc                                                     | AbstractPreparedStatementInstrumentation (×4)                                                               | `"java-jdbc-prepared_statement"`                           |
| jdbc                                                     | StatementInstrumentation (×3)                                                                               | `"java-jdbc-statement"`                                    |
| jdbc                                                     | DataSourceInstrumentation                                                                                   | `"java-jdbc-connection"`                                   |
| jdbc                                                     | Dbcp2LinkedBlockingDequeInstrumentation                                                                     | `"java-jdbc-pool-waiting"`                                 |
| jedis/jedis-3.0, 4.0                                     | JedisInstrumentation                                                                                        | `"redis-command"`                                          |
| jetty/jetty-client/jetty-client-9.1, 10.0, 12.0          | JettyClientInstrumentation / SendAdvice                                                                     | `"jetty-client"`                                           |
| jms/javax-jms-1.1                                        | JMSMessageConsumerInstrumentation (×3), DatadogMessageListener (×2), JMSMessageProducerInstrumentation (×2) | `"jms"`                                                    |
| jsp-2.3                                                  | JasperJSPCompilationContextInstrumentation                                                                  | `"jsp-http-servlet"`                                       |
| junit/junit-4, junit-5                                   | JUnit4/5BeforeAfterOperationsTracer                                                                         | `"junit"`                                                  |
| kafka/kafka-clients-0.11                                 | KafkaProducerInstrumentation (×2), TracingIterator (×3), KafkaConsumerInfoInstrumentation                   | `"java-kafka"`                                             |
| kafka/kafka-clients-3.8                                  | TracingIterator (×3), ProducerAdvice (×2), RecordsAdvice                                                    | `"java-kafka"`                                             |
| kafka/kafka-streams-0.11                                 | KafkaStreamTaskInstrumentation (×4)                                                                         | `"java-kafka-streams"`                                     |
| karate-1.0                                               | KarateTracingHook                                                                                           | `"karate"`                                                 |
| micronaut/micronaut-http-server-netty-4.0                | ChannelAcceptAdvice, ChannelAcceptAdvice2                                                                   | `"micronaut-controller"`                                   |
| micronaut/micronaut-http-server-netty-common             | ChannelRead0Advice                                                                                          | `"micronaut-controller"`                                   |
| mongo/mongo-common                                       | MongoCommandListener                                                                                        | `"java-mongo"`                                             |
| mongo/mongo-driver-3/mongo-driver-3.6, 3.8               | DefaultServerConnection*Instrumentation                                                                     | `"java-mongo"`                                             |
| mule-4.5                                                 | MuleDecorator (×2)                                                                                          | `"mule"`                                                   |
| netty/netty-3.8, 4.0, 4.1                                | ChannelFutureListenerInstrumentation                                                                        | `"netty"`                                                  |
| netty/netty-3.8, 4.0, 4.1                                | HttpClientRequestTracingHandler                                                                             | `"netty-client"`                                           |
| ognl-appsec-3.3.2                                        | OgnlInstrumentation                                                                                         | `"ognl"`                                                   |
| okhttp/okhttp-2.2, 3.0                                   | TracingInterceptor                                                                                          | `"okhttp"`                                                 |
| opensearch/opensearch-rest-1.0, opensearch-transport-1.0 | Opensearch*ClientInstrumentation                                                                            | `"opensearch-java"`                                        |
| pekko/pekko-http-1.0                                     | PekkoHttpSingleRequestInstrumentation                                                                       | `"pekko-http-client"`                                      |
| play-ws/play-ws-1.0, 2.0, 2.1                            | PlayWSClientInstrumentation                                                                                 | `"play-ws"`                                                |
| play/play-2.3, 2.4, 2.6                                  | PlayAdvice                                                                                                  | `"play-action"`                                            |
| quartz-2.0                                               | QuartzSchedulingInstrumentation                                                                             | `"quartz"`                                                 |
| rabbitmq-amqp-2.7                                        | RabbitChannelInstrumentation (×2)                                                                           | `"rabbitmq-amqp"`                                          |
| ratpack-1.5                                              | TracingHandler                                                                                              | `"ratpack"`                                                |
| rediscala-1.8                                            | RediscalaInstrumentation                                                                                    | `"redis-command"`                                          |
| redisson/redisson-2.0.0, 2.3.0, 3.10.3                   | RedissonInstrumentation (×2 each)                                                                           | `"redis-command"`                                          |
| renaissance-0.7                                          | RenaissanceInstrumentation                                                                                  | `"renaissance"`                                            |
| restlet-2.2                                              | ResourceInstrumentation                                                                                     | `"restlet-controller"`                                     |
| rs/jakarta-rs-annotations-3.0                            | RequestFilterHelper                                                                                         | `"jakarta-rs-controller"`                                  |
| rs/jax-rs/jax-rs-annotations-1.1.1, 2.0                  | JaxRsAnnotationsInstrumentation, RequestFilterHelper, DefaultRequestContextInstrumentation                  | `"jax-rs-controller"`                                      |
| rs/jax-rs/jax-rs-client-1.1, 2.0                         | JaxRsClientV1Instrumentation, ClientTracingFilter                                                           | `"jax-rs.client"`                                          |
| servlet/javax-servlet-common                             | FilterInstrumentation                                                                                       | `"java-web-servlet-filter"`                                |
| servlet/javax-servlet-common                             | HttpServletInstrumentation                                                                                  | `"java-web-servlet-service"`                               |
| servlet/javax-servlet-common                             | HttpServletResponseInstrumentation                                                                          | `"java-web-servlet-response"`                              |
| sofarpc/sofarpc-5.0                                      | AbstractClusterInstrumentation                                                                              | `"sofarpc-client"`                                         |
| sofarpc/sofarpc-5.0                                      | ProviderProxyInvokerInstrumentation                                                                         | `"sofarpc-server"`                                         |
| spark/spark-executor-common                              | SparkExecutorInstrumentation                                                                                | `"spark"`                                                  |
| spray-1.3                                                | SprayHttpServerRunSealedRouteAdvice                                                                         | `"spray-http-server"`                                      |
| spring/spring-data-1.8                                   | RepositoryInterceptor                                                                                       | `"spring-data"`                                            |
| spring/spring-messaging-4.0                              | SpringMessageHandlerInstrumentation                                                                         | `"spring-messaging"`                                       |
| spring/spring-rabbit-1.5                                 | AbstractMessageListenerContainerInstrumentation                                                             | `"rabbitmq-amqp"`                                          |
| spring/spring-scheduling-3.1                             | SpannedMethodInvocation                                                                                     | `"spring-scheduling"`                                      |
| spring/spring-webflux-5.0                                | DispatcherHandlerAdvice                                                                                     | `"spring-webflux-controller"`                              |
| spring/spring-webflux-5.0                                | WebClientTracingFilter                                                                                      | `"spring-webflux-client"`                                  |
| spring/spring-webmvc-3.1, 6.0                            | DispatcherServletInstrumentation / RenderAdvice                                                             | `"spring-webmvc"`                                          |
| spring/spring-webmvc-3.1, 6.0                            | HandlerAdapterInstrumentation / ControllerAdvice                                                            | `"spring-web-controller"`                                  |
| synapse-3.0                                              | SynapseClientInstrumentation (×2)                                                                           | `"synapse-client"`                                         |
| tibco-businessworks-5.14                                 | JobInstrumentation, JobPoolInstrumentation                                                                  | `"tibco_bw"`                                               |
| tibco-businessworks-6.5                                  | ProcessInstrumentation                                                                                      | `"tibco_bw"`                                               |
| twilio-0.0.1                                             | TwilioAsyncInstrumentation, TwilioSyncInstrumentation                                                       | `"twilio-sdk"`                                             |
| valkey-java-5.3                                          | ValkeyInstrumentation                                                                                       | `"valkey-command"`                                         |
| vertx/vertx-redis-client-3.9                             | VertxRedisClientDecorator                                                                                   | `"redis-command"`                                          |
| vertx/vertx-sql-client-3.9                               | VertxSqlClientDecorator                                                                                     | `"vertx-sql-statement"` / `"vertx-sql-prepared_statement"` |
| vertx/vertx-web-3.4, 4.0                                 | RouteHandlerWrapper                                                                                         | `"vertx"`                                                  |
| ws/jakarta-ws-annotations-3.0                            | WebServiceInstrumentation                                                                                   | `"jakarta-ws-endpoint"`                                    |
| ws/jax-ws/jax-ws-annotations-1.1, 2.0                    | WebServiceInstrumentation, WebServiceProviderInstrumentation                                                | `"jax-ws-endpoint"`                                        |

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
