### PR TITLE
🪞 11178 - Skip JUnit 5 TIA tests before constructing the test class 

### DIFF
--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5ExecutionInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5ExecutionInstrumentation.java
@@ -11,9 +11,11 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.execution.TestExecutionPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.instrumentation.junit5.JUnitPlatformUtils;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService;
 import org.junit.platform.engine.support.hierarchical.Node;
@@ -46,7 +49,9 @@ public class JUnit5ExecutionInstrumentation extends InstrumenterModule.CiVisibil
 
   @Override
   public boolean isEnabled() {
-    return super.isEnabled() && Config.get().isCiVisibilityExecutionPoliciesEnabled();
+    return super.isEnabled()
+        && (Config.get().isCiVisibilityExecutionPoliciesEnabled()
+            || Config.get().isCiVisibilityTestSkippingEnabled());
   }
 
   @Override
@@ -146,6 +151,26 @@ public class JUnit5ExecutionInstrumentation extends InstrumenterModule.CiVisibil
       TestIdentifier testIdentifier = TestDataFactory.createTestIdentifier(testDescriptor);
       TestSourceData testSource = TestDataFactory.createTestSourceData(testDescriptor);
       Collection<String> testTags = JUnitPlatformUtils.getTags(testDescriptor);
+
+      // skip before prepare() so the test-class instance is never constructed
+      SkipReason skipReason =
+          TestEventsHandlerHolder.HANDLERS.get(framework).skipReason(testIdentifier);
+      if (skipReason != null) {
+        boolean unskippable = false;
+        if (skipReason == SkipReason.ITR) {
+          for (TestTag tag : testDescriptor.getTags()) {
+            if (CIConstants.Tags.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {
+              unskippable = true;
+              break;
+            }
+          }
+        }
+        if (!unskippable) {
+          taskHandle.getListener().executionSkipped(testDescriptor, skipReason.getDescription());
+          return Boolean.TRUE;
+        }
+      }
+
       TestExecutionPolicy executionPolicy =
           TestEventsHandlerHolder.HANDLERS
               .get(framework)

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -30,6 +30,7 @@ import org.example.TestSkipped
 import org.example.TestSkippedClass
 import org.example.TestSkippedNested
 import org.example.TestSucceed
+import org.example.TestSucceedAndFieldInitResource
 import org.example.TestSucceedAndSkipped
 import org.example.TestSucceedExpectedException
 import org.example.TestSucceedNested
@@ -112,6 +113,20 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
     "test-itr-unskippable"                       | [TestSucceedUnskippable]      | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
     "test-itr-unskippable-suite"                 | [TestSucceedUnskippableSuite] | [new TestIdentifier("org.example.TestSucceedUnskippableSuite", "test_succeed", null)]
     "test-itr-unskippable-not-skipped"           | [TestSucceedUnskippable]      | []
+  }
+
+  def "test ITR does not construct skipped test class"() {
+    given:
+    TestSucceedAndFieldInitResource.CONSTRUCTOR_INVOCATIONS.set(0)
+    givenSkippableTests([
+      new TestIdentifier("org.example.TestSucceedAndFieldInitResource", "test_skippable", null)
+    ])
+
+    when:
+    runTests([TestSucceedAndFieldInitResource])
+
+    then:
+    TestSucceedAndFieldInitResource.CONSTRUCTOR_INVOCATIONS.get() == 1
   }
 
   def "test flaky retries #testcaseName"() {

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/test/java/org/example/TestSucceedAndFieldInitResource.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/test/java/org/example/TestSucceedAndFieldInitResource.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class TestSucceedAndFieldInitResource {
+
+  public static final AtomicInteger CONSTRUCTOR_INVOCATIONS = new AtomicInteger(0);
+
+  public TestSucceedAndFieldInitResource() {
+    CONSTRUCTOR_INVOCATIONS.incrementAndGet();
+  }
+
+  @Test
+  public void test_skippable() {}
+
+  @Test
+  public void test_runs() {}
+}


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/11178
**Original Author:** @jbolsens-legion
**Original Branch:** jbolsens-legion/dd-trace-java:jb/fix-junit5-tia-skip-class-construction

Closes #11178

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*