### PR TITLE
Fix DebuggerAgent commonInit

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -182,13 +182,16 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
     if (log.isDebugEnabled()) {
       log.debug(
-          "discovered traceEndpoint={}, metricsEndpoint={}, supportsDropping={}, supportsLongRunning={}, dataStreamsEndpoint={}, configEndpoint={}, evpProxyEndpoint={}, telemetryProxyEndpoint={}",
+          "discovered traceEndpoint={}, metricsEndpoint={}, supportsDropping={}, supportsLongRunning={}, dataStreamsEndpoint={}, configEndpoint={}, logEndpoint={}, snapshotEndpoint={}, diagnosticsEndpoint={}, evpProxyEndpoint={}, telemetryProxyEndpoint={}",
           newState.traceEndpoint,
           newState.metricsEndpoint,
           newState.supportsDropping,
           newState.supportsLongRunning,
           newState.dataStreamsEndpoint,
           newState.configEndpoint,
+          newState.debuggerLogEndpoint,
+          newState.debuggerSnapshotEndpoint,
+          newState.debuggerDiagnosticsEndpoint,
           newState.evpProxyEndpoint,
           newState.telemetryProxyEndpoint);
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -126,7 +126,8 @@ public class DebuggerAgent {
       Redaction.addUserDefinedTypes(config);
       DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery =
           sharedCommunicationObjects.featuresDiscovery(config);
-      ddAgentFeaturesDiscovery.discoverIfOutdated();
+      // force to discover because commonInit can be retried if previously failed
+      ddAgentFeaturesDiscovery.discover();
       agentVersion = ddAgentFeaturesDiscovery.getVersion();
       String diagnosticEndpoint = getDiagnosticEndpoint(config, ddAgentFeaturesDiscovery);
       ProbeStatusSink probeStatusSink =
@@ -152,6 +153,8 @@ public class DebuggerAgent {
       return true;
     } catch (Exception ex) {
       LOGGER.debug("Failed to init common component for debugger agent", ex);
+      // reset commonInitDone to be able to retry commonInit next time
+      commonInitDone.set(false);
       return false;
     }
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -592,7 +592,7 @@ public abstract class BaseIntegrationTest {
   }
 
   protected static class MockDispatcher extends okhttp3.mockwebserver.QueueDispatcher {
-    private Function<RecordedRequest, MockResponse> dispatcher;
+    private volatile Function<RecordedRequest, MockResponse> dispatcher;
 
     @Override
     public MockResponse dispatch(RecordedRequest request) throws InterruptedException {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -98,7 +98,6 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   @Test
   @DisplayName("testExceptionReplayEnablementFailure")
   void testExceptionReplayEnablementFailure() throws Exception {
-    additionalJvmArgs.add("-Ddd.symbol.database.upload.enabled=true"); // enabled by default
     additionalJvmArgs.add("-Ddd.exception.replay.enabled=true");
     additionalJvmArgs.add("-Ddd.third.party.excludes=datadog.smoketest");
     this.probeMockDispatcher.setDispatcher(this::noEndpointDispatch);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -98,12 +98,16 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   @Test
   @DisplayName("testExceptionReplayEnablementFailure")
   void testExceptionReplayEnablementFailure() throws Exception {
-    additionalJvmArgs.add("-Ddd.symbol.database.upload.enabled=false"); // enabled by default
+    additionalJvmArgs.add("-Ddd.symbol.database.upload.enabled=true"); // enabled by default
     additionalJvmArgs.add("-Ddd.exception.replay.enabled=true");
     additionalJvmArgs.add("-Ddd.third.party.excludes=datadog.smoketest");
     this.probeMockDispatcher.setDispatcher(this::noEndpointDispatch);
     appUrl = startAppAndAndGetUrl();
     waitForSpecificLine(appUrl, "Failed to init common component for debugger agent");
+    probeMockDispatcher.setDispatcher(this::datadogAgentDispatch);
+    setConfigOverrides(createConfigOverrides(true, true));
+    waitForFeatureStarted(appUrl, "Dynamic Instrumentation");
+    waitForFeatureStarted(appUrl, "Exception Replay");
   }
 
   private MockResponse noEndpointDispatch(RecordedRequest request) {


### PR DESCRIPTION
# What Does This Do
flag commonInitDone is not reset if the method fails, therefore it cannot be retried if we start another product or restart the same one.
Force also to discover agent features/endpoints

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5440]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
