### PR TITLE
Use noqueue workflow_type for Merge Queue

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -2,7 +2,13 @@
 schema-version: v1
 kind: mergequeue # https://datadoghq.atlassian.net/wiki/x/XgUQug
 enable: true
+# Each PR in the MQ is processed in parallel
+# Conflicts between PRs in the MQ will not be detected
+workflow_type: noqueue
 merge_method: squash
+# Ensure head commit Gitlab pipelines complete and are successful before merging the PR
+gitlab_check_enable: true
+# Do not add merge queue status labels on the PR - they may cause race condition errors with existing label checks
 skip_labels: true
 gitlab_check_enable: true
 branches:


### PR DESCRIPTION
# What Does This Do

Use the `noqueue` workflow type for the Merge Queue. 

# Motivation

This is recommended by the DevFlow team to reduce MQ time, but may introduce occasional merge conflict failures to `master`. Since our MQ time can be long (e.g. mostly 2hr p90), let's try this out.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
