### PR TITLE
Bump `develocity` plugin correctly in 2 places simultaneously.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # NOTE: Ranges for some versions are needed to allow instrumentation tests to specify the desired version.
 
 # Build
-develocity = "4.2.2"
+develocity = "4.4.1"
 forbiddenapis = "3.10"
 spotbugs_annotations = "4.9.8"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.4.0"
+  id("com.gradle.develocity") version "4.4.1"
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
# What Does This Do
Bump `develocity` plugin correctly in 2 places simultaneously.

# Motivation
Latest build tools.

# Additional Notes
I found that we updated only one place but should update in two places.
I investigated a bit how this can be refactored to be in one place, but Codex generated ugly code, so I decided to keep things as-is.
