### PR TITLE
Update evaluation reason for empty waterfall to DEFAULT instead of ERROR/GENERAL per REASON.9

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -101,10 +101,6 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .build();
       }
 
-      if (isEmpty(flag.allocations)) {
-        return error(defaultValue, ErrorCode.GENERAL, "Missing allocations for flag " + flag.key);
-      }
-
       final Date now = new Date();
       final String targetingKey = context.getTargetingKey();
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -101,6 +101,10 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .build();
       }
 
+      if (flag.allocations == null) {
+        return error(defaultValue, ErrorCode.GENERAL, "null allocations for flag " + key);
+      }
+
       final Date now = new Date();
       final String targetingKey = context.getTargetingKey();
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -102,7 +102,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       }
 
       if (flag.allocations == null) {
-        return error(defaultValue, ErrorCode.GENERAL, "null allocations for flag " + key);
+        return error(defaultValue, ErrorCode.GENERAL, "Missing allocations for flag " + key);
       }
 
       final Date now = new Date();

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -13,6 +13,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.oneOf;
@@ -174,8 +175,8 @@ public class DDEvaluatorTest {
 
     details = evaluator.evaluate(Integer.class, "empty-allocation", 23, ctx);
     assertThat(details.getValue(), equalTo(23));
-    assertThat(details.getReason(), equalTo(ERROR.name()));
-    assertThat(details.getErrorCode(), equalTo(ErrorCode.GENERAL));
+    assertThat(details.getReason(), equalTo(DEFAULT.name()));
+    assertThat(details.getErrorCode(), nullValue());
   }
 
   private static Arguments[] flatteningTestCases() {


### PR DESCRIPTION
:eyes: see [REASON RFC](https://docs.google.com/document/d/1n2f6TlfR85yG41VYGE0_TT7tTXg7u-_ejL79GdndqXQ/edit?tab=t.0)

## Summary

Treats empty waterfall as valid state instead of an error.

- Removes the early-exit guard that returned `ErrorCode.GENERAL` when `flag.allocations` was an empty list.
- With the guard removed, the `for` loop at line 111 simply does not iterate, and execution falls through to the existing `return DEFAULT` at line 155.
- Per [ADR-001](https://docs.google.com/document/d/1n2f6TlfR85yG41VYGE0_TT7tTXg7u-_ejL79GdndqXQ/edit?tab=t.0#heading=h.f1lsx14gh2dg), an empty allocations waterfall is a platform data-invariant violation, not an SDK error. The SDK must return the coded default with `reason=DEFAULT` and no error code.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| `flag.allocations` is empty | `reason=ERROR`, `errorCode=GENERAL` | `reason=DEFAULT`, no error code |
| `flag.allocations` is null | `reason=ERROR`, `errorCode=GENERAL` (explicit guard) | `reason=ERROR`, `errorCode=GENERAL` (NPE caught by existing catch block) |

## Test plan

- [ ] Unit tests covering `evaluate()` with an empty allocations list assert `reason=DEFAULT` and no error code.
- [ ] Existing tests for the null-allocations path still pass (behaviour unchanged for null).