### PR TITLE
Fix FFE evaluation reason logic: SPLIT precedence, DEFAULT for waterfall catch-all, ADR-003 date window

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -386,10 +386,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     final ProviderEvaluation<T> result =
         ProviderEvaluation.<T>builder()
             .value(mappedValue)
-            .reason(
-                !isEmpty(allocation.rules)
-                    ? Reason.TARGETING_MATCH.name()
-                    : !isEmpty(split.shards) ? Reason.SPLIT.name() : Reason.STATIC.name())
+            .reason(resolveReason(allocation, split, flag))
             .variant(variant.key)
             .flagMetadata(metadataBuilder.build())
             .build();
@@ -398,6 +395,25 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       dispatchExposure(key, result, context);
     }
     return result;
+  }
+
+  private static String resolveReason(
+      final Allocation allocation, final Split split, final Flag flag) {
+    // ADR-004: SPLIT overrides TARGETING_MATCH when both rules and shard contributed
+    if (!isEmpty(allocation.rules) && !isEmpty(split.shards)) {
+      return Reason.SPLIT.name();
+    }
+    if (!isEmpty(allocation.rules)) {
+      return Reason.TARGETING_MATCH.name();
+    }
+    if (!isEmpty(split.shards)) {
+      return Reason.SPLIT.name();
+    }
+    // No rules, no shards (vacuous split). STATIC only when this is the sole allocation
+    // with no date-window constraints (ADR-003: time-gated result is not permanently stable).
+    final boolean hasDateWindow = allocation.startAt != null || allocation.endAt != null;
+    final boolean isSoleStaticAlloc = flag.allocations.size() == 1 && !hasDateWindow;
+    return isSoleStaticAlloc ? Reason.STATIC.name() : Reason.DEFAULT.name();
   }
 
   private static Object resolveAttribute(final String name, final EvaluationContext context) {


### PR DESCRIPTION
## Summary

- **ADR-004 (REASON-17):** When an allocation has both `rules` and `shards`, the old code returned `TARGETING_MATCH`. ADR-004 requires SPLIT to win when a shard contributed to the result. The new `resolveReason` method checks rules+shards together first and returns `SPLIT`.
- **Group A (REASON-14, 16, 18, 20, 24, 26):** Multi-allocation waterfall catch-all allocations (no rules, no shards, index > 0) returned `STATIC`. RFC says catch-all allocations in a waterfall must return `DEFAULT`. Fix: `STATIC` is now returned only when the flag has exactly one allocation and no date-window constraints.
- **ADR-003 (REASON-21, 23):** Allocations with `startAt`/`endAt` but no rules returned `STATIC`. ADR-003 says time-gated results are not permanently stable, so `STATIC` is inappropriate — `DEFAULT` must be returned instead. Fix: `hasDateWindow` check precludes `STATIC` in the sole-allocation case.

The inline ternary in `resolveVariant` is replaced by a call to the new private static `resolveReason(Allocation, Split, Flag)` method.

## Test plan

- [ ] Run unit tests: `./gradlew :products:feature-flagging:feature-flagging-api:test`
- [ ] Verify REASON-14, 16, 17, 18, 20, 21, 23, 24, 26 scenario cases return the correct reason
- [ ] Verify existing STATIC/TARGETING_MATCH/SPLIT cases are unaffected

## Tags

`tag: no release note`
`tag: ai generated`