### PR TITLE
Fix NPE in PayloadDispatcherImpl

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
@@ -68,7 +68,7 @@ public class PayloadDispatcherImpl implements ByteBufferConsumer, PayloadDispatc
     // there are alternative approaches to avoid blocking here, such as
     // introducing an unbound queue and another thread to do the IO
     // however, we can't block the application threads from here.
-    if (null == mapper || null == packer || !packer.format(trace, mapper)) {
+    if (null == mapper || !packer.format(trace, mapper)) {
       healthMetrics.onFailedPublish(
           trace.isEmpty() ? 0 : trace.get(0).samplingPriority(), trace.size());
     }
@@ -79,14 +79,13 @@ public class PayloadDispatcherImpl implements ByteBufferConsumer, PayloadDispatc
       if (mapperDiscovery.getMapper() == null) {
         mapperDiscovery.discover();
       }
-
       mapper = mapperDiscovery.getMapper();
-      if (null != mapper && null == packer) {
-        batchTimer =
-            monitoring.newTimer("tracer.trace.buffer.fill.time", "endpoint:" + mapper.endpoint());
-        packer = new MsgPackWriter(new FlushingBuffer(mapper.messageBufferSize(), this));
-        batchTimer.start();
-      }
+    }
+    if (null == packer && null != mapper) {
+      batchTimer =
+          monitoring.newTimer("tracer.trace.buffer.fill.time", "endpoint:" + mapper.endpoint());
+      packer = new MsgPackWriter(new FlushingBuffer(mapper.messageBufferSize(), this));
+      batchTimer.start();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
@@ -68,7 +68,7 @@ public class PayloadDispatcherImpl implements ByteBufferConsumer, PayloadDispatc
     // there are alternative approaches to avoid blocking here, such as
     // introducing an unbound queue and another thread to do the IO
     // however, we can't block the application threads from here.
-    if (null == mapper || !packer.format(trace, mapper)) {
+    if (null == mapper || null == packer || !packer.format(trace, mapper)) {
       healthMetrics.onFailedPublish(
           trace.isEmpty() ? 0 : trace.get(0).samplingPriority(), trace.size());
     }


### PR DESCRIPTION
# What Does This Do

Fixes:

```
java.lang.NullPointerException
  at writer.PayloadDispatcherImpl.addTrace(PayloadDispatcherImpl.java:71)
```

Since `mapper` and `packer` are set on the same codePath, hence they need both to be nullChecked

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
