### PR TITLE
Allow mapping process tags from env or sysprops

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -34,6 +34,8 @@ public final class GeneralConfig {
   public static final String EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED =
       "experimental.propagate.process.tags.enabled";
 
+  public static final String PROCESS_TAGS_MAPPING = "process.tags.mapping";
+
   public static final String LOG_LEVEL = "log.level";
   public static final String TRACE_LOG_LEVEL = "trace.log.level";
   public static final String TRACE_DEBUG = "trace.debug";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -378,6 +378,7 @@ import static datadog.trace.api.config.GeneralConfig.JDK_SOCKET_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.LOG_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
+import static datadog.trace.api.config.GeneralConfig.PROCESS_TAGS_MAPPING;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_RUNTIME_ID_ENABLED;
@@ -862,6 +863,7 @@ public class Config {
   private final Map<String, String> peerServiceComponentOverrides;
   private final boolean removeIntegrationServiceNamesEnabled;
   private final boolean experimentalPropagateProcessTagsEnabled;
+  private final Map<String, String> processTagsMapping;
   private final Map<String, String> peerServiceMapping;
   private final Map<String, String> serviceMapping;
   private final Map<String, String> tags;
@@ -1657,6 +1659,7 @@ public class Config {
         configProvider.getBoolean(TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED, false);
     experimentalPropagateProcessTagsEnabled =
         configProvider.getBoolean(EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, true);
+    processTagsMapping = configProvider.getMergedMap(PROCESS_TAGS_MAPPING);
 
     peerServiceMapping = configProvider.getMergedMap(TRACE_PEER_SERVICE_MAPPING);
 
@@ -3214,6 +3217,10 @@ public class Config {
 
   public boolean isExperimentalPropagateProcessTagsEnabled() {
     return experimentalPropagateProcessTagsEnabled;
+  }
+
+  public Map<String, String> getProcessTagsMapping() {
+    return processTagsMapping;
   }
 
   public boolean isTraceEnabled() {
@@ -6391,6 +6398,8 @@ public class Config {
         + cloudResponsePayloadTagging
         + ", experimentalPropagateProcessTagsEnabled="
         + experimentalPropagateProcessTagsEnabled
+        + ", processTagsMapping="
+        + processTagsMapping
         + ", rumInjectorConfig="
         + (rumInjectorConfig == null ? "null" : rumInjectorConfig.jsonPayload())
         + ", aiGuardEnabled="

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -34,6 +36,7 @@ public class ProcessTags {
   private static class Lazy {
     // the tags are used to compute a hash for dsm hence that map must be sorted.
     static final SortedMap<String, String> TAGS = loadTags(Config.get());
+    private static final Pattern MAPPING_KEY_PATTERN = Pattern.compile("^\\{(\\w+)}(\\S+)$");
     static volatile UTF8BytesString serializedForm;
     static volatile List<UTF8BytesString> utf8ListForm;
     static volatile List<String> stringListForm;
@@ -48,8 +51,44 @@ public class ProcessTags {
         } catch (Throwable t) {
           LOGGER.debug("Unable to calculate default process tags", t);
         }
+        fillMappingTags(tags, config.getProcessTagsMapping());
       }
       return tags;
+    }
+
+    private static void fillMappingTags(
+        SortedMap<String, String> tags, Map<String, String> mappings) {
+      for (Map.Entry<String, String> entry : mappings.entrySet()) {
+        parseMappingEntry(tags, entry.getKey(), entry.getValue());
+      }
+    }
+
+    private static void parseMappingEntry(
+        SortedMap<String, String> tags, String sourceAndKey, String processTagKey) {
+      // sourceAndKey format: {source}config_key (colon-split already done by getMergedMap)
+      Matcher matcher = MAPPING_KEY_PATTERN.matcher(sourceAndKey != null ? sourceAndKey : "");
+      if (!matcher.matches()) {
+        LOGGER.warn("Malformed process.tags.mapping key: '{}'", sourceAndKey);
+        return;
+      }
+      String source = matcher.group(1);
+      String configKey = matcher.group(2);
+      String value;
+      if ("env".equals(source)) {
+        value = envGetter.apply(configKey);
+      } else if ("prop".equals(source)) {
+        value = SystemProperties.get(configKey);
+      } else {
+        LOGGER.warn(
+            "Unsupported source '{}' in process.tags.mapping for key: '{}'", source, sourceAndKey);
+        return;
+      }
+      if (value == null || value.isEmpty()) {
+        LOGGER.debug(
+            "No value for key '{}' from source '{}' in process.tags.mapping", configKey, source);
+        return;
+      }
+      tags.put(processTagKey, value);
     }
 
     private static void fillJeeTags(SortedMap<String, String> tags) {

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -33,10 +33,6 @@ public class ProcessTags {
   // visible for testing
   static Function<String, String> envGetter = EnvironmentVariables::get;
 
-  private static class LazyRegexp {
-    static final Pattern MAPPING_KEY_PATTERN = Pattern.compile("^\\{(\\w+)}(\\S+)$");
-  }
-
   private static class Lazy {
     // the tags are used to compute a hash for dsm hence that map must be sorted.
     static final SortedMap<String, String> TAGS = loadTags(Config.get());
@@ -61,16 +57,22 @@ public class ProcessTags {
 
     private static void fillMappingTags(
         SortedMap<String, String> tags, Map<String, String> mappings) {
+      if (mappings.isEmpty()) {
+        return;
+      }
+      final Pattern mappingKeyPattern = Pattern.compile("^\\{(\\w+)}(\\S+)$");
       for (Map.Entry<String, String> entry : mappings.entrySet()) {
-        parseMappingEntry(tags, entry.getKey(), entry.getValue());
+        parseMappingEntry(tags, mappingKeyPattern, entry.getKey(), entry.getValue());
       }
     }
 
     private static void parseMappingEntry(
-        SortedMap<String, String> tags, String sourceAndKey, String processTagKey) {
+        SortedMap<String, String> tags,
+        Pattern mappingKeyPattern,
+        String sourceAndKey,
+        String processTagKey) {
       // sourceAndKey format: {source}config_key (colon-split already done by getMergedMap)
-      Matcher matcher =
-          LazyRegexp.MAPPING_KEY_PATTERN.matcher(sourceAndKey != null ? sourceAndKey : "");
+      final Matcher matcher = mappingKeyPattern.matcher(sourceAndKey != null ? sourceAndKey : "");
       if (!matcher.matches()) {
         LOGGER.warn("Malformed process.tags.mapping key: '{}'", sourceAndKey);
         return;

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -33,10 +33,13 @@ public class ProcessTags {
   // visible for testing
   static Function<String, String> envGetter = EnvironmentVariables::get;
 
+  private static class LazyRegexp {
+    static final Pattern MAPPING_KEY_PATTERN = Pattern.compile("^\\{(\\w+)}(\\S+)$");
+  }
+
   private static class Lazy {
     // the tags are used to compute a hash for dsm hence that map must be sorted.
     static final SortedMap<String, String> TAGS = loadTags(Config.get());
-    private static final Pattern MAPPING_KEY_PATTERN = Pattern.compile("^\\{(\\w+)}(\\S+)$");
     static volatile UTF8BytesString serializedForm;
     static volatile List<UTF8BytesString> utf8ListForm;
     static volatile List<String> stringListForm;
@@ -66,7 +69,8 @@ public class ProcessTags {
     private static void parseMappingEntry(
         SortedMap<String, String> tags, String sourceAndKey, String processTagKey) {
       // sourceAndKey format: {source}config_key (colon-split already done by getMergedMap)
-      Matcher matcher = MAPPING_KEY_PATTERN.matcher(sourceAndKey != null ? sourceAndKey : "");
+      Matcher matcher =
+          LazyRegexp.MAPPING_KEY_PATTERN.matcher(sourceAndKey != null ? sourceAndKey : "");
       if (!matcher.matches()) {
         LOGGER.warn("Malformed process.tags.mapping key: '{}'", sourceAndKey);
         return;

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -86,7 +86,9 @@ public class ProcessTags {
         value = SystemProperties.get(configKey);
       } else {
         LOGGER.warn(
-            "Unsupported source '{}' in process.tags.mapping for key: '{}'", source, sourceAndKey);
+            "Unsupported source '{}' in process.tags.mapping for key: '{}' (supported sources: 'env', 'prop' — lowercase only)",
+            source,
+            sourceAndKey);
         return;
       }
       if (value == null || value.isEmpty()) {

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -96,7 +96,7 @@ public class ProcessTags {
             "No value for key '{}' from source '{}' in process.tags.mapping", configKey, source);
         return;
       }
-      tags.put(processTagKey, value);
+      tags.put(TraceUtils.normalizeTagValue(processTagKey), value);
     }
 
     private static void fillJeeTags(SortedMap<String, String> tags) {

--- a/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
@@ -142,6 +142,114 @@ class ProcessTagsForkedTest extends DDSpecification {
     assert ProcessTags.tagsAsUTF8ByteStringList[0].toString() == "0test:value"
   }
 
+  def 'should resolve process tag from system property via {prop} source'() {
+    setup:
+    System.setProperty("my.property", "my.value")
+    injectSysConfig("process.tags.mapping", "{prop}my.property:some_key")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    tags.contains("some_key:my.value")
+    cleanup:
+    System.clearProperty("my.property")
+  }
+
+  def 'should resolve process tag from environment variable via {env} source'() {
+    setup:
+    ProcessTags.envGetter = key -> key == "MY_ENV_VAR" ? "myvalue" : null
+    injectSysConfig("process.tags.mapping", "{env}MY_ENV_VAR:my_tag")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    tags.contains("my_tag:myvalue")
+    cleanup:
+    ProcessTags.envGetter = System::getenv
+    ProcessTags.reset()
+  }
+
+  def 'should not emit process tag when key is missing from source'() {
+    setup:
+    injectSysConfig("process.tags.mapping", "{prop}nonexistent.key:should_not_appear")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    !tags.any { it.startsWith("should_not_appear:") }
+  }
+
+  def 'should not emit process tag when value is empty'() {
+    setup:
+    System.setProperty("empty.key", "")
+    injectSysConfig("process.tags.mapping", "{prop}empty.key:should_not_appear")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    !tags.any { it.startsWith("should_not_appear:") }
+    cleanup:
+    System.clearProperty("empty.key")
+  }
+
+  def 'should not emit process tag for unsupported source'() {
+    setup:
+    injectSysConfig("process.tags.mapping", "{unknown}some.key:should_not_appear")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    !tags.any { it.startsWith("should_not_appear:") }
+  }
+
+  def 'should ignore malformed process tag mapping entries'() {
+    setup:
+    injectSysConfig("process.tags.mapping", malformed)
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    !tags.any { it.startsWith("bad_tag:") }
+    where:
+    malformed                     | _
+    "no_braces:key:bad_tag"       | _
+    "{unclosed_brace key:bad_tag" | _
+    "{prop}keyonly"               | _
+    "{prop}:bad_tag"              | _
+    "{prop}some.key:"             | _
+  }
+
+  def 'last mapping wins when same source key is repeated'() {
+    setup:
+    System.setProperty("my.key", "first_value")
+    // getMergedMap keeps the last value for the same map key
+    injectSysConfig("process.tags.mapping", "{prop}my.key:tag_v1,{prop}my.key:tag_v2")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    tags.contains("tag_v2:first_value")
+    !tags.any { it.startsWith("tag_v1:") }
+    cleanup:
+    System.clearProperty("my.key")
+  }
+
+  def 'should handle multiple valid mapping entries'() {
+    setup:
+    System.setProperty("prop.a", "valueA")
+    System.setProperty("prop.b", "valueB")
+    injectSysConfig("process.tags.mapping", "{prop}prop.a:tag_a,{prop}prop.b:tag_b")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    tags.contains("tag_a:valuea")
+    tags.contains("tag_b:valueb")
+    cleanup:
+    System.clearProperty("prop.a")
+    System.clearProperty("prop.b")
+  }
+
   def 'process tag value normalization'() {
     setup:
     ProcessTags.addTag("test", testValue)

--- a/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
@@ -211,12 +211,11 @@ class ProcessTagsForkedTest extends DDSpecification {
     then:
     !tags.any { it.startsWith("bad_tag:") }
     where:
+    // all three cases reach parseMappingEntry and trigger a WARN
     malformed                     | _
-    "no_braces:key:bad_tag"       | _
-    "{unclosed_brace key:bad_tag" | _
-    "{prop}keyonly"               | _
-    "{prop}:bad_tag"              | _
-    "{prop}some.key:"             | _
+    "no_braces:key:bad_tag"       | _ // loadMap splits on first ':', key="no_braces" has no {source} prefix
+    "{unclosed_brace key:bad_tag" | _ // key has a space, regex does not match
+    "{prop}:bad_tag"              | _ // key is "{prop}" with no config-key after '}'
   }
 
   def 'last mapping wins when same source key is repeated'() {

--- a/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ProcessTagsForkedTest.groovy
@@ -249,6 +249,22 @@ class ProcessTagsForkedTest extends DDSpecification {
     System.clearProperty("prop.b")
   }
 
+  def 'should normalize mapped process tag key'() {
+    setup:
+    System.setProperty("my.prop", "some_value")
+    injectSysConfig("process.tags.mapping", "{prop}my.prop:1Tenant")
+    ProcessTags.reset()
+    when:
+    def tags = ProcessTags.getTagsAsStringList()
+    then:
+    // key '1Tenant' is valid (leading digit is allowed) but the colon in raw keys would be invalid;
+    // normalizeTagValue strips leading non-alphanumeric chars and replaces colons — verify the key is stored normalized
+    tags.any { it.startsWith("1tenant:") }
+    !tags.any { it.startsWith("1Tenant:") }
+    cleanup:
+    System.clearProperty("my.prop")
+  }
+
   def 'process tag value normalization'() {
     setup:
     ProcessTags.addTag("test", testValue)

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -2452,7 +2452,7 @@
     "DD_PROCESS_TAGS_MAPPING": [
       {
         "version": "A",
-        "type": "string",
+        "type": "map",
         "default": null,
         "aliases": []
       }

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -2449,6 +2449,14 @@
         "aliases": []
       }
     ],
+    "DD_PROCESS_TAGS_MAPPING": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_PROFILING_AGENTLESS": [
       {
         "version": "A",


### PR DESCRIPTION
# What Does This Do

Introduces a new configuration that lets customers derive process tags from environment variables or Java system properties. 

**Format:** `DD_PROCESS_TAGS_MAPPING={source}config_key:process_tag_key` (comma-separated list)

**Example:**
```
DD_PROCESS_TAGS_MAPPING={prop}my.cluster:cluster_name
```
If `my.cluster=cluster1` is set as a system property, the process tag cluster_name:cluster1` is emitted.

**Supported sources:** `env` (environment variables), `prop` (Java system properties)

**Behaviour:**
- Tag is emitted only if the source is recognised, the key exists, and the value is non-empty
- Normalization applies (same rules as all other process tags)
- Malformed entries → `WARN` log; missing key or empty value → `DEBUG` log

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
