### PR TITLE
Add support for case insensitivity file names 

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -85,7 +85,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerTransformer.class);
   private static final String CANNOT_FIND_METHOD = "Cannot find method %s::%s%s";
   private static final String INSTRUMENTATION_FAILS = "Instrumentation failed for %s: %s";
-  private static final String CANNOT_FIND_LINE = "No executable code was found at %s:L%s";
   private static final Pattern COMMA_PATTERN = Pattern.compile(",");
   private static final List<Class<?>> PROBE_ORDER =
       Arrays.asList(
@@ -258,7 +257,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     if (instrumentTheWorld) {
       return transformTheWorld(loader, classFilePath, protectionDomain, classfileBuffer);
     }
-    if (skipInstrumentation(loader, classFilePath)) {
+    if (skipInstrumentation(classFilePath)) {
       return null;
     }
     List<ProbeDefinition> definitions = Collections.emptyList();
@@ -375,7 +374,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     return true;
   }
 
-  private boolean skipInstrumentation(ClassLoader loader, String classFilePath) {
+  private boolean skipInstrumentation(String classFilePath) {
     if (definitionMatcher.isEmpty()) {
       LOGGER.debug("No debugger definitions present.");
       return true;
@@ -892,7 +891,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
     LogProbe.Capture capture = null;
     boolean captureSnapshot = false;
     ProbeCondition probeCondition = null;
-    List<LogProbe.CaptureExpression> captureExpressions = null;
     Where where = capturedContextProbes.get(0).getWhere();
     ProbeId probeId = capturedContextProbes.get(0).getProbeId();
     for (ProbeDefinition definition : capturedContextProbes) {
@@ -904,8 +902,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
         LogProbe logProbe = (LogProbe) definition;
         captureSnapshot = captureSnapshot | logProbe.isCaptureSnapshot();
         capture = mergeCapture(capture, logProbe.getCapture());
-        // captureExpressions = mergeCaptureExpressions(captureExpressions,
-        // logProbe.getCaptureExpressions());
         if (probeCondition == null) {
           probeCondition = logProbe.getProbeCondition();
         }
@@ -951,19 +947,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
         Math.max(current.getMaxFieldCount(), newCapture.getMaxFieldCount()));
   }
 
-  private static List<LogProbe.CaptureExpression> mergeCaptureExpressions(
-      List<LogProbe.CaptureExpression> captureExpressions,
-      List<LogProbe.CaptureExpression> newCaptureExpressions) {
-    if (captureExpressions == null) {
-      return newCaptureExpressions;
-    }
-    if (newCaptureExpressions == null) {
-      return captureExpressions;
-    }
-    captureExpressions.addAll(newCaptureExpressions);
-    return captureExpressions;
-  }
-
   private InstrumentationResult.Status preCheckInstrumentation(
       Map<ProbeId, List<DiagnosticMessage>> diagnostics, MethodInfo methodInfo) {
     if ((methodInfo.getMethodNode().access & (Opcodes.ACC_NATIVE | Opcodes.ACC_ABSTRACT)) != 0) {
@@ -1000,43 +983,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
   private static void addDiagnosticForAllProbes(
       DiagnosticMessage diagnosticMessage, Map<ProbeId, List<DiagnosticMessage>> diagnostics) {
     diagnostics.forEach((probeId, diagnosticMessages) -> diagnosticMessages.add(diagnosticMessage));
-  }
-
-  private List<MethodNode> matchMethodDescription(
-      ClassNode classNode, Where where, ClassFileLines classFileLines) {
-    List<MethodNode> result = new ArrayList<>();
-    try {
-      for (MethodNode methodNode : classNode.methods) {
-        if (where.isMethodMatching(methodNode, classFileLines) == Where.MethodMatching.MATCH) {
-          result.add(methodNode);
-        }
-      }
-    } catch (Exception ex) {
-      LOGGER.warn("Cannot match method: {}", ex.toString());
-    }
-    return result;
-  }
-
-  private MethodNode matchSourceFile(
-      ClassNode classNode, Where where, ClassFileLines classFileLines) {
-    Where.SourceLine[] lines = where.getSourceLines();
-    if (lines == null || lines.length == 0) {
-      return null;
-    }
-    Where.SourceLine sourceLine = lines[0]; // assume only 1 range
-    int matchingLine = sourceLine.getFrom();
-    List<MethodNode> matchingMethods = classFileLines.getMethodsByLine(matchingLine);
-    if (matchingMethods != null) {
-      matchingMethods.forEach(
-          methodNode -> {
-            LOGGER.debug("Found lineNode {} method: {}", matchingLine, methodNode.name);
-          });
-      // pick the first matching method.
-      // TODO need a way to disambiguate if multiple methods match the same line
-      return matchingMethods.isEmpty() ? null : matchingMethods.get(0);
-    }
-    LOGGER.debug("Cannot find line: {} in class {}", matchingLine, classNode.name);
-    return null;
   }
 
   private void dumpInstrumentedClassFile(String className, byte[] data) {
@@ -1125,7 +1071,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
       try {
         TypeDescription td1 = tpDatadogClassLoader.describe(type1.replace('/', '.')).resolve();
         TypeDescription td2 = tpDatadogClassLoader.describe(type2.replace('/', '.')).resolve();
-        TypeDescription common = null;
+        TypeDescription common;
         if (td1.isAssignableFrom(td2)) {
           common = td1;
         } else if (td2.isAssignableFrom(td1)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ public class TransformerDefinitionMatcher {
         continue;
       }
       fileName = normalizeWindowsToUnixPath(fileName);
-      fileName = fileName.toLowerCase();
+      fileName = fileName.toLowerCase(Locale.ROOT);
       Map<String, List<ProbeDefinition>> targetMap =
           fileName.indexOf('/') != -1
               ? definitionsByQualifiedFileNames
@@ -140,7 +141,7 @@ public class TransformerDefinitionMatcher {
       sb.append(reversedPackageName);
     }
     String reversedFileName = sb.toString();
-    reversedFileName = reversedFileName.toLowerCase();
+    reversedFileName = reversedFileName.toLowerCase(Locale.ROOT);
     List<ProbeDefinition> bySourceFileDefinitions = new ArrayList<>();
     // try match qualified filenames
     Collection<String> matchingFileNames =
@@ -155,7 +156,7 @@ public class TransformerDefinitionMatcher {
       }
     }
     // try match simple filenames
-    sourceFileName = sourceFileName.toLowerCase();
+    sourceFileName = sourceFileName.toLowerCase(Locale.ROOT);
     List<ProbeDefinition> definitions = definitionsBySimpleFileNames.get("/" + sourceFileName);
     if (definitions != null) {
       bySourceFileDefinitions.addAll(definitions);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -60,6 +60,7 @@ public class TransformerDefinitionMatcher {
         continue;
       }
       fileName = normalizeWindowsToUnixPath(fileName);
+      fileName = fileName.toLowerCase();
       Map<String, List<ProbeDefinition>> targetMap =
           fileName.indexOf('/') != -1
               ? definitionsByQualifiedFileNames
@@ -139,6 +140,7 @@ public class TransformerDefinitionMatcher {
       sb.append(reversedPackageName);
     }
     String reversedFileName = sb.toString();
+    reversedFileName = reversedFileName.toLowerCase();
     List<ProbeDefinition> bySourceFileDefinitions = new ArrayList<>();
     // try match qualified filenames
     Collection<String> matchingFileNames =
@@ -153,6 +155,7 @@ public class TransformerDefinitionMatcher {
       }
     }
     // try match simple filenames
+    sourceFileName = sourceFileName.toLowerCase();
     List<ProbeDefinition> definitions = definitionsBySimpleFileNames.get("/" + sourceFileName);
     if (definitions != null) {
       bySourceFileDefinitions.addAll(definitions);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -65,6 +65,15 @@ public class TransformerDefinitionMatcherTest {
   }
 
   @Test
+  public void sourceFileFullFileNameCaseInsensitive() {
+    LogProbe probe = createProbe(PROBE_ID1, "Src/Main/Java/Java/LanG/STRING.jAvA", 23);
+    TransformerDefinitionMatcher matcher = createMatcher(probe);
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(1, probeDefinitions.size());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+  }
+
+  @Test
   public void sourceFileAbsoluteFileName() {
     LogProbe probe =
         createProbe(PROBE_ID1, "/home/user/project/src/main/java/java/lang/String.java", 23);
@@ -97,6 +106,15 @@ public class TransformerDefinitionMatcherTest {
   @Test
   public void sourceFileSimpleFileName() {
     LogProbe probe = createProbe(PROBE_ID1, "String.java", 23);
+    TransformerDefinitionMatcher matcher = createMatcher(probe);
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(1, probeDefinitions.size());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+  }
+
+  @Test
+  public void sourceFileSimpleFileNameCaseInsensitive() {
+    LogProbe probe = createProbe(PROBE_ID1, "sTRINg.JAVA", 23);
     TransformerDefinitionMatcher matcher = createMatcher(probe);
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());


### PR DESCRIPTION
# What Does This Do
Add support for case-insensitive path matching for line probes. When a
probe path contains different casing (e.g., Controllers/DebuggerController.java vs actual
controllers/DebuggerController.java), we should match them case-insensitively.
this allows to support case-insensitive filesystem (Windows, MacOs)

# Motivation

# Additional Notes
Did some cleanup in DebuggerTransformer class for unused field and methods

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5105]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5105]: https://datadoghq.atlassian.net/browse/DEBUG-5105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ