### PR TITLE
Move network.client.ip out of AppSec into HttpServerDecorator

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -370,6 +370,9 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       } else {
         span.setTag(Tags.PEER_HOST_IPV4, peerIp);
       }
+      if (clientIpResolverEnabled) {
+        span.setTag(Tags.NETWORK_CLIENT_IP, peerIp);
+      }
     }
     setPeerPort(span, peerPort);
     Flow<Void> flow = callIGCallbackAddressAndPort(span, peerIp, peerPort, inferredAddressStr);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -218,6 +218,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     1 * this.span.setTag(Tags.HTTP_FORWARDED_HOST, "somehost")
     if (conn?.peerIp) {
       1 * this.span.setTag(ipv4 ? Tags.PEER_HOST_IPV4 : Tags.PEER_HOST_IPV6, conn.peerIp)
+      1 * this.span.setTag(Tags.NETWORK_CLIENT_IP, conn.peerIp)
     }
     if (conn?.ip) {
       1 * this.span.setTag(Tags.HTTP_CLIENT_IP, conn.ip)
@@ -253,6 +254,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     1 * this.span.setTag(Tags.HTTP_CLIENT_IP, result)
+    1 * this.span.setTag(Tags.NETWORK_CLIENT_IP, peerIpAddr)
 
     where:
     headerIpAddr | peerIpAddr  | result
@@ -277,6 +279,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     0 * extracted.getForwarded()
     0 * span.setTag(Tags.HTTP_FORWARDED, _)
     0 * this.span.setTag(Tags.HTTP_CLIENT_IP, _)
+    0 * this.span.setTag(Tags.NETWORK_CLIENT_IP, _)
   }
 
   void 'disabling appsec disables header collection and ip address resolution'() {
@@ -294,6 +297,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     0 * extracted.getForwarded()
     0 * span.setTag(Tags.HTTP_FORWARDED, _)
     0 * this.span.setTag(Tags.HTTP_CLIENT_IP, _)
+    0 * this.span.setTag(Tags.NETWORK_CLIENT_IP, _)
   }
 
   void 'disabling appsec but enabling client_ip_without_appsec enables header collection and ip address resolution'() {
@@ -313,6 +317,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     2 * extracted.getXForwardedFor() >> '2.3.4.5'
     1 * this.span.setTag(Tags.HTTP_CLIENT_IP, '2.3.4.5')
     1 * this.span.setTag(Tags.HTTP_FORWARDED_IP, '2.3.4.5')
+    1 * this.span.setTag(Tags.NETWORK_CLIENT_IP, '4.4.4.4')
 
     // Forwarded doesn't participate in client ip resolution anymore
     1 * extracted.getForwarded() >> 'for=9.9.9.9'
@@ -333,6 +338,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     then:
     1 * extracted.getCustomIpHeader() >> '5.5.5.5'
     1 * this.span.setTag(Tags.HTTP_CLIENT_IP, '5.5.5.5')
+    1 * this.span.setTag(Tags.NETWORK_CLIENT_IP, '4.4.4.4')
   }
 
   def "test onResponse"() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -986,9 +986,6 @@ public class GatewayBridge {
 
         span.setTag("appsec.event", true);
 
-        String peerAddress = ctx.getPeerAddress();
-        span.setTag("network.client.ip", peerAddress);
-
         // Reflect client_ip as actor.ip for backward compatibility
         Object clientIp = tags.get(Tags.HTTP_CLIENT_IP);
         if (clientIp != null) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -189,12 +189,10 @@ class GatewayBridgeSpecification extends DDSpecification {
     then:
     1 * spanInfo.getTags() >> TagMap.fromMap(['http.client_ip': '1.1.1.1'])
     1 * mockAppSecCtx.transferCollectedEvents() >> [event]
-    1 * mockAppSecCtx.peerAddress >> '2001::1'
     1 * mockAppSecCtx.close()
     1 * spanInfo.setMetric("_dd.appsec.enabled", 1)
     1 * spanInfo.setTag("_dd.runtime_family", "jvm")
     1 * spanInfo.setTag('appsec.event', true)
-    1 * spanInfo.setTag('network.client.ip', '2001::1')
     1 * spanInfo.setTag('actor.ip', '1.1.1.1')
     1 * traceSegment.setDataTop('appsec', new AppSecEventWrapper([event]))
     1 * mockAppSecCtx.isWafBlocked()

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2571,22 +2571,18 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
           if (hasPeerPort) {
             "$Tags.PEER_PORT" Integer
           }
+          def peerHostTag = Tags.PEER_HOST_IPV4
+          def expectedPeerIp = "127.0.0.1"
           if (span.getTag(Tags.PEER_HOST_IPV6) != null) {
-            "$Tags.PEER_HOST_IPV6" {
-              it == "0:0:0:0:0:0:0:1"
-            }
-            "$Tags.HTTP_CLIENT_IP" {
-              it == "0:0:0:0:0:0:0:1" || (endpoint == FORWARDED && it == endpoint.body)
-            }
-          } else {
-            "$Tags.PEER_HOST_IPV4" {
-              it == "127.0.0.1"
-            }
-            "$Tags.HTTP_CLIENT_IP" {
-              it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body)
-            }
+            peerHostTag = Tags.PEER_HOST_IPV6
+            expectedPeerIp = "0:0:0:0:0:0:0:1"
           }
+          tag(peerHostTag, expectedPeerIp)
+          "$Tags.HTTP_CLIENT_IP" clientIp ?: expectedPeerIp
+          "$Tags.NETWORK_CLIENT_IP" expectedPeerIp
         } else {
+          // http.client_ip is inferred from forwarded headers; network.client.ip requires peerIp.
+          "$Tags.NETWORK_CLIENT_IP" null
           "$Tags.HTTP_CLIENT_IP" clientIp
         }
         "$Tags.HTTP_HOSTNAME" address.host

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -74,6 +74,7 @@ class LagomTest extends InstrumentationSpecification {
             "$Tags.PEER_HOST_IPV4" '127.0.0.1'
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_CLIENT_IP" '127.0.0.1'
+            "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
             defaultTags()
           }
         }
@@ -121,6 +122,7 @@ class LagomTest extends InstrumentationSpecification {
             "$Tags.PEER_HOST_IPV4" '127.0.0.1'
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_CLIENT_IP" '127.0.0.1'
+            "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/cxf-2.1/src/latestDepTest/groovy/CxfContextPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/latestDepTest/groovy/CxfContextPropagationTest.groovy
@@ -75,6 +75,7 @@ class CxfContextPropagationTest extends InstrumentationSpecification {
             "$InstrumentationTags.SERVLET_PATH" "/test"
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             withCustomIntegrationName("jetty-server")
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/cxf-2.1/src/test/groovy/CxfContextPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/test/groovy/CxfContextPropagationTest.groovy
@@ -73,6 +73,7 @@ class CxfContextPropagationTest extends InstrumentationSpecification {
             "servlet.path" { it == null || it == "/test" }
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             withCustomIntegrationName("jetty-server")
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -37,6 +37,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             defaultTags()
@@ -114,6 +115,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/getQuery.jsp"
             defaultTags()
@@ -187,6 +189,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/post.jsp"
             defaultTags()
@@ -256,6 +259,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             "error.type" { String tagExceptionType ->
@@ -345,6 +349,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeHtml.jsp"
             defaultTags()
@@ -414,6 +419,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeMulti.jsp"
             defaultTags()
@@ -537,6 +543,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             errorTags(JasperException, String)
@@ -602,6 +609,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$staticFile"
             defaultTags()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -34,6 +34,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$forwardFromFileName"
             defaultTags()
@@ -136,6 +137,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToHtml.jsp"
             defaultTags()
@@ -205,6 +207,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToIncludeMulti.jsp"
             defaultTags()
@@ -358,6 +361,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToJspForward.jsp"
             defaultTags()
@@ -483,6 +487,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToCompileError.jsp"
             errorTags(JasperException, String)
@@ -569,6 +574,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.HTTP_STATUS" 404
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToNonExistent.jsp"
             defaultTags()

--- a/dd-java-agent/instrumentation/mule-4.5/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4.5/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -115,6 +115,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
             defaultTags()
           }
@@ -174,6 +175,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.PEER_PORT" { Integer }
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/play/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
@@ -56,6 +56,7 @@ class PlayServerTest extends HttpServerTest<TestServer> {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-2.6/src/testFixtures/groovy/datadog/trace/instrumentation/play26/server/AbstractPlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-2.6/src/testFixtures/groovy/datadog/trace/instrumentation/play26/server/AbstractPlayServerTest.groovy
@@ -136,6 +136,7 @@ class AbstractPlayServerTest extends HttpServerTest<Server> {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
@@ -100,6 +100,7 @@ class PlayScalaRoutesServerTest extends PlayServerTest {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
@@ -137,6 +137,7 @@ class PlayServerTest extends HttpServerTest<Server> {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-appsec-2.7/src/test/groovy/datadog/trace/instrumentation/play27/server/test/PlayAsyncServerRoutesScalaWithErrorHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.7/src/test/groovy/datadog/trace/instrumentation/play27/server/test/PlayAsyncServerRoutesScalaWithErrorHandlerTest.groovy
@@ -88,6 +88,7 @@ class PlayAsyncServerRoutesScalaWithErrorHandlerTest extends AbstractPlayServer2
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -80,6 +80,7 @@ class RatpackOtherTest extends InstrumentationSpecification {
             "$Tags.HTTP_ROUTE" "/$route"
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             defaultTags()
           }
         }
@@ -100,6 +101,7 @@ class RatpackOtherTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "/$route"
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -143,6 +143,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         "$Tags.HTTP_STATUS" Integer
         "$Tags.HTTP_ROUTE" String
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.NETWORK_CLIENT_IP" '127.0.0.1'
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
@@ -110,6 +110,7 @@ class ReactorNettyHttp2ClientTest extends InstrumentationSpecification {
             "$Tags.PEER_PORT" Integer
             "$Tags.PEER_HOST_IPV4" { String }
             "$Tags.HTTP_CLIENT_IP" { String }
+            "$Tags.NETWORK_CLIENT_IP" { String }
 
             "$Tags.HTTP_HOSTNAME" { String }
             "$Tags.HTTP_URL" "http://localhost:${server.port()}/firstUrl"
@@ -132,6 +133,7 @@ class ReactorNettyHttp2ClientTest extends InstrumentationSpecification {
               "$Tags.PEER_PORT" Integer
               "$Tags.PEER_HOST_IPV4" { String }
               "$Tags.HTTP_CLIENT_IP" { String }
+              "$Tags.NETWORK_CLIENT_IP" { String }
 
               "$Tags.HTTP_HOSTNAME" { String }
               "$Tags.HTTP_URL" "http://localhost:${server.port()}/"

--- a/dd-java-agent/instrumentation/spark/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spark/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -63,6 +63,7 @@ class SparkJavaBasedTest extends InstrumentationSpecification {
             "$Tags.HTTP_ROUTE" String
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -91,6 +91,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -172,6 +173,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -315,6 +317,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 404
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             defaultTags(true)
           }
         }
@@ -371,6 +374,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 202
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/echo"
             defaultTags(true)
           }
@@ -437,6 +441,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -527,6 +532,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 307
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags(true)
           }
@@ -572,6 +578,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags(true)
           }
@@ -631,6 +638,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
               "$Tags.HTTP_STATUS" 200
               "$Tags.HTTP_USER_AGENT" String
               "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+              "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
               "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
               defaultTags(true)
             }
@@ -708,6 +716,7 @@ class SpringWebfluxTest extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 101
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/websocket"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -90,6 +90,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -171,6 +172,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -313,6 +315,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 404
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             defaultTags(true)
           }
         }
@@ -369,6 +372,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 202
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/echo"
             defaultTags(true)
           }
@@ -435,6 +439,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags(true)
           }
@@ -525,6 +530,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 307
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags(true)
           }
@@ -570,6 +576,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags(true)
           }
@@ -629,6 +636,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
               "$Tags.HTTP_STATUS" 200
               "$Tags.HTTP_USER_AGENT" String
               "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+              "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
               "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
               defaultTags(true)
             }
@@ -704,6 +712,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/very-delayed"
             defaultTags(true)
           }
@@ -759,6 +768,7 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
             "$Tags.HTTP_STATUS" 101
             "$Tags.HTTP_USER_AGENT" String
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_ROUTE" "/websocket"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -561,6 +561,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_HOSTNAME" address.host
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" "GET"

--- a/dd-java-agent/instrumentation/spring/spring-ws-2.0/src/test/groovy/SpringWebServiceTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-ws-2.0/src/test/groovy/SpringWebServiceTest.groovy
@@ -77,6 +77,7 @@ class SpringWebServiceTest extends WithHttpServer<ConfigurableApplicationContext
             "$Tags.COMPONENT" "tomcat-server"
             "$Tags.SPAN_KIND" "$Tags.SPAN_KIND_SERVER"
             "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+            "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
             "$Tags.HTTP_HOSTNAME" "localhost"
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_STATUS" { failed ? "500" : "200" }

--- a/dd-java-agent/instrumentation/synapse-3.0/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -253,6 +253,7 @@ abstract class SynapseTest extends VersionedNamingTestBase {
         "$Tags.HTTP_STATUS" statusCode
         "$Tags.HTTP_USER_AGENT" String
         "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+        "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
         defaultTags(distributedRootSpan)
       }
     }
@@ -281,6 +282,7 @@ abstract class SynapseTest extends VersionedNamingTestBase {
         "$Tags.HTTP_STATUS" statusCode
         "$Tags.HTTP_USER_AGENT" String
         "$Tags.HTTP_CLIENT_IP" "127.0.0.1"
+        "$Tags.NETWORK_CLIENT_IP" "127.0.0.1"
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/latestDepTest/groovy/TomcatNoPropagationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/latestDepTest/groovy/TomcatNoPropagationForkedTest.groovy
@@ -73,6 +73,7 @@ class TomcatNoPropagationForkedTest extends InstrumentationSpecification {
             "$Tags.COMPONENT" "tomcat-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_CLIENT_IP" { it != null }
+            "$Tags.NETWORK_CLIENT_IP" { it != null }
             "$Tags.PEER_HOST_IPV4" { it != null }
             "$Tags.PEER_PORT" { it != null }
             "$Tags.HTTP_HOSTNAME" { it != null }

--- a/dd-java-agent/instrumentation/wildfly-9.0/src/test/groovy/WildFlyForkedTest.groovy
+++ b/dd-java-agent/instrumentation/wildfly-9.0/src/test/groovy/WildFlyForkedTest.groovy
@@ -73,6 +73,7 @@ class WildFlyForkedTest extends WithHttpServer<EmbeddedWildfly> implements Testi
             "$Tags.PEER_PORT" Integer
             "$Tags.PEER_HOST_IPV4" { String }
             "$Tags.HTTP_CLIENT_IP" { String }
+            "$Tags.NETWORK_CLIENT_IP" { String }
             "$Tags.HTTP_HOSTNAME" address.host
             "$Tags.HTTP_URL" { String }
             "$Tags.HTTP_METHOD" "GET"

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -487,6 +487,11 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     rootSpans.each { assert it.meta['actor.ip'] == '1.2.3.4' }
     rootSpans.each {
+      // network.client.ip is the raw peer (socket) address, not the header-spoofed value
+      assert it.meta['network.client.ip'] != null
+      assert it.meta['network.client.ip'] != '1.2.3.4'
+    }
+    rootSpans.each {
       assert it.meta['http.response.headers.content-type'] == 'text/plain;charset=UTF-8'
       assert it.meta['http.response.headers.content-length'] == '15'
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -27,6 +27,7 @@ public class Tags {
   public static final String HTTP_FORWARDED_PORT = "http.forwarded.port";
   public static final String HTTP_USER_AGENT = "http.useragent";
   public static final String HTTP_CLIENT_IP = "http.client_ip";
+  public static final String NETWORK_CLIENT_IP = "network.client.ip";
   public static final String HTTP_REQUEST_CONTENT_LENGTH = "http.request_content_length";
   public static final String HTTP_RESPONSE_CONTENT_LENGTH = "http.response_content_length";
   public static final String PEER_HOST_IPV4 = "peer.ipv4";


### PR DESCRIPTION
# What Does This Do

- `network.client.ip` now shares the same activation logic as `http.client_ip` (`DD_APPSEC_ENABLED=true` or `DD_TRACE_CLIENT_IP_ENABLED=true`) and is no longer exclusive to AppSec events. Moved it from `GatewayBridge` (where it was set only when security events fired) into `HttpServerDecorator` alongside `http.client_ip`, using the raw peer/socket IP.

Main changes:
* `dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java` (older, appsec-only tagging)
* `dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java` (new tagging)
* The rest is just small test updates, where `dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy` is the one needing the most attention.

# Motivation

Align with spec upgrades, in which `network.client.ip` becomes more broadly available, just as `http.client_ip`.

# Additional Notes

- [Updated internal spec](https://datadoghq.atlassian.net/wiki/x/ugBKfg)
- New system tests: https://github.com/DataDog/system-tests/pull/6707
- `actor.ip` remains in AppSec as a deprecated backward-compatibility tag. It does not make sense to broaden it's support and should be scheduled for removal eventually.
- This PR adds a few comments documenting incorrect behavior for peer IP address collection in Dropwizard and Play. Fixing that is out of the scope of this PR, but hopefully it is now more clear what's going on.
- [APPSEC-62219](https://datadoghq.atlassian.net/browse/APPSEC-62219)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-62219]: https://datadoghq.atlassian.net/browse/APPSEC-62219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ