### PR TITLE
Added a timestamp to protect logs from being overwritten on retries.

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -4,6 +4,9 @@ import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.utils.PortUtils
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -17,6 +20,8 @@ abstract class ProcessManager extends Specification {
   public static final String ENV = "smoketest"
   public static final String VERSION = "99"
   public static final Set<String> NOISY_ENVIRONMENT_VARIABLES = ImmutableSet.of('CI_COMMIT_MESSAGE', 'CI_COMMIT_DESCRIPTION')
+  private static final DateTimeFormatter LOG_FILE_TIMESTAMP_FORMATTER =
+  DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss.SSS", Locale.ROOT).withZone(ZoneOffset.UTC)
 
   @Shared
   protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
@@ -45,9 +50,13 @@ abstract class ProcessManager extends Specification {
   @Shared
   protected Process testedProcess
 
+  // Added a timestamp to protect logs from being overwritten on retries.
+  @Shared
+  private String logFileTimestamp = LOG_FILE_TIMESTAMP_FORMATTER.format(Instant.now())
+
   @Shared
   private String[] logFilePaths = (0..<numberOfProcesses).collect { idx ->
-    "${buildDirectory}/reports/testProcess.${this.getClass().getName()}.${idx}.log"
+    "${buildDirectory}/reports/testProcess.${this.getClass().getName()}.${logFileTimestamp}.${idx}.log"
   }
 
   // Here for backwards compatibility with single process case


### PR DESCRIPTION
# What Does This Do
Added a timestamp to protect logs from being overwritten on retries.

# Motivation
Keep real reason of flaky test.

# Additional Notes
Since we have Develocity plugin that auto-reties failed test, there is a chance that useful information will be overwritten on retry.