### PR TITLE
Remove noise at boostrap due to telemetry failures

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -327,7 +327,7 @@ public abstract class BootstrapInitializationTelemetry {
         try (OutputStream out = process.getOutputStream()) {
           out.write(payload);
         } catch (IOException ignoredException) {
-          // iif this happens it can generate noise into the customer logs.
+          // iif this happens it can generate noise into the logs.
           // we'll only log if the error is more severe
         }
       } catch (Throwable e) {

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -7,6 +7,7 @@ import datadog.json.JsonWriter;
 import datadog.trace.bootstrap.environment.EnvironmentVariables;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -325,6 +326,9 @@ public abstract class BootstrapInitializationTelemetry {
         Process process = builder.start();
         try (OutputStream out = process.getOutputStream()) {
           out.write(payload);
+        } catch (IOException ignoredException) {
+          // iif this happens it can generate noise into the customer logs.
+          // we'll only log if the error is more severe
         }
       } catch (Throwable e) {
         // We don't have a log manager here, so just print.

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -327,7 +327,7 @@ public abstract class BootstrapInitializationTelemetry {
         try (OutputStream out = process.getOutputStream()) {
           out.write(payload);
         } catch (IOException ignoredException) {
-          // iif this happens it can generate noise into the logs.
+          // if this happens it can generate noise into the logs.
           // we'll only log if the error is more severe
         }
       } catch (Throwable e) {

--- a/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
+++ b/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
@@ -193,7 +193,7 @@ public class AgentPreCheck {
           out = process.getOutputStream();
           out.write(payload.getBytes(StandardCharsets.UTF_8));
         } catch (IOException ignored) {
-          // iif this happens it can generate noise into the customer logs.
+          // iif this happens it can generate noise into the logs.
           // we'll only log if the error is more severe
         } finally {
           if (out != null) {

--- a/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
+++ b/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -191,9 +192,15 @@ public class AgentPreCheck {
         try {
           out = process.getOutputStream();
           out.write(payload.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException ignored) {
+          // iif this happens it can generate noise into the customer logs.
+          // we'll only log if the error is more severe
         } finally {
           if (out != null) {
-            out.close();
+            try {
+              out.close();
+            } catch (IOException ignored) {
+            }
           }
         }
       } catch (Throwable e) {

--- a/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
+++ b/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
@@ -193,7 +193,7 @@ public class AgentPreCheck {
           out = process.getOutputStream();
           out.write(payload.getBytes(StandardCharsets.UTF_8));
         } catch (IOException ignored) {
-          // iif this happens it can generate noise into the logs.
+          // if this happens it can generate noise into the logs.
           // we'll only log if the error is more severe
         } finally {
           if (out != null) {


### PR DESCRIPTION
# What Does This Do

We have customers reporting noisy spurious logs at bootstrap like `Failed to send telemetry: Stream closed.`.
The telemetry forwarder is not something we control (is set by SSI through `DD_TELEMETRY_FORWARDER_PATH`)

However, if some failure occurs, we might avoid printing errors on the stderr for most common cases since it's not actionable for a customer. We also cannot use a logger here since sounds too early. 

This PR mute the errors for common IOException and also close the out stream quietly. The generic Throwable catchall is still logging.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
