### PR TITLE
Fix NullPointerException in Exception Replay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -182,7 +182,7 @@ public class ExceptionProbeManager {
 
   public static class ThrowableState {
     private final String exceptionId;
-    private List<Snapshot> snapshots;
+    private final List<Snapshot> snapshots = new ArrayList<>();
     private boolean snapshotSent;
 
     private ThrowableState(String exceptionId) {
@@ -198,13 +198,10 @@ public class ExceptionProbeManager {
     }
 
     public boolean isSampling() {
-      return snapshots != null && !snapshots.isEmpty();
+      return !snapshots.isEmpty();
     }
 
     public void addSnapshot(Snapshot snapshot) {
-      if (snapshots == null) {
-        snapshots = new ArrayList<>();
-      }
       snapshots.add(snapshot);
     }
 


### PR DESCRIPTION
# What Does This Do
make ThrowableState always instantiate the list of snpashots and mark it final

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5505]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5505]: https://datadoghq.atlassian.net/browse/DEBUG-5505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ