### PR TITLE
Use ParentBasedAlwaysOnSampler by default when OTLP traces export is enabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -80,7 +80,6 @@ public interface Sampler {
             log.error("Invalid sampler configuration. Using AllSampler", e);
             sampler = new AllSampler();
           }
-          // TODO: if OTLP trace export enabled, select ParentBasedAlwaysOnSampler here
         } else if (config.isPrioritySamplingEnabled()) {
           if (KEEP.equalsIgnoreCase(config.getPrioritySamplingForce())) {
             log.debug("Force Sampling Priority to: SAMPLER_KEEP.");
@@ -90,9 +89,19 @@ public interface Sampler {
             log.debug("Force Sampling Priority to: SAMPLER_DROP.");
             sampler =
                 new ForcePrioritySampler(PrioritySampling.SAMPLER_DROP, SamplingMechanism.DEFAULT);
+          } else if (config.isTraceOtlpExporterEnabled()) {
+            // RateByServiceTraceSampler relies on the Datadog Agent for rate updates.
+            log.debug(
+                "OTLP traces export enabled. Using ParentBasedAlwaysOnSampler instead of RateByServiceTraceSampler.");
+            sampler = new ParentBasedAlwaysOnSampler();
           } else {
             sampler = new RateByServiceTraceSampler();
           }
+        } else if (config.isTraceOtlpExporterEnabled()) {
+          // AllSampler does not emit a sampling priority; OTLP export requires one.
+          log.debug(
+              "OTLP traces export enabled. Using ParentBasedAlwaysOnSampler instead of AllSampler.");
+          sampler = new ParentBasedAlwaysOnSampler();
         } else {
           sampler = new AllSampler();
         }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
@@ -1,6 +1,10 @@
 package datadog.trace.common.sampling
 
 import datadog.trace.api.Config
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDSpan
 import datadog.trace.test.util.DDSpecification
 
 class SamplerTest extends DDSpecification{
@@ -146,5 +150,26 @@ class SamplerTest extends DDSpecification{
     then:
     sampler instanceof ForcePrioritySampler
     !(sampler instanceof ParentBasedAlwaysOnSampler)
+  }
+
+  void "test that spans built with OTLP traces export enabled and priority sampling disabled have a non-UNSET sampling priority"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    System.setProperty("dd.priority.sampling", "false")
+    Config config = new Config()
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+    CoreTracer tracer = CoreTracer.builder().writer(new ListWriter()).sampler(sampler).build()
+
+    when:
+    DDSpan span = (DDSpan) tracer.buildSpan("test").start()
+    ((PrioritySampler) sampler).setSamplingPriority(span)
+
+    then:
+    span.getSamplingPriority() != null
+    span.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
+
+    cleanup:
+    span.finish()
+    tracer.close()
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
@@ -66,4 +66,85 @@ class SamplerTest extends DDSpecification{
     then:
     !(sampler instanceof AsmStandaloneSampler)
   }
+
+  void "test that ParentBasedAlwaysOnSampler replaces AllSampler when OTLP traces export is enabled and priority sampling is disabled"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    System.setProperty("dd.priority.sampling", "false")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof ParentBasedAlwaysOnSampler
+  }
+
+  void "test that AllSampler is selected when OTLP traces export is disabled and priority sampling is disabled"() {
+    setup:
+    System.setProperty("dd.priority.sampling", "false")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof AllSampler
+    !(sampler instanceof ParentBasedAlwaysOnSampler)
+  }
+
+  void "test that trace sampling rules are respected when OTLP traces export is enabled"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    System.setProperty("dd.trace.sample.rate", "0.5")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof RuleBasedTraceSampler
+    !(sampler instanceof ParentBasedAlwaysOnSampler)
+  }
+
+  void "test that ParentBasedAlwaysOnSampler replaces RateByServiceTraceSampler when OTLP traces export is enabled with default priority sampling"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof ParentBasedAlwaysOnSampler
+    !(sampler instanceof RateByServiceTraceSampler)
+  }
+
+  void "test that ForcePrioritySampler is respected when OTLP traces export is enabled and priority sampling is forced to keep"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    System.setProperty("dd.priority.sampling.force", "keep")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof ForcePrioritySampler
+    !(sampler instanceof ParentBasedAlwaysOnSampler)
+  }
+
+  void "test that ForcePrioritySampler is respected when OTLP traces export is enabled and priority sampling is forced to drop"() {
+    setup:
+    System.setProperty("dd.trace.otel.exporter", "otlp")
+    System.setProperty("dd.priority.sampling.force", "drop")
+    Config config = new Config()
+
+    when:
+    Sampler sampler = Sampler.Builder.forConfig(config, null)
+
+    then:
+    sampler instanceof ForcePrioritySampler
+    !(sampler instanceof ParentBasedAlwaysOnSampler)
+  }
 }


### PR DESCRIPTION

# What Does This Do
Selects `ParentBasedAlwaysOnSampler` in `Sampler.Builder.forConfig()` when `dd.trace.otel.exporter=otlp`, replacing `AllSampler` and  `RateByServiceTraceSampler`. User-configured samplers — `RuleBasedTraceSampler` (rules / `DD_TRACE_SAMPLE_RATE`), `ForcePrioritySampler` (`dd.priority.sampling.force`), and `AsmStandaloneSampler` — are preserved.

# Motivation

The OpenTelemetry Tracing SDK [spec](https://opentelemetry.io/docs/specs/otel/trace/sdk/#recording-sampled-reaction-table) requires that only sampled spans reach the exporter, so the SDK sampler must emit a sampling decision. The upcoming OTLP writer implementation explicitly [checks for sampling priority](https://github.com/DataDog/dd-trace-java/pull/11200/changes#diff-8db38de97b2b96f7c8e9aa3a9fefee9c4f82e31a37abef729f76ac5723f8502dR61-R68) when deciding whether to include a span. Neither of the default-path samplers is suitable on the OTLP path:

- `AllSampler` (priority sampling disabled) doesn't emit a sampling priority — it leaves the trace UNSET, which the upcoming OTLP exporter would discard. 
- `RateByServiceTraceSampler` (the default) depends on the Datadog Agent for per-service rate updates, which isn't part of an OTLP-only deployment

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
