### PR TITLE
Added missing thread metadata in V1 trace mapper.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV1.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV1.java
@@ -374,9 +374,13 @@ public final class TraceMapperV1 implements TraceMapper {
         (tagCount
                 + baggage.size()
                 + metaStruct.size()
+                + 2
                 + (writeHttpStatus ? 1 : 0)
                 + (writeTopLevel ? 1 : 0))
             * 3);
+
+    writeAttribute(writable, DDTags.THREAD_ID, meta.getThreadId());
+    writeAttribute(writable, DDTags.THREAD_NAME, meta.getThreadName());
 
     for (Map.Entry<String, String> entry : baggage.entrySet()) {
       writeAttribute(writable, entry.getKey(), entry.getValue());
@@ -470,16 +474,19 @@ public final class TraceMapperV1 implements TraceMapper {
 
   private void writeAttribute(Writable writable, String key, Object value) {
     writeStreamingString(writable, key);
+
     if (value instanceof Number) {
       writable.writeInt(VALUE_TYPE_FLOAT);
       writable.writeDouble(((Number) value).doubleValue());
       return;
     }
+
     if (value instanceof Boolean) {
       writable.writeInt(VALUE_TYPE_BOOLEAN);
       writable.writeBoolean((Boolean) value);
       return;
     }
+
     if (!(value instanceof String) && value != null) {
       log.debug("Not a string value for key: {}, value: {}", key, value);
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV1PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV1PayloadTest.groovy
@@ -1051,9 +1051,6 @@ class TraceMapperV1PayloadTest extends DDSpecification {
         case TraceMapperV1.VALUE_TYPE_FLOAT:
           value = unpacker.unpackDouble()
           break
-        case TraceMapperV1.VALUE_TYPE_INT:
-          value = unpacker.unpackLong()
-          break
         case TraceMapperV1.VALUE_TYPE_BYTES:
           int len = unpacker.unpackBinaryHeader()
           byte[] data = new byte[len]
@@ -1237,9 +1234,6 @@ class TraceMapperV1PayloadTest extends DDSpecification {
                 break
               case TraceMapperV1.VALUE_TYPE_FLOAT:
                 unpacker.unpackDouble()
-                break
-              case TraceMapperV1.VALUE_TYPE_INT:
-                unpacker.unpackLong()
                 break
               case TraceMapperV1.VALUE_TYPE_BYTES:
                 int len = unpacker.unpackBinaryHeader()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV1PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV1PayloadTest.groovy
@@ -701,6 +701,40 @@ class TraceMapperV1PayloadTest extends DDSpecification {
     assertEquals(4.25d, (attributes.get("tag.double") as Number).doubleValue(), 0.000001d)
   }
 
+  def "test thread metadata is encoded in v1 attributes"() {
+    setup:
+    def span = new TraceGenerator.PojoSpan(
+      "service-a",
+      "operation-a",
+      "resource-a",
+      DDTraceId.ONE,
+      123L,
+      0L,
+      1000L,
+      2000L,
+      0,
+      [:],
+      [:],
+      "web",
+      false,
+      PrioritySampling.SAMPLER_KEEP,
+      0,
+      null)
+
+    TraceMapperV1 mapper = new TraceMapperV1()
+    byte[] encoded = serializeMappedPayload(mapper, [[span]])
+    MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(encoded)
+    List<String> stringTable = new ArrayList<>()
+    stringTable.add("")
+
+    when:
+    Map<String, Object> attributes = readFirstSpanAttributes(unpacker, stringTable)
+
+    then:
+    assertAttributeValueEquals(span.getTag(DDTags.THREAD_ID), attributes.get(DDTags.THREAD_ID), DDTags.THREAD_ID)
+    assertEquals(span.getTag(DDTags.THREAD_NAME).toString(), attributes.get(DDTags.THREAD_NAME))
+  }
+
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
     private final List<List<TraceGenerator.PojoSpan>> expectedTraces
@@ -973,6 +1007,8 @@ class TraceMapperV1PayloadTest extends DDSpecification {
     for (Map.Entry<String, String> entry : expectedSpan.getBaggage().entrySet()) {
       expectedAttributes.put(entry.getKey(), entry.getValue())
     }
+    expectedAttributes.put(DDTags.THREAD_ID, expectedSpan.getTag(DDTags.THREAD_ID))
+    expectedAttributes.put(DDTags.THREAD_NAME, expectedSpan.getTag(DDTags.THREAD_NAME))
     for (Map.Entry<String, Object> entry : expectedSpan.getTags().entrySet()) {
       if (DDTags.SPAN_EVENTS == entry.getKey()) {
         continue
@@ -1014,6 +1050,9 @@ class TraceMapperV1PayloadTest extends DDSpecification {
           break
         case TraceMapperV1.VALUE_TYPE_FLOAT:
           value = unpacker.unpackDouble()
+          break
+        case TraceMapperV1.VALUE_TYPE_INT:
+          value = unpacker.unpackLong()
           break
         case TraceMapperV1.VALUE_TYPE_BYTES:
           int len = unpacker.unpackBinaryHeader()
@@ -1198,6 +1237,9 @@ class TraceMapperV1PayloadTest extends DDSpecification {
                 break
               case TraceMapperV1.VALUE_TYPE_FLOAT:
                 unpacker.unpackDouble()
+                break
+              case TraceMapperV1.VALUE_TYPE_INT:
+                unpacker.unpackLong()
                 break
               case TraceMapperV1.VALUE_TYPE_BYTES:
                 int len = unpacker.unpackBinaryHeader()


### PR DESCRIPTION
# What Does This Do
Adds missing thread-related metadata (thread name and id) to spans in the V1 trace mapper.

# Motivation
While dogfooding the `v1` protocol in a real application and inspecting traces in the Datadog Web UI, I noticed that the initial implementation in #10801 does not include thread metadata in spans.

# Additional Notes
The `v0.4` protocol already serializes these attributes, so the V1 implementation should align with that behavior.
