### PR TITLE
Reduce aether timeout for Maven instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/AbstractMavenTest.java
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/AbstractMavenTest.java
@@ -51,11 +51,15 @@ public abstract class AbstractMavenTest {
 
     File pomFile = new File(AbstractMavenTest.class.getResource(pomPath).toURI());
 
-    String[] arguments = new String[additionalArgs.length + 3];
+    String[] arguments = new String[additionalArgs.length + 4];
     arguments[0] = "-f";
     arguments[1] = pomFile.getAbsolutePath();
     arguments[2] = goal;
-    System.arraycopy(additionalArgs, 0, arguments, 3, additionalArgs.length);
+    // Cap Aether's HTTP read timeout so a stalled Maven Central fetch fails fast.
+    // Default is 30 min, which exceeds the 20-min Gradle test task timeout and turns
+    // a network stall into an opaque "Timeout has been exceeded" task abort.
+    arguments[3] = "-Daether.connector.requestTimeout=60000";
+    System.arraycopy(additionalArgs, 0, arguments, 4, additionalArgs.length);
 
     mavenCli.doMain(arguments, WORKING_DIRECTORY.toAbsolutePath().toString(), stdOut, stderr);
 


### PR DESCRIPTION
# What Does This Do

- Reduces `aether.connector.requestTimeout` to 60s vs the default 30m for the Maven instrumentation tests.

# Motivation

- The test task occasionally fails with `Timeout has been exceeded` when an HTTPS fetch from Maven Central stalls inside the in-process `MavenCli.doMain` calls. Because the default request timeout is 30m vs the Gradle task timeout of 20m, the stalled GET is killed by the Gradle task instead of surfacing the network failure faster. 

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
