### PR TITLE
Report dropped stats aggregates in health metrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -3,6 +3,7 @@ package datadog.trace.common.metrics;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.trace.common.metrics.SignalItem.StopSignal;
+import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.util.LRUCache;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Iterator;
@@ -46,7 +47,8 @@ final class Aggregator implements Runnable {
       final Set<MetricKey> commonKeys,
       int maxAggregates,
       long reportingInterval,
-      TimeUnit reportingIntervalTimeUnit) {
+      TimeUnit reportingIntervalTimeUnit,
+      HealthMetrics healthMetrics) {
     this(
         writer,
         batchPool,
@@ -56,7 +58,8 @@ final class Aggregator implements Runnable {
         maxAggregates,
         reportingInterval,
         reportingIntervalTimeUnit,
-        DEFAULT_SLEEP_MILLIS);
+        DEFAULT_SLEEP_MILLIS,
+        healthMetrics);
   }
 
   Aggregator(
@@ -68,14 +71,18 @@ final class Aggregator implements Runnable {
       int maxAggregates,
       long reportingInterval,
       TimeUnit reportingIntervalTimeUnit,
-      long sleepMillis) {
+      long sleepMillis,
+      HealthMetrics healthMetrics) {
     this.writer = writer;
     this.batchPool = batchPool;
     this.inbox = inbox;
     this.commonKeys = commonKeys;
     this.aggregates =
         new LRUCache<>(
-            new CommonKeyCleaner(commonKeys), maxAggregates * 4 / 3, 0.75f, maxAggregates);
+            new CommonKeyCleaner(commonKeys, healthMetrics),
+            maxAggregates * 4 / 3,
+            0.75f,
+            maxAggregates);
     this.pending = pending;
     this.reportingIntervalNanos = reportingIntervalTimeUnit.toNanos(reportingInterval);
     this.sleepMillis = sleepMillis;
@@ -183,14 +190,17 @@ final class Aggregator implements Runnable {
       implements LRUCache.ExpiryListener<MetricKey, AggregateMetric> {
 
     private final Set<MetricKey> commonKeys;
+    private final HealthMetrics healthMetrics;
 
-    private CommonKeyCleaner(Set<MetricKey> commonKeys) {
+    private CommonKeyCleaner(Set<MetricKey> commonKeys, HealthMetrics healthMetrics) {
       this.commonKeys = commonKeys;
+      this.healthMetrics = healthMetrics;
     }
 
     @Override
     public void accept(Map.Entry<MetricKey, AggregateMetric> expired) {
       commonKeys.remove(expired.getKey());
+      healthMetrics.onStatsAggregateDropped();
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -200,7 +200,9 @@ final class Aggregator implements Runnable {
     @Override
     public void accept(Map.Entry<MetricKey, AggregateMetric> expired) {
       commonKeys.remove(expired.getKey());
-      healthMetrics.onStatsAggregateDropped();
+      if (expired.getValue().getHitCount() > 0) {
+        healthMetrics.onStatsAggregateDropped();
+      }
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -204,7 +204,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             keys.keySet(),
             maxAggregates,
             reportingInterval,
-            timeUnit);
+            timeUnit,
+            healthMetric);
     this.thread = newAgentThread(METRICS_AGGREGATOR, aggregator);
     this.reportingInterval = reportingInterval;
     this.reportingIntervalTimeUnit = timeUnit;

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -91,6 +91,8 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onClientStatDowngraded() {}
 
+  public void onStatsAggregateDropped() {}
+
   /**
    * @return Human-readable summary of the current health metrics.
    */

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -97,6 +97,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final LongAdder clientStatsErrors = new LongAdder();
   private final LongAdder clientStatsDowngrades = new LongAdder();
 
+  private final LongAdder statsAggregateDropped = new LongAdder();
+
   private final StatsDClient statsd;
   private final long interval;
   private final TimeUnit units;
@@ -351,6 +353,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
+  public void onStatsAggregateDropped() {
+    statsAggregateDropped.increment();
+  }
+
+  @Override
   public void close() {
     if (null != cancellation) {
       cancellation.cancel();
@@ -366,8 +373,9 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     private static final String[] SERIAL_FAILED_TAG = new String[] {"failure:serial"};
     private static final String[] UNSET_TAG = new String[] {"priority:unset"};
     private static final String[] SINGLE_SPAN_SAMPLER = new String[] {"sampler:single-span"};
+    private static final String[] REASON_LRU_EVICTION_TAG = new String[] {"reason:lru_eviction"};
 
-    private final long[] previousCounts = new long[50];
+    private final long[] previousCounts = new long[51];
 
     @SuppressFBWarnings("AT_STALE_THREAD_WRITE_OF_PRIMITIVE")
     private int countIndex;
@@ -491,6 +499,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(target.statsd, "stats.flush_errors", target.clientStatsErrors, NO_TAGS);
         reportIfChanged(
             target.statsd, "stats.agent_downgrades", target.clientStatsDowngrades, NO_TAGS);
+        reportIfChanged(
+            target.statsd,
+            "stats.dropped_aggregates",
+            target.statsAggregateDropped,
+            REASON_LRU_EVICTION_TAG);
 
       } catch (ArrayIndexOutOfBoundsException e) {
         log.warn(
@@ -622,6 +635,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         + "\nclientStatsProcessedSpans="
         + clientStatsProcessedSpans.sum()
         + "\nclientStatsProcessedTraces="
-        + clientStatsProcessedTraces.sum();
+        + clientStatsProcessedTraces.sum()
+        + "\nstatsAggregateDropped="
+        + statsAggregateDropped.sum();
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -944,6 +944,40 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     aggregator.close()
   }
 
+  def "should report dropped aggregate to health metrics on LRU eviction"() {
+    setup:
+    int maxAggregates = 10
+    MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
+    features.peerTags() >> []
+    HealthMetrics healthMetrics = Mock(HealthMetrics)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
+    long duration = 100
+    aggregator.start()
+
+    when:
+    CountDownLatch latch = new CountDownLatch(1)
+    for (int i = 0; i < maxAggregates + 1; ++i) {
+      aggregator.publish([
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
+        .setTag(SPAN_KIND, "baz")
+      ])
+    }
+    aggregator.report()
+    def latchTriggered = latch.await(2, SECONDS)
+
+    then:
+    latchTriggered
+    1 * writer.finishBucket() >> { latch.countDown() }
+    1 * healthMetrics.onStatsAggregateDropped()
+
+    cleanup:
+    aggregator.close()
+  }
+
   def "aggregate not updated in reporting interval not reported"() {
     setup:
     int maxAggregates = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -978,6 +978,52 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     aggregator.close()
   }
 
+  def "should not report dropped aggregate when evicted entry was already flushed"() {
+    setup:
+    int maxAggregates = 5
+    MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
+    features.peerTags() >> []
+    HealthMetrics healthMetrics = Mock(HealthMetrics)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
+    aggregator.start()
+
+    when: "fill cache and flush — entries are cleared (hitCount=0) but stay in the LRU"
+    CountDownLatch latch1 = new CountDownLatch(1)
+    for (int i = 0; i < maxAggregates; ++i) {
+      aggregator.publish([
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, 100, HTTP_OK)
+        .setTag(SPAN_KIND, "baz")
+      ])
+    }
+    aggregator.report()
+    latch1.await(2, SECONDS)
+
+    then:
+    1 * writer.finishBucket() >> { latch1.countDown() }
+
+    when: "publish new distinct spans — LRU evicts the cleared entries before the next report"
+    CountDownLatch latch2 = new CountDownLatch(1)
+    for (int i = maxAggregates; i < maxAggregates * 2; ++i) {
+      aggregator.publish([
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, 100, HTTP_OK)
+        .setTag(SPAN_KIND, "baz")
+      ])
+    }
+    aggregator.report()
+    latch2.await(2, SECONDS)
+
+    then: "no drop metric because all evicted entries had hitCount=0 (already reported)"
+    1 * writer.finishBucket() >> { latch2.countDown() }
+    0 * healthMetrics.onStatsAggregateDropped()
+
+    cleanup:
+    aggregator.close()
+  }
+
   def "aggregate not updated in reporting interval not reported"() {
     setup:
     int maxAggregates = 10

--- a/dd-trace-core/src/test/java/datadog/trace/core/monitor/HealthMetricsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/monitor/HealthMetricsTest.java
@@ -385,6 +385,19 @@ class HealthMetricsTest {
     verifyNoMoreInteractions(statsD);
   }
 
+  @Test
+  void testOnStatsAggregateDropped() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    try (TracerHealthMetrics healthMetrics =
+        new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)) {
+      healthMetrics.start();
+      healthMetrics.onStatsAggregateDropped();
+      assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+    verify(statsD).count("stats.dropped_aggregates", 1L, "reason:lru_eviction");
+    verifyNoMoreInteractions(statsD);
+  }
+
   private static class Latched implements StatsDClient {
     private final StatsDClient delegate;
     private final CountDownLatch latch;


### PR DESCRIPTION
# What Does This Do

ConflatingMetricsAggregator` bounds its aggregate cache to `maxAggregates` entries via an LRU eviction policy. When the limit is exceeded, the least-recently-used aggregate is silently discarded — its accumulated hit counts and durations are lost and never reported to the agent.


This PR wires the existing `CommonKeyCleaner` eviction callback into `HealthMetrics`, emitting a new StatsD counter `stats.dropped_aggregates` (tagged `reason:lru_eviction`) each time an aggregate is evicted. 


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
