### PR TITLE
Load jetty-server instrumentation in dropwizard-0.8 tests

### DIFF
--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-0.8/build.gradle
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-0.8/build.gradle
@@ -5,6 +5,15 @@ apply from: "$rootDir/gradle/java.gradle"
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:rs:jax-rs:jax-rs-annotations:jax-rs-annotations-2.0')
   testImplementation project(':dd-java-agent:instrumentation:servlet:javax-servlet:javax-servlet-3.0')
+  // Dropwizard 0.8 transitively depends on Jetty 9.2.9, so load the jetty-server
+  // instrumentation modules whose muzzle ranges cover that version, matching the
+  // production classpath:
+  //   - jetty-server-9.0     applies to [9, 10) and owns the request span
+  //   - jetty-server-9.0.4   applies to [9.0.4, 9.3.0.M1) and owns the AppSec
+  //                          response-commit hook used by Jetty 9.2.x
+  // Without these, the server span is owned by Servlet3Decorator.
+  testImplementation project(':dd-java-agent:instrumentation:jetty:jetty-server:jetty-server-9.0')
+  testImplementation project(':dd-java-agent:instrumentation:jetty:jetty-server:jetty-server-9.0.4')
 
   // First version with DropwizardTestSupport:
   testImplementation group: 'io.dropwizard', name: 'dropwizard-testing', version: '0.8.0'

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-0.8/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-0.8/src/test/groovy/DropwizardTest.groovy
@@ -95,7 +95,10 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
 
   @Override
   String expectedIntegrationName() {
-    "java-web-servlet"
+    // In production, Jetty's server instrumentation creates the request span before Servlet3
+    // gets a chance to. Servlet3Advice detects the existing span and skips, so the span is
+    // owned by jetty-server, not java-web-servlet.
+    "jetty-server"
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Dropwizard 0.8 runs on Jetty 9.2.9, where jetty-server owns the request span in production. Add jetty-server-9.0 and jetty-server-9.0.4 as test dependencies so the test classpath matches, and update the expected integration name on DropwizardTest accordingly.

# Motivation

Related to [APPSEC-62560](https://datadoghq.atlassian.net/browse/APPSEC-62560); found while investigating why Dropwizard 0.8 tests tag `network.client.ip` with the `X-Forwarded-For` IP instead of the raw peer IP.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-62560]: https://datadoghq.atlassian.net/browse/APPSEC-62560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ