### PR TITLE
Fix peer IP tags in Jetty/Dropwizard and Play 2.3/2.4/2.5

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2573,14 +2573,14 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
           }
           if (span.getTag(Tags.PEER_HOST_IPV6) != null) {
             "$Tags.PEER_HOST_IPV6" {
-              it == "0:0:0:0:0:0:0:1" || (endpoint == FORWARDED && it == endpoint.body)
+              it == "0:0:0:0:0:0:0:1"
             }
             "$Tags.HTTP_CLIENT_IP" {
               it == "0:0:0:0:0:0:0:1" || (endpoint == FORWARDED && it == endpoint.body)
             }
           } else {
             "$Tags.PEER_HOST_IPV4" {
-              it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body)
+              it == "127.0.0.1"
             }
             "$Tags.HTTP_CLIENT_IP" {
               it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body)

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-10.0/src/main/java11/datadog/trace/instrumentation/jetty10/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-10.0/src/main/java11/datadog/trace/instrumentation/jetty10/JettyDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import datadog.trace.instrumentation.jetty9.RequestURIDataAdapter;
+import java.net.InetSocketAddress;
 import javax.servlet.ServletException;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
@@ -61,11 +62,28 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer overrides it with
+    // the value resolved from x-forwarded-for and similar proxy headers. Peer information
+    // must be the actual socket peer.
+    HttpChannel channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null && remote.getAddress() != null) {
+        return remote.getAddress().getHostAddress();
+      }
+    }
     return request.getRemoteAddr();
   }
 
   @Override
   protected int peerPort(final Request request) {
+    HttpChannel channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null) {
+        return remote.getPort();
+      }
+    }
     return request.getRemotePort();
   }
 

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import jakarta.servlet.ServletException;
+import java.net.InetSocketAddress;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -61,11 +62,28 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer overrides it with
+    // the value resolved from x-forwarded-for and similar proxy headers. Peer information
+    // must be the actual socket peer.
+    HttpChannel channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null && remote.getAddress() != null) {
+        return remote.getAddress().getHostAddress();
+      }
+    }
     return request.getRemoteAddr();
   }
 
   @Override
   protected int peerPort(final Request request) {
+    HttpChannel channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null) {
+        return remote.getPort();
+      }
+    }
     return request.getRemotePort();
   }
 

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/main/java17/datadog/trace/instrumentation/jetty12/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-12.0/src/main/java17/datadog/trace/instrumentation/jetty12/JettyDecorator.java
@@ -7,6 +7,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.internal.HttpChannelState;
@@ -71,12 +77,48 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer wraps
+    // ConnectionMetaData.getRemoteSocketAddress() with the value resolved from
+    // x-forwarded-for and similar proxy headers. Peer information must be the actual
+    // socket peer.
+    final InetSocketAddress remote = remoteSocketAddress(request);
+    if (remote != null) {
+      final InetAddress address = remote.getAddress();
+      if (address != null) {
+        return address.getHostAddress();
+      }
+      return Request.getRemoteAddr(request);
+    }
     return Request.getRemoteAddr(request);
   }
 
   @Override
   protected int peerPort(final Request request) {
+    final InetSocketAddress remote = remoteSocketAddress(request);
+    if (remote != null) {
+      return remote.getPort();
+    }
     return Request.getRemotePort(request);
+  }
+
+  private static InetSocketAddress remoteSocketAddress(final Request request) {
+    final ConnectionMetaData metaData = request.getConnectionMetaData();
+    if (metaData == null) {
+      return null;
+    }
+    final Connection connection = metaData.getConnection();
+    if (connection == null) {
+      return null;
+    }
+    final EndPoint endPoint = connection.getEndPoint();
+    if (endPoint == null) {
+      return null;
+    }
+    final SocketAddress remote = endPoint.getRemoteSocketAddress();
+    if (remote instanceof InetSocketAddress) {
+      return (InetSocketAddress) remote;
+    }
+    return null;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import javax.servlet.ServletException;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -60,11 +61,31 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer overrides it with
+    // the value resolved from x-forwarded-for and similar proxy headers. Peer information
+    // must be the actual socket peer.
+    final HttpConnection connection = request.getConnection();
+    if (connection != null) {
+      final EndPoint endPoint = connection.getEndPoint();
+      if (endPoint != null) {
+        final String remoteAddr = endPoint.getRemoteAddr();
+        if (remoteAddr != null) {
+          return remoteAddr;
+        }
+      }
+    }
     return request.getRemoteAddr();
   }
 
   @Override
   protected int peerPort(final Request request) {
+    final HttpConnection connection = request.getConnection();
+    if (connection != null) {
+      final EndPoint endPoint = connection.getEndPoint();
+      if (endPoint != null) {
+        return endPoint.getRemotePort();
+      }
+    }
     return request.getRemotePort();
   }
 

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import javax.servlet.ServletException;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.AbstractHttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -60,11 +61,31 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer overrides it with
+    // the value resolved from x-forwarded-for and similar proxy headers. Peer information
+    // must be the actual socket peer.
+    final AbstractHttpConnection connection = request.getConnection();
+    if (connection != null) {
+      final EndPoint endPoint = connection.getEndPoint();
+      if (endPoint != null) {
+        final String remoteAddr = endPoint.getRemoteAddr();
+        if (remoteAddr != null) {
+          return remoteAddr;
+        }
+      }
+    }
     return request.getRemoteAddr();
   }
 
   @Override
   protected int peerPort(final Request request) {
+    final AbstractHttpConnection connection = request.getConnection();
+    if (connection != null) {
+      final EndPoint endPoint = connection.getEndPoint();
+      if (endPoint != null) {
+        return endPoint.getRemotePort();
+      }
+    }
     return request.getRemotePort();
   }
 

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
@@ -9,6 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
+import java.net.InetSocketAddress;
 import javax.servlet.ServletException;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
@@ -60,11 +61,28 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
 
   @Override
   protected String peerHostIP(final Request request) {
+    // Avoid Request.getRemoteAddr() since ForwardedRequestCustomizer (used by default in
+    // Dropwizard) overrides it with the value resolved from x-forwarded-for and similar
+    // proxy headers. Peer information must be the actual socket peer.
+    HttpChannel<?> channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null && remote.getAddress() != null) {
+        return remote.getAddress().getHostAddress();
+      }
+    }
     return request.getRemoteAddr();
   }
 
   @Override
   protected int peerPort(final Request request) {
+    HttpChannel<?> channel = request.getHttpChannel();
+    if (channel != null) {
+      InetSocketAddress remote = channel.getRemoteAddress();
+      if (remote != null) {
+        return remote.getPort();
+      }
+    }
     return request.getRemotePort();
   }
 

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -88,7 +89,14 @@ public class PlayHttpServerDecorator
       final Request<?> connection,
       final Request<?> request,
       final Context parentContext) {
-    super.onRequest(span, connection, request, parentContext);
+    // Play's Request#remoteAddress() returns the address resolved from X-Forwarded-For (and
+    // similar) proxy headers, not the actual TCP socket peer. If the upstream framework
+    // (akka/netty) already populated peer information on the span from the real socket,
+    // wrap the connection so super.onRequest sees the captured value instead of Play's
+    // forwarded one. This way the IG callbacks and tags receive the correct peer.
+    // (APPSEC-62562)
+    final Request<?> connectionForSuper = withCapturedPeer(span, connection);
+    super.onRequest(span, connectionForSuper, request, parentContext);
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes
@@ -131,6 +139,23 @@ public class PlayHttpServerDecorator
     } catch (final Throwable t) {
       LOG.debug("Failed to dispatch route", t);
     }
+  }
+
+  /**
+   * If the span already carries a peer IP (set by the upstream akka/netty instrumentation from the
+   * real TCP socket peer), wrap the request so {@code remoteAddress()} returns that value instead
+   * of Play's X-Forwarded-For-resolved one.
+   */
+  private static Request<?> withCapturedPeer(final AgentSpan span, final Request<?> connection) {
+    if (connection == null) {
+      return null;
+    }
+    final Object capturedIp = span.getTag(Tags.PEER_HOST_IPV4);
+    final Object peerIp = capturedIp != null ? capturedIp : span.getTag(Tags.PEER_HOST_IPV6);
+    if (peerIp != null) {
+      return new RequestWithCapturedPeer(connection, peerIp.toString());
+    }
+    return connection;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayInstrumentation.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayInstrumentation.java
@@ -37,7 +37,8 @@ public final class PlayInstrumentation extends InstrumenterModule.Tracing
       packageName + ".PlayHeaders$Result",
       packageName + ".PlayHttpServerDecorator",
       packageName + ".RequestCompleteCallback",
-      packageName + ".RequestURIDataAdapter"
+      packageName + ".RequestURIDataAdapter",
+      packageName + ".RequestWithCapturedPeer"
     };
   }
 

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestWithCapturedPeer.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestWithCapturedPeer.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.play23;
+
+import play.api.mvc.Request;
+import play.api.mvc.WrappedRequest;
+
+/**
+ * Wraps a {@link Request} so that {@link #remoteAddress()} returns a previously captured peer IP
+ * (typically read from the upstream akka/netty span, which obtained it from the actual TCP socket
+ * peer). This bypasses Play's X-Forwarded-For-resolved {@code remoteAddress} when tagging peer
+ * information. See APPSEC-62562.
+ */
+public class RequestWithCapturedPeer extends WrappedRequest<Object> {
+  private final String capturedPeerAddress;
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public RequestWithCapturedPeer(final Request<?> request, final String capturedPeerAddress) {
+    super((Request) request);
+    this.capturedPeerAddress = capturedPeerAddress;
+  }
+
+  @Override
+  public String remoteAddress() {
+    return capturedPeerAddress;
+  }
+}

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -88,7 +89,14 @@ public class PlayHttpServerDecorator
       final Request<?> connection,
       final Request<?> request,
       final Context parentContext) {
-    super.onRequest(span, connection, request, parentContext);
+    // Play's Request#remoteAddress() returns the address resolved from X-Forwarded-For (and
+    // similar) proxy headers, not the actual TCP socket peer. If the upstream framework
+    // (akka/netty) already populated peer information on the span from the real socket,
+    // wrap the connection so super.onRequest sees the captured value instead of Play's
+    // forwarded one. This way the IG callbacks and tags receive the correct peer.
+    // (APPSEC-62562)
+    final Request<?> connectionForSuper = withCapturedPeer(span, connection);
+    super.onRequest(span, connectionForSuper, request, parentContext);
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes
@@ -131,6 +139,23 @@ public class PlayHttpServerDecorator
     } catch (final Throwable t) {
       LOG.debug("Failed to dispatch route", t);
     }
+  }
+
+  /**
+   * If the span already carries a peer IP (set by the upstream akka/netty instrumentation from the
+   * real TCP socket peer), wrap the request so {@code remoteAddress()} returns that value instead
+   * of Play's X-Forwarded-For-resolved one.
+   */
+  private static Request<?> withCapturedPeer(final AgentSpan span, final Request<?> connection) {
+    if (connection == null) {
+      return null;
+    }
+    final Object capturedIp = span.getTag(Tags.PEER_HOST_IPV4);
+    final Object peerIp = capturedIp != null ? capturedIp : span.getTag(Tags.PEER_HOST_IPV6);
+    if (peerIp != null) {
+      return new RequestWithCapturedPeer(connection, peerIp.toString());
+    }
+    return connection;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayInstrumentation.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayInstrumentation.java
@@ -39,7 +39,8 @@ public final class PlayInstrumentation extends InstrumenterModule.Tracing
       packageName + ".RequestCompleteCallback",
       packageName + ".RequestURIDataAdapter",
       packageName + ".RequestHelper",
-      packageName + ".RequestHelper$SFunction0"
+      packageName + ".RequestHelper$SFunction0",
+      packageName + ".RequestWithCapturedPeer"
     };
   }
 

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestWithCapturedPeer.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestWithCapturedPeer.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.play24;
+
+import play.api.mvc.Request;
+import play.api.mvc.WrappedRequest;
+
+/**
+ * Wraps a {@link Request} so that {@link #remoteAddress()} returns a previously captured peer IP
+ * (typically read from the upstream akka/netty span, which obtained it from the actual TCP socket
+ * peer). This bypasses Play's X-Forwarded-For-resolved {@code remoteAddress} when tagging peer
+ * information. See APPSEC-62562.
+ */
+public class RequestWithCapturedPeer extends WrappedRequest<Object> {
+  private final String capturedPeerAddress;
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public RequestWithCapturedPeer(final Request<?> request, final String capturedPeerAddress) {
+    super((Request) request);
+    this.capturedPeerAddress = capturedPeerAddress;
+  }
+
+  @Override
+  public String remoteAddress() {
+    return capturedPeerAddress;
+  }
+}


### PR DESCRIPTION
# What Does This Do

**UPDATE:** This PR did not work as intended for Play, and there is a follow up fix at https://github.com/DataDog/dd-trace-java/pull/11274

Jetty's ForwardedRequestCustomizer (enabled by default in Dropwizard) and
Play's RequestHeader#remoteAddress() both return the IP resolved from
x-forwarded-for / similar proxy headers. That value is correct for
http.client_ip but must not be reported as the actual socket peer
(peer.ip, peer.port, network.client.ip).

Jetty / Dropwizard ([APPSEC-62560](https://datadoghq.atlassian.net/browse/APPSEC-62560)):
- Read the unwrapped socket address directly from the Jetty channel /
  endpoint in every JettyDecorator (jetty 7.0, 7.6, 9, 10, 11, 12).
- Add jetty-server-9.0 as a testImplementation of dropwizard-0.8 so the
  test classpath matches production (Jetty owns the server span; Servlet3
  skips when it sees the existing context). Update DropwizardTest's
  expectedIntegrationName to jetty-server.

Play 2.3 / 2.4 / 2.5 ([APPSEC-62562](https://datadoghq.atlassian.net/browse/APPSEC-62562)):
- In PlayHttpServerDecorator, wrap the Request handed to super.onRequest
  with a play.api.mvc.WrappedRequest whose remoteAddress() returns the
  peer IP already captured on the span by the upstream akka / netty
  instrumentation. This prevents super.onRequest -> peerHostIP from
   overwriting the real socket peer with the forwarded value, and keeps
   IG callbacks consistent. Mirrors the Play 2.6+ behavior already
  provided by RemoteConnectionWithRawAddress.

 HttpServerTest:
- Tighten PEER_HOST_IPV4 / PEER_HOST_IPV6 assertions on the FORWARDED
  endpoint to strictly expect the loopback address.

# Motivation

# Additional Notes

- Requires: https://github.com/DataDog/dd-trace-java/pull/11235

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-62560]: https://datadoghq.atlassian.net/browse/APPSEC-62560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-62562]: https://datadoghq.atlassian.net/browse/APPSEC-62562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ