### PR TITLE
Enable sending crashtracking reports to errors intake by default

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
@@ -272,7 +272,7 @@ public class CrashUploaderTest {
     // When
     uploader = new CrashUploader(config, crashConfig);
     server.enqueue(new MockResponse().setResponseCode(200));
-    uploader.upload(getResourcePath(inputLog));
+    uploader.remoteUpload(readFileAsString(inputLog), true, false);
 
     final RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CrashTrackingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CrashTrackingConfig.java
@@ -26,7 +26,7 @@ public final class CrashTrackingConfig {
 
   public static final String CRASH_TRACKING_ERRORS_INTAKE_ENABLED =
       "crashtracking.errors-intake.enabled";
-  public static final boolean CRASH_TRACKING_ERRORS_INTAKE_ENABLED_DEFAULT = false;
+  public static final boolean CRASH_TRACKING_ERRORS_INTAKE_ENABLED_DEFAULT = true;
 
   public static final String CRASH_TRACKING_EXTENDED_INFO_ENABLED =
       "crashtracking.extended-info.enabled";


### PR DESCRIPTION
# What Does This Do

Enable by default sending crash reports to error tracking intake

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
