### PR TITLE
Recalculate startup benchmark thresholds with 15% significant-impact-threshold

### DIFF
--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -52,10 +52,10 @@ experiments:
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Atracing%3AAgent.start&trendsType=scenario
           - name: "startup:petclinic:tracing:Agent.start"
             thresholds:
-              - execution_time < 1194.03 ms
+              - execution_time < 1255.96 ms # generated with --significant-impact-threshold 0.15
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aprofiling%3AAgent.start&trendsType=scenario
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aappsec%3AAgent.start&trendsType=scenario
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aiast%3AAgent.start&trendsType=scenario
           - name: "startup:petclinic:(profiling|appsec|iast):Agent.start"
             thresholds:
-              - execution_time < 1442.46 ms
+              - execution_time < 1483.46 ms # generated with --significant-impact-threshold 0.15


### PR DESCRIPTION
# What Does This Do

Re-set the startup benchmark thresholds to automatically generated SLOs with `--significant-impact-threshold 0.15`.

# Motivation

We increased the `--significant-impact-threshold` from 0.10 to 0.15 because the previous startup SLOs were too close to the 10% warning boundary, defined earlier in the file. This meant that we were left with very little buffer between our expected benchmark variation and warnings being triggered. The new 0.15 threshold should still allow for more room for slight variation. See the [Perf SLOs dashboard](https://app.datadoghq.com/dashboard/w6a-xc3-kyz?fromUser=false&refresh_mode=sliding&tpl_var_project%5B0%5D=dd-trace-java&from_ts=1769610298002&to_ts=1777382698002&live=true) and [Legacy dashboard](https://app.datadoghq.com/dashboard/67v-vwd-u2t/apm-sdk-perf-slos-with-micros-cloned?fromUser=true&refresh_mode=paused&tpl_var_project%5B0%5D=%2Ajava%2A&tpl_var_scenario%5B0%5D=startup%2A&from_ts=1764997200000&to_ts=1772945999999&live=false) for historical benchmark data.

# Additional Notes

The values were calculated based on the automatically generated SLO values, referenced in the changed file, and the artifacts from the latest three runs on `master`.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
