### PR TITLE
OTLP encodes trace/span ids as big-endian byte-arrays

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
@@ -194,13 +194,13 @@ public final class OtlpTraceProto {
 
   public static void writeTraceId(StreamingBuffer buf, DDTraceId traceId) {
     writeVarInt(buf, 16);
-    writeI64(buf, traceId.toLong());
-    writeI64(buf, traceId.toHighOrderLong());
+    buf.putLong(traceId.toHighOrderLong());
+    buf.putLong(traceId.toLong());
   }
 
   public static void writeSpanId(StreamingBuffer buf, long spanId) {
     writeVarInt(buf, 8);
-    writeI64(buf, spanId);
+    buf.putLong(spanId);
   }
 
   private static void writeSpanTag(StreamingBuffer buf, TagMap.EntryReader tagEntry) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
@@ -723,8 +723,9 @@ class OtlpTraceProtoTest {
         assertNotNull(parsedTraceId, "trace_id must be present in every span");
         assertEquals(16, parsedTraceId.length, "trace_id must be 16 bytes");
         assertEquals(8, parsedSpanId.length, "span_id must be 8 bytes");
-        parsedSpanIds.add(readLittleEndianLong(parsedSpanId));
-        parsedTraceIds.add(readLittleEndianLong(parsedTraceId));
+        parsedSpanIds.add(readBigEndianLong(parsedSpanId));
+        // low-order part of traceId occupies parsedTraceId[8..15] (big-endian)
+        parsedTraceIds.add(readBigEndianLong(copyOfRange(parsedTraceId, 8, 16)));
       } else {
         ss.skipField(ssTag);
       }
@@ -964,8 +965,8 @@ class OtlpTraceProtoTest {
     assertNotNull(parsedTraceId, "trace_id must be present [" + caseName + "]");
     assertEquals(16, parsedTraceId.length, "trace_id must be 16 bytes [" + caseName + "]");
     if (spec.use128BitTraceId) {
-      // high-order bytes occupy parsedTraceId[8..15] (little-endian in the wire format)
-      long highOrderBytes = readLittleEndianLong(copyOfRange(parsedTraceId, 8, 16));
+      // high-order part of traceId occupies parsedTraceId[0..7] (big-endian)
+      long highOrderBytes = readBigEndianLong(parsedTraceId);
       assertNotEquals(
           0L,
           highOrderBytes,
@@ -976,9 +977,7 @@ class OtlpTraceProtoTest {
     assertNotNull(parsedSpanId, "span_id must be present [" + caseName + "]");
     assertEquals(8, parsedSpanId.length, "span_id must be 8 bytes [" + caseName + "]");
     assertEquals(
-        span.getSpanId(),
-        readLittleEndianLong(parsedSpanId),
-        "span_id mismatch [" + caseName + "]");
+        span.getSpanId(), readBigEndianLong(parsedSpanId), "span_id mismatch [" + caseName + "]");
 
     // ── parent_span_id (field 4) ──────────────────────────────────────────────
     if (spec.parentIndex >= 0) {
@@ -988,14 +987,14 @@ class OtlpTraceProtoTest {
           8, parsedParentSpanId.length, "parent_span_id must be 8 bytes [" + caseName + "]");
       assertEquals(
           span.getParentId(),
-          readLittleEndianLong(parsedParentSpanId),
+          readBigEndianLong(parsedParentSpanId),
           "parent_span_id mismatch [" + caseName + "]");
     } else {
       // root spans either omit the field or write zero bytes
       if (parsedParentSpanId != null) {
         assertEquals(
             0L,
-            readLittleEndianLong(parsedParentSpanId),
+            readBigEndianLong(parsedParentSpanId),
             "root span parent_span_id must be zero [" + caseName + "]");
       }
     }
@@ -1191,10 +1190,10 @@ class OtlpTraceProtoTest {
     return key;
   }
 
-  /** Reads a little-endian 64-bit integer from the first 8 bytes of the given array. */
-  private static long readLittleEndianLong(byte[] bytes) {
+  /** Reads a big-endian 64-bit value from the first 8 bytes of the given array. */
+  private static long readBigEndianLong(byte[] bytes) {
     long value = 0;
-    for (int i = 7; i >= 0; i--) {
+    for (int i = 0; i < 8; i++) {
       value = (value << 8) | (bytes[i] & 0xFF);
     }
     return value;


### PR DESCRIPTION
# Motivation

Found while doing further testing of OTLP trace export.

While data is usually little-endian in protobuf/OTLP, trace and span ids are kept as big-endian byte arrays.

# Additional Notes

https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java#L99

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
