### PR TITLE
Add benchmark sts policy

### DIFF
--- a/.github/chainguard/self.gitlab.benchmarks.post-pr-comment.sts.yaml
+++ b/.github/chainguard/self.gitlab.benchmarks.post-pr-comment.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-java:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
# What Does This Do

Add an STS policy to upload `apm-sdks-benchmarks` results as a PR comment

# Motivation

This is part of migrating our dacapo, load, and startup benchmarks from `dd-trace-java` to `apm-sdks-benchmarks`. The PR commenting step has not been created yet, but this policy (on `master`) is necessary to write results to PRs. It's also based on the following policy in `apm-sdks-benchmarks`: https://github.com/DataDog/apm-sdks-benchmarks/blob/main/.github/chainguard/gitlab.github-access.read.sts.yaml

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
