### PR TITLE
fix: grizzly client reverse muzzle check

### DIFF
--- a/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/build.gradle
@@ -5,7 +5,7 @@ muzzle {
     module = "grizzly-http-client"
     // The old 1.16 upper bound was historical; Grizzly 5 still exposes the com.ning AHC API
     // this instrumentation matches, so inverse muzzle should not treat 5.x as unsupported.
-    versions = "[1.9,6)"
+    versions = "[1.9,1.16],[5,6)"
     assertInverse = true
   }
   pass {

--- a/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly/grizzly-client-1.9/build.gradle
@@ -3,7 +3,9 @@ muzzle {
   pass {
     group = "org.glassfish.grizzly"
     module = "grizzly-http-client"
-    versions = "[1.9,1.16]"
+    // The old 1.16 upper bound was historical; Grizzly 5 still exposes the com.ning AHC API
+    // this instrumentation matches, so inverse muzzle should not treat 5.x as unsupported.
+    versions = "[1.9,6)"
     assertInverse = true
   }
   pass {


### PR DESCRIPTION
# What Does This Do

Widen Grizzly client muzzle range because Grizzly 5 still exposes the com.ning AHC API and the old 1.16 cap causes a false inverse muzzle failure

# Motivation

Broken CI

# Additional Notes

```
:dd-java-agent:instrumentation:grizzly:grizzly-client-1.9:muzzle-AssertFail-org.glassfish.grizzly-grizzly-http-client-5.0.0 FAILED
```

Ref: #11256

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
