### PR TITLE
Skip reporting synthetic failures

### DIFF
--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -12,33 +12,32 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/// Tags intermediate `initializationError` retries with `dd_tags[test.final_status]=skip`.
+/// Tags synthetic testcases with `dd_tags[test.final_status]=skip` so Test Optimization does not
+/// treat them as real failures.
 ///
-/// Gradle generates synthetic "initializationError" testcases in JUnit reports for setup methods.
-/// When a setup is retried and eventually succeeds, multiple testcases are created, with only the
-/// last one passing. All intermediate attempts are marked skip so Test Optimization is not misled.
+/// **`initializationError`** — Gradle generates these for setup methods. When retried and eventually
+/// successful, multiple testcases appear; only the last one passes. All intermediate attempts are
+/// tagged skip. Files with only one (or zero) `initializationError` entries are left unmodified.
 ///
-/// For any suite with multiple `initializationError` test cases (when retries occurred), all entries
-/// but the last one are tagged by this script with `dd_tags[test.final_status]=skip`. The last
-/// entry is left unmodified, allowing **Test Optimization** to apply its default status inference based
-/// on the actual outcome. Files with only one (or zero) `initializationError` test cases are left unmodified.
+/// **`executionError`** and **`test exception`** — Framework-level synthetic failures that never
+/// represent a real test result and never fail CI. All occurrences are tagged skip unconditionally.
 ///
 /// Before:
-/// 
+///
 /// ```
-/// <testcase name="initializationError" />
+/// <testcase name="executionError" />
 /// ```
-/// 
+///
 /// After:
-/// 
+///
 /// ```
-/// <testcase name="initializationError">
+/// <testcase name="executionError">
 ///   <properties>
-///     <property name="dd_tags[test.final_status]" value="skip" /> 
+///     <property name="dd_tags[test.final_status]" value="skip" />
 ///   </properties>
 /// </testcase>
 /// ```
-/// 
+///
 /// Usage (Java 25): `java TagInitializationErrors.java junit-report.xml`
 
 class TagInitializationErrors {
@@ -71,32 +70,14 @@ class TagInitializationErrors {
     for (var group : byClassname.values()) {
       if (group.size() <= 1) continue;
       for (int i = 0; i < group.size() - 1; i++) {
-        var testcase = group.get(i);
-        var existingProperties = testcase.getElementsByTagName("properties");
-        if (existingProperties.getLength() > 0) {
-          var props = (Element) existingProperties.item(0);
-          var existingProps = props.getElementsByTagName("property");
-          boolean alreadyTagged = false;
-          for (int j = 0; j < existingProps.getLength(); j++) {
-            if ("dd_tags[test.final_status]".equals(((Element) existingProps.item(j)).getAttribute("name"))) {
-              alreadyTagged = true;
-              break;
-            }
-          }
-          if (alreadyTagged) continue;
-          var property = doc.createElement("property");
-          property.setAttribute("name", "dd_tags[test.final_status]");
-          property.setAttribute("value", "skip");
-          props.appendChild(property);
-        } else {
-          var properties = doc.createElement("properties");
-          var property = doc.createElement("property");
-          property.setAttribute("name", "dd_tags[test.final_status]");
-          property.setAttribute("value", "skip");
-          properties.appendChild(property);
-          testcase.appendChild(properties);
-        }
-        modified = true;
+        if (tagSkip(doc, group.get(i))) modified = true;
+      }
+    }
+    for (int i = 0; i < testcases.getLength(); i++) {
+      var e = (Element) testcases.item(i);
+      var name = e.getAttribute("name");
+      if ("executionError".equals(name) || "test exception".equals(name)) {
+        if (tagSkip(doc, e)) modified = true;
       }
     }
     if (!modified) return;
@@ -110,5 +91,30 @@ class TagInitializationErrors {
       tmpFile.delete();
       throw e;
     }
+  }
+
+  static boolean tagSkip(org.w3c.dom.Document doc, Element testcase) {
+    var existingProperties = testcase.getElementsByTagName("properties");
+    if (existingProperties.getLength() > 0) {
+      var props = (Element) existingProperties.item(0);
+      var existingProps = props.getElementsByTagName("property");
+      for (int j = 0; j < existingProps.getLength(); j++) {
+        if ("dd_tags[test.final_status]".equals(((Element) existingProps.item(j)).getAttribute("name"))) {
+          return false;
+        }
+      }
+      var property = doc.createElement("property");
+      property.setAttribute("name", "dd_tags[test.final_status]");
+      property.setAttribute("value", "skip");
+      props.appendChild(property);
+    } else {
+      var properties = doc.createElement("properties");
+      var property = doc.createElement("property");
+      property.setAttribute("name", "dd_tags[test.final_status]");
+      property.setAttribute("value", "skip");
+      properties.appendChild(property);
+      testcase.appendChild(properties);
+    }
+    return true;
   }
 }

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -17,10 +17,10 @@ import java.util.Map;
 ///
 /// **`initializationError`** — Gradle generates these for setup methods. When retried and eventually
 /// successful, multiple testcases appear; only the last one passes. All intermediate attempts are
-/// tagged skip. Files with only one (or zero) `initializationError` entries are left unmodified.
+/// tagged skip. Groups with only one (or zero) `initializationError` entries per classname are left unmodified.
 ///
-/// **`executionError`** and **`test exception`** — Framework-level synthetic failures that never
-/// represent a real test result and never fail CI. All occurrences are tagged skip unconditionally.
+/// **`executionError`** and **`test exception`** — Framework-level synthetic failures that do not
+/// represent real test results. Tagged skip unconditionally so Test Optimization treats them as non-failures.
 ///
 /// Before (two retries of the same class — first is intermediate, second is the final outcome):
 ///

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -1,28 +1,32 @@
-import org.w3c.dom.Element;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /// Tags synthetic testcases (`initializationError`, `executionError`, `test exception`) with
 /// `dd_tags[test.final_status]=skip` so Test Optimization does not treat them as real failures.
 /// The script is idempotent — testcases that already carry a `dd_tags[test.final_status]` property
 /// are left unchanged.
 ///
-/// **`initializationError`** — Gradle generates these for setup methods. When retried and eventually
+/// **`initializationError`** — Gradle generates these for setup methods. When retried and
+// eventually
 /// successful, multiple testcases appear; only the last one passes. All intermediate attempts are
-/// tagged skip. Groups with only one (or zero) `initializationError` entries per classname are left unmodified.
+/// tagged skip. Groups with only one (or zero) `initializationError` entries per classname are left
+// unmodified.
 ///
 /// **`executionError`** and **`test exception`** — Framework-level synthetic failures that do not
-/// represent real test results. Tagged skip unconditionally so Test Optimization treats them as non-failures.
+/// represent real test results. Tagged skip unconditionally so Test Optimization treats them as
+// non-failures.
 ///
 /// Before (two retries of the same class — first is intermediate, second is the final outcome):
 ///
@@ -75,18 +79,22 @@ class TagInitializationErrors {
       }
     }
     for (var group : byClassname.values()) {
-      if (group.size() <= 1) continue;
       for (int i = 0; i < group.size() - 1; i++) {
-        if (tagSkip(doc, group.get(i))) modified = true;
+        if (tagSkip(doc, group.get(i))) {
+          modified = true;
+        }
       }
     }
-    if (!modified) return;
+    if (!modified) {
+      return;
+    }
     var tmpFile = File.createTempFile("TagInitializationErrors", ".xml", xmlFile.getParentFile());
     try {
       var transformer = TransformerFactory.newInstance().newTransformer();
       transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       transformer.transform(new DOMSource(doc), new StreamResult(tmpFile));
-      Files.move(tmpFile.toPath(), xmlFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      Files.move(
+          tmpFile.toPath(), xmlFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
     } catch (Exception e) {
       tmpFile.delete();
       throw e;
@@ -97,12 +105,14 @@ class TagInitializationErrors {
     var children = parent.getChildNodes();
     for (int i = 0; i < children.getLength(); i++) {
       var child = children.item(i);
-      if (child instanceof Element e && tagName.equals(e.getTagName())) return e;
+      if (child instanceof Element e && tagName.equals(e.getTagName())) {
+        return e;
+      }
     }
     return null;
   }
 
-  static boolean tagSkip(org.w3c.dom.Document doc, Element testcase) {
+  static boolean tagSkip(Document doc, Element testcase) {
     var props = firstChildElement(testcase, "properties");
     if (props != null) {
       var children = props.getChildNodes();

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -12,8 +12,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/// Tags synthetic testcases with `dd_tags[test.final_status]=skip` so Test Optimization does not
-/// treat them as real failures.
+/// Tags synthetic testcases (`initializationError`, `executionError`, `test exception`) with
+/// `dd_tags[test.final_status]=skip` so Test Optimization does not treat them as real failures.
+/// The script is idempotent — testcases that already carry a `dd_tags[test.final_status]` property
+/// are left unchanged.
 ///
 /// **`initializationError`** — Gradle generates these for setup methods. When retried and eventually
 /// successful, multiple testcases appear; only the last one passes. All intermediate attempts are

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -93,10 +93,18 @@ class TagInitializationErrors {
     }
   }
 
+  static Element firstChildElement(Element parent, String tagName) {
+    var children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      var child = children.item(i);
+      if (child instanceof Element e && tagName.equals(e.getTagName())) return e;
+    }
+    return null;
+  }
+
   static boolean tagSkip(org.w3c.dom.Document doc, Element testcase) {
-    var existingProperties = testcase.getElementsByTagName("properties");
-    if (existingProperties.getLength() > 0) {
-      var props = (Element) existingProperties.item(0);
+    var props = firstChildElement(testcase, "properties");
+    if (props != null) {
       var existingProps = props.getElementsByTagName("property");
       for (int j = 0; j < existingProps.getLength(); j++) {
         if ("dd_tags[test.final_status]".equals(((Element) existingProps.item(j)).getAttribute("name"))) {

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -64,24 +64,20 @@ class TagInitializationErrors {
     var doc = dbf.newDocumentBuilder().parse(xmlFile);
     var testcases = doc.getElementsByTagName("testcase");
     Map<String, List<Element>> byClassname = new LinkedHashMap<>();
+    boolean modified = false;
     for (int i = 0; i < testcases.getLength(); i++) {
       var e = (Element) testcases.item(i);
-      if ("initializationError".equals(e.getAttribute("name"))) {
+      var name = e.getAttribute("name");
+      if ("initializationError".equals(name)) {
         byClassname.computeIfAbsent(e.getAttribute("classname"), k -> new ArrayList<>()).add(e);
+      } else if ("executionError".equals(name) || "test exception".equals(name)) {
+        if (tagSkip(doc, e)) modified = true;
       }
     }
-    boolean modified = false;
     for (var group : byClassname.values()) {
       if (group.size() <= 1) continue;
       for (int i = 0; i < group.size() - 1; i++) {
         if (tagSkip(doc, group.get(i))) modified = true;
-      }
-    }
-    for (int i = 0; i < testcases.getLength(); i++) {
-      var e = (Element) testcases.item(i);
-      var name = e.getAttribute("name");
-      if ("executionError".equals(name) || "test exception".equals(name)) {
-        if (tagSkip(doc, e)) modified = true;
       }
     }
     if (!modified) return;

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -105,9 +105,11 @@ class TagInitializationErrors {
   static boolean tagSkip(org.w3c.dom.Document doc, Element testcase) {
     var props = firstChildElement(testcase, "properties");
     if (props != null) {
-      var existingProps = props.getElementsByTagName("property");
-      for (int j = 0; j < existingProps.getLength(); j++) {
-        if ("dd_tags[test.final_status]".equals(((Element) existingProps.item(j)).getAttribute("name"))) {
+      var children = props.getChildNodes();
+      for (int j = 0; j < children.getLength(); j++) {
+        if (children.item(j) instanceof Element e
+            && "property".equals(e.getTagName())
+            && "dd_tags[test.final_status]".equals(e.getAttribute("name"))) {
           return false;
         }
       }

--- a/.gitlab/TagInitializationErrors.java
+++ b/.gitlab/TagInitializationErrors.java
@@ -22,20 +22,22 @@ import java.util.Map;
 /// **`executionError`** and **`test exception`** — Framework-level synthetic failures that never
 /// represent a real test result and never fail CI. All occurrences are tagged skip unconditionally.
 ///
-/// Before:
+/// Before (two retries of the same class — first is intermediate, second is the final outcome):
 ///
 /// ```
-/// <testcase name="executionError" />
+/// <testcase name="initializationError" classname="com.example.MyTest" />
+/// <testcase name="initializationError" classname="com.example.MyTest" />
 /// ```
 ///
-/// After:
+/// After (only the intermediate attempt is tagged; the last entry is left untouched):
 ///
 /// ```
-/// <testcase name="executionError">
+/// <testcase name="initializationError" classname="com.example.MyTest">
 ///   <properties>
 ///     <property name="dd_tags[test.final_status]" value="skip" />
 ///   </properties>
 /// </testcase>
+/// <testcase name="initializationError" classname="com.example.MyTest" />
 /// ```
 ///
 /// Usage (Java 25): `java TagInitializationErrors.java junit-report.xml`

--- a/.gitlab/collect_results.sh
+++ b/.gitlab/collect_results.sh
@@ -90,7 +90,7 @@ do
     echo " (non-stable test names detected)"
   fi
 
-  echo "Add dd_tags[test.final_status] property on retried synthetics testcase initializationErrors"
+  echo "Add dd_tags[test.final_status] property on retried synthetics testcase initializationErrors, and all executionError and test exception synthetic testcases"
   $JAVA_25_HOME/bin/java "$(dirname "$0")/TagInitializationErrors.java" "$TARGET_DIR/$AGGREGATED_FILE_NAME"
 
   echo "Add dd_tags[test.final_status] property to each testcase on $TARGET_DIR/$AGGREGATED_FILE_NAME"

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1248,7 +1248,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   }
 
   @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/9396", suites = ["PekkoHttpServerInstrumentationAsyncHttp2Test"])
-  def "test exception"() {
+  def "Instrumentation test exception"() {
     setup:
     def method = "GET"
     def body = null


### PR DESCRIPTION
## What Does This Do
  
  Extends `TagInitializationErrors.java` to also tag `executionError` and `test exception` synthetic testcases
  with `dd_tags[test.final_status]=skip`, unconditionally. Previously, only intermediate                   
  `initializationError` retries were tagged.
                                                                                                         
  The tagging logic is refactored into a shared `tagSkip` helper that uses direct child element lookups    
  (instead of `getElementsByTagName`, which searches all descendants) and is idempotent - testcases already
   carrying the property are left unchanged.     

> This fix has been applied with Claude Code, and refactors have been made to optimize the code and enhance the comments with the help of the local code review Claude plugin. A follow up PR will be opened to rename the executor file to `TagSyntheticFailures.java`                                                        
                                                            
[Detected in CI](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A111335274%20%40test.final_status%3Askip%20%40test.name%3A%22test%20exception%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&refresh_mode=sliding&start=1777322728973&end=1777927528973&paused=false): 
<img width="827" height="721" alt="Screenshot 2026-05-04 at 4 35 51 PM" src="https://github.com/user-attachments/assets/e054af5d-c931-40c9-9c2d-c256002d3204" />


Which should stop such tests from being labelled as failures (`master`)
<img width="1345" height="559" alt="Screenshot 2026-05-04 at 4 47 42 PM" src="https://github.com/user-attachments/assets/0d300ee2-9c7e-4796-93f0-d2efee7fac66" />

##  Motivation

  `executionError` and `test exception` are framework-level synthetic entries that never represent a real    
  test result. Without this change, Test Optimization treats them as genuine failures, producing noise in
   the test results dashboard. Like `initializationError` intermediates, they should be skipped so only    
  real test outcomes are surfaced.    

# Additional Notes
- [x] Follow up PR -  Rename from `TagInitializationErrors.java` to `TagSyntheticFailures.java`

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMLP-1296]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1296]: https://datadoghq.atlassian.net/browse/APMLP-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ