### PR TITLE
Minor OTLP fixes

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/NoopOtlpMetricsCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/NoopOtlpMetricsCollector.java
@@ -1,0 +1,11 @@
+package datadog.trace.core.otlp.metrics;
+
+import datadog.trace.core.otlp.common.OtlpPayload;
+
+final class NoopOtlpMetricsCollector extends OtlpMetricsCollector {
+  static final NoopOtlpMetricsCollector INSTANCE = new NoopOtlpMetricsCollector();
+
+  public OtlpPayload collectMetrics() {
+    return OtlpPayload.EMPTY;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsCollector.java
@@ -3,8 +3,6 @@ package datadog.trace.core.otlp.metrics;
 import datadog.trace.core.otlp.common.OtlpPayload;
 
 /** Collects metrics ready for export. */
-public interface OtlpMetricsCollector {
-  OtlpMetricsCollector NOOP_COLLECTOR = () -> OtlpPayload.EMPTY;
-
-  OtlpPayload collectMetrics();
+public abstract class OtlpMetricsCollector {
+  public abstract OtlpPayload collectMetrics();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoCollector.java
@@ -47,11 +47,8 @@ import java.util.function.Consumer;
  * points) to the payload. Once all the metrics data has been chunked we add the enclosing resource
  * metrics message to the start of the payload.
  */
-public final class OtlpMetricsProtoCollector
-    implements OtlpMetricsVisitor,
-        OtlpScopedMetricsVisitor,
-        OtlpMetricVisitor,
-        OtlpMetricsCollector {
+public final class OtlpMetricsProtoCollector extends OtlpMetricsCollector
+    implements OtlpMetricsVisitor, OtlpScopedMetricsVisitor, OtlpMetricVisitor {
 
   public static final OtlpMetricsProtoCollector INSTANCE =
       new OtlpMetricsProtoCollector(SystemTimeSource.INSTANCE);

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
@@ -51,7 +51,7 @@ public final class OtlpMetricsService {
         break;
       default:
         LOGGER.debug("Unsupported OTLP metrics protocol: {}", config.getOtlpMetricsProtocol());
-        this.collector = OtlpMetricsCollector.NOOP_COLLECTOR;
+        this.collector = NoopOtlpMetricsCollector.INSTANCE;
         this.sender = null;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
@@ -25,6 +25,8 @@ public final class OtlpMetricsService {
 
   private final int intervalMillis;
 
+  private AgentTaskScheduler.Scheduled<?> scheduledTask = null;
+
   private OtlpMetricsService(Config config) {
     this.scheduler = new AgentTaskScheduler(OTLP_METRICS_EXPORTER);
 
@@ -59,6 +61,10 @@ public final class OtlpMetricsService {
   }
 
   public void start() {
+    if (sender == null) {
+      return;
+    }
+
     // add random jitter of up to 5 seconds to initial delay; avoids a fleet
     // of apps starting at the same time from exporting OTLP metrics in sync
     long initialMillis =
@@ -70,8 +76,9 @@ public final class OtlpMetricsService {
                         / Math.log(1 - 0.25)),
                 5_000);
 
-    scheduler.scheduleAtFixedRate(
-        this::export, initialMillis, intervalMillis, TimeUnit.MILLISECONDS);
+    scheduledTask =
+        scheduler.scheduleAtFixedRate(
+            this::export, initialMillis, intervalMillis, TimeUnit.MILLISECONDS);
   }
 
   public void flush() {
@@ -79,6 +86,9 @@ public final class OtlpMetricsService {
   }
 
   public void shutdown() {
+    if (scheduledTask != null) {
+      scheduledTask.cancel();
+    }
     if (sender != null) {
       sender.shutdown();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
@@ -5,10 +5,9 @@ import datadog.trace.core.otlp.common.OtlpPayload;
 import java.util.List;
 
 /** Collects traces ready for export. */
-public interface OtlpTraceCollector {
-  OtlpTraceCollector NOOP_COLLECTOR = () -> OtlpPayload.EMPTY;
+public abstract class OtlpTraceCollector {
 
-  OtlpPayload collectTraces();
+  public abstract void addTrace(List<? extends CoreSpan<?>> spans);
 
-  default void addTrace(List<? extends CoreSpan<?>> spans) {}
+  public abstract OtlpPayload collectTraces();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
@@ -32,7 +32,7 @@ import java.util.List;
  * to the payload. Once all the span data has been chunked we add the enclosing resource span
  * message to the start of the payload.
  */
-public final class OtlpTraceProtoCollector implements OtlpTraceCollector {
+public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
 
   private static final OtelInstrumentationScope DEFAULT_TRACE_SCOPE =
       new OtelInstrumentationScope("", null, null);


### PR DESCRIPTION
# What Does This Do

* Refactor OTLP trace and metrics collectors to use abstract base class pattern
* Don't schedule OTLP metrics export if configured sender is invalid

# Motivation

Apply the review feedback from the [OTLP logs PR](#11253) to trace and metrics as well.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
