### PR TITLE
Correctly export overflow histogram bucket over OTLP

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.47/src/test/java/opentelemetry147/metrics/OpenTelemetryMetricsTest.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.47/src/test/java/opentelemetry147/metrics/OpenTelemetryMetricsTest.java
@@ -166,6 +166,38 @@ class OpenTelemetryMetricsTest extends AbstractInstrumentationTest {
   }
 
   @Test
+  void testLongHistogramOverflow() {
+    io.opentelemetry.api.metrics.LongHistogram histogram =
+        meter.histogramBuilder("long-histogram-overflow").ofLongs().build();
+    histogram.record(20_000); // exceeds highest default boundary of 10_000
+    OtelMetricRegistry.INSTANCE.collectMetrics(meterReader);
+
+    assertEquals(
+        new HistogramData(
+            1.0,
+            Arrays.asList(10_000.0, Double.POSITIVE_INFINITY),
+            Arrays.asList(0.0, 1.0),
+            20_000.0),
+        points.get("test:long-histogram-overflow"));
+  }
+
+  @Test
+  void testDoubleHistogramOverflow() {
+    io.opentelemetry.api.metrics.DoubleHistogram histogram =
+        meter.histogramBuilder("double-histogram-overflow").build();
+    histogram.record(20_000.5); // exceeds highest default boundary of 10_000
+    OtelMetricRegistry.INSTANCE.collectMetrics(meterReader);
+
+    assertEquals(
+        new HistogramData(
+            1.0,
+            Arrays.asList(10_000.0, Double.POSITIVE_INFINITY),
+            Arrays.asList(0.0, 1.0),
+            20_000.5),
+        points.get("test:double-histogram-overflow"));
+  }
+
+  @Test
   void testObservableLongCounter() {
     AutoCloseable observable =
         meter

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProto.java
@@ -134,13 +134,24 @@ public final class OtlpMetricsProto {
       writeI64(buf, histogram.min);
       writeTag(buf, 12, I64_WIRE_TYPE);
       writeI64(buf, histogram.max);
-      for (double bucketCount : histogram.bucketCounts) {
-        writeTag(buf, 6, I64_WIRE_TYPE);
-        writeI64(buf, (long) bucketCount);
-      }
-      for (double bucketBoundary : histogram.bucketBoundaries) {
-        writeTag(buf, 7, I64_WIRE_TYPE);
-        writeI64(buf, bucketBoundary);
+      if (!histogram.bucketCounts.isEmpty()) {
+        boolean hasOverflow = false;
+        for (double bucketBoundary : histogram.bucketBoundaries) {
+          if (!Double.isInfinite(bucketBoundary)) {
+            writeTag(buf, 7, I64_WIRE_TYPE);
+            writeI64(buf, bucketBoundary);
+          } else {
+            hasOverflow = true; // don't write the overflow boundary
+          }
+        }
+        for (double bucketCount : histogram.bucketCounts) {
+          writeTag(buf, 6, I64_WIRE_TYPE);
+          writeI64(buf, (long) bucketCount);
+        }
+        if (!hasOverflow) { // write one more count than boundaries
+          writeTag(buf, 6, I64_WIRE_TYPE);
+          writeI64(buf, 0L);
+        }
       }
     }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoTest.java
@@ -357,63 +357,92 @@ class OtlpMetricsProtoTest {
                         boolAttr("success", true),
                         dblAttr("rate", 0.5))))),
 
-        // ── histogram — no buckets ────────────────────────────────────────────
+        // ── histogram — overflow only (no explicit bounds) ────────────────────
         Arguments.of(
-            "histogram no buckets",
+            "histogram no explicit bounds — overflow bucket only",
             asList(
                 scope(
                     "io.hist",
-                    histogram("response.time", 1.0, emptyList(), asList(1.0), 0.5, 0.5, 0.5)))),
+                    histogram(
+                        "response.time",
+                        1.0,
+                        asList(Double.POSITIVE_INFINITY),
+                        asList(1.0),
+                        0.5,
+                        0.5,
+                        0.5)))),
 
-        // ── histogram — zero count and sum ────────────────────────────────────
+        // ── histogram — zero count and sum with overflow bucket ───────────────
         Arguments.of(
             "histogram zero count and sum",
             asList(
                 scope(
                     "io.hist",
-                    histogram("idle.time", 0.0, emptyList(), asList(0.0), 0.0, 0.0, 0.0)))),
+                    histogram(
+                        "idle.time",
+                        0.0,
+                        asList(Double.POSITIVE_INFINITY),
+                        asList(0.0),
+                        0.0,
+                        0.0,
+                        0.0)))),
 
-        // ── histogram — single explicit bound ─────────────────────────────────
+        // ── histogram — single explicit bound with overflow ───────────────────
         Arguments.of(
-            "histogram single bound",
+            "histogram single bound with overflow",
             asList(
                 scope(
                     "io.hist",
                     histogram(
                         "request.size",
                         5.0,
-                        asList(100.0),
+                        asList(100.0, Double.POSITIVE_INFINITY),
                         asList(4.0, 1.0),
                         280.0,
                         20.0,
                         200.0)))),
 
-        // ── histogram — with explicit bounds and attrs ────────────────────────
+        // ── histogram — finite bounds only (no overflow) — extra zero appended ─
         Arguments.of(
-            "histogram with bounds and string attr",
+            "histogram finite bounds — no overflow — extra zero bucket appended",
+            asList(
+                scope(
+                    "io.hist",
+                    histogram(
+                        "queue.size",
+                        8.0,
+                        asList(50.0, 100.0),
+                        asList(3.0, 5.0),
+                        750.0,
+                        10.0,
+                        95.0)))),
+
+        // ── histogram — with explicit bounds, overflow, and attrs ─────────────
+        Arguments.of(
+            "histogram with bounds, overflow, and string attr",
             asList(
                 scope(
                     "io.hist",
                     histogram(
                         "response.time",
                         10.0,
-                        asList(1.0, 5.0, 10.0),
+                        asList(1.0, 5.0, 10.0, Double.POSITIVE_INFINITY),
                         asList(2.0, 3.0, 4.0, 1.0),
                         45.5,
                         0.5,
                         12.0,
                         strAttr("region", "us-east"))))),
 
-        // ── histogram — many buckets with multiple attrs ───────────────────────
+        // ── histogram — many buckets with overflow and multiple attrs ──────────
         Arguments.of(
-            "histogram many buckets with long and bool attrs",
+            "histogram many buckets with overflow, long and bool attrs",
             asList(
                 scope(
                     "io.hist",
                     histogram(
                         "latency.ms",
                         100.0,
-                        asList(1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0),
+                        asList(1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, Double.POSITIVE_INFINITY),
                         asList(5.0, 10.0, 20.0, 30.0, 15.0, 12.0, 6.0, 2.0),
                         4321.0,
                         0.5,
@@ -985,26 +1014,67 @@ class OtlpMetricsProtoTest {
     assertTrue(foundMin, "min required for histogram " + expected.name);
     assertTrue(foundMax, "max required for histogram " + expected.name);
 
-    assertEquals(
-        hp.bucketCounts.size(),
-        parsedBucketCounts.size(),
-        "bucket_counts size for " + expected.name);
-    for (int i = 0; i < hp.bucketCounts.size(); i++) {
+    // Input uses equal counts and boundaries; derive the expected OTLP wire output:
+    // - finite boundaries are written as explicit_bounds (+Infinity overflow marker is dropped)
+    // - when there is no overflow boundary, one extra zero count is appended so that
+    //   bucket_counts.size() == explicit_bounds.size() + 1, as required by the OTLP spec
+    List<Double> expectedBounds = new ArrayList<>();
+    boolean hasOverflow = false;
+    for (double b : hp.bucketBoundaries) {
+      if (Double.isInfinite(b)) {
+        hasOverflow = true;
+      } else {
+        expectedBounds.add(b);
+      }
+    }
+    List<Long> expectedCounts = new ArrayList<>();
+    for (double c : hp.bucketCounts) {
+      expectedCounts.add((long) c);
+    }
+    if (!expectedCounts.isEmpty() && !hasOverflow) {
+      expectedCounts.add(0L);
+    }
+
+    // OTLP spec: bucket_counts.size() == explicit_bounds.size() + 1, or both 0
+    if (expectedCounts.isEmpty()) {
       assertEquals(
-          (long) hp.bucketCounts.get(i).doubleValue(),
-          (long) parsedBucketCounts.get(i),
-          "bucket_counts[" + i + "] for " + expected.name);
+          0,
+          parsedBounds.size(),
+          "explicit_bounds must be 0 when bucket_counts is 0 for " + expected.name);
+      assertEquals(
+          0,
+          parsedBucketCounts.size(),
+          "bucket_counts must be 0 when explicit_bounds is 0 for " + expected.name);
+    } else {
+      assertEquals(
+          parsedBounds.size() + 1,
+          parsedBucketCounts.size(),
+          "OTLP spec: bucket_counts must be explicit_bounds + 1 for " + expected.name);
+    }
+
+    // +Infinity must never appear as an explicit bound on the wire
+    assertFalse(
+        parsedBounds.stream().anyMatch(b -> Double.isInfinite(b)),
+        "+Infinity must not appear in explicit_bounds for " + expected.name);
+
+    assertEquals(
+        expectedBounds.size(), parsedBounds.size(), "explicit_bounds size for " + expected.name);
+    for (int i = 0; i < expectedBounds.size(); i++) {
+      assertEquals(
+          Double.doubleToRawLongBits(expectedBounds.get(i)),
+          Double.doubleToRawLongBits(parsedBounds.get(i)),
+          "explicit_bounds[" + i + "] for " + expected.name);
     }
 
     assertEquals(
-        hp.bucketBoundaries.size(),
-        parsedBounds.size(),
-        "explicit_bounds size for " + expected.name);
-    for (int i = 0; i < hp.bucketBoundaries.size(); i++) {
+        expectedCounts.size(),
+        parsedBucketCounts.size(),
+        "bucket_counts size for " + expected.name);
+    for (int i = 0; i < expectedCounts.size(); i++) {
       assertEquals(
-          Double.doubleToRawLongBits(hp.bucketBoundaries.get(i)),
-          Double.doubleToRawLongBits(parsedBounds.get(i)),
-          "explicit_bounds[" + i + "] for " + expected.name);
+          (long) expectedCounts.get(i),
+          (long) parsedBucketCounts.get(i),
+          "bucket_counts[" + i + "] for " + expected.name);
     }
 
     assertEquals(


### PR DESCRIPTION
# Motivation

According to [metrics.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto)

> The number of elements in bucket_counts array must be by one greater than the number of elements in explicit_bounds array. The exception to this rule is when the length of bucket_counts is 0, then the length of explicit_bounds must also be 0.

# What Does This Do

When exporting compact OTLP histograms we should omit the overflow bucket boundary of +Infinity, but still export the counts for that bucket. If the overflow bucket is missing  from DDSketch (because it had no counts) then we should export a count of zero for it.

This guarantees the expected behaviour that
```
len(bucket_counts) == len(bucket_boundaries) + 1
```
# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
