### PR TITLE
Consider Gradle wrapper as a wrapper for headless calculations

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ProcessHierarchy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ProcessHierarchy.java
@@ -90,7 +90,8 @@ public class ProcessHierarchy {
   private boolean isGradleLauncher() {
     ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
     return contextClassLoader.getResource("org/gradle/launcher/Main.class") != null
-        || contextClassLoader.getResource("org/gradle/launcher/GradleMain.class") != null;
+        || contextClassLoader.getResource("org/gradle/launcher/GradleMain.class") != null
+        || contextClassLoader.getResource("org/gradle/wrapper/GradleWrapperMain.class") != null;
   }
 
   @Nullable

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ProcessHierarchy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ProcessHierarchy.java
@@ -67,7 +67,7 @@ public class ProcessHierarchy {
   private boolean isWrapper() {
     // Maven Wrapper runs in the same JVM as Maven itself,
     // so it is not included here
-    return isGradleLauncher();
+    return isGradleLauncher() || isGradleWrapper();
   }
 
   private boolean isMavenParent() {
@@ -90,8 +90,16 @@ public class ProcessHierarchy {
   private boolean isGradleLauncher() {
     ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
     return contextClassLoader.getResource("org/gradle/launcher/Main.class") != null
-        || contextClassLoader.getResource("org/gradle/launcher/GradleMain.class") != null
-        || contextClassLoader.getResource("org/gradle/wrapper/GradleWrapperMain.class") != null;
+        || contextClassLoader.getResource("org/gradle/launcher/GradleMain.class") != null;
+  }
+
+  private boolean isGradleWrapper() {
+    // The Gradle Wrapper bootstraps before the launcher classes are on the classpath,
+    // so at premain only the wrapper's own class is visible.
+    return Thread.currentThread()
+            .getContextClassLoader()
+            .getResource("org/gradle/wrapper/GradleWrapperMain.class")
+        != null;
   }
 
   @Nullable

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
@@ -80,8 +80,9 @@ class GradleLauncherSmokeTest extends AbstractGradleTest {
       "DD_CIVISIBILITY_AGENTLESS_URL"     : "${mockBackend.intakeUrl}".toString(),
       "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED": "false",
       "DD_CIVISIBILITY_GIT_CLIENT_ENABLED": "false",
-      "DD_CODE_ORIGIN_FOR_SPANS_ENABLED"  : "false",
-      "DD_API_KEY"                        : "dummy"
+      "DD_CODE_ORIGIN_FOR_SPANS_ENABLED"     : "false",
+      "DD_CIVISIBILITY_CODE_COVERAGE_ENABLED": "false",
+      "DD_API_KEY"                           : "dummy"
     ])
     String[] command = ["./gradlew", "--no-daemon", "--info"]
     if (gradleDaemonCmdLineParams) {


### PR DESCRIPTION
# What Does This Do

- Fixes `ProcessHierarchy.isGradleLauncher()` to not misclassify Gradle wrapper as headless.
- Disables code coverage gathering in the launcher tests to avoid building the repository index for tracer repo on every iteration. 

# Motivation

`:dd-smoke-tests:gradle:test` was timing out on master. Each launcher test iteration was building the repository index twice: once in the Gradle wrapper JVM and once in the spawned Gradle daemon. ProcessHierarchy misclassified the wrapper JVMs as headless due to launcher classes (`org.gradle.launcher.Main/GradleMain`) being missing at premain, since the wrapper loads the Gradle distribution later. Verified by enabling debug logs and seeing two `Building index of source files...` lines in the test output instead of one.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
