### PR TITLE
Fix peer IP tag in Play 2.3/2.4/2.5

### DIFF
--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -153,7 +153,7 @@ public class PlayHttpServerDecorator
       return null;
     }
     final AgentSpan source = span.getLocalRootSpan();
-    final AgentSpan peerSource = (source != null && source != span) ? source : span;
+    final AgentSpan peerSource = source != null ? source : span;
     final Object capturedIp = peerSource.getTag(Tags.PEER_HOST_IPV4);
     final Object peerIp = capturedIp != null ? capturedIp : peerSource.getTag(Tags.PEER_HOST_IPV6);
     if (peerIp != null) {

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -142,16 +142,20 @@ public class PlayHttpServerDecorator
   }
 
   /**
-   * If the span already carries a peer IP (set by the upstream akka/netty instrumentation from the
-   * real TCP socket peer), wrap the request so {@code remoteAddress()} returns that value instead
-   * of Play's X-Forwarded-For-resolved one.
+   * Wraps the connection so that {@code remoteAddress()} returns the real socket peer IP instead of
+   * Play's X-Forwarded-For-resolved value. We look up the local root span (the upstream akka/netty
+   * span) because the play span is a fresh child that has no peer tags yet when {@code onRequest}
+   * is called. When called on the root span itself (e.g. to propagate route info), we use the root
+   * span's existing peer IP so the forwarded value cannot overwrite it.
    */
   private static Request<?> withCapturedPeer(final AgentSpan span, final Request<?> connection) {
     if (connection == null) {
       return null;
     }
-    final Object capturedIp = span.getTag(Tags.PEER_HOST_IPV4);
-    final Object peerIp = capturedIp != null ? capturedIp : span.getTag(Tags.PEER_HOST_IPV6);
+    final AgentSpan source = span.getLocalRootSpan();
+    final AgentSpan peerSource = (source != null && source != span) ? source : span;
+    final Object capturedIp = peerSource.getTag(Tags.PEER_HOST_IPV4);
+    final Object peerIp = capturedIp != null ? capturedIp : peerSource.getTag(Tags.PEER_HOST_IPV6);
     if (peerIp != null) {
       return new RequestWithCapturedPeer(connection, peerIp.toString());
     }

--- a/dd-java-agent/instrumentation/play/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
@@ -54,8 +54,8 @@ class PlayServerTest extends HttpServerTest<TestServer> {
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" (endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
-        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
+        "$Tags.PEER_HOST_IPV4" '127.0.0.1'
+        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -142,16 +142,20 @@ public class PlayHttpServerDecorator
   }
 
   /**
-   * If the span already carries a peer IP (set by the upstream akka/netty instrumentation from the
-   * real TCP socket peer), wrap the request so {@code remoteAddress()} returns that value instead
-   * of Play's X-Forwarded-For-resolved one.
+   * Wraps the connection so that {@code remoteAddress()} returns the real socket peer IP instead of
+   * Play's X-Forwarded-For-resolved value. We look up the local root span (the upstream akka/netty
+   * span) because the play span is a fresh child that has no peer tags yet when {@code onRequest}
+   * is called. When called on the root span itself (e.g. to propagate route info), we use the root
+   * span's existing peer IP so the forwarded value cannot overwrite it.
    */
   private static Request<?> withCapturedPeer(final AgentSpan span, final Request<?> connection) {
     if (connection == null) {
       return null;
     }
-    final Object capturedIp = span.getTag(Tags.PEER_HOST_IPV4);
-    final Object peerIp = capturedIp != null ? capturedIp : span.getTag(Tags.PEER_HOST_IPV6);
+    final AgentSpan source = span.getLocalRootSpan();
+    final AgentSpan peerSource = (source != null && source != span) ? source : span;
+    final Object capturedIp = peerSource.getTag(Tags.PEER_HOST_IPV4);
+    final Object peerIp = capturedIp != null ? capturedIp : peerSource.getTag(Tags.PEER_HOST_IPV6);
     if (peerIp != null) {
       return new RequestWithCapturedPeer(connection, peerIp.toString());
     }

--- a/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
@@ -98,7 +98,7 @@ class PlayScalaRoutesServerTest extends PlayServerTest {
       tags {
         "$Tags.COMPONENT" 'play-action'
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
+        "$Tags.PEER_HOST_IPV4" '127.0.0.1'
         "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host

--- a/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.5/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayServerTest.groovy
@@ -135,8 +135,8 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" (endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
-        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
+        "$Tags.PEER_HOST_IPV4" '127.0.0.1'
+        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String

--- a/dd-java-agent/instrumentation/play/play-appsec-2.7/src/test/groovy/datadog/trace/instrumentation/play27/server/test/PlayAsyncServerRoutesScalaWithErrorHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/play/play-appsec-2.7/src/test/groovy/datadog/trace/instrumentation/play27/server/test/PlayAsyncServerRoutesScalaWithErrorHandlerTest.groovy
@@ -87,7 +87,7 @@ class PlayAsyncServerRoutesScalaWithErrorHandlerTest extends AbstractPlayServer2
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" '127.0.0.1'
-        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
+        "$Tags.HTTP_CLIENT_IP" (endpoint == FORWARDED ? endpoint.body : '127.0.0.1')
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_HOSTNAME" address.host
         "$Tags.HTTP_METHOD" String


### PR DESCRIPTION


# What Does This Do

Follow up to APPSEC-62562, make tests for peer IP tags stricter (never accept IP resolved from `X-Forwarded-For`).

See https://github.com/DataDog/dd-trace-java/pull/11237

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
