### PR TITLE
Remove support for full configuration as RC record

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -447,6 +447,9 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
 
   // only visible for tests
   Map<String, ProbeDefinition> getAppliedDefinitions() {
+    if (currentTransformer == null) {
+      return Collections.emptyMap();
+    }
     return currentConfiguration.getDefinitions().stream()
         .collect(
             Collectors.toMap(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -91,7 +92,6 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
       new EnumMap<>(Source.class);
   private volatile Configuration currentConfiguration;
   private DebuggerTransformer currentTransformer;
-  private final Map<String, ProbeDefinition> appliedDefinitions = new ConcurrentHashMap<>();
   private final ProbeMetadata probeMetadata = new ProbeMetadata();
   private final DebuggerSink sink;
   private final ClassesToRetransformFinder finder;
@@ -201,7 +201,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
 
   private void handleProbesChanges(ConfigurationComparer changes, Configuration newConfiguration) {
     removeCurrentTransformer();
-    storeDebuggerDefinitions(changes);
+    updateProbeMetadata(changes);
     installNewDefinitions(newConfiguration);
     reportReceived(changes);
     if (!finder.hasChangedClasses(changes)) {
@@ -359,7 +359,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
 
   private void installNewDefinitions(Configuration newConfiguration) {
     DebuggerContext.initClassFilter(new DenyListHelper(newConfiguration.getDenyList()));
-    if (appliedDefinitions.isEmpty()) {
+    if (newConfiguration.getDefinitions().isEmpty()) {
       return;
     }
     // install new probe definitions
@@ -372,7 +372,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
             sink);
     instrumentation.addTransformer(newTransformer, true);
     currentTransformer = newTransformer;
-    LOGGER.debug("New transformer installed");
+    LOGGER.debug("New transformer installed with probes: {}", newConfiguration.getDefinitions());
   }
 
   private void recordInstrumentationProgress(
@@ -418,15 +418,10 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     }
   }
 
-  private void storeDebuggerDefinitions(ConfigurationComparer changes) {
+  private void updateProbeMetadata(ConfigurationComparer changes) {
     for (ProbeDefinition definition : changes.getRemovedDefinitions()) {
-      appliedDefinitions.remove(definition.getProbeId().getEncodedId());
       probeMetadata.removeProbe(definition.getProbeId().getEncodedId());
     }
-    for (ProbeDefinition definition : changes.getAddedDefinitions()) {
-      appliedDefinitions.put(definition.getProbeId().getEncodedId(), definition);
-    }
-    LOGGER.debug("Stored appliedDefinitions: {}", appliedDefinitions.values());
   }
 
   // /!\ This is called potentially by multiple threads from the instrumented code /!\
@@ -452,7 +447,11 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
 
   // only visible for tests
   Map<String, ProbeDefinition> getAppliedDefinitions() {
-    return appliedDefinitions;
+    return currentConfiguration.getDefinitions().stream()
+        .collect(
+            Collectors.toMap(
+                probeDefinition -> probeDefinition.getProbeId().getEncodedId(),
+                Function.identity()));
   }
 
   Map<String, InstrumentationResult> getInstrumentationResults() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -188,7 +188,7 @@ public class DebuggerAgent {
       return;
     }
     if (configurationPoller != null) {
-      subscribeLiveDebugging(config, configurationUpdater);
+      subscribeLiveDebugging(configurationUpdater);
     } else {
       LOGGER.debug("No configuration poller available from SharedCommunicationObjects");
     }
@@ -211,11 +211,10 @@ public class DebuggerAgent {
     }
   }
 
-  private static void subscribeLiveDebugging(
-      Config config, ConfigurationUpdater configurationUpdater) {
+  private static void subscribeLiveDebugging(ConfigurationUpdater configurationUpdater) {
     LOGGER.debug("Subscribing to Live Debugging...");
     configurationPoller.addListener(
-        Product.LIVE_DEBUGGING, new DebuggerProductChangesListener(config, configurationUpdater));
+        Product.LIVE_DEBUGGING, new DebuggerProductChangesListener(configurationUpdater));
   }
 
   public static void startSymbolDatabase(Config config) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -1,7 +1,6 @@
 package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
-import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeConfiguration;
 import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeLogProbe;
 import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeMetricProbe;
 import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeSpanDecorationProbe;
@@ -17,14 +16,9 @@ import com.datadog.debugger.probe.TriggerProbe;
 import datadog.remoteconfig.PollingRateHinter;
 import datadog.remoteconfig.state.ConfigKey;
 import datadog.remoteconfig.state.ProductListener;
-import datadog.trace.api.Config;
-import datadog.trace.util.TagsHelper;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -44,12 +38,10 @@ public class DebuggerProductChangesListener implements ProductListener {
               "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
           .asPredicate();
 
-  private final String serviceName;
   private final ConfigurationAcceptor configurationAcceptor;
-  private final Map<String, Consumer<DefinitionBuilder>> configChunks = new HashMap<>();
+  private final Map<String, ProbeDefinition> probeByConfigId = new HashMap<>();
 
-  DebuggerProductChangesListener(Config config, ConfigurationAcceptor configurationAcceptor) {
-    this.serviceName = TagsHelper.sanitize(config.getServiceName());
+  DebuggerProductChangesListener(ConfigurationAcceptor configurationAcceptor) {
     this.configurationAcceptor = configurationAcceptor;
   }
 
@@ -60,31 +52,19 @@ public class DebuggerProductChangesListener implements ProductListener {
     try {
       if (configId.startsWith(METRIC_PROBE_PREFIX)) {
         MetricProbe metricProbe = deserializeMetricProbe(content);
-        configChunks.put(configId, definitions -> definitions.add(metricProbe));
+        probeByConfigId.put(configId, metricProbe);
       } else if (configId.startsWith(LOG_PROBE_PREFIX)) {
         LogProbe logProbe = deserializeLogProbe(content);
-        configChunks.put(configId, definitions -> definitions.add(logProbe));
+        probeByConfigId.put(configId, logProbe);
       } else if (configId.startsWith(SPAN_PROBE_PREFIX)) {
         SpanProbe spanProbe = deserializeSpanProbe(content);
-        configChunks.put(configId, definitions -> definitions.add(spanProbe));
+        probeByConfigId.put(configId, spanProbe);
       } else if (configId.startsWith(TRIGGER_PROBE_PREFIX)) {
         TriggerProbe triggerProbe = deserializeTriggerProbe(content);
-        configChunks.put(configId, definitions -> definitions.add(triggerProbe));
+        probeByConfigId.put(configId, triggerProbe);
       } else if (configId.startsWith(SPAN_DECORATION_PROBE_PREFIX)) {
         SpanDecorationProbe spanDecorationProbe = deserializeSpanDecorationProbe(content);
-        configChunks.put(configId, definitions -> definitions.add(spanDecorationProbe));
-      } else if (IS_UUID.test(configId)) {
-        Configuration newConfig = deserializeConfiguration(content);
-        if (newConfig.getService().equals(serviceName)) {
-          configChunks.put(
-              configId,
-              (builder) -> {
-                builder.addAll(newConfig.getDefinitions());
-              });
-        } else {
-          throw new IOException(
-              "got config.serviceName = " + newConfig.getService() + ", ignoring configuration");
-        }
+        probeByConfigId.put(configId, spanDecorationProbe);
       } else {
         LOGGER.debug("Unsupported configuration id: {}, ignoring configuration", configId);
       }
@@ -96,59 +76,11 @@ public class DebuggerProductChangesListener implements ProductListener {
 
   @Override
   public void remove(ConfigKey configKey, PollingRateHinter pollingRateHinter) throws IOException {
-    configChunks.remove(configKey.getConfigId());
+    probeByConfigId.remove(configKey.getConfigId());
   }
 
   @Override
   public void commit(PollingRateHinter pollingRateHinter) {
-    DefinitionBuilder builder = new DefinitionBuilder();
-    for (Consumer<DefinitionBuilder> chunk : configChunks.values()) {
-      chunk.accept(builder);
-    }
-    configurationAcceptor.accept(REMOTE_CONFIG, builder.build());
-  }
-
-  static class DefinitionBuilder {
-    private final Collection<ProbeDefinition> definitions = new ArrayList<>();
-
-    void add(MetricProbe probe) {
-      definitions.add(probe);
-    }
-
-    void add(LogProbe probe) {
-      definitions.add(probe);
-    }
-
-    void add(SpanProbe probe) {
-      definitions.add(probe);
-    }
-
-    void add(TriggerProbe probe) {
-      definitions.add(probe);
-    }
-
-    void add(SpanDecorationProbe probe) {
-      definitions.add(probe);
-    }
-
-    void addAll(Collection<ProbeDefinition> newDefinitions) {
-      for (ProbeDefinition definition : newDefinitions) {
-        if (definition instanceof MetricProbe) {
-          add((MetricProbe) definition);
-        } else if (definition instanceof LogProbe) {
-          add((LogProbe) definition);
-        } else if (definition instanceof SpanProbe) {
-          add((SpanProbe) definition);
-        } else if (definition instanceof TriggerProbe) {
-          add((TriggerProbe) definition);
-        } else if (definition instanceof SpanDecorationProbe) {
-          add((SpanDecorationProbe) definition);
-        }
-      }
-    }
-
-    Collection<ProbeDefinition> build() {
-      return definitions;
-    }
+    configurationAcceptor.accept(REMOTE_CONFIG, probeByConfigId.values());
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -17,6 +17,7 @@ import datadog.remoteconfig.PollingRateHinter;
 import datadog.remoteconfig.state.ConfigKey;
 import datadog.remoteconfig.state.ProductListener;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -81,6 +82,7 @@ public class DebuggerProductChangesListener implements ProductListener {
 
   @Override
   public void commit(PollingRateHinter pollingRateHinter) {
-    configurationAcceptor.accept(REMOTE_CONFIG, probeByConfigId.values());
+    // create a snapshot of the actual probes stored into probeByConfigId map
+    configurationAcceptor.accept(REMOTE_CONFIG, new ArrayList<>(probeByConfigId.values()));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -1,6 +1,5 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.probe.ProbeDefinitionSerializer.serializeConfiguration;
 import static com.datadog.debugger.probe.ProbeDefinitionSerializer.serializeLogProbe;
 import static com.datadog.debugger.probe.ProbeDefinitionSerializer.serializeMetricProbe;
 import static com.datadog.debugger.probe.ProbeDefinitionSerializer.serializeSpanDecorationProbe;
@@ -32,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.UUID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +43,7 @@ public class DebuggerProductChangesListenerTest {
 
   @Mock private Config tracerConfig;
 
-  class SimpleAcceptor implements ConfigurationAcceptor {
+  static class SimpleAcceptor implements ConfigurationAcceptor {
     private Collection<? extends ProbeDefinition> definitions;
     private Exception lastException;
 
@@ -77,51 +75,7 @@ public class DebuggerProductChangesListenerTest {
   public void testNoConfiguration() {
     SimpleAcceptor acceptor = new SimpleAcceptor();
 
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
-    listener.commit(NOOP);
-
-    assertTrue(acceptor.getDefinitions().isEmpty());
-  }
-
-  @Test
-  public void testSingleConfiguration() {
-    Configuration config =
-        Configuration.builder()
-            .setService(SERVICE_NAME)
-            .add(createLogProbeWithSnapshot(UUID.randomUUID().toString()))
-            .addDenyList(createFilteredList())
-            .build();
-    SimpleAcceptor acceptor = new SimpleAcceptor();
-
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
-
-    acceptConfig(listener, config, UUID.randomUUID().toString());
-    listener.commit(NOOP);
-
-    assertEquals(config.getDefinitions(), acceptor.getDefinitions());
-  }
-
-  @Test
-  public void rejectConfigurationsFromOtherServices() {
-    Configuration config =
-        Configuration.builder()
-            .setService("other-service")
-            .add(createLogProbeWithSnapshot(UUID.randomUUID().toString()))
-            .addDenyList(createFilteredList())
-            .build();
-    SimpleAcceptor acceptor = new SimpleAcceptor();
-
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
-
-    Assertions.assertThrows(
-        IOException.class,
-        () ->
-            listener.accept(
-                createConfigKey(UUID.randomUUID().toString()), toContent(config), NOOP));
-
+    DebuggerProductChangesListener listener = new DebuggerProductChangesListener(acceptor);
     listener.commit(NOOP);
 
     assertTrue(acceptor.getDefinitions().isEmpty());
@@ -131,8 +85,7 @@ public class DebuggerProductChangesListenerTest {
   public void testMultipleSingleProbesConfigurations() {
     SimpleAcceptor acceptor = new SimpleAcceptor();
 
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
+    DebuggerProductChangesListener listener = new DebuggerProductChangesListener(acceptor);
 
     MetricProbe metricProbe = createMetricProbe(UUID.randomUUID().toString());
     LogProbe logProbe = createLogProbe(UUID.randomUUID().toString());
@@ -191,49 +144,9 @@ public class DebuggerProductChangesListenerTest {
   }
 
   @Test
-  public void testMergeConfigWithSingleProbe() {
-    SimpleAcceptor acceptor = new SimpleAcceptor();
-
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
-
-    LogProbe logProbeWithSnapshot = createLogProbeWithSnapshot("123");
-    MetricProbe metricProbe = createMetricProbe("345");
-    LogProbe logProbe = createLogProbe("567");
-    SpanProbe spanProbe = createSpanProbe("890");
-    SpanDecorationProbe spanDecorationProbe = createSpanDecorationProbe("891");
-    TriggerProbe triggerProbe = createTriggerProbe("892");
-
-    Configuration config =
-        Configuration.builder()
-            .setService(SERVICE_NAME)
-            .add(metricProbe)
-            .add(logProbe)
-            .add(spanProbe)
-            .add(spanDecorationProbe)
-            .add(triggerProbe)
-            .add(new LogProbe.Sampling(3.0))
-            .addDenyList(createFilteredList())
-            .build();
-
-    acceptLogProbe(listener, logProbeWithSnapshot);
-    acceptConfig(listener, config, UUID.randomUUID().toString());
-    listener.commit(NOOP);
-    assertDefinitions(
-        acceptor.getDefinitions(),
-        logProbeWithSnapshot,
-        metricProbe,
-        logProbe,
-        spanProbe,
-        spanDecorationProbe,
-        triggerProbe);
-  }
-
-  @Test
   public void badConfigIDFailsToAccept() throws IOException {
     SimpleAcceptor acceptor = new SimpleAcceptor();
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
+    DebuggerProductChangesListener listener = new DebuggerProductChangesListener(acceptor);
     listener.accept(createConfigKey("bad-config-id"), null, NOOP);
     assertNull(acceptor.definitions);
   }
@@ -241,8 +154,7 @@ public class DebuggerProductChangesListenerTest {
   @Test
   public void parsingException() throws IOException {
     SimpleAcceptor acceptor = new SimpleAcceptor();
-    DebuggerProductChangesListener listener =
-        new DebuggerProductChangesListener(tracerConfig, acceptor);
+    DebuggerProductChangesListener listener = new DebuggerProductChangesListener(acceptor);
     String probeUUID = UUID.randomUUID().toString();
     IOException ioException =
         assertThrows(
@@ -263,10 +175,6 @@ public class DebuggerProductChangesListenerTest {
         new HashSet<>(Arrays.asList(expectedDefinitions)), new HashSet<>(actualDefinitions));
   }
 
-  byte[] toContent(Configuration configuration) {
-    return serializeConfiguration(configuration).getBytes(StandardCharsets.UTF_8);
-  }
-
   byte[] toContent(MetricProbe probe) {
     return serializeMetricProbe(probe).getBytes(StandardCharsets.UTF_8);
   }
@@ -285,11 +193,6 @@ public class DebuggerProductChangesListenerTest {
 
   byte[] toContent(TriggerProbe probe) {
     return serializeTriggerProbe(probe).getBytes(StandardCharsets.UTF_8);
-  }
-
-  void acceptConfig(
-      DebuggerProductChangesListener listener, Configuration config, String configId) {
-    assertDoesNotThrow(() -> listener.accept(createConfigKey(configId), toContent(config), NOOP));
   }
 
   void acceptMetricProbe(DebuggerProductChangesListener listener, MetricProbe probe) {


### PR DESCRIPTION
# What Does This Do
In early days we started to have one big configuration per service with all probe definitions. we migrated for one probe per RC record since then. We do not have to support the big configuration record as this is no longer distributed by RemoteConfig.
Remove also appliedConfiguration as this map is in practice useless

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [DEBUG-5515, DEBUG-5511]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
