### PR TITLE
Fix commit push GitHub workflows

### DIFF
--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -43,22 +43,13 @@ jobs:
         run: |
           echo "${{ steps.get-release-version.outputs.VERSION }}: ${{ steps.get-release-url.outputs.URL }}" >> index.yml
       - name: Commit changes
-        id: create-commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if [[ -z "$(git status -s)" ]]; then
-            echo "No changes to commit, exiting."
-            exit 0;
-          fi
-
           git add --all
           git commit -m "chore: Add version ${{ steps.get-release-version.outputs.VERSION }} to Cloud Foundry"
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push changes
         uses: DataDog/commit-headless@ad3668640012ec69186398f43d61923f6878bbbe # action/v3.2.0
-        if: ${{ steps.create-commit.outputs.commit != '' }}
         with:
           branch: cloudfoundry
           command: push

--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -62,4 +62,3 @@ jobs:
         with:
           branch: cloudfoundry
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -115,12 +115,10 @@ jobs:
           fi
       
       - name: Commit changes
-        id: create-commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: Pin system-tests for release branch" .github/workflows/run-system-tests.yaml .gitlab-ci.yml
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       
       - name: Push changes
         uses: DataDog/commit-headless@ad3668640012ec69186398f43d61923f6878bbbe # action/v3.2.0
@@ -130,7 +128,6 @@ jobs:
           head-sha: "${{ steps.get-latest-commit-sha.outputs.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
 
       - name: Create pull request
         env:

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -69,11 +69,9 @@ jobs:
 
       - name: Create core commit
         if: steps.check-core-changes.outputs.commit_changes == 'true'
-        id: create-core-commit
         run: |
           git add --all
           git commit -m "chore: Update Gradle dependencies"
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push core changes
         if: steps.check-core-changes.outputs.commit_changes == 'true'
@@ -84,7 +82,6 @@ jobs:
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-core-commit.outputs.commit }}"
 
       - name: Create core pull request
         if: steps.check-core-changes.outputs.commit_changes == 'true'
@@ -129,11 +126,9 @@ jobs:
 
       - name: Create instrumentation commit
         if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'
-        id: create-instrumentation-commit
         run: |
           git add --all
           git commit -m "chore: Update instrumentation Gradle dependencies"
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push instrumentation changes
         if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'
@@ -144,7 +139,6 @@ jobs:
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-instrumentation-commit.outputs.commit }}"
 
       - name: Create instrumentation pull request
         if: steps.check-instrumentation-changes.outputs.commit_changes == 'true'

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -40,12 +40,10 @@ jobs:
         run: echo "branch=ci/update-jmxfetch-submodule-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Commit changes
         if: steps.check-changes.outputs.commit_changes == 'true'
-        id: create-commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "feat(ci): Update agent-jmxfetch submodule" dd-java-agent/agent-jmxfetch/integrations-core
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push changes
         uses: DataDog/commit-headless@ad3668640012ec69186398f43d61923f6878bbbe # action/v3.2.0
         if: steps.check-changes.outputs.commit_changes == 'true'
@@ -57,7 +55,6 @@ jobs:
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
       - name: Create pull request
         if: steps.check-changes.outputs.commit_changes == 'true'
         env:

--- a/.github/workflows/update-smoke-test-latest-versions.yaml
+++ b/.github/workflows/update-smoke-test-latest-versions.yaml
@@ -121,12 +121,10 @@ jobs:
 
       - name: Create commit
         if: steps.check-changes.outputs.has_changes == 'true'
-        id: create-commit
         run: |
           git add dd-smoke-tests/gradle/src/test/resources/latest-tool-versions.properties \
                   dd-smoke-tests/maven/src/test/resources/latest-tool-versions.properties
           git commit -m "chore: Update smoke test latest tool versions"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push changes
         if: steps.check-changes.outputs.has_changes == 'true'
@@ -137,7 +135,6 @@ jobs:
           head-sha: "${{ github.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
 
       - name: Create pull request
         if: steps.check-changes.outputs.has_changes == 'true'


### PR DESCRIPTION
# What Does This Do

This PR fixes GitHub workflows pushing commits.
They broke after the migration to the next major version of DataDog/comit-headless: https://github.com/DataDog/commit-headless/blob/main/CHANGELOG.md#breaking-changes

# Motivation

It was broke during from this PR: https://github.com/DataDog/dd-trace-java/pull/11114

# Additional Notes

I will backport this PR to the 1.62.x patch branch once approved.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
