### PR TITLE
add mode fingerprint

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.api.Config.DBM_PROPAGATION_MODE_FULL;
-import static datadog.trace.api.Config.DBM_PROPAGATION_MODE_STATIC;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DBM_TRACE_INJECTED;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.INSTRUMENTATION_TIME_MS;
@@ -58,9 +57,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   private static final boolean DBM_INJECT_SQL_BASE_HASH = Config.get().isDbmInjectSqlBaseHash();
   private static final boolean PROPAGATE_PROCESS_TAGS =
       Config.get().isExperimentalPropagateProcessTagsEnabled();
-  public static final boolean INJECT_COMMENT =
-      DBM_PROPAGATION_MODE.equals(DBM_PROPAGATION_MODE_FULL)
-          || DBM_PROPAGATION_MODE.equals(DBM_PROPAGATION_MODE_STATIC);
+  public static final boolean INJECT_COMMENT = Config.get().isDbmCommentInjectionEnabled();
   private static final boolean INJECT_TRACE_CONTEXT =
       DBM_PROPAGATION_MODE.equals(DBM_PROPAGATION_MODE_FULL);
   public static final boolean DBM_TRACE_PREPARED_STATEMENTS =

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/DBMInjectionForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/DBMInjectionForkedTest.groovy
@@ -118,3 +118,36 @@ class DBMBaseHashInjectionForkedTest extends InjectionTest {
     }
   }
 }
+
+class DBMFingerprintInjectionForkedTest extends InjectionTest {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig(TraceInstrumentationConfig.DB_DBM_PROPAGATION_MODE_MODE, "fingerprint")
+  }
+
+  def "fingerprint mode injects base hash without trace context"() {
+    setup:
+    ProcessTags.reset()
+    BaseHash.updateBaseHash(123456789L)
+    def connection = new TestConnection(false)
+
+    when:
+    def statement = connection.createStatement() as TestStatement
+    statement.executeQuery(query)
+
+    then:
+    assert statement.sql == "/*${serviceInjection},ddsh='123456789'*/ ${query}"
+    assertTraces(1) {
+      trace(1) {
+        span {
+          spanType DDSpanTypes.SQL
+          tags(false) {
+            "$Tags.BASE_HASH" "123456789"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCDecoratorTest.groovy
@@ -57,6 +57,18 @@ class JDBCDecoratorServicePropagationForkedTest extends JDBCDecoratorTest {
   }
 }
 
+class JDBCDecoratorFingerprintPropagationForkedTest extends JDBCDecoratorTest {
+  @Override
+  protected void setupPropagationMode() {
+    injectSysConfig(DB_DBM_PROPAGATION_MODE_MODE, "fingerprint")
+  }
+
+  @Override
+  protected boolean expectedFromConfig() {
+    return false
+  }
+}
+
 class JDBCDecoratorNoPropagationForkedTest extends JDBCDecoratorTest {
   @Override
   protected void setupPropagationMode() {

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
@@ -146,6 +146,20 @@ class SQLCommenterTest extends InstrumentationSpecification {
     "/*ddsh='-3750763034362895579'*/ SELECT *" | true       | 234563   | true               | ""    | "/*ddsh='-3750763034362895579'*/ SELECT *"
   }
 
+  def "fingerprint propagation mode enables base hash injection"() {
+    setup:
+    injectSysConfig("dd.service", "")
+    injectSysConfig("dd.env", "")
+    injectSysConfig("dbm.propagation.mode", "fingerprint")
+    ProcessTags.reset()
+    BaseHash.updateBaseHash(234563L)
+
+    expect:
+    Config.get().isDbmCommentInjectionEnabled()
+    Config.get().isDbmInjectSqlBaseHash()
+    SQLCommenter.inject("SELECT *", "", "", "", "", null, false) == "/*ddsh='234563'*/ SELECT *"
+  }
+
   def "test encode Sql Comment with peer service"() {
     setup:
     injectSysConfig("dd.service", "SqlCommenter")

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1778,7 +1778,9 @@ public class Config {
         configProvider.getBoolean(
             DB_DBM_ALWAYS_APPEND_SQL_COMMENT, DEFAULT_DB_DBM_ALWAYS_APPEND_SQL_COMMENT);
 
-    dbmInjectSqlBaseHash = configProvider.getBoolean(DB_DBM_INJECT_SQL_BASEHASH, false);
+    dbmInjectSqlBaseHash =
+        DBM_PROPAGATION_MODE_FINGERPRINT.equals(dbmPropagationMode)
+            || configProvider.getBoolean(DB_DBM_INJECT_SQL_BASEHASH, false);
 
     splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
 
@@ -5648,6 +5650,7 @@ public class Config {
   // Database monitoring propagation mode constants
   public static final String DBM_PROPAGATION_MODE_STATIC = "service";
   public static final String DBM_PROPAGATION_MODE_FULL = "full";
+  public static final String DBM_PROPAGATION_MODE_FINGERPRINT = "fingerprint";
 
   // Helper method to check if comment injection is enabled
   public boolean isDbmCommentInjectionEnabled() {
@@ -5655,7 +5658,8 @@ public class Config {
       return false;
     }
     return dbmPropagationMode.equals(DBM_PROPAGATION_MODE_FULL)
-        || dbmPropagationMode.equals(DBM_PROPAGATION_MODE_STATIC);
+        || dbmPropagationMode.equals(DBM_PROPAGATION_MODE_STATIC)
+        || dbmPropagationMode.equals(DBM_PROPAGATION_MODE_FINGERPRINT);
   }
 
   private void logIgnoredSettingWarning(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1778,8 +1778,10 @@ public class Config {
         configProvider.getBoolean(
             DB_DBM_ALWAYS_APPEND_SQL_COMMENT, DEFAULT_DB_DBM_ALWAYS_APPEND_SQL_COMMENT);
 
+    boolean dbmFingerprintPropagationMode =
+        DBM_PROPAGATION_MODE_FINGERPRINT.equals(dbmPropagationMode);
     dbmInjectSqlBaseHash =
-        DBM_PROPAGATION_MODE_FINGERPRINT.equals(dbmPropagationMode)
+        dbmFingerprintPropagationMode
             || configProvider.getBoolean(DB_DBM_INJECT_SQL_BASEHASH, false);
 
     splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -3347,6 +3347,30 @@ class ConfigTest extends DDSpecification {
     "false" | "true"  | false   // sys prop takes precedence
   }
 
+  def "dbm propagation mode #propagationMode enables base hash injection #expectedBaseHashInjection"() {
+    setup:
+    System.setProperty("dd.dbm.propagation.mode", propagationMode)
+    if (injectBaseHash != null) {
+      System.setProperty("dd.dbm.inject.sql.basehash", injectBaseHash)
+    }
+
+    when:
+    def config = new Config()
+
+    then:
+    config.isDbmCommentInjectionEnabled() == expectedCommentInjection
+    config.isDbmInjectSqlBaseHash() == expectedBaseHashInjection
+
+    where:
+    propagationMode | injectBaseHash | expectedCommentInjection | expectedBaseHashInjection
+    "disabled"      | null           | false                    | false
+    "service"       | null           | true                     | false
+    "full"          | null           | true                     | false
+    "fingerprint"   | null           | true                     | true
+    "fingerprint"   | "false"        | true                     | true
+    "service"       | "true"         | true                     | true
+  }
+
   def "db client info fetching enabled with sys = #sys env = #env"() {
     setup:
     if (sys != null) {


### PR DESCRIPTION
# What Does This Do\

Add a dedicated mode for DBM called `fingerprint` to replace `service` mode

The feature is currently behind `DB_DBM_INJECT_SQL_BASEHASH=true` and having a mode enabled. Instead adding a dedicated mode.

This should be used especially when service names are defined by container tags or in the backend


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
