### PR TITLE
Update latest tracing benchmark SLOs

### DIFF
--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -1,8 +1,8 @@
 # Auto-generated SLO Thresholds
-# Generated: 2026-03-31
+# Generated: 2026-05-05
 #
 # Generation Strategy: tight
-#   Formula: CI_bound / (1 ± T) (T = 10.0%)
+#   Formula: CI_bound / (1 ± T) (T = 15.0%)
 #
 # SLO Checking:
 #   - BREACH: 90% CI boundary crosses threshold
@@ -31,31 +31,31 @@ experiments:
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=normal_operation%2Fonly-tracing&trendsType=scenario
           - name: normal_operation/only-tracing
             thresholds:
-              - agg_http_req_duration_p50 < 2.526 ms
-              - agg_http_req_duration_p99 < 8.5 ms
+              - agg_http_req_duration_p50 < 2.438 ms
+              - agg_http_req_duration_p99 < 8.353 ms
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=normal_operation%2Fotel-latest&trendsType=scenario
           - name: normal_operation/otel-latest
             thresholds:
-              - agg_http_req_duration_p50 < 2.5 ms
-              - agg_http_req_duration_p99 < 10 ms
+              - agg_http_req_duration_p50 < 2.412 ms
+              - agg_http_req_duration_p99 < 10.475 ms
 
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=high_load%2Fonly-tracing&trendsType=scenario
           - name: high_load/only-tracing
             thresholds:
-              - throughput > 1100.0 op/s
+              - throughput > 1042.35 op/s
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=high_load%2Fotel-latest&trendsType=scenario
           - name: high_load/otel-latest
             thresholds:
-              - throughput > 1100.0 op/s
+              - throughput > 1065.01 op/s
 
           # Startup macrobenchmarks
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Atracing%3AAgent.start&trendsType=scenario
           - name: "startup:petclinic:tracing:Agent.start"
             thresholds:
-              - execution_time < 1255.96 ms # generated with --significant-impact-threshold 0.15
+              - execution_time < 1255.96 ms
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aprofiling%3AAgent.start&trendsType=scenario
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aappsec%3AAgent.start&trendsType=scenario
           # https://benchmarking.us1.prod.dog/trends?projectId=4&branch=master&trendsTab=per_scenario&scenario=startup%3Apetclinic%3Aiast%3AAgent.start&trendsType=scenario
           - name: "startup:petclinic:(profiling|appsec|iast):Agent.start"
             thresholds:
-              - execution_time < 1483.46 ms # generated with --significant-impact-threshold 0.15
+              - execution_time < 1483.46 ms


### PR DESCRIPTION
# What Does This Do

Update latest macrobenchmark benchmark failure thresholds based on automatically generated SLOs. Exact changes include:
* `normal_operation/only-tracing`: 
  * tighten `agg_http_req_duration_p50` by 3.5%
  * tighten `agg_http_req_duration_p99` by 1.7%
* `normal_operation/otel-latest`: 
  * tighten `agg_http_req_duration_p50` by 3.5% 
  * loosen `agg_http_req_duration_p99` by 4.8%
* `high_load/only-tracing`: 
  * loosen `throughput` by 5.2%
* `high_load/otel-latest`:
  * loosen `throughput` by 3.2%

# Motivation

The benchmarks are stable according to [the APM SDKs Perf SLOs dashboard](https://app.datadoghq.com/dashboard/w6a-xc3-kyz?fromUser=false&refresh_mode=sliding&tpl_var_conclusion%5B0%5D=%2Awarning&tpl_var_project%5B0%5D=dd-trace-java&tpl_var_scenario%5B0%5D=high_load%2Fonly-tracing&tpl_var_scenario%5B1%5D=high_load%2Fotel-latest&tpl_var_scenario%5B2%5D=normal_operation%2Fotel-latest&tpl_var_scenario%5B3%5D=normal_operation%2Fonly-tracing&from_ts=1770314189862&to_ts=1778086589862&live=true), but they have been emitting warnings for the past few weeks. Loosen the threshold with T=15% to avoid these noisy warnings while still maintaining a strict bound. The values were auto-generated based on the latest runs of `master`, so even with the increase of T from 10 to 15%, some thresholds tightened.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
