### PR TITLE
Remove deprecated internal spanBuilder methods

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -25,7 +25,7 @@ public class DebuggerTracer implements DebuggerContext.Tracer {
       return DebuggerSpan.NOOP_SPAN;
     }
     AgentSpan dynamicSpan =
-        tracerAPI.buildSpan(OPERATION_NAME).withResourceName(resourceName).start();
+        tracerAPI.buildSpan("debugger", OPERATION_NAME).withResourceName(resourceName).start();
     if (tags != null) {
       for (String tag : tags) {
         int idx = tag.indexOf(':');

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -25,7 +25,10 @@ public class DebuggerTracer implements DebuggerContext.Tracer {
       return DebuggerSpan.NOOP_SPAN;
     }
     AgentSpan dynamicSpan =
-        tracerAPI.buildSpan("debugger", OPERATION_NAME).withResourceName(resourceName).start();
+        tracerAPI
+            .buildSpan("dynamic-instrumentation", OPERATION_NAME)
+            .withResourceName(resourceName)
+            .start();
     if (tags != null) {
       for (String tag : tags) {
         int idx = tag.indexOf(':');

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -24,7 +24,7 @@ public class CapturedSnapshot20 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("process").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "process").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       if (arg.equals("exception") || arg.equals("illegal")) {
         return new CapturedSnapshot20().processWithException(arg);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -24,7 +24,7 @@ public class CapturedSnapshot20 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "process").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "process").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       if (arg.equals("exception") || arg.equals("illegal")) {
         return new CapturedSnapshot20().processWithException(arg);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
@@ -24,7 +24,7 @@ public class CapturedSnapshot21 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("rootProcess").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "rootProcess").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot21().rootProcess(arg);
     } finally {
@@ -34,7 +34,7 @@ public class CapturedSnapshot21 {
 
   private int rootProcess(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("process1").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "process1").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process1(arg) + 1;
     } finally {
@@ -44,7 +44,7 @@ public class CapturedSnapshot21 {
 
   private int process1(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("process2").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "process2").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process2(arg) + 1;
     } finally {
@@ -54,7 +54,7 @@ public class CapturedSnapshot21 {
 
   private int process2(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("process3").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "process3").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process3(arg) + 1;
     } finally {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
@@ -24,7 +24,7 @@ public class CapturedSnapshot21 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "rootProcess").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "rootProcess").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot21().rootProcess(arg);
     } finally {
@@ -34,7 +34,7 @@ public class CapturedSnapshot21 {
 
   private int rootProcess(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "process1").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "process1").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process1(arg) + 1;
     } finally {
@@ -44,7 +44,7 @@ public class CapturedSnapshot21 {
 
   private int process1(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "process2").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "process2").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process2(arg) + 1;
     } finally {
@@ -54,7 +54,7 @@ public class CapturedSnapshot21 {
 
   private int process2(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "process3").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "process3").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return process3(arg) + 1;
     } finally {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
@@ -25,7 +25,7 @@ public class CapturedSnapshot28 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("process").start();
+    AgentSpan span = tracerAPI.buildSpan("debugger", "process").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot28().process(arg);
     } finally {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
@@ -25,7 +25,7 @@ public class CapturedSnapshot28 {
 
   public static int main(String arg) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    AgentSpan span = tracerAPI.buildSpan("debugger", "process").start();
+    AgentSpan span = tracerAPI.buildSpan("dynamic-instrumentation", "process").start();
     try (AgentScope scope = tracerAPI.activateManualSpan(span)) {
       return new CapturedSnapshot28().process(arg);
     } finally {

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestTracer.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestTracer.java
@@ -50,7 +50,7 @@ public class DatadogRequestTracer implements RequestTracer {
       seedNodes = parent.getTag(InstrumentationTags.COUCHBASE_SEED_NODES);
     }
 
-    AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder(spanName);
+    AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder("couchbase", spanName);
     if (null != parent) {
       builder.asChildOf(parent.context());
     }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestTracer.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestTracer.java
@@ -54,7 +54,7 @@ public class DatadogRequestTracer implements RequestTracer {
       }
     }
     if (requestSpan == null) {
-      AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder(spanName);
+      AgentTracer.SpanBuilder builder = tracer.singleSpanBuilder("couchbase", spanName);
       if (null != parent) {
         builder.asChildOf(parent.context());
       }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -86,7 +86,11 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
             // The span ID is pre-determined so that we can reference it when setting the context
             final long spanID = DECORATE.setContextInfo(connection, dbInfo);
             // we then force that pre-determined span ID for the span covering the actual query
-            span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
+            span =
+                AgentTracer.get()
+                    .singleSpanBuilder("java-jdbc-prepared_statement", DATABASE_QUERY)
+                    .withSpanId(spanID)
+                    .start();
             span.setTag(DBM_TRACE_INJECTED, true);
           } else if (DECORATE.isPostgres(dbInfo) && DBM_TRACE_PREPARED_STATEMENTS) {
             span = startSpan("java-jdbc-prepared_statement", DATABASE_QUERY);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -336,7 +336,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     // potentially get build span like here
     AgentSpan instrumentationSpan =
         AgentTracer.get()
-            .singleSpanBuilder("set context_info")
+            .singleSpanBuilder("java-jdbc", "set context_info")
             .withTag("dd.instrumentation", true)
             .start();
     DECORATE.afterStart(instrumentationSpan);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -98,7 +98,11 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
             // The span ID is pre-determined so that we can reference it when setting the context
             final long spanID = DECORATE.setContextInfo(connection, dbInfo);
             // we then force that pre-determined span ID for the span covering the actual query
-            span = AgentTracer.get().singleSpanBuilder(DATABASE_QUERY).withSpanId(spanID).start();
+            span =
+                AgentTracer.get()
+                    .singleSpanBuilder("java-jdbc-statement", DATABASE_QUERY)
+                    .withSpanId(spanID)
+                    .start();
           } else if (isOracle) {
             span = startSpan("java-jdbc-statement", DATABASE_QUERY);
             DECORATE.setAction(span, connection);

--- a/dd-java-agent/instrumentation/kotlin-coroutines-1.3/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines-1.3/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -364,7 +364,7 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
     activeSpan().setSpanName(opName)
   }
 
-  protected fun childSpan(opName: String): AgentSpan = get().buildSpan(opName)
+  protected fun childSpan(opName: String): AgentSpan = get().buildSpan("kotlin_coroutine", opName)
     .withResourceName("coroutines-test-span")
     .start()
 

--- a/dd-java-agent/instrumentation/ognl-appsec-3.3.2/src/test/groovy/datadog/trace/instrumentation/ognl/OgnlInstrumentationSpec.groovy
+++ b/dd-java-agent/instrumentation/ognl-appsec-3.3.2/src/test/groovy/datadog/trace/instrumentation/ognl/OgnlInstrumentationSpec.groovy
@@ -8,7 +8,7 @@ import ognl.Ognl
 class OgnlInstrumentationSpec extends InstrumentationSpecification {
   void 'creates a new span for ognl parsing expressions'() {
     when:
-    AgentSpan span = AgentTracer.get().buildSpan("top-span").start()
+    AgentSpan span = AgentTracer.get().buildSpan("ognl", "top-span").start()
     def ognlExpr
     AgentTracer.activateSpan(span).withCloseable {
       ognlExpr = Ognl.parseExpression('foo')

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -417,7 +417,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
     where:
     spanType      | buildSpan                                                                                                                      | finishSpan
     "datadog"     | {
-      TEST_TRACER.buildSpan("contextual").start()
+      TEST_TRACER.buildSpan("reactor-core", "contextual").start()
     }                                                                                | {
       AgentSpan span -> span.finish()
     }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -417,7 +417,7 @@ class ReactorCoreTest extends InstrumentationSpecification {
     where:
     spanType      | buildSpan                                                                                                                      | finishSpan
     "datadog"     | {
-      TEST_TRACER.buildSpan("contextual").start()
+      TEST_TRACER.buildSpan("reactor-core", "contextual").start()
     }                                                                                | {
       AgentSpan span -> span.finish()
     }

--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -1092,7 +1092,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
 
   private AgentTracer.SpanBuilder buildSparkSpan(String spanName, Properties properties) {
     AgentTracer.SpanBuilder builder =
-        tracer.buildSpan(spanName).withSpanType("spark").withTag("app_id", appId);
+        tracer.buildSpan("spark", spanName).withSpanType("spark").withTag("app_id", appId);
 
     if (databricksServiceName != null) {
       builder.withServiceName(databricksServiceName);

--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/SparkLauncherListener.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/SparkLauncherListener.java
@@ -38,7 +38,7 @@ public class SparkLauncherListener implements SparkAppHandle.Listener {
     AgentTracer.TracerAPI tracer = AgentTracer.get();
     AgentSpan span =
         tracer
-            .buildSpan("spark.launcher.launch")
+            .buildSpan("spark-launcher", "spark.launcher.launch")
             .withSpanType("spark")
             .withResourceName("SparkLauncher.startApplication")
             .start();

--- a/dd-java-agent/instrumentation/spark/spark-common/src/test/groovy/datadog/trace/instrumentation/spark/SparkLauncherTest.groovy
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/test/groovy/datadog/trace/instrumentation/spark/SparkLauncherTest.groovy
@@ -100,7 +100,7 @@ class SparkLauncherTest extends InstrumentationSpecification {
     SparkLauncherListener.launcherSpan = null
     def tracer = AgentTracer.get()
     SparkLauncherListener.launcherSpan = tracer
-      .buildSpan("spark.launcher.launch")
+      .buildSpan("spark-launcher", "spark.launcher.launch")
       .withSpanType("spark")
       .withResourceName("SparkLauncher.startApplication")
       .start()
@@ -135,7 +135,7 @@ class SparkLauncherTest extends InstrumentationSpecification {
     SparkLauncherListener.launcherSpan = null
     def tracer = AgentTracer.get()
     SparkLauncherListener.launcherSpan = tracer
-      .buildSpan("spark.launcher.launch")
+      .buildSpan("spark-launcher", "spark.launcher.launch")
       .withSpanType("spark")
       .withResourceName("SparkLauncher.startApplication")
       .start()
@@ -167,7 +167,7 @@ class SparkLauncherTest extends InstrumentationSpecification {
     SparkLauncherListener.launcherSpan = null
     def tracer = AgentTracer.get()
     SparkLauncherListener.launcherSpan = tracer
-      .buildSpan("spark.launcher.launch")
+      .buildSpan("spark-launcher", "spark.launcher.launch")
       .withSpanType("spark")
       .withResourceName("SparkLauncher.startApplication")
       .start()

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
@@ -121,7 +121,7 @@ object ZioTestFixtures {
         ddSpan <- ZIO.succeed(
           AgentTracer
             .get()
-            .buildSpan(opName)
+            .buildSpan("zio.experimental", opName)
             .withResourceName("zio-test")
             .start()
         )

--- a/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
@@ -126,7 +126,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
 
   def createSpans(int count, int delay) {
     for (def index: 1..count) {
-      def span = tracer.buildSpan("operation-${index}").start()
+      def span = tracer.buildSpan("datadog", "operation-${index}").start()
       Thread.sleep(delay)
       span.finish()
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -20,7 +20,7 @@ class PrintingWriterTest extends DDCoreSpecification {
   Types.newParameterizedType(List, Map))))
 
   def setup() {
-    def builder = tracer.buildSpan("fakeOperation")
+    def builder = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanType("fakeType")

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityApmProtocolInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityApmProtocolInterceptorTest.groovy
@@ -20,9 +20,9 @@ class CiVisibilityApmProtocolInterceptorTest extends DDCoreSpecification {
     setup:
     tracer.addTraceInterceptor(CiVisibilityApmProtocolInterceptor.INSTANCE)
 
-    tracer.buildSpan("test-module").withSpanType(DDSpanTypes.TEST_MODULE_END).start().finish()
-    tracer.buildSpan("test-suite").withSpanType(DDSpanTypes.TEST_SUITE_END).start().finish()
-    tracer.buildSpan("test").withSpanType(DDSpanTypes.TEST).start().finish()
+    tracer.buildSpan("datadog", "test-module").withSpanType(DDSpanTypes.TEST_MODULE_END).start().finish()
+    tracer.buildSpan("datadog", "test-suite").withSpanType(DDSpanTypes.TEST_SUITE_END).start().finish()
+    tracer.buildSpan("datadog", "test").withSpanType(DDSpanTypes.TEST).start().finish()
 
     writer.waitForTraces(1)
 
@@ -38,7 +38,7 @@ class CiVisibilityApmProtocolInterceptorTest extends DDCoreSpecification {
     setup:
     tracer.addTraceInterceptor(CiVisibilityApmProtocolInterceptor.INSTANCE)
 
-    def testSpan = tracer.buildSpan("test").withSpanType(DDSpanTypes.TEST).start()
+    def testSpan = tracer.buildSpan("datadog", "test").withSpanType(DDSpanTypes.TEST).start()
     testSpan.setTag(Tags.TEST_SESSION_ID, "session ID")
     testSpan.setTag(Tags.TEST_MODULE_ID, "module ID")
     testSpan.setTag(Tags.TEST_SUITE_ID, "suite ID")

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptorTest.groovy
@@ -20,7 +20,7 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
 
   def "discard a trace that does not come from ci app"() {
     tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
-    tracer.buildSpan("sample-span").start().finish()
+    tracer.buildSpan("datadog", "sample-span").start().finish()
 
     expect:
     writer.size() == 0
@@ -29,7 +29,7 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
   def "do not discard a trace that comes from ci app"() {
     tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
 
-    def span = tracer.buildSpan("sample-span").start()
+    def span = tracer.buildSpan("datadog", "sample-span").start()
     ((DDSpanContext) span.context()).origin = CIConstants.CIAPP_TEST_ORIGIN
     span.finish()
 
@@ -42,7 +42,7 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
     tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
 
 
-    def span = tracer.buildSpan("sample-span").withSpanType(spanType).start()
+    def span = tracer.buildSpan("datadog", "sample-span").withSpanType(spanType).start()
     ((DDSpanContext) span.context()).origin = CIConstants.CIAPP_TEST_ORIGIN
     span.finish()
     writer.waitForTraces(1)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/AsmStandaloneSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/AsmStandaloneSamplerTest.groovy
@@ -23,7 +23,7 @@ class AsmStandaloneSamplerTest extends DDCoreSpecification{
     def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     when:
-    def span1 = tracer.buildSpan("test").start()
+    def span1 = tracer.buildSpan("datadog", "test").start()
     sampler.setSamplingPriority(span1)
 
     then:
@@ -33,7 +33,7 @@ class AsmStandaloneSamplerTest extends DDCoreSpecification{
     span1.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
 
     when:
-    def span2 = tracer.buildSpan("test2").start()
+    def span2 = tracer.buildSpan("datadog", "test2").start()
     sampler.setSamplingPriority(span2)
 
     then:
@@ -43,7 +43,7 @@ class AsmStandaloneSamplerTest extends DDCoreSpecification{
     span2.getSamplingPriority() == PrioritySampling.SAMPLER_DROP
 
     when:
-    def span3 = tracer.buildSpan("test3").start()
+    def span3 = tracer.buildSpan("datadog", "test3").start()
     sampler.setSamplingPriority(span3)
 
     then: "Mock one minute later"

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/ForcePrioritySamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/ForcePrioritySamplerTest.groovy
@@ -17,7 +17,7 @@ class ForcePrioritySamplerTest extends DDCoreSpecification {
     def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     when:
-    def span1 = tracer.buildSpan("test").start()
+    def span1 = tracer.buildSpan("datadog", "test").start()
     sampler.setSamplingPriority(span1)
 
     then:
@@ -43,7 +43,7 @@ class ForcePrioritySamplerTest extends DDCoreSpecification {
     def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
 
     then:
     span.getSamplingPriority() == null
@@ -69,7 +69,7 @@ class ForcePrioritySamplerTest extends DDCoreSpecification {
     when:
     def sampler = new ForcePrioritySampler(SAMPLER_KEEP, DEFAULT)
     def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
     }
@@ -91,7 +91,7 @@ class ForcePrioritySamplerTest extends DDCoreSpecification {
     setup:
     def sampler = new ForcePrioritySampler(SAMPLER_KEEP, DEFAULT)
     def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceTraceSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceTraceSamplerTest.groovy
@@ -90,7 +90,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     when:
     String response = '{"rate_by_service": {"service:spock,env:test":0.0}}'
     serviceSampler.onResponse("traces", serializer.fromJson(response))
-    DDSpan span1 = tracer.buildSpan("fakeOperation")
+    DDSpan span1 = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("foo")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -106,7 +106,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     response = '{"rate_by_service": {"service:spock,env:test":1.0, "service:SPOCK,env:Test": 0.0}}'
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
-    DDSpan span2 = tracer.buildSpan("fakeOperation")
+    DDSpan span2 = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("spock")
       .withTag("env", "test")
       .ignoreActiveSpan().start()
@@ -129,7 +129,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     def response = '{"rate_by_service": {"service:spock,env:test":1.0}}'
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
-    DDSpan span = tracer.buildSpan("fakeOperation")
+    DDSpan span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("SPOCK")
       .withTag("env", "Test")
       .ignoreActiveSpan().start()
@@ -151,7 +151,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
     when:
-    DDSpan span = tracer.buildSpan("fakeOperation")
+    DDSpan span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("spock")
       .withTag("env", "test")
       .ignoreActiveSpan().start()
@@ -176,7 +176,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
       .fromJson('{"rate_by_service":{"service:,env:":1.0,"service:spock,env:":0.0}}'))
 
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
 
     then:
     span.getSamplingPriority() == null
@@ -190,7 +190,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     span.getSamplingPriority() == PrioritySampling.SAMPLER_DROP
 
     when:
-    span = tracer.buildSpan("test").withTag(DDTags.SERVICE_NAME, "spock").start()
+    span = tracer.buildSpan("datadog", "test").withTag(DDTags.SERVICE_NAME, "spock").start()
     span.finish()
     writer.waitForTraces(2)
 
@@ -205,7 +205,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     when:
     def sampler = new RateByServiceTraceSampler()
     def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
     }
@@ -392,7 +392,7 @@ class RateByServiceTraceSamplerTest extends DDCoreSpecification {
     setup:
     def sampler = new RateByServiceTraceSampler()
     def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
@@ -61,7 +61,7 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     sampler instanceof PrioritySampler
 
     when:
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -167,7 +167,7 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     sampler instanceof PrioritySampler
 
     when:
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .withTag("tag", "foo")
@@ -305,7 +305,7 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     PrioritySampler sampler = (PrioritySampler)Sampler.Builder.forConfig(properties)
 
     when:
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withResourceName("resource")
       .withTag("env", "bar")
@@ -370,12 +370,12 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     properties.setProperty(TRACE_RATE_LIMIT, "1")
     Sampler sampler = Sampler.Builder.forConfig(properties)
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
 
-    DDSpan span2 = tracer.buildSpan("operation")
+    DDSpan span2 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -409,12 +409,12 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     properties.setProperty(TRACE_RATE_LIMIT, "1")
     Sampler sampler = Sampler.Builder.forConfig(properties)
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
 
-    DDSpan span2 = tracer.buildSpan("operation")
+    DDSpan span2 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -448,11 +448,11 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     properties.setProperty(TRACE_RATE_LIMIT, "1")
     Sampler sampler = Sampler.Builder.forConfig(properties)
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
-    DDSpan span2 = tracer.buildSpan("operation")
+    DDSpan span2 = tracer.buildSpan("datadog", "operation")
       .withServiceName("foo")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SamplerTest.groovy
@@ -161,7 +161,7 @@ class SamplerTest extends DDSpecification{
     CoreTracer tracer = CoreTracer.builder().writer(new ListWriter()).sampler(sampler).build()
 
     when:
-    DDSpan span = (DDSpan) tracer.buildSpan("test").start()
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "test").start()
     ((PrioritySampler) sampler).setSamplingPriority(span)
 
     then:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SingleSpanSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SingleSpanSamplerTest.groovy
@@ -51,7 +51,7 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     when:
     SingleSpanSampler sampler = SingleSpanSampler.Builder.forConfig(Config.get(properties))
 
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start() as DDSpan
@@ -87,11 +87,11 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     when:
     SingleSpanSampler sampler = SingleSpanSampler.Builder.forConfig(Config.get(properties))
 
-    DDSpan rootSpan = tracer.buildSpan("web.request")
+    DDSpan rootSpan = tracer.buildSpan("datadog", "web.request")
       .withServiceName("webserver")
       .ignoreActiveSpan().start() as DDSpan
 
-    DDSpan childSpan = tracer.buildSpan("web.handler")
+    DDSpan childSpan = tracer.buildSpan("datadog", "web.handler")
       .withServiceName("webserver")
       .asChildOf(rootSpan)
       .ignoreActiveSpan().start() as DDSpan
@@ -127,12 +127,12 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     when:
     SingleSpanSampler sampler = SingleSpanSampler.Builder.forConfig(Config.get(properties))
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start() as DDSpan
 
-    DDSpan span2 = tracer.buildSpan("operation")
+    DDSpan span2 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start() as DDSpan
@@ -167,7 +167,7 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     when:
     SingleSpanSampler sampler = SingleSpanSampler.Builder.forConfig(Config.get(properties))
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start() as DDSpan
@@ -189,7 +189,7 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     when:
     SingleSpanSampler sampler = SingleSpanSampler.Builder.forConfig(Config.get(properties))
 
-    DDSpan span1 = tracer.buildSpan("operation")
+    DDSpan span1 = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start() as DDSpan

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -101,7 +101,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       .flushIntervalMilliseconds(-1)
       .build()
     writer.start()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     writer.write(trace)
@@ -132,7 +132,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       .flushIntervalMilliseconds(-1)
       .build()
     writer.start()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     (1..traceCount).each {
@@ -167,7 +167,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       .flushIntervalMilliseconds(1000)
       .build()
     writer.start()
-    def span = dummyTracer.buildSpan("fakeOperation").start()
+    def span = dummyTracer.buildSpan("datadog", "fakeOperation").start()
     def trace = (1..10).collect { span }
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -109,7 +109,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish succeeds"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish succeeds"
     writer.write(trace)
@@ -122,7 +122,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish for single span sampling"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish succeeds"
     writer.write(trace)
@@ -135,7 +135,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish fails"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish fails"
     writer.write(trace)
@@ -161,7 +161,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
   def "test writer.write closed"() {
     setup:
     writer.close()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     writer.write(trace)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -98,7 +98,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       .alwaysFlush(false)
       .build()
     writer.start()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     writer.write(trace)
@@ -127,7 +127,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       .alwaysFlush(false)
       .build()
     writer.start()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     (1..traceCount).each {
@@ -160,7 +160,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       .alwaysFlush(false)
       .build()
     writer.start()
-    def span = dummyTracer.buildSpan("fakeOperation").start()
+    def span = dummyTracer.buildSpan("datadog", "fakeOperation").start()
     def trace = (1..10).collect { span }
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -99,7 +99,7 @@ class DDIntakeWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish succeeds"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish succeeds"
     writer.write(trace)
@@ -113,7 +113,7 @@ class DDIntakeWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish for single span sampling"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish succeeds"
     writer.write(trace)
@@ -127,7 +127,7 @@ class DDIntakeWriterTest extends DDCoreSpecification {
 
   def "test writer.write publish fails"() {
     setup:
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when: "publish fails"
     writer.write(trace)
@@ -155,7 +155,7 @@ class DDIntakeWriterTest extends DDCoreSpecification {
   def "test writer.write closed"() {
     setup:
     writer.close()
-    def trace = [dummyTracer.buildSpan("fakeOperation").start()]
+    def trace = [dummyTracer.buildSpan("datadog", "fakeOperation").start()]
 
     when:
     writer.write(trace)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceMapperTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceMapperTest.groovy
@@ -17,7 +17,7 @@ class TraceMapperTest extends DDCoreSpecification {
   def "test trace mapper v0.5"() {
     setup:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
-    DDSpan span = (DDSpan) tracer.buildSpan(null).withTag("service.name", "my-service")
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", null).withTag("service.name", "my-service")
       .withTag("elasticsearch.version", "7.0").start()
     span.setBaggageItem("baggage", "item")
     span.context().setDataTop("mydata", "[1,2,3]")

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
@@ -22,7 +22,7 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
 
   def "test normalization for dd intake"() {
     setup:
-    tracer.buildSpan("my-operation-name")
+    tracer.buildSpan("datadog", "my-operation-name")
       .withResourceName("my-resource-name")
       .withSpanType("my-span-type")
       .withServiceName("my-service-name")
@@ -58,7 +58,7 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
   def "test normalization does not implicitly convert span type"() {
     setup:
     def originalSpanType = UTF8BytesString.create("a UTF8 span type")
-    tracer.buildSpan("my-operation-name")
+    tracer.buildSpan("datadog", "my-operation-name")
       .withSpanType(originalSpanType)
       .start().finish()
 
@@ -75,7 +75,7 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
 
   def "test default env setting"() {
     setup:
-    tracer.buildSpan("my-operation-name").start().finish()
+    tracer.buildSpan("datadog", "my-operation-name").start().finish()
     writer.waitForTraces(1)
 
     expect:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -37,7 +37,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "null values for tags delete existing tags"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanType("fakeType")
@@ -68,7 +68,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "special tags set certain values"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanType("fakeType")
@@ -94,7 +94,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "tags can be added to the context"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanType("fakeType")
@@ -126,7 +126,7 @@ class DDSpanContextTest extends DDCoreSpecification {
   def "metrics use the expected types"() {
     // floats should be converted to doubles.
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .start()
@@ -158,7 +158,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "force keep really keeps the trace"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .start()
@@ -188,10 +188,10 @@ class DDSpanContextTest extends DDCoreSpecification {
     def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", tracer.getPropagationTagsFactory().empty(), DATADOG)
       .withRequestContextDataAppSec("dummy")
 
-    def top = tracer.buildSpan("top").asChildOf((AgentSpanContext) extracted).start()
+    def top = tracer.buildSpan("datadog", "top").asChildOf((AgentSpanContext) extracted).start()
     def topC = (DDSpanContext) top.context()
     def topTS = top.getRequestContext().getTraceSegment()
-    def current = tracer.buildSpan("current").asChildOf(top).start()
+    def current = tracer.buildSpan("datadog", "current").asChildOf(top).start()
     def currentTS = current.getRequestContext().getTraceSegment()
     def currentC = (DDSpanContext) current.context()
 
@@ -218,7 +218,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "set single span sampling tags"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .start()
@@ -248,7 +248,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "setting resource name to null is ignored"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .start()
@@ -262,7 +262,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "setting operation name triggers constant encoding"() {
     when:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .start()
@@ -294,13 +294,13 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "Span IDs printed as unsigned long"() {
     setup:
-    def parent = tracer.buildSpan("fakeOperation")
+    def parent = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanId(-987654321)
       .start()
 
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanId(-123456789)
@@ -317,12 +317,12 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "service name source is propagated from parent to child span"() {
     setup:
-    def parent = tracer.buildSpan("parentOperation")
+    def parent = tracer.buildSpan("datadog", "parentOperation")
       .withServiceName("fakeService")
       .start()
 
     when:
-    def child = tracer.buildSpan("childOperation")
+    def child = tracer.buildSpan("datadog", "childOperation")
       .asChildOf(parent.context())
       .start()
     def childContext = child.context() as DDSpanContext

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -39,7 +39,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "getters and setters"() {
     setup:
-    def span = tracer.buildSpan("fakeOperation")
+    def span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("fakeService")
       .withResourceName("fakeResource")
       .withSpanType("fakeType")
@@ -88,7 +88,7 @@ class DDSpanTest extends DDCoreSpecification {
     def span
 
     when:
-    span = tracer.buildSpan(opName).start()
+    span = tracer.buildSpan("datadog", opName).start()
     then:
     span.getResourceName() == opName
     span.getServiceName() != ""
@@ -97,7 +97,7 @@ class DDSpanTest extends DDCoreSpecification {
     final String resourceName = "fake"
     final String serviceName = "myService"
     span = tracer
-      .buildSpan(opName)
+      .buildSpan("datadog", opName)
       .withResourceName(resourceName)
       .withServiceName(serviceName)
       .start()
@@ -109,7 +109,7 @@ class DDSpanTest extends DDCoreSpecification {
   def "duration measured in nanoseconds"() {
     setup:
     def mod = TimeUnit.MILLISECONDS.toNanos(1)
-    def builder = tracer.buildSpan("test")
+    def builder = tracer.buildSpan("datadog", "test")
     def start = System.nanoTime()
     def span = builder.start()
     def between = System.nanoTime()
@@ -128,7 +128,7 @@ class DDSpanTest extends DDCoreSpecification {
   def "phasedFinish captures duration but doesn't publish immediately"() {
     setup:
     def mod = TimeUnit.MILLISECONDS.toNanos(1)
-    def builder = tracer.buildSpan("test")
+    def builder = tracer.buildSpan("datadog", "test")
     def start = System.nanoTime()
     def span = builder.start()
     def between = System.nanoTime()
@@ -192,7 +192,7 @@ class DDSpanTest extends DDCoreSpecification {
     setup:
     def mod = TimeUnit.MILLISECONDS.toNanos(1)
     def start = System.currentTimeMillis()
-    def builder = tracer.buildSpan("test")
+    def builder = tracer.buildSpan("datadog", "test")
       .withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()))
     def span = builder.start()
     def between = System.currentTimeMillis()
@@ -211,7 +211,7 @@ class DDSpanTest extends DDCoreSpecification {
   def "stopping with a timestamp disables nanotime"() {
     setup:
     def mod = TimeUnit.MILLISECONDS.toNanos(1)
-    def builder = tracer.buildSpan("test")
+    def builder = tracer.buildSpan("datadog", "test")
     def start = System.currentTimeMillis()
     def span = builder.start()
     def between = System.currentTimeMillis()
@@ -230,7 +230,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "stopping with a timestamp before start time yields a min duration of 1"() {
     setup:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
 
     // remove tick precision part of our internal time to match previous test condition
     span.finish(TimeUnit.MILLISECONDS.toMicros(TimeUnit.NANOSECONDS.toMillis(span.startTimeNano)) - 10)
@@ -241,14 +241,14 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "priority sampling metric set only on root span"() {
     setup:
-    def parent = tracer.buildSpan("testParent").start()
-    def child1 = tracer.buildSpan("testChild1").asChildOf(parent).start()
+    def parent = tracer.buildSpan("datadog", "testParent").start()
+    def child1 = tracer.buildSpan("datadog", "testChild1").asChildOf(parent).start()
 
     child1.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     child1.context().lockSamplingPriority()
     parent.setSamplingPriority(PrioritySampling.SAMPLER_DROP)
     child1.finish()
-    def child2 = tracer.buildSpan("testChild2").asChildOf(parent).start()
+    def child2 = tracer.buildSpan("datadog", "testChild2").asChildOf(parent).start()
     child2.finish()
     parent.finish()
 
@@ -264,8 +264,8 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "origin set only on root span"() {
     setup:
-    def parent = tracer.buildSpan("testParent").asChildOf(extractedContext).start().context()
-    def child = tracer.buildSpan("testChild1").asChildOf(parent).start().context()
+    def parent = tracer.buildSpan("datadog", "testParent").asChildOf(extractedContext).start().context()
+    def child = tracer.buildSpan("datadog", "testChild1").asChildOf(parent).start().context()
 
     expect:
     parent.origin == "some-origin"
@@ -281,8 +281,8 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
     setup:
-    def root = tracer.buildSpan("root").asChildOf((AgentSpanContext) extractedContext).start()
-    def child = tracer.buildSpan("child").asChildOf(root).start()
+    def root = tracer.buildSpan("datadog", "root").asChildOf((AgentSpanContext) extractedContext).start()
+    def child = tracer.buildSpan("datadog", "child").asChildOf(root).start()
 
     expect:
     root.isRootSpan() == isTraceRootSpan
@@ -300,8 +300,8 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
     setup:
-    def root = tracer.buildSpan("root").asChildOf((AgentSpanContext) extractedContext).start()
-    def child = tracer.buildSpan("child").asChildOf(root).start()
+    def root = tracer.buildSpan("datadog", "root").asChildOf((AgentSpanContext) extractedContext).start()
+    def child = tracer.buildSpan("datadog", "child").asChildOf(root).start()
 
     expect:
     root.localRootSpan == root
@@ -324,8 +324,8 @@ class DDSpanTest extends DDCoreSpecification {
     setup:
     def reqContextData = Mock(Closeable)
     def context = new TagContext().withRequestContextDataAppSec(reqContextData)
-    def root = tracer.buildSpan("root").asChildOf(context).start()
-    def child = tracer.buildSpan("child").asChildOf(root).start()
+    def root = tracer.buildSpan("datadog", "root").asChildOf(context).start()
+    def child = tracer.buildSpan("datadog", "child").asChildOf(root).start()
 
     expect:
     root.requestContext.getData(RequestContextSlot.APPSEC).is(reqContextData)
@@ -384,7 +384,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "broken pipe exception does not create error span"() {
     when:
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     span.addThrowable(new IOException("Broken pipe"))
     then:
     !span.isError()
@@ -394,7 +394,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "wrapped broken pipe exception does not create error span"() {
     when:
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     span.addThrowable(new RuntimeException(new IOException("Broken pipe")))
     then:
     !span.isError()
@@ -404,7 +404,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "null exception safe to add"() {
     when:
-    def span = tracer.buildSpan("root").start()
+    def span = tracer.buildSpan("datadog", "root").start()
     span.addThrowable(null)
     then:
     !span.isError()
@@ -413,7 +413,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "set single span sampling tags"() {
     setup:
-    def span = tracer.buildSpan("testSpan").start() as DDSpan
+    def span = tracer.buildSpan("datadog", "testSpan").start() as DDSpan
 
     expect:
     span.samplingPriority() == UNSET
@@ -437,7 +437,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "error priorities should be respected"() {
     setup:
-    def span = tracer.buildSpan("testSpan").start() as DDSpan
+    def span = tracer.buildSpan("datadog", "testSpan").start() as DDSpan
 
     expect:
     !span.isError()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/KnuthSamplingRateTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/KnuthSamplingRateTest.groovy
@@ -73,7 +73,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
     when:
-    DDSpan span = tracer.buildSpan("fakeOperation")
+    DDSpan span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("spock")
       .withTag("env", "test")
       .ignoreActiveSpan().start()
@@ -104,7 +104,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
 
     when:
     Sampler sampler = Sampler.Builder.forConfig(properties)
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -139,7 +139,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
 
     when:
     Sampler sampler = Sampler.Builder.forConfig(properties)
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -166,7 +166,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
 
     when:
     Sampler sampler = Sampler.Builder.forConfig(properties)
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -191,7 +191,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
 
     when:
     Sampler sampler = Sampler.Builder.forConfig(properties)
-    DDSpan span = tracer.buildSpan("operation")
+    DDSpan span = tracer.buildSpan("datadog", "operation")
       .withServiceName("service")
       .withTag("env", "bar")
       .ignoreActiveSpan().start()
@@ -215,7 +215,7 @@ class KnuthSamplingRateTest extends DDCoreSpecification {
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
     when:
-    DDSpan span = tracer.buildSpan("fakeOperation")
+    DDSpan span = tracer.buildSpan("datadog", "fakeOperation")
       .withServiceName("spock")
       .withTag("env", "test")
       .ignoreActiveSpan().start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -16,7 +16,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
   def writer = new ListWriter()
   def tracer = tracerBuilder().writer(writer).build()
 
-  DDSpan rootSpan = tracer.buildSpan("fakeOperation").start()
+  DDSpan rootSpan = tracer.buildSpan("datadog", "fakeOperation").start()
   PendingTrace traceCollector = rootSpan.context().traceCollector
 
   def setup() {
@@ -42,7 +42,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
 
   def "child finishes before parent"() {
     when:
-    def child = tracer.buildSpan("child").asChildOf(rootSpan).start()
+    def child = tracer.buildSpan("datadog", "child").asChildOf(rootSpan).start()
 
     then:
     traceCollector.pendingReferenceCount == 2
@@ -68,7 +68,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
 
   def "parent finishes before child which holds up trace"() {
     when:
-    def child = tracer.buildSpan("child").asChildOf(rootSpan).start()
+    def child = tracer.buildSpan("datadog", "child").asChildOf(rootSpan).start()
 
     then:
     traceCollector.pendingReferenceCount == 2
@@ -98,7 +98,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
     // this shouldn't happen, but it's possible users of the api
     // may incorrectly add spans after the trace is reported.
     // in those cases we should still decrement the pending trace count
-    DDSpan childSpan = tracer.buildSpan("child").asChildOf(rootSpan).start()
+    DDSpan childSpan = tracer.buildSpan("datadog", "child").asChildOf(rootSpan).start()
     childSpan.finish()
     writer.waitForTraces(2)
 
@@ -118,10 +118,10 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
     when:
     injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "2")
     def quickTracer = tracerBuilder().writer(writer).build()
-    def rootSpan = quickTracer.buildSpan("root").start()
+    def rootSpan = quickTracer.buildSpan("datadog", "root").start()
     def traceCollector = rootSpan.context().traceCollector
-    def child1 = quickTracer.buildSpan("child1").asChildOf(rootSpan).start()
-    def child2 = quickTracer.buildSpan("child2").asChildOf(rootSpan).start()
+    def child1 = quickTracer.buildSpan("datadog", "child1").asChildOf(rootSpan).start()
+    def child2 = quickTracer.buildSpan("datadog", "child2").asChildOf(rootSpan).start()
 
     then:
     traceCollector.pendingReferenceCount == 3
@@ -163,10 +163,10 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
     when:
     injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "2")
     def quickTracer = tracerBuilder().writer(writer).build()
-    def rootSpan = quickTracer.buildSpan("root").start()
+    def rootSpan = quickTracer.buildSpan("datadog", "root").start()
     def trace = rootSpan.context().traceCollector
-    def child1 = quickTracer.buildSpan("child1").asChildOf(rootSpan).start()
-    def child2 = quickTracer.buildSpan("child2").asChildOf(rootSpan).start()
+    def child1 = quickTracer.buildSpan("datadog", "child1").asChildOf(rootSpan).start()
+    def child2 = quickTracer.buildSpan("datadog", "child2").asChildOf(rootSpan).start()
 
     then:
     trace.pendingReferenceCount == 3

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -101,7 +101,7 @@ class TraceInterceptorTest extends DDCoreSpecification {
           return priority
         }
       })
-    tracer.buildSpan("test " + score).start().finish()
+    tracer.buildSpan("datadog", "test " + score).start().finish()
     if (score == TestInterceptor.priority) {
       // the interceptor didn't get added, so latch will never be released.
       writer.waitForTraces(1)
@@ -148,7 +148,7 @@ class TraceInterceptorTest extends DDCoreSpecification {
           return 1
         }
       })
-    tracer.buildSpan("test").start().finish()
+    tracer.buildSpan("datadog", "test").start().finish()
     writer.waitForTraces(1)
 
     expect:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/IterationSpansForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/IterationSpansForkedTest.groovy
@@ -30,7 +30,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
   def "root iteration scope lifecycle"() {
     when:
     tracer.closePrevious(true)
-    def span1 = tracer.buildSpan("next1").start()
+    def span1 = tracer.buildSpan("datadog", "next1").start()
     def scope1 = tracer.activateNext(span1)
 
     then:
@@ -43,7 +43,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
     when:
     tracer.closePrevious(true)
-    def span2 = tracer.buildSpan("next2").start()
+    def span2 = tracer.buildSpan("datadog", "next2").start()
     def scope2 = tracer.activateNext(span2)
 
     then:
@@ -57,7 +57,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
     when:
     tracer.closePrevious(true)
-    def span3 = tracer.buildSpan("next3").start()
+    def span3 = tracer.buildSpan("datadog", "next3").start()
     def scope3 = tracer.activateNext(span3)
 
     then:
@@ -83,12 +83,12 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
   def "non-root iteration scope lifecycle"() {
     setup:
-    def span0 = tracer.buildSpan("parent").start()
+    def span0 = tracer.buildSpan("datadog", "parent").start()
     def scope0 = tracer.activateSpan(span0)
 
     when:
     tracer.closePrevious(true)
-    def span1 = tracer.buildSpan("next1").start()
+    def span1 = tracer.buildSpan("datadog", "next1").start()
     def scope1 = tracer.activateNext(span1)
 
     then:
@@ -101,7 +101,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
     when:
     tracer.closePrevious(true)
-    def span2 = tracer.buildSpan("next2").start()
+    def span2 = tracer.buildSpan("datadog", "next2").start()
     def scope2 = tracer.activateNext(span2)
 
     then:
@@ -115,7 +115,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
     when:
     tracer.closePrevious(true)
-    def span3 = tracer.buildSpan("next3").start()
+    def span3 = tracer.buildSpan("datadog", "next3").start()
     def scope3 = tracer.activateNext(span3)
 
     then:
@@ -146,7 +146,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
   def "nested iteration scope lifecycle"() {
     when:
     tracer.closePrevious(true)
-    def span1 = tracer.buildSpan("next").start()
+    def span1 = tracer.buildSpan("datadog", "next").start()
     def scope1 = tracer.activateNext(span1)
 
     then:
@@ -158,12 +158,12 @@ class IterationSpansForkedTest extends DDCoreSpecification {
     !spanFinished(span1)
 
     when:
-    def span1A = tracer.buildSpan("method").start()
+    def span1A = tracer.buildSpan("datadog", "method").start()
     def scope1A = tracer.activateSpan(span1A)
 
     and:
     tracer.closePrevious(true)
-    def span1A1 = tracer.buildSpan("next").start()
+    def span1A1 = tracer.buildSpan("datadog", "next").start()
     def scope1A1 = tracer.activateNext(span1A1)
 
     then:
@@ -177,7 +177,7 @@ class IterationSpansForkedTest extends DDCoreSpecification {
 
     when:
     tracer.closePrevious(true)
-    def span1A2 = tracer.buildSpan("next").start()
+    def span1A2 = tracer.buildSpan("datadog", "next").start()
     def scope1A2 = tracer.activateNext(span1A2)
 
     then:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -38,7 +38,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    def span = tracer.buildSpan("some span").withTag(tag, name).start()
+    def span = tracer.buildSpan("datadog", "some span").withTag(tag, name).start()
     span.finish()
 
     then:
@@ -73,7 +73,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    def span = tracer.buildSpan("some span").start()
+    def span = tracer.buildSpan("datadog", "some span").start()
     span.finish()
 
     then:
@@ -92,7 +92,7 @@ class TagInterceptorTest extends DDCoreSpecification {
   def "set service name from servlet.context with context '#context'"() {
     when:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag(DDTags.SERVICE_NAME, serviceName)
     span.setTag("servlet.context", context)
 
@@ -118,7 +118,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     when:
     injectSysConfig("service", serviceName)
     def tracer = tracerBuilder().writer(new ListWriter()).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag("servlet.context", context)
 
     then:
@@ -153,7 +153,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    def span = tracer.buildSpan("some span").start()
+    def span = tracer.buildSpan("datadog", "some span").start()
     span.setTag("servlet.context", context)
     span.finish()
 
@@ -192,7 +192,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       Collections.emptySet(), new RuleFlags(), jeeActive))
       .build()
     when:
-    def span = tracer.buildSpan("some span").start()
+    def span = tracer.buildSpan("datadog", "some span").start()
     span.setTag(InstrumentationTags.SERVLET_CONTEXT, "some-context")
     span.finish()
 
@@ -213,7 +213,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:
-    def span = tracer.buildSpan("some span")
+    def span = tracer.buildSpan("datadog", "some span")
       .withTag(Tags.PEER_SERVICE, "peer-service")
       .withTag(Tags.MESSAGE_BUS_DESTINATION, "some-queue")
       .start()
@@ -231,7 +231,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:
-    def span = tracer.buildSpan("some span").start()
+    def span = tracer.buildSpan("datadog", "some span").start()
     span.setTag(Tags.PEER_SERVICE, "peer-service")
     span.setTag(Tags.MESSAGE_BUS_DESTINATION, "some-queue")
     span.finish()
@@ -249,7 +249,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:
-    def span = tracer.buildSpan("some span")
+    def span = tracer.buildSpan("datadog", "some span")
       .withTag(Tags.MESSAGE_BUS_DESTINATION, "some-queue")
       .withTag(Tags.PEER_SERVICE, "peer-service")
       .start()
@@ -271,7 +271,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:
-    def span = tracer.buildSpan("some span").start()
+    def span = tracer.buildSpan("datadog", "some span").start()
     span.setTag(Tags.MESSAGE_BUS_DESTINATION, "some-queue")
     span.setTag(Tags.PEER_SERVICE, "peer-service")
     span.finish()
@@ -288,7 +288,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
 
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag(DDTags.RESOURCE_NAME, name)
     span.finish()
     writer.waitForTraces(1)
@@ -308,7 +308,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
 
-    def span = tracer.buildSpan("test").withResourceName("keep").start()
+    def span = tracer.buildSpan("datadog", "test").withResourceName("keep").start()
     span.setTag(DDTags.RESOURCE_NAME, null)
     span.finish()
     writer.waitForTraces(1)
@@ -323,7 +323,7 @@ class TagInterceptorTest extends DDCoreSpecification {
   def "set span type"() {
     when:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setSpanType(type)
     span.finish()
 
@@ -341,7 +341,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     when:
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag(DDTags.SPAN_TYPE, type)
     span.finish()
     writer.waitForTraces(1)
@@ -360,7 +360,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     when:
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
 
     then:
     span.getTag(ANALYTICS_SAMPLE_RATE) == null
@@ -399,7 +399,7 @@ class TagInterceptorTest extends DDCoreSpecification {
   def "set priority sampling via tag"() {
     when:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag(tag, value)
 
     then:
@@ -443,7 +443,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     when:
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("datadog", "test").start()
     span.setTag(Tags.ERROR, error)
     span.finish()
     writer.waitForTraces(1)
@@ -466,7 +466,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = tracerBuilder().writer(writer).build()
 
     when:
-    def span = tracer.buildSpan("interceptor.test").withTag(name, value).start()
+    def span = tracer.buildSpan("datadog", "interceptor.test").withTag(name, value).start()
     span.finish()
     writer.waitForTraces(1)
 
@@ -489,7 +489,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     def tracer = tracerBuilder().writer(writer).build()
 
     when:
-    def span = tracer.buildSpan("decorator.test").withTag("sn.tag1", "some val").start()
+    def span = tracer.buildSpan("datadog", "decorator.test").withTag("sn.tag1", "some val").start()
     span.finish()
     writer.waitForTraces(1)
 
@@ -497,13 +497,13 @@ class TagInterceptorTest extends DDCoreSpecification {
     span.serviceName == "some val"
 
     when:
-    span = tracer.buildSpan("decorator.test").withTag("servlet.context", "/my-servlet").start()
+    span = tracer.buildSpan("datadog", "decorator.test").withTag("servlet.context", "/my-servlet").start()
 
     then:
     span.serviceName == "my-servlet"
 
     when:
-    span = tracer.buildSpan("decorator.test").withTag("error", "true").start()
+    span = tracer.buildSpan("datadog", "decorator.test").withTag("error", "true").start()
     span.finish()
     writer.waitForTraces(2)
 
@@ -511,7 +511,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     span.error
 
     when:
-    span = tracer.buildSpan("decorator.test").withTag(Tags.DB_STATEMENT, "some-statement").start()
+    span = tracer.buildSpan("datadog", "decorator.test").withTag(Tags.DB_STATEMENT, "some-statement").start()
     span.finish()
     writer.waitForTraces(3)
 
@@ -533,7 +533,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    def span = tracer.buildSpan("some span").withTag(DDTags.SERVICE_NAME, "other-service").start()
+    def span = tracer.buildSpan("datadog", "some span").withTag(DDTags.SERVICE_NAME, "other-service").start()
     span.finish()
 
     then:
@@ -561,7 +561,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    def span = tracer.buildSpan("some span").withTag(tag, name).start()
+    def span = tracer.buildSpan("datadog", "some span").withTag(tag, name).start()
     span.finish()
 
     then:
@@ -585,11 +585,11 @@ class TagInterceptorTest extends DDCoreSpecification {
       .sampler(new AllSampler())
       .build()
 
-    AgentSpan parent = tracer.buildSpan("parent")
+    AgentSpan parent = tracer.buildSpan("datadog", "parent")
       .withServiceName("parent").start()
 
     when: "the service name doesn't match the parent"
-    AgentSpan child = tracer.buildSpan("child")
+    AgentSpan child = tracer.buildSpan("datadog", "child")
       .withServiceName("child")
       .asChildOf(parent)
       .start()
@@ -622,7 +622,7 @@ class TagInterceptorTest extends DDCoreSpecification {
       .build()
 
     when:
-    AgentSpan span = tracer.buildSpan("test").start()
+    AgentSpan span = tracer.buildSpan("datadog", "test").start()
 
     then:
     span.getSamplingPriority() == null
@@ -649,7 +649,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     setup:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
 
-    def span = tracer.buildSpan("fakeOperation").start()
+    def span = tracer.buildSpan("datadog", "fakeOperation").start()
     meta.each {
       span.setTag(it.key, (String) it.value)
     }
@@ -681,7 +681,7 @@ class TagInterceptorTest extends DDCoreSpecification {
     setup:
     def tracer = tracerBuilder().writer(new ListWriter()).build()
 
-    def span = tracer.buildSpan("fakeOperation").start()
+    def span = tracer.buildSpan("datadog", "fakeOperation").start()
 
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/llmobs/writer/ddintake/LLMObsSpanMapperTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/llmobs/writer/ddintake/LLMObsSpanMapperTest.groovy
@@ -28,7 +28,7 @@ class LLMObsSpanMapperTest extends DDCoreSpecification {
 
 
     // Create a real LLMObs span using the tracer
-    def llmSpan = tracer.buildSpan("openai.request")
+    def llmSpan = tracer.buildSpan("datadog", "openai.request")
       .withResourceName("createCompletion")
       .withTag("_ml_obs_tag.span.kind", Tags.LLMOBS_LLM_SPAN_KIND)
       .withTag("_ml_obs_tag.model_name", "gpt-4")
@@ -183,14 +183,14 @@ class LLMObsSpanMapperTest extends DDCoreSpecification {
     def mapper = new LLMObsSpanMapper()
     def tracer = tracerBuilder().writer(new ListWriter()).build()
 
-    def regularSpan1 = tracer.buildSpan("http.request")
+    def regularSpan1 = tracer.buildSpan("datadog", "http.request")
       .withResourceName("GET /api/users")
       .withTag("http.method", "GET")
       .withTag("http.url", "https://example.com/api/users")
       .start()
     regularSpan1.finish()
 
-    def regularSpan2 = tracer.buildSpan("database.query")
+    def regularSpan2 = tracer.buildSpan("datadog", "database.query")
       .withResourceName("SELECT * FROM users")
       .withTag("db.type", "postgresql")
       .start()
@@ -215,7 +215,7 @@ class LLMObsSpanMapperTest extends DDCoreSpecification {
     def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     // First trace with 2 LLMObs spans
-    def llmSpan1 = tracer.buildSpan("chat-completion-1")
+    def llmSpan1 = tracer.buildSpan("datadog", "chat-completion-1")
       .withTag("_ml_obs_tag.span.kind", Tags.LLMOBS_LLM_SPAN_KIND)
       .withTag("_ml_obs_tag.model_name", "gpt-4")
       .withTag("_ml_obs_tag.model_provider", "openai")
@@ -223,7 +223,7 @@ class LLMObsSpanMapperTest extends DDCoreSpecification {
     llmSpan1.setSpanType(InternalSpanTypes.LLMOBS)
     llmSpan1.finish()
 
-    def llmSpan2 = tracer.buildSpan("chat-completion-2")
+    def llmSpan2 = tracer.buildSpan("datadog", "chat-completion-2")
       .withTag("_ml_obs_tag.span.kind", Tags.LLMOBS_LLM_SPAN_KIND)
       .withTag("_ml_obs_tag.model_name", "gpt-3.5")
       .withTag("_ml_obs_tag.model_provider", "openai")
@@ -232,7 +232,7 @@ class LLMObsSpanMapperTest extends DDCoreSpecification {
     llmSpan2.finish()
 
     // Second trace with 1 LLMObs span
-    def llmSpan3 = tracer.buildSpan("chat-completion-3")
+    def llmSpan3 = tracer.buildSpan("datadog", "chat-completion-3")
       .withTag("_ml_obs_tag.span.kind", Tags.LLMOBS_LLM_SPAN_KIND)
       .withTag("_ml_obs_tag.model_name", "claude-3")
       .withTag("_ml_obs_tag.model_provider", "anthropic")

--- a/dd-trace-core/src/test/java/datadog/trace/common/sampling/ParentBasedAlwaysOnSamplerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/sampling/ParentBasedAlwaysOnSamplerTest.java
@@ -40,7 +40,7 @@ class ParentBasedAlwaysOnSamplerTest {
     ParentBasedAlwaysOnSampler sampler = new ParentBasedAlwaysOnSampler();
     CoreTracer tracer = buildTracer(sampler);
 
-    DDSpan span = (DDSpan) tracer.buildSpan("test").start();
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "test").start();
     try {
       assertTrue(sampler.sample(span));
     } finally {
@@ -53,7 +53,7 @@ class ParentBasedAlwaysOnSamplerTest {
     ParentBasedAlwaysOnSampler sampler = new ParentBasedAlwaysOnSampler();
     CoreTracer tracer = buildTracer(sampler);
 
-    DDSpan span = (DDSpan) tracer.buildSpan("test").start();
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "test").start();
     try {
       sampler.setSamplingPriority(span);
       assertEquals(SAMPLER_KEEP, span.getSamplingPriority());
@@ -67,9 +67,10 @@ class ParentBasedAlwaysOnSamplerTest {
     ParentBasedAlwaysOnSampler sampler = new ParentBasedAlwaysOnSampler();
     CoreTracer tracer = buildTracer(sampler);
 
-    DDSpan rootSpan = (DDSpan) tracer.buildSpan("root").start();
+    DDSpan rootSpan = (DDSpan) tracer.buildSpan("datadog", "root").start();
     sampler.setSamplingPriority(rootSpan);
-    DDSpan childSpan = (DDSpan) tracer.buildSpan("child").asChildOf(rootSpan.context()).start();
+    DDSpan childSpan =
+        (DDSpan) tracer.buildSpan("datadog", "child").asChildOf(rootSpan.context()).start();
     try {
       assertEquals(SAMPLER_KEEP, rootSpan.getSamplingPriority());
       assertEquals(SAMPLER_KEEP, childSpan.getSamplingPriority());
@@ -95,7 +96,7 @@ class ParentBasedAlwaysOnSamplerTest {
         new ExtractedContext(
             DDTraceId.ONE, 2, parentPriority, null, PropagationTags.factory().empty(), DATADOG);
 
-    DDSpan span = (DDSpan) tracer.buildSpan("child").asChildOf(extractedContext).start();
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "child").asChildOf(extractedContext).start();
     try {
       assertEquals(parentPriority, span.getSamplingPriority());
     } finally {

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -78,7 +78,8 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     tags.put("2", "fakeString");
     tags.put("3", 42.0);
 
-    AgentTracer.SpanBuilder builder = tracer.buildSpan(expectedName).withServiceName("foo");
+    AgentTracer.SpanBuilder builder =
+        tracer.buildSpan("datadog", expectedName).withServiceName("foo");
     for (Map.Entry<String, Object> entry : tags.entrySet()) {
       builder = builder.withTag(entry.getKey(), entry.getValue());
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
@@ -199,8 +199,8 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     Map<String, Object> localRootSpanTags = new LinkedHashMap<>();
     localRootSpanTags.put("only_root", "value");
     CoreTracer tracer = tracerBuilder().localRootSpanTags(localRootSpanTags).build();
-    AgentSpan root = tracer.buildSpan("my_root").start();
-    AgentSpan child = tracer.buildSpan("my_child").asChildOf(root.context()).start();
+    AgentSpan root = tracer.buildSpan("datadog", "my_root").start();
+    AgentSpan child = tracer.buildSpan("datadog", "my_child").asChildOf(root.context()).start();
     try {
       assertTrue(root.getTags().containsKey("only_root"));
       assertFalse(child.getTags().containsKey("only_root"));
@@ -216,7 +216,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     ListWriter writer = new ListWriter();
     CoreTracer tracer = tracerBuilder().writer(writer).build();
     try {
-      DDSpan span = (DDSpan) tracer.buildSpan("operation").start();
+      DDSpan span = (DDSpan) tracer.buildSpan("datadog", "operation").start();
       span.finish();
       writer.waitForTraces(1);
       assertEquals(PrioritySampling.SAMPLER_KEEP, (int) span.getSamplingPriority());
@@ -230,8 +230,9 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     ListWriter writer = new ListWriter();
     CoreTracer tracer = tracerBuilder().writer(writer).build();
     try {
-      DDSpan root = (DDSpan) tracer.buildSpan("operation").start();
-      DDSpan child = (DDSpan) tracer.buildSpan("my_child").asChildOf(root.context()).start();
+      DDSpan root = (DDSpan) tracer.buildSpan("datadog", "operation").start();
+      DDSpan child =
+          (DDSpan) tracer.buildSpan("datadog", "my_child").asChildOf(root.context()).start();
       root.finish();
 
       assertNull(root.getSamplingPriority());
@@ -476,12 +477,13 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
       DDSpan span =
-          (DDSpan) tracer.buildSpan("def").withTag(GeneralConfig.SERVICE_NAME, "foo").start();
+          (DDSpan)
+              tracer.buildSpan("datadog", "def").withTag(GeneralConfig.SERVICE_NAME, "foo").start();
       span.finish();
       assertEquals("foo", span.getServiceName());
       assertFalse(span.getTags().containsKey("version"));
 
-      DDSpan span2 = (DDSpan) tracer.buildSpan("abc").start();
+      DDSpan span2 = (DDSpan) tracer.buildSpan("datadog", "abc").start();
       span2.finish();
       assertEquals("dd_service_name", span2.getServiceName());
       assertEquals("1.0.0", String.valueOf(span2.getTags().get("version")));
@@ -494,7 +496,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   void flushesOnTracerCloseIfConfiguredToDoSo() {
     WriterWithExplicitFlush writer = new WriterWithExplicitFlush();
     CoreTracer tracer = tracerBuilder().writer(writer).flushOnClose(true).build();
-    tracer.buildSpan("my_span").start().finish();
+    tracer.buildSpan("datadog", "my_span").start().finish();
     tracer.close();
     assertFalse(writer.flushedTraces.isEmpty());
   }
@@ -553,9 +555,9 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   void serviceNameSourceIsRecordedWhenUsingTwoParameterSetServiceName() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
-      DDSpan span = (DDSpan) tracer.buildSpan("operation").start();
+      DDSpan span = (DDSpan) tracer.buildSpan("datadog", "operation").start();
       span.setServiceName("custom-service", "my-integration");
-      DDSpan child = (DDSpan) tracer.buildSpan("child").start();
+      DDSpan child = (DDSpan) tracer.buildSpan("datadog", "child").start();
       child.finish();
       span.finish();
 
@@ -570,7 +572,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   void serviceNameSourceIsMarkedAsManualWhenUsingOneParameterSetServiceName() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
-      DDSpan span = (DDSpan) tracer.buildSpan("operation").start();
+      DDSpan span = (DDSpan) tracer.buildSpan("datadog", "operation").start();
       span.setServiceName("custom-service", "my-integration");
       span.setServiceName("another");
       span.finish();
@@ -586,7 +588,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   void serviceNameSourceIsMissingWhenNotExplicitlySettingServiceName() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
-      DDSpan span = (DDSpan) tracer.buildSpan("operation").start();
+      DDSpan span = (DDSpan) tracer.buildSpan("datadog", "operation").start();
       span.finish();
 
       assertEquals(tracer.serviceName, span.getServiceName());

--- a/dd-trace-core/src/test/java/datadog/trace/core/DDSpanContextPropagationTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/DDSpanContextPropagationTagsTest.java
@@ -57,7 +57,7 @@ public class DDSpanContextPropagationTagsTest extends DDCoreJavaSpecification {
     AgentSpanContext extracted =
         new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
             .withRequestContextDataAppSec("dummy");
-    DDSpan span = (DDSpan) tracer.buildSpan("top").asChildOf(extracted).start();
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "top").asChildOf(extracted).start();
     PropagationTags dd = span.context().getPropagationTags();
 
     span.setSamplingPriority(newPriority, newMechanism);
@@ -89,9 +89,10 @@ public class DDSpanContextPropagationTagsTest extends DDCoreJavaSpecification {
     AgentSpanContext extracted =
         new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
             .withRequestContextDataAppSec("dummy");
-    DDSpan rootSpan = (DDSpan) tracer.buildSpan("top").asChildOf(extracted).start();
+    DDSpan rootSpan = (DDSpan) tracer.buildSpan("datadog", "top").asChildOf(extracted).start();
     PropagationTags ddRoot = rootSpan.context().getPropagationTags();
-    DDSpan span = (DDSpan) tracer.buildSpan("current").asChildOf(rootSpan.context()).start();
+    DDSpan span =
+        (DDSpan) tracer.buildSpan("datadog", "current").asChildOf(rootSpan.context()).start();
 
     span.setSamplingPriority(newPriority, newMechanism);
 
@@ -114,7 +115,7 @@ public class DDSpanContextPropagationTagsTest extends DDCoreJavaSpecification {
     AgentSpanContext extracted =
         new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
             .withRequestContextDataAppSec("dummy");
-    DDSpan span = (DDSpan) tracer.buildSpan("top").asChildOf(extracted).start();
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "top").asChildOf(extracted).start();
     PropagationTags dd = span.context().getPropagationTags();
 
     span.context().forceKeep();
@@ -142,9 +143,10 @@ public class DDSpanContextPropagationTagsTest extends DDCoreJavaSpecification {
     AgentSpanContext extracted =
         new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
             .withRequestContextDataAppSec("dummy");
-    DDSpan rootSpan = (DDSpan) tracer.buildSpan("top").asChildOf(extracted).start();
+    DDSpan rootSpan = (DDSpan) tracer.buildSpan("datadog", "top").asChildOf(extracted).start();
     PropagationTags ddRoot = rootSpan.context().getPropagationTags();
-    DDSpan span = (DDSpan) tracer.buildSpan("current").asChildOf(rootSpan.context()).start();
+    DDSpan span =
+        (DDSpan) tracer.buildSpan("datadog", "current").asChildOf(rootSpan.context()).start();
 
     span.context().forceKeep();
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/TraceCorrelationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/TraceCorrelationTest.java
@@ -24,7 +24,7 @@ public class TraceCorrelationTest extends DDCoreJavaSpecification {
         TRACE_128_BIT_TRACEID_LOGGING_ENABLED, String.valueOf(log128bTraceId));
 
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
-    AgentSpan span = tracer.buildSpan("test").start();
+    AgentSpan span = tracer.buildSpan("datadog", "test").start();
     AgentScope scope = tracer.activateSpan(span);
     scope.close();
 
@@ -43,7 +43,7 @@ public class TraceCorrelationTest extends DDCoreJavaSpecification {
         TRACE_128_BIT_TRACEID_LOGGING_ENABLED, String.valueOf(log128bTraceId));
 
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
-    AgentSpan span = tracer.buildSpan("test").start();
+    AgentSpan span = tracer.buildSpan("datadog", "test").start();
     AgentScope scope = tracer.activateSpan(span);
 
     DDTraceId traceId = ((DDSpan) scope.span()).getTraceId();
@@ -58,7 +58,7 @@ public class TraceCorrelationTest extends DDCoreJavaSpecification {
   @Test
   void getSpanIdWithoutSpan() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
-    AgentSpan span = tracer.buildSpan("test").start();
+    AgentSpan span = tracer.buildSpan("datadog", "test").start();
     AgentScope scope = tracer.activateSpan(span);
     scope.close();
 
@@ -71,7 +71,7 @@ public class TraceCorrelationTest extends DDCoreJavaSpecification {
   @Test
   void getSpanIdWithTrace() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
-    AgentSpan span = tracer.buildSpan("test").start();
+    AgentSpan span = tracer.buildSpan("datadog", "test").start();
     AgentScope scope = tracer.activateSpan(span);
 
     assertEquals(Long.toString(((DDSpan) scope.span()).getSpanId()), tracer.getSpanId());

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -67,7 +67,7 @@ class DDApiIntegrationTest extends AbstractTraceAgentTest {
 
   def setup() {
     tracer = CoreTracer.builder().writer(new ListWriter()).build()
-    span = tracer.buildSpan("fakeOperation").start()
+    span = tracer.buildSpan("datadog", "fakeOperation").start()
     Thread.sleep(1)
     span.finish()
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DefaultLogHandlerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DefaultLogHandlerTest.groovy
@@ -19,7 +19,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the error passed in the fields"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final String differentMessage = "differentMessage"
     final Throwable error = new Throwable(errorMessage)
@@ -38,7 +38,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the error passed in the fields when called with timestamp"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final String differentMessage = "differentMessage"
     final Throwable error = new Throwable(errorMessage)
@@ -57,7 +57,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields but the span is not an error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     fields.put(Fields.MESSAGE, errorMessage)
@@ -72,7 +72,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields when called with timestamp but the span is not an error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     fields.put(Fields.MESSAGE, errorMessage)
@@ -87,7 +87,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields when the span is error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     span.setError(true)
@@ -103,7 +103,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields when called with timestamp when the span is error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     span.setError(true)
@@ -119,7 +119,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields when the event is error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     fields.put(Fields.EVENT, "error")
@@ -135,7 +135,7 @@ class DefaultLogHandlerTest extends DDSpecification {
   def "handles correctly the message passed in the fields when called with timestampwhen the event is error"() {
     setup:
     final LogHandler underTest = new DefaultLogHandler()
-    final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
+    final DDSpan span = tracer.buildSpan("datadog", "op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final Map<String, ?> fields = new HashMap<>()
     fields.put(Fields.EVENT, "error")

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
@@ -32,7 +32,7 @@ class IterationSpansForkedTest extends DDSpecification {
   def "root iteration scope lifecycle"() {
     when:
     coreTracer.closePrevious(true)
-    def span1 = coreTracer.buildSpan("next1").start()
+    def span1 = coreTracer.buildSpan("datadog", "next1").start()
     def scope1 = coreTracer.activateNext(span1)
 
     then:
@@ -45,7 +45,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     when:
     coreTracer.closePrevious(true)
-    def span2 = coreTracer.buildSpan("next2").start()
+    def span2 = coreTracer.buildSpan("datadog", "next2").start()
     def scope2 = coreTracer.activateNext(span2)
 
     then:
@@ -59,7 +59,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     when:
     coreTracer.closePrevious(true)
-    def span3 = coreTracer.buildSpan("next3").start()
+    def span3 = coreTracer.buildSpan("datadog", "next3").start()
     def scope3 = coreTracer.activateNext(span3)
     writer.waitForTraces(2)
 
@@ -83,12 +83,12 @@ class IterationSpansForkedTest extends DDSpecification {
 
   def "non-root iteration scope lifecycle"() {
     setup:
-    def span0 = coreTracer.buildSpan("parent").start()
+    def span0 = coreTracer.buildSpan("datadog", "parent").start()
     def scope0 = coreTracer.activateSpan(span0)
 
     when:
     coreTracer.closePrevious(true)
-    def span1 = coreTracer.buildSpan("next1").start()
+    def span1 = coreTracer.buildSpan("datadog", "next1").start()
     def scope1 = coreTracer.activateNext(span1)
 
     then:
@@ -101,7 +101,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     when:
     coreTracer.closePrevious(true)
-    def span2 = coreTracer.buildSpan("next2").start()
+    def span2 = coreTracer.buildSpan("datadog", "next2").start()
     def scope2 = coreTracer.activateNext(span2)
 
     then:
@@ -115,7 +115,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     when:
     coreTracer.closePrevious(true)
-    def span3 = coreTracer.buildSpan("next3").start()
+    def span3 = coreTracer.buildSpan("datadog", "next3").start()
     def scope3 = coreTracer.activateNext(span3)
 
     then:
@@ -142,7 +142,7 @@ class IterationSpansForkedTest extends DDSpecification {
   def "nested iteration scope lifecycle"() {
     when:
     coreTracer.closePrevious(true)
-    def span1 = coreTracer.buildSpan("next1").start()
+    def span1 = coreTracer.buildSpan("datadog", "next1").start()
     def scope1 = coreTracer.activateNext(span1)
 
     then:
@@ -154,12 +154,12 @@ class IterationSpansForkedTest extends DDSpecification {
     !spanFinished(span1)
 
     when:
-    def span1A = coreTracer.buildSpan("methodA").start()
+    def span1A = coreTracer.buildSpan("datadog", "methodA").start()
     def scope1A = coreTracer.activateSpan(span1A)
 
     and:
     coreTracer.closePrevious(true)
-    def span1A1 = coreTracer.buildSpan("next1A1").start()
+    def span1A1 = coreTracer.buildSpan("datadog", "next1A1").start()
     def scope1A1 = coreTracer.activateNext(span1A1)
 
     then:
@@ -173,7 +173,7 @@ class IterationSpansForkedTest extends DDSpecification {
 
     when:
     coreTracer.closePrevious(true)
-    def span1A2 = coreTracer.buildSpan("next1A2").start()
+    def span1A2 = coreTracer.buildSpan("datadog", "next1A2").start()
     def scope1A2 = coreTracer.activateNext(span1A2)
 
     then:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -346,17 +346,6 @@ public class AgentTracer {
       return new BlackHoleSpan(active != null ? active.getTraceId() : DDTraceId.ZERO);
     }
 
-    /** Deprecated. Use {@link #buildSpan(String, CharSequence)} instead. */
-    @Deprecated
-    default SpanBuilder buildSpan(CharSequence spanName) {
-      return buildSpan("datadog", spanName);
-    }
-
-    @Deprecated
-    default SpanBuilder singleSpanBuilder(CharSequence spanName) {
-      return singleSpanBuilder("datadog", spanName);
-    }
-
     /**
      * Returns a SpanBuilder that can be used to produce multiple spans. To minimize overhead, use
      * of {@link #singleSpanBuilder(String, CharSequence)} is preferred when only a single span is


### PR DESCRIPTION
# What Does This Do

Follows up #11181 by finishing cleaning up deprecated signature for `buildSpan` and `buildSingleSpan` that were not carrying instrumentation name.

Note: usages are mostly in tests for this ones

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
