### PR TITLE
Enable publishing process context by default

### DIFF
--- a/dd-java-agent/agent-profiling/src/test/java/com/datadog/profiling/agent/ProcessContextTest.java
+++ b/dd-java-agent/agent-profiling/src/test/java/com/datadog/profiling/agent/ProcessContextTest.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.agent;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -79,24 +80,8 @@ class ProcessContextTest {
   }
 
   @Test
-  void testRegisterSkipsByDefault() {
-    ConfigProvider configProvider = mock(ConfigProvider.class);
-    when(configProvider.getBoolean(
-            eq(ProfilingConfig.PROFILING_PROCESS_CONTEXT_ENABLED),
-            eq(ProfilingConfig.PROFILING_PROCESS_CONTEXT_ENABLED_DEFAULT)))
-        .thenReturn(ProfilingConfig.PROFILING_PROCESS_CONTEXT_ENABLED_DEFAULT);
-
-    DdprofLibraryLoader.OTelContextHolder holder =
-        mock(DdprofLibraryLoader.OTelContextHolder.class);
-
-    try (MockedStatic<DdprofLibraryLoader> ddprofMock = mockStatic(DdprofLibraryLoader.class)) {
-      ddprofMock.when(DdprofLibraryLoader::otelContext).thenReturn(holder);
-
-      ProcessContext.register(configProvider);
-
-      verify(holder, org.mockito.Mockito.never()).getReasonNotLoaded();
-      verify(holder, org.mockito.Mockito.never()).getComponent();
-    }
+  void testEnabledByDefault() {
+    assertTrue(ProfilingConfig.PROFILING_PROCESS_CONTEXT_ENABLED_DEFAULT);
   }
 
   @Test

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -127,7 +127,7 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_PROCESS_CONTEXT_ENABLED =
       "profiling.experimental.process_context.enabled";
-  public static final boolean PROFILING_PROCESS_CONTEXT_ENABLED_DEFAULT = false;
+  public static final boolean PROFILING_PROCESS_CONTEXT_ENABLED_DEFAULT = true;
 
   public static final String PROFILING_DATADOG_PROFILER_LOG_LEVEL = "profiling.ddprof.loglevel";
 


### PR DESCRIPTION
# What Does This Do

This PR changes the default of `PROFILING_PROCESS_CONTEXT_ENABLED` to `true`, thus enabling publishing of the
[OpenTelemetry process context](https://github.com/open-telemetry/opentelemetry-specification/pull/4719) by default.

# Motivation

When we added this feature, the specification linked above was still a work-in-progress and that's why we chose to not enable it by default. As of version 1.62.0 of dd-trace-java we already ship with the latest version of the spec (that got accepted by opentelemetry).

Publishing this information will enable the Datadog Full Host Profiler (which itself is based on the OTel eBPF Profiler) to provide a better experience when profiling apps using dd-trace-java. (And there's plans for more features built atop it -- e.g. in the Datadog agent).

This feature is already turned on by default in libdatadog (thus dd-trace-rb, dd-trace-py, dd-trace-dotnet) + dd-trace-rs + dd-trace-go and we're working to make sure every lib has it enabled.

# Additional Notes

Note that the process context is only supported on Linux, so you won't see anything on macOS/Linux (outside of docker). The code already turns those into a no-op, so there's no problem there, just calling it out for folks interested in testing.

Other than the unit tests, the `otel_process_ctx_dump.sh` script from [this repo](https://github.com/open-telemetry/sig-profiling/tree/main/process-context/c-and-cpp) can be used to see the feature working.

# Contributor Checklist

- ✅ Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- ✅ Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- ✅ Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ✅ Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- ✅ Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: N/A

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
