### PR TITLE
DRAFT: Trigger non-default JVM tests via PR labels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ include:
   - local: ".gitlab/macrobenchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
+  - local: ".gitlab/extra-jvms-tests.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-spring-petclinic-parallel.yml'
     ref: 'main'
@@ -41,6 +42,7 @@ stages:
   - test-summary
   - exploration-tests
   - ci-visibility-tests
+  - extra-jvms-tests
   - generate-signing-key
 
 variables:
@@ -64,6 +66,9 @@ variables:
   NON_DEFAULT_JVMS:
     description: "Enable tests on JVMs that are not the default"
     value: "false"
+  EXTRA_TEST_JVMS:
+    description: "Regex matching specific JVMs to test (e.g. /^(semeru17|zulu11)$/). Set automatically by the label-triggered pipeline. Takes priority over NON_DEFAULT_JVMS and DEFAULT_TEST_JVMS."
+    value: ""
   RUN_FLAKY_TESTS:
     description: "Enable flaky tests"
     value: "false"
@@ -621,11 +626,17 @@ muzzle-dep-report:
       when: on_success
     - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
       when: on_success
-    # Enable for default test JVMs or for NON_DEFAULT_JVMS
+    # EXTRA_TEST_JVMS takes priority: only the matching JVMs run (set by label-triggered pipelines)
+    - if: '$EXTRA_TEST_JVMS != "" && $testJvm =~ $EXTRA_TEST_JVMS'
+      when: on_success
+    - if: '$EXTRA_TEST_JVMS != ""'
+      when: never
+    # Enable all non-default JVMs
     - if: '$NON_DEFAULT_JVMS == "true"'
       when: on_success
     - if: '$CI_COMMIT_MESSAGE =~ /\[ci: NON_DEFAULT_JVMS\]/'
       when: on_success
+    # Default: only run default JVMs
     - if: '$testJvm =~ $DEFAULT_TEST_JVMS'
       when: on_success
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,9 @@ workflow:
     - if: '$CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       auto_cancel:
         on_new_commit: none
+    # Don't run a full pipeline when triggered by extra-jvms-trigger with nothing to do
+    - if: '$CI_PIPELINE_SOURCE == "pipeline" && $EXTRA_TEST_JVMS == "" && $NON_DEFAULT_JVMS != "true"'
+      when: never
     - when: always
 
 .test_matrix: &test_matrix

--- a/.gitlab/extra-jvms-tests.yml
+++ b/.gitlab/extra-jvms-tests.yml
@@ -1,0 +1,29 @@
+extra-jvms-trigger:
+  stage: extra-jvms-tests
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  tags: [ "arch:amd64" ]
+  needs: [ publish-artifacts-to-s3 ]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    # Skip in pipelines triggered by another pipeline to prevent infinite loops
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(master|release\/)/'
+      when: on_success
+    - when: never
+  before_script:
+    - dd-octo-sts version
+    - dd-octo-sts debug --scope DataDog/dd-trace-java --policy self.gitlab.github-access.read
+    - dd-octo-sts token --scope DataDog/dd-trace-java --policy self.gitlab.github-access.read > github-token.txt
+    - gh auth login --with-token < github-token.txt
+  script:
+    - .gitlab/extra_jvms_generate_jobs.sh
+  after_script:
+    - dd-octo-sts revoke -t $(cat github-token.txt) || true
+  retry:
+    max: 2
+    when: always

--- a/.gitlab/extra-jvms-tests.yml
+++ b/.gitlab/extra-jvms-tests.yml
@@ -1,4 +1,4 @@
-extra-jvms-trigger:
+extra-jvms-check:
   stage: extra-jvms-tests
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
   tags: [ "arch:amd64" ]
@@ -24,6 +24,31 @@ extra-jvms-trigger:
     - .gitlab/extra_jvms_generate_jobs.sh
   after_script:
     - dd-octo-sts revoke -t $(cat github-token.txt) || true
+  artifacts:
+    reports:
+      dotenv: extra-jvms.env
   retry:
     max: 2
     when: always
+
+extra-jvms-trigger:
+  stage: extra-jvms-tests
+  needs:
+    - job: extra-jvms-check
+      artifacts: true
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    # Skip in pipelines triggered by another pipeline to prevent infinite loops
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(master|release\/)/'
+      when: on_success
+    - when: never
+  trigger:
+    project: $CI_PROJECT_PATH
+    branch: $CI_COMMIT_BRANCH
+    strategy: depend
+  variables:
+    EXTRA_TEST_JVMS: $EXTRA_TEST_JVMS
+    NON_DEFAULT_JVMS: $NON_DEFAULT_JVMS

--- a/.gitlab/extra-jvms-tests.yml
+++ b/.gitlab/extra-jvms-tests.yml
@@ -46,7 +46,7 @@ extra-jvms-trigger:
       when: on_success
     - when: never
   trigger:
-    project: $CI_PROJECT_PATH
+    project: DataDog/apm-reliability/dd-trace-java
     branch: $CI_COMMIT_BRANCH
     strategy: depend
   variables:

--- a/.gitlab/extra_jvms_generate_jobs.sh
+++ b/.gitlab/extra_jvms_generate_jobs.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+DOTENV_FILE="extra-jvms.env"
+
+# Initialise with empty values so the bridge job always has the variables defined
+printf 'EXTRA_TEST_JVMS=\nNON_DEFAULT_JVMS=false\n' > "$DOTENV_FILE"
+
 if [ -z "$CI_COMMIT_BRANCH" ]; then
   echo "No branch detected - skipping extra JVM tests"
   exit 0
@@ -35,31 +40,10 @@ if [ $labels_status -ne 0 ]; then
   exit 0
 fi
 
-trigger_pipeline() {
-  local variables_json="$1"
-  local description="$2"
-  echo "Triggering extra JVM pipeline: $description"
-  set +e
-  response=$(curl --fail --silent --request POST \
-    --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-    --header "Content-Type: application/json" \
-    --data "{\"ref\":\"${CI_COMMIT_BRANCH}\",\"variables\":${variables_json}}" \
-    "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline")
-  curl_status=$?
-  set -e
-  if [ $curl_status -ne 0 ]; then
-    echo "Failed to trigger pipeline (curl exit $curl_status)"
-    exit 1
-  fi
-  pipeline_id=$(echo "$response" | jq -r '.id')
-  pipeline_url=$(echo "$response" | jq -r '.web_url')
-  echo "Triggered pipeline #${pipeline_id}: ${pipeline_url}"
-}
-
 # Check for run-tests: all to run every non-default JVM without filtering
 if echo "$labels" | grep -qF 'run-tests: all'; then
-  echo "PR #$pr_number has 'run-tests: all' label - triggering all non-default JVM tests"
-  trigger_pipeline '[{"key":"NON_DEFAULT_JVMS","value":"true"}]' "all non-default JVMs"
+  echo "PR #$pr_number has 'run-tests: all' label - will trigger all non-default JVM tests"
+  printf 'EXTRA_TEST_JVMS=\nNON_DEFAULT_JVMS=true\n' > "$DOTENV_FILE"
   exit 0
 fi
 
@@ -82,6 +66,7 @@ fi
 # Build the EXTRA_TEST_JVMS regex matching the format used by DEFAULT_TEST_JVMS in .gitlab-ci.yml
 jvm_pattern=$(IFS='|'; echo "${requested_jvms[*]}")
 extra_test_jvms="/^($jvm_pattern)\$/"
+echo "Will trigger extra JVM tests for: ${requested_jvms[*]}"
 echo "EXTRA_TEST_JVMS: $extra_test_jvms"
 
-trigger_pipeline "[{\"key\":\"EXTRA_TEST_JVMS\",\"value\":\"${extra_test_jvms}\"}]" "${requested_jvms[*]}"
+printf 'EXTRA_TEST_JVMS=%s\nNON_DEFAULT_JVMS=false\n' "$extra_test_jvms" > "$DOTENV_FILE"

--- a/.gitlab/extra_jvms_generate_jobs.sh
+++ b/.gitlab/extra_jvms_generate_jobs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$CI_COMMIT_BRANCH" ]; then
+  echo "No branch detected - skipping extra JVM tests"
+  exit 0
+fi
+
+echo "Checking extra JVM test labels for branch $CI_COMMIT_BRANCH..."
+
+set +e
+pr_number=$(gh pr list --repo DataDog/dd-trace-java --head "$CI_COMMIT_BRANCH" --state open --json number --jq '.[0].number' 2>&1)
+pr_number_status=$?
+set -e
+
+if [ $pr_number_status -ne 0 ]; then
+  echo "Failed to query PR (gh command failed with status $pr_number_status) - skipping"
+  exit 0
+fi
+if [ -z "$pr_number" ]; then
+  echo "No open PR found for branch $CI_COMMIT_BRANCH - skipping"
+  exit 0
+fi
+
+echo "PR #${pr_number} found, checking labels..."
+
+set +e
+labels=$(gh pr view "$pr_number" --repo DataDog/dd-trace-java --json labels --jq '.labels[].name' 2>&1)
+labels_status=$?
+set -e
+
+if [ $labels_status -ne 0 ]; then
+  echo "Failed to query PR labels (gh command failed with status $labels_status) - skipping"
+  exit 0
+fi
+
+trigger_pipeline() {
+  local variables_json="$1"
+  local description="$2"
+  echo "Triggering extra JVM pipeline: $description"
+  set +e
+  response=$(curl --fail --silent --request POST \
+    --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+    --header "Content-Type: application/json" \
+    --data "{\"ref\":\"${CI_COMMIT_BRANCH}\",\"variables\":${variables_json}}" \
+    "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline")
+  curl_status=$?
+  set -e
+  if [ $curl_status -ne 0 ]; then
+    echo "Failed to trigger pipeline (curl exit $curl_status)"
+    exit 1
+  fi
+  pipeline_id=$(echo "$response" | jq -r '.id')
+  pipeline_url=$(echo "$response" | jq -r '.web_url')
+  echo "Triggered pipeline #${pipeline_id}: ${pipeline_url}"
+}
+
+# Check for run-tests: all to run every non-default JVM without filtering
+if echo "$labels" | grep -qF 'run-tests: all'; then
+  echo "PR #$pr_number has 'run-tests: all' label - triggering all non-default JVM tests"
+  trigger_pipeline '[{"key":"NON_DEFAULT_JVMS","value":"true"}]' "all non-default JVMs"
+  exit 0
+fi
+
+# Valid non-default JVM identifiers (must match testJvm values in .gitlab-ci.yml)
+ALL_NON_DEFAULT_JVMS=("semeru8" "semeru11" "semeru17" "zulu8" "zulu11" "oracle8" "ibm8")
+
+requested_jvms=()
+for jvm in "${ALL_NON_DEFAULT_JVMS[@]}"; do
+  if echo "$labels" | grep -qF "run-tests: $jvm"; then
+    requested_jvms+=("$jvm")
+    echo "Found label: run-tests: $jvm"
+  fi
+done
+
+if [ ${#requested_jvms[@]} -eq 0 ]; then
+  echo "PR #$pr_number has no run-tests: <jvm> labels - skipping extra JVM tests"
+  exit 0
+fi
+
+# Build the EXTRA_TEST_JVMS regex matching the format used by DEFAULT_TEST_JVMS in .gitlab-ci.yml
+jvm_pattern=$(IFS='|'; echo "${requested_jvms[*]}")
+extra_test_jvms="/^($jvm_pattern)\$/"
+echo "EXTRA_TEST_JVMS: $extra_test_jvms"
+
+trigger_pipeline "[{\"key\":\"EXTRA_TEST_JVMS\",\"value\":\"${extra_test_jvms}\"}]" "${requested_jvms[*]}"


### PR DESCRIPTION
This was a follow-up to #11148 attempt to support Github PR label mechanism to run test jobs with a specific test jvm. The goal was to try to revive a feature we had with Circle CI. That was able to run jobs if a certain label was present.

The attempts in this PR didn't work well.


# What Does This Do


The idea was to add a label-based mechanism to run non-default JVM tests on demand.
When a PR has `run-tests: <jvm>` labels (e.g. `run-tests: semeru17`,
`run-tests: zulu11`) or `run-tests: all`, the corresponding non-default
JVM test pipeline is triggered automatically.

The mechanism tried a similar approach to what exists with the ci-visibility (`ci-visibility-tests.yml` and `ci_visibility_generate_jobs.sh`), so the following was started with the following:
- `.gitlab/extra_jvms_generate_jobs.sh` — queries PR labels via `gh`,
  builds an `EXTRA_TEST_JVMS` regex or sets `NON_DEFAULT_JVMS=true`
- `.gitlab/extra-jvms-tests.yml` — `extra-jvms-check` job (runs the
  script) + `extra-jvms-trigger` bridge job
- `.gitlab-ci.yml` — adds the `extra-jvms-tests` stage, `EXTRA_TEST_JVMS`
  variable, and rules to filter which JVMs run when the variable is set

# Motivation

Allow contributors to run non-default JVM tests on demand by adding a
GitHub label instead of pushing a commit token or manually triggering a
pipeline.

# Additional Notes

Summary of the attempts (AI generated)

## Investigation log — self-triggering a GitLab pipeline

The core design requires triggering a new pipeline for the **same** project
(`DataDog/apm-reliability/dd-trace-java`) with different variables
(`EXTRA_TEST_JVMS`, `NON_DEFAULT_JVMS`). Every approach tried so far hits
a GitLab limitation.

### Attempt 1 — dynamic child pipeline + `trigger: project:` (wrong path)

Generated a YAML artifact (like CI Visibility does) containing a
`trigger: project: DataDog/dd-trace-java` job. Failed with:
> `downstream project could not be found`

Root cause: `DataDog/dd-trace-java` is the GitHub path. The GitLab path is
`DataDog/apm-reliability/dd-trace-java`.

### Attempt 2 — dynamic child pipeline + `trigger: project: $CI_PROJECT_PATH`

Used `$CI_PROJECT_PATH` so the path is resolved at runtime. Failed with:
> `downstream pipeline trigger definition is invalid`

Root cause: `trigger: project:` does not support variable expansion in the
version of GitLab used internally. Additionally, GitLab forbids a project
from triggering itself via `trigger: project:` inside a dynamic child
pipeline (circular dependency guard).

### Attempt 3 — dynamic child pipeline + GitLab API via `CI_JOB_TOKEN`

Replaced the `trigger:` job with a `script:` that calls
`POST ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline` using
`CI_JOB_TOKEN`. Failed with:
> `curl exit 22` (HTTP 403 Forbidden)

Root cause: `CI_JOB_TOKEN` does not have permission to create pipelines in
this project (the "Allow job token to create pipelines" project setting is
not enabled).

### Attempt 4 — parent pipeline bridge job + `trigger: project: $CI_PROJECT_PATH`

Moved the bridge job out of the child pipeline (into the parent) to avoid
the child-pipeline circular dependency guard. Used `$CI_PROJECT_PATH` in
`trigger: project:`. Failed with:
> `downstream pipeline trigger definition is invalid`

Root cause: same as attempt 2 — `trigger: project:` does not expand
variables.

### Attempt 5 — parent pipeline bridge job + hardcoded project path

Hardcoded `trigger: project: DataDog/apm-reliability/dd-trace-java`.
Still fails with:
> `downstream pipeline trigger definition is invalid`

Root cause: **GitLab does not allow a project to trigger itself via
`trigger: project:`**, even from the parent pipeline. The self-referential
multi-project pipeline is rejected at definition validation time,
regardless of how the project path is specified.

### Untried ideas

- **Pipeline trigger token**: create a CI/CD trigger token in project
  settings, store it as a protected variable, use `curl` with
  `token=$TRIGGER_TOKEN` against `/projects/:id/trigger/pipelines`.
  Trigger tokens bypass the self-referential restriction.
- **GitHub Actions webhook**: a workflow on the `labeled` event calls the
  GitLab pipeline trigger API externally.

