### PR TITLE
Resolve Hibernate test DTDs from classpath.

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/test/resources/hibernate.cfg.xml
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-3.3/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/test/resources/hibernate.cfg.xml
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-4.0/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 

--- a/dd-java-agent/instrumentation/hibernate/hibernate-core-4.3/src/test/resources/hibernate.cfg.xml
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-core-4.3/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 


### PR DESCRIPTION
# What Does This Do
Updates Hibernate instrumentation test `hibernate.cfg.xml` files to reference the Hibernate configuration DTD via `classpath://org/hibernate/hibernate-configuration-3.0.dtd` instead of an HTTP URL.

# Motivation
Hibernate 3.3 only resolves some DTD system IDs locally. When the resolver does not recognize the HTTP URL, SAX parsing falls back to opening the external DTD over the network, which can hang tests in CI.
Using `classpath://` makes DTD resolution explicit and avoids network access during test setup.

# Additional Notes
Previous attempt in #11177 failed because older versions of Hibernate require a different URL to fall back to local resolution. Therefore, it’s better to explicitly specify where the DTD should be resolved from.

Verified locally with: `./gradlew :dd-java-agent:instrumentation:hibernate:hibernate-core-3.3:test`