### PR TITLE
Update class name to TagSyntheticFailures.java

### DIFF
--- a/.gitlab/TagSyntheticFailures.java
+++ b/.gitlab/TagSyntheticFailures.java
@@ -46,12 +46,12 @@ import org.w3c.dom.Element;
 /// <testcase name="initializationError" classname="com.example.MyTest" />
 /// ```
 ///
-/// Usage (Java 25): `java TagInitializationErrors.java junit-report.xml`
+/// Usage (Java 25): `java TagSyntheticFailures.java junit-report.xml`
 
-class TagInitializationErrors {
+class TagSyntheticFailures {
   public static void main(String[] args) throws Exception {
     if (args.length == 0) {
-      System.err.println("Usage: java TagInitializationErrors.java <xml-file>");
+      System.err.println("Usage: java TagSyntheticFailures.java <xml-file>");
       System.exit(1);
     }
     var xmlFile = new File(args[0]);
@@ -88,7 +88,7 @@ class TagInitializationErrors {
     if (!modified) {
       return;
     }
-    var tmpFile = File.createTempFile("TagInitializationErrors", ".xml", xmlFile.getParentFile());
+    var tmpFile = File.createTempFile("TagSyntheticFailures", ".xml", xmlFile.getParentFile());
     try {
       var transformer = TransformerFactory.newInstance().newTransformer();
       transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");

--- a/.gitlab/collect_results.sh
+++ b/.gitlab/collect_results.sh
@@ -91,7 +91,7 @@ do
   fi
 
   echo "Add dd_tags[test.final_status] property on retried synthetics testcase initializationErrors, and all executionError and test exception synthetic testcases"
-  $JAVA_25_HOME/bin/java "$(dirname "$0")/TagInitializationErrors.java" "$TARGET_DIR/$AGGREGATED_FILE_NAME"
+  $JAVA_25_HOME/bin/java "$(dirname "$0")/TagSyntheticFailures.java" "$TARGET_DIR/$AGGREGATED_FILE_NAME"
 
   echo "Add dd_tags[test.final_status] property to each testcase on $TARGET_DIR/$AGGREGATED_FILE_NAME"
   xsl_file="$(dirname "$0")/add_final_status.xsl"


### PR DESCRIPTION
### What Does This Do
Follow up on https://github.com/DataDog/dd-trace-java/pull/11259

### Checklist
- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMLP-1296](https://datadoghq.atlassian.net/browse/APMLP-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1296]: https://datadoghq.atlassian.net/browse/APMLP-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ