### PR TITLE
Bump to Gradle 8.14.5 (from 8.14.4)

### DIFF
--- a/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# What Does This Do

Bump Gradle from 8.14.4 to 8.14.5

https://docs.gradle.org/8.14.5/release-notes.html

* [#37048](https://github.com/gradle/gradle/issues/37048) [8.14 backport] TransformedClassLoader is not thread-safe
* [#37486](https://github.com/gradle/gradle/issues/37486) [Backport] Excluding dependencies from included builds doesn't work

```
./gradlew wrapper --gradle-version=8.14.5 --gradle-distribution-sha256-sum 6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
```

Hash sources:
* https://services.gradle.org/distributions/gradle-8.14.5-bin.zip.sha256
* https://gradle.org/release-checksums/#8.14.5