### PR TITLE
Change gitlab codeowners to LP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,10 +21,6 @@
 /dd-smoke-tests/vertx-*/                                                                         @DataDog/apm-idm-java
 /dd-smoke-tests/wildfly/                                                                         @DataDog/apm-idm-java
 
-# @DataDog/apm-release-platform
-/.gitlab/                              @DataDog/apm-release-platform
-/.gitlab-ci.yml                        @DataDog/apm-release-platform
-
 # @DataDog/apm-sdk-capabilities-java
 /dd-java-agent/agent-otel                                       @DataDog/apm-sdk-capabilities-java
 /dd-smoke-tests/log-injection                                   @DataDog/apm-sdk-capabilities-java
@@ -56,6 +52,8 @@
 
 # @DataDog/apm-lang-platform-java
 /.github/                               @DataDog/apm-lang-platform-java
+/.gitlab/                               @DataDog/apm-lang-platform-java
+/.gitlab-ci.yml                         @DataDog/apm-lang-platform-java
 /benchmark/                             @DataDog/apm-lang-platform-java
 /components/                            @DataDog/apm-lang-platform-java
 /dd-java-agent/instrumentation/java/    @DataDog/apm-lang-platform-java


### PR DESCRIPTION
# What Does This Do

Change the codeowners for `.gitlab-ci.yml` and `.gitlab/` from Release Platform to Language Platform

# Motivation

The majority of contributions in this area are now from LP, so it makes more sense for the LP team to be tagged on related reviews. RP reviews can still be manually requested from any team.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
