### PR TITLE
Upgrade protobuf Gradle plugin to 0.10.0 across all modules

### DIFF
--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -115,14 +115,6 @@ tasks.named("forbiddenApisJmh") {
   ignoreFailures = true
 }
 
-sourceSets {
-  test {
-    java {
-      srcDirs += [layout.buildDirectory.dir("generated/sources/proto/test/java")]
-    }
-  }
-}
-
 tasks.withType(JavaCompile).configureEach {
   if (name == 'compileJava') {
     options.errorprone {

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -4,7 +4,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 plugins {
   id 'com.gradleup.shadow'
   id 'me.champeau.jmh'
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.10.0'
   id 'net.ltgt.errorprone' version '3.1.0'
 }
 
@@ -118,7 +118,7 @@ tasks.named("forbiddenApisJmh") {
 sourceSets {
   test {
     java {
-      srcDirs += ["$buildDir/generated/source/proto/test/java"]
+      srcDirs += [layout.buildDirectory.dir("generated/sources/proto/test/java")]
     }
   }
 }

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/protobuf-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/protobuf-3.0/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.9.4'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -37,7 +37,7 @@ dependencies {
 sourceSets {
   test {
     java {
-      srcDir "$buildDir/generated/source/proto/test/java"
+      srcDir layout.buildDirectory.dir("generated/sources/proto/test/java")
     }
   }
 }

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -1,14 +1,8 @@
-buildscript {
-  dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.3'
-  }
-}
-
 plugins {
   id 'application'
   id 'java'
   id 'com.gradleup.shadow' version '8.3.9'
-  id 'com.google.protobuf' version '0.9.3'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 def sharedRootDir = "$rootDir/../../../"
@@ -39,8 +33,8 @@ protobuf {
     }
   }
   generateProtoTasks {
-    ofSourceSet('main')*.plugins {
-      grpc {}
+    ofSourceSet('main').configureEach {
+      plugins { grpc {} }
     }
   }
 }

--- a/dd-smoke-tests/armeria-grpc/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.google.protobuf' version '0.9.3'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -33,8 +33,8 @@ protobuf {
     }
   }
   generateProtoTasks {
-    ofSourceSet('main')*.plugins {
-      grpc {}
+    ofSourceSet('main').configureEach {
+      plugins { grpc {} }
     }
   }
 }

--- a/dd-smoke-tests/grpc-1.5/build.gradle
+++ b/dd-smoke-tests/grpc-1.5/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'application'
   id 'java'
   id 'java-test-fixtures'
-  id 'com.google.protobuf' version '0.9.4'
+  id 'com.google.protobuf' version '0.10.0'
   id 'com.gradleup.shadow'
 }
 

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id 'com.gradleup.shadow'
-  id 'com.google.protobuf' version '0.8.18'
+  id 'com.google.protobuf' version '0.10.0'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -26,8 +26,8 @@ protobuf {
     }
   }
   generateProtoTasks {
-    all()*.plugins {
-      grpc {}
+    ofSourceSet("main").configureEach {
+      plugins { grpc {} }
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Aligns all 8 usages from 0.8.18/0.9.3/0.9.4 to 0.10.0 as part of Gradle 9 preparation. Also fixes related Gradle 9 incompatibilities:

* Replace deprecated `$buildDir` with `layout.buildDirectory.dir()` and fix the generated source path (source -> sources)
* Replace eager spread-operator `*.plugins {}` with lazy `configureEach`
* Remove redundant legacy `buildscript { classpath }` block in armeria-grpc/application

# Motivation

Prepare Gradle 9
Improve build quality

# Additional Notes

Sub-PR from #10402, #11272