### PR TITLE
Allow `campaigner-automated-change` label in PR validation

### DIFF
--- a/.github/workflows/check-pull-request-labels.yaml
+++ b/.github/workflows/check-pull-request-labels.yaml
@@ -141,6 +141,11 @@ jobs:
               'performance:',  // To refactor to 'ci: ' in the future
               'run-tests:'     // Unused since GitLab migration
             ]
+            // Exact-match labels that don't fit a category prefix (e.g. labels applied
+            // by external automation tooling).
+            const exactAllowlist = [
+              'campaigner-automated-change'
+            ]
             // Re-fetch labels only if the previous step modified them (ex: "Bits AI" removal)
             let prLabels
             if (process.env.LABELS_STALE === 'true') {
@@ -156,7 +161,10 @@ jobs:
             // Look for invalid labels
             const invalidLabels = prLabels
               .map(label => label.name)
-              .filter(label => validCategories.every(prefix => !label.startsWith(prefix)))
+              .filter(label =>
+                !exactAllowlist.includes(label) &&
+                validCategories.every(prefix => !label.startsWith(prefix))
+              )
             const hasInvalidLabels = invalidLabels.length > 0
             // Get existing comments to check for blocking comment
             const comments = await github.rest.issues.listComments({


### PR DESCRIPTION
# What Does This Do

Adds an exact-match allowlist to `.github/workflows/check-pull-request-labels.yaml` and includes `campaigner-automated-change` in it, so that label no longer fails the "Validate PR Label Format" check.

The validation now passes a label if **either**:
- it starts with one of the existing category prefixes (`type:`, `comp:`, `inst:`, `tag:`, `mergequeue-status:`, `team:`, `performance:`, `run-tests:`), **or**
- its full name appears in the new `exactAllowlist` array.

# Motivation

The `campaigner-automated-change` label is applied by external automation (Campaigner) and doesn't fit any of the existing category prefixes. Without this change, every PR that automation labels triggers a sticky `<!-- dd-trace-java-check-pr-labels-workflow -->` blocking comment that a maintainer must manually delete to unblock the merge — even though the label itself is intentional and valid.

A separate `exactAllowlist` (rather than dropping the label name into `validCategories` directly) keeps the "category prefix" and "specific exempt label" concepts distinct, which is friendlier to future readers and makes it obvious where to add similar automation labels in the future.

# Additional Notes

- No behavior change for any existing label.
- Future automation-applied labels can be added by appending to the `exactAllowlist` array.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion (N/A — no source files added/moved/removed)
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors (N/A — CI-only change)

Jira ticket: N/A

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).