### PR TITLE
Skip GitLab pipelines for GitHub merge queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,9 @@ workflow:
   auto_cancel:
     on_new_commit: interruptible
   rules:
+    # skip gitlab pipeline for github merge queue - we are currently using the datadog merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       auto_cancel:
         on_new_commit: none


### PR DESCRIPTION
# What Does This Do

Skip running GitLab pipelines for PRs on the GitHub merge queue

# Motivation

Our current use of GitHub merge queues is that they direct PRs to the Datadog queue. However during this redirection process, a GitLab GH MQ pipeline for the PR is still created. We don't actually need this pipeline since we use the Datadog queue, so this PR should auto-cancel pipelines coming from the GH MQ. Example pipeline: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/112036798

# Additional Notes

We can test this by merging this PR via the GH MQ and checking its associated GitLab pipeline.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
