### PR TITLE
Red hat maven repo hot fix.

### DIFF
--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -1,6 +1,13 @@
 repositories {
   maven {
     url = 'https://maven.repository.redhat.com/ga/'
+    // Restrict this repository to Red Hat / WildFly / JBoss artifacts only.
+    // Without this filter, Gradle may probe this host for unrelated dependencies
+    // (for example JUnit), which makes the build flaky when the host is unreachable.
+    content {
+      includeGroupAndSubgroups 'org.wildfly'
+      includeGroupAndSubgroups 'org.jboss'
+    }
   }
 }
 

--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -1,16 +1,3 @@
-repositories {
-  maven {
-    url = 'https://maven.repository.redhat.com/ga/'
-    // Restrict this repository to Red Hat / WildFly / JBoss artifacts only.
-    // Without this filter, Gradle may probe this host for unrelated dependencies
-    // (for example JUnit), which makes the build flaky when the host is unreachable.
-    content {
-      includeGroupAndSubgroups 'org.wildfly'
-      includeGroupAndSubgroups 'org.jboss'
-    }
-  }
-}
-
 muzzle {
   extraRepository('redhat-ga', 'https://maven.repository.redhat.com/ga/')
   pass {
@@ -22,6 +9,20 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+
+repositories {
+  // Declared after java.gradle so Maven Central is tried first; this repo only acts as a
+  // fallback for WildFly / JBoss artifacts not published to Central. The content filter
+  // also prevents Gradle from probing this host for unrelated dependencies (e.g. JUnit),
+  // which made the build flaky when the host was unreachable.
+  maven {
+    url = 'https://maven.repository.redhat.com/ga/'
+    content {
+      includeGroupAndSubgroups 'org.wildfly'
+      includeGroupAndSubgroups 'org.jboss'
+    }
+  }
+}
 
 testJvmConstraints {
   minJavaVersion = JavaVersion.VERSION_11


### PR DESCRIPTION
# What Does This Do
Hot fix for error:
```
* What went wrong:
Execution failed for task ':dd-java-agent:instrumentation:wildfly-9.0:resolveAndLockAll'.
> Could not resolve all files for configuration ':dd-java-agent:instrumentation:wildfly-9.0:latestDepForkedTestCompileClasspath'.
   > Could not resolve org.junit.jupiter:junit-jupiter:5.14.1.
     Required by:
         project :dd-java-agent:instrumentation:wildfly-9.0
      > Repository maven is disabled due to earlier error below:
         > Could not resolve org.wildfly.security:wildfly-elytron-permission:2.8.4.Final.
            > Could not get resource 'https://maven.repository.redhat.com/ga/org/wildfly/security/wildfly-elytron-permission/2.8.4.Final/wildfly-elytron-permission-2.8.4.Final.pom'.
               > Could not GET 'https://maven.repository.redhat.com/ga/org/wildfly/security/wildfly-elytron-permission/2.8.4.Final/wildfly-elytron-permission-2.8.4.Final.pom'. Received status code 503 from server: Service Unavailable
   > Could not resolve com.squareup.okhttp3:logging-interceptor:[3.0,3.12.12].
     Required by:
         project :dd-java-agent:instrumentation:wildfly-9.0 > project :dd-java-agent:instrumentation-testing > project :dd-java-agent:testing
      > Repository maven is disabled due to earlier error below:
> There are 55 more failures with identical causes.
```

# Motivation
Green CI

# Additional Notes
Probably this is side-effect of recent update from Gradle `8.14.4` to `8.14.5` in #11302
Similar issue #10826

