### PR TITLE
Replace `.gradle cp-r` dance with `sudo chown`.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,15 +231,9 @@ default:
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - export GRADLE_ARGS=" --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
-    # for weird reasons, Gradle will always "chmod 700" the .gradle folder
-    # with Gitlab caching, .gradle is always owned by root and thus Gradle's chmod invocation fails
-    # This dance is a hack to have .gradle owned by the Gitlab runner user
-    - gitlab_section_start "gradle-dance" "Fix .gradle directory permissions"
-    - cp -r .gradle .gradle-copy
-    - rm -rf .gradle
-    - mv .gradle-copy .gradle
-    - ls -la
-    - gitlab_section_end "gradle-dance"
+    # GitLab's cache helper restores .gradle as root, but we run as non-root-user (uid 1001),
+    # and Gradle does `chmod 700 .gradle` on startup which requires user ownership.
+    - sudo chown -R 1001:1001 .gradle
   after_script:
     - *cgroup_info
     - *container_info


### PR DESCRIPTION
# What Does This Do
Simplify gradle build.

# Motivation
Faster CI.

# Additional Notes
Instead of 10-30 seconds it will take only 1 second.


