### PR TITLE
Update g2j migration Claude skill

### DIFF
--- a/.claude/skills/migrate-groovy-to-java/SKILL.md
+++ b/.claude/skills/migrate-groovy-to-java/SKILL.md
@@ -12,7 +12,6 @@ Migrate test Groovy files to Java using JUnit 5
 2. Convert Groovy files to Java using JUnit 5
 3. Make sure the tests are still passing after migration and that the test count has not changed
 4. Remove Groovy files
-5. Add the migrated module path(s) to `.github/g2j-migrated-modules.txt`
 
 When converting Groovy code to Java code, make sure that:
 - The Java code generated is compatible with JDK 8


### PR DESCRIPTION
# What Does This Do

Remove the outdated command to add migrated module names to the `.github/g2j-migrated-modules.txt` file in the g2j migration Claude skill

# Motivation

This file no longer exists following #11216 

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
