### PR TITLE
Implement Iterator.remove() on OptimizedTagMap view iterators

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -2082,9 +2082,11 @@ final class OptimizedTagMap implements TagMap {
   }
 
   abstract static class IteratorBase {
+    private final OptimizedTagMap map;
     private final Object[] buckets;
 
     private Entry nextEntry;
+    private Entry lastReturnedEntry;
 
     private int bucketIndex = -1;
 
@@ -2092,6 +2094,7 @@ final class OptimizedTagMap implements TagMap {
     private int groupIndex = 0;
 
     IteratorBase(OptimizedTagMap map) {
+      this.map = map;
       this.buckets = map.buckets;
     }
 
@@ -2108,12 +2111,14 @@ final class OptimizedTagMap implements TagMap {
 
     final Entry nextEntryOrThrowNoSuchElement() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        Entry result = this.nextEntry;
         this.nextEntry = null;
-        return nextEntry;
+        this.lastReturnedEntry = result;
+        return result;
       }
 
       if (this.hasNext()) {
+        this.lastReturnedEntry = this.nextEntry;
         return this.nextEntry;
       } else {
         throw new NoSuchElementException();
@@ -2122,12 +2127,26 @@ final class OptimizedTagMap implements TagMap {
 
     final Entry nextEntryOrNull() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        Entry result = this.nextEntry;
         this.nextEntry = null;
-        return nextEntry;
+        this.lastReturnedEntry = result;
+        return result;
       }
 
-      return this.hasNext() ? this.nextEntry : null;
+      if (this.hasNext()) {
+        this.lastReturnedEntry = this.nextEntry;
+        return this.nextEntry;
+      }
+      return null;
+    }
+
+    public final void remove() {
+      Entry last = this.lastReturnedEntry;
+      if (last == null) {
+        throw new IllegalStateException("next() must be called before remove()");
+      }
+      this.lastReturnedEntry = null;
+      this.map.getAndRemove(last.tag);
     }
 
     private final Entry advance() {

--- a/internal-api/src/test/java/datadog/trace/api/TagMapTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,6 +94,124 @@ public class TagMapTest {
 
     TagMap emptyMap = factory.empty();
     assertEquals(optimized, emptyMap.isOptimized());
+  }
+
+  @ParameterizedTest
+  @EnumSource(TagMapType.class)
+  public void entrySet_removeIf(TagMapType type) {
+    TagMap map = type.create();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    boolean removed =
+        map.entrySet().removeIf(e -> "a".equals(e.getKey()) || "c".equals(e.getKey()));
+
+    assertTrue(removed);
+    assertEquals(1, map.size());
+    assertNull(map.getEntry("a"));
+    assertNotNull(map.getEntry("b"));
+    assertNull(map.getEntry("c"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(TagMapType.class)
+  public void keySet_removeAll(TagMapType type) {
+    TagMap map = type.create();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    boolean removed = map.keySet().removeAll(Arrays.asList("a", "c"));
+
+    assertTrue(removed);
+    assertEquals(1, map.size());
+    assertNull(map.getEntry("a"));
+    assertNotNull(map.getEntry("b"));
+    assertNull(map.getEntry("c"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(TagMapType.class)
+  public void values_removeIf(TagMapType type) {
+    TagMap map = type.create();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    boolean removed = map.values().removeIf(v -> v.equals(1) || v.equals(3));
+
+    assertTrue(removed);
+    assertEquals(1, map.size());
+    assertNull(map.getEntry("a"));
+    assertNotNull(map.getEntry("b"));
+    assertNull(map.getEntry("c"));
+  }
+
+  @Test
+  public void optimizedIterator_remove() {
+    TagMap map = TagMapType.OPTIMIZED.create();
+    map.set("a", 1);
+    map.set("b", 2);
+
+    Iterator<TagMap.EntryReader> iter = map.iterator();
+    while (iter.hasNext()) {
+      if ("a".equals(iter.next().tag())) {
+        iter.remove();
+      }
+    }
+
+    assertEquals(1, map.size());
+    assertNull(map.getEntry("a"));
+    assertNotNull(map.getEntry("b"));
+  }
+
+  @Test
+  public void optimizedIterator_remove_acrossBucketCollisions() {
+    // OptimizedTagMap uses 16 buckets, so 64 entries guarantees BucketGroup chains.
+    TagMap map = TagMapType.OPTIMIZED.create();
+    for (int i = 0; i < 64; i++) {
+      map.set("k" + i, i);
+    }
+    assertEquals(64, map.size());
+
+    Iterator<TagMap.EntryReader> iter = map.iterator();
+    while (iter.hasNext()) {
+      iter.next();
+      iter.remove();
+    }
+
+    assertEquals(0, map.size());
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void optimizedIterator_remove_beforeNext_throws() {
+    TagMap map = TagMapType.OPTIMIZED.create();
+    map.set("a", 1);
+    Iterator<TagMap.EntryReader> iter = map.iterator();
+    assertThrows(IllegalStateException.class, iter::remove);
+  }
+
+  @Test
+  public void optimizedIterator_remove_twice_throws() {
+    TagMap map = TagMapType.OPTIMIZED.create();
+    map.set("a", 1);
+    Iterator<TagMap.EntryReader> iter = map.iterator();
+    iter.next();
+    iter.remove();
+    assertThrows(IllegalStateException.class, iter::remove);
+  }
+
+  @Test
+  public void optimizedIterator_remove_onFrozenMap_throws() {
+    TagMap map = TagMapType.OPTIMIZED.create();
+    map.set("a", 1);
+    map.set("b", 2);
+    Iterator<TagMap.EntryReader> iter = map.iterator();
+    iter.next();
+    map.freeze();
+    assertThrows(IllegalStateException.class, iter::remove);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary

The view iterators returned by `OptimizedTagMap.entrySet().iterator()`, `keySet().iterator()`, `values().iterator()`, and the `TagMap.iterator()` overload all extend `IteratorBase`, which inherited the default `Iterator.remove()` that throws `UnsupportedOperationException`. As a result, `AbstractSet`/`AbstractCollection` bulk operations that rely on iterator-remove (`removeAll`, `removeIf`, `retainAll`) silently failed mid-iteration on optimized maps — a `Map` contract gap.

This patch tracks the last-returned entry on `IteratorBase` and removes by tag through `OptimizedTagMap.getAndRemove`, which enforces the frozen check. The fix is contained entirely in `IteratorBase`, so all three subclasses (`EntryReaderIterator`, `KeysIterator`, `ValuesIterator`) inherit `remove()` automatically.

`LegacyTagMap` is unaffected: its view iterators are inherited from `HashMap` and already support remove. (Its TagMap-level `iterator()` does not, but that's a separate divergence — see follow-up work below.)

## Test plan

- [x] New tests in `TagMapTest`:
  - `entrySet_removeIf` (parameterized over OPTIMIZED + LEGACY)
  - `keySet_removeAll` (parameterized over OPTIMIZED + LEGACY)
  - `values_removeIf` (parameterized over OPTIMIZED + LEGACY)
  - `optimizedIterator_remove`
  - `optimizedIterator_remove_acrossBucketCollisions` (forces BucketGroup chains, then removes all entries via iterator)
  - `optimizedIterator_remove_beforeNext_throws`
  - `optimizedIterator_remove_twice_throws`
  - `optimizedIterator_remove_onFrozenMap_throws`
- [x] `./gradlew :internal-api:test` passes
- [x] `./gradlew :internal-api:spotlessCheck` passes
- [ ] CI matrix

## Follow-up not in scope

- `LegacyTagMap.IteratorImpl.remove()` is also unsupported (would need to delegate to the wrapped HashMap iterator). Different mechanism, different PR.
- Pre-existing class-init ordering issue: running a single `@EnumSource(TagMapType.class)` test in isolation (e.g. `--tests TagMapTest.numericZeroToBooleanCoercion`) fails with NPE in `TagMap.<clinit>` because `TagMapType` loads `OptimizedTagMapFactory.INSTANCE` before `TagMap`. Reproduces on master without these changes; orthogonal to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)