### PR TITLE
Read trace propagation behavior from tracer's config, not global singleton

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1778,7 +1778,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
 
       // Handle remote terminated context as span links
       if (parentContext != null && parentContext.isRemote()) {
-        switch (Config.get().getTracePropagationBehaviorExtract()) {
+        switch (tracer.initialConfig.getTracePropagationBehaviorExtract()) {
           case RESTART:
             links = addParentContextLink(links, parentContext);
             parentContext = null;

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -27,6 +27,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TagMap;
+import datadog.trace.api.TracePropagationBehaviorExtract;
 import datadog.trace.api.datastreams.NoopPathwayContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.naming.SpanNaming;
@@ -45,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -417,6 +419,48 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     assertNotEquals(extractedContext.getSpanId(), span.getParentId());
     assertEquals(PrioritySampling.UNSET, span.samplingPriority());
     assertTrue(span.getLinks().isEmpty());
+  }
+
+  @Test
+  void extractBehaviorReadsTracerConfigNotGlobalSingleton() {
+    // Build a tracer with a Properties-based config that selects RESTART. The global
+    // Config.get() singleton is unaffected (default CONTINUE). The span build path must
+    // read the tracer's own config — not Config.get() — so the resulting span should
+    // reflect RESTART behavior (parent dropped, parent context attached as a link).
+    Properties props = new Properties();
+    props.setProperty("trace.propagation.behavior.extract", "restart");
+    CoreTracer customTracer = tracerBuilder().withProperties(props).writer(writer).build();
+    assertEquals(
+        TracePropagationBehaviorExtract.RESTART,
+        customTracer.initialConfig.getTracePropagationBehaviorExtract(),
+        "precondition: customTracer's config must reflect Properties override");
+
+    ExtractedContext extractedContext =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            2,
+            PrioritySampling.SAMPLER_DROP,
+            null,
+            0,
+            Collections.<String, String>emptyMap(),
+            Collections.<String, Object>emptyMap(),
+            null,
+            PropagationTags.factory()
+                .fromHeaderValue(
+                    PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"),
+            null,
+            DATADOG);
+    DDSpan span =
+        (DDSpan) customTracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
+
+    assertNotEquals(extractedContext.getTraceId(), span.getTraceId());
+    assertNotEquals(extractedContext.getSpanId(), span.getParentId());
+
+    List<? extends AgentSpanLink> spanLinks = span.getLinks();
+    assertEquals(1, spanLinks.size());
+    AgentSpanLink link = spanLinks.get(0);
+    assertEquals(extractedContext.getTraceId(), link.traceId());
+    assertEquals(extractedContext.getSpanId(), link.spanId());
   }
 
   @TableTest({


### PR DESCRIPTION
## Summary

`CoreSpanBuilder.startSpan` reads `Config.get().getTracePropagationBehaviorExtract()` for every remote-parent span build. Tracers configured via `withProperties(...)` end up with an `initialConfig` distinct from the global `Config.get()` singleton, and on master the override is silently ignored — span behavior follows the singleton, not the tracer's configuration.

This patch switches that one call site to `tracer.initialConfig.getTracePropagationBehaviorExtract()`, matching the pattern already used elsewhere in this file (e.g. line 841 in the constructor, the `ConfigSnapshot` class, and the various `flush*` methods that read `initialConfig`). Marginal getfield savings on the hot path; the main benefit is correctness.

## Test plan

- [x] New regression test `CoreSpanBuilderTest.extractBehaviorReadsTracerConfigNotGlobalSingleton`:
  - Builds a `CoreTracer` via `tracerBuilder().withProperties(props).build()` where `props` selects RESTART.
  - Asserts the precondition that `customTracer.initialConfig` reflects the override.
  - Builds a span with a remote `ExtractedContext` parent and asserts RESTART behavior (parent dropped, parent context attached as a link).
  - I verified the test fails on master (without the production change) — global `Config.get()` returns CONTINUE, the parent isn't dropped, and `assertNotEquals(extractedContext.getTraceId(), span.getTraceId())` fails.
- [x] `./gradlew :dd-trace-core:test --tests 'datadog.trace.core.CoreSpanBuilderTest'` passes.
- [x] `./gradlew :dd-trace-core:spotlessCheck` passes.
- [ ] CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)