### PR TITLE
Send Aliases for `update_central_configurations_version_range_v2` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1129,3 +1129,4 @@ update_central_configurations_version_range_v2:
     LOCAL_JSON_PATH: "metadata/supported-configurations.json"
     LANGUAGE_NAME: "java"
     MULTIPLE_RELEASE_LINES: "false"
+    SEND_ALIASES: "true"


### PR DESCRIPTION
# What Does This Do
Given the original state of the script prior to the modifications to the Updated Supported Range job made [here](https://github.com/DataDog/libdatadog-build/pull/220), the job would pass under the following conditions:
1. `SEND_ALIASES=false`, Language implementations in the registry has no aliases
2. `SEND_ALIASES=true`, Language implementations in the registry has aliases

dd-trace-java had some aliases in the registry and `SEND_ALIASES=false`, causing the script to fail. The registry has since been migrated to have language implementation aliases, so `SEND_ALIASES` needs to be set to true to keep the script working for the future.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
