### PR TITLE
Remove nullable type in TestJvmSpec

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/testJvmConstraints/TestJvmSpec.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/testJvmConstraints/TestJvmSpec.kt
@@ -14,6 +14,7 @@ import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
+import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.support.serviceOf
 import java.nio.file.Files
 import java.nio.file.Path
@@ -151,7 +152,7 @@ class TestJvmSpec(val project: Project) {
     project.providers.zip(testJvmSpec, normalizedTestJvm) { jvmSpec, testJvm ->
       // Only change test JVM if it's not the one we are running the gradle build with
       if ((jvmSpec as? SpecificInstallationToolchainSpec)?.javaHome == currentJavaHomePath.get()) {
-        project.providers.provider<JavaLauncher?> { null }
+        project.objects.property<JavaLauncher>()
       } else {
         // The provider always says that a value is present so we need to wrap it for proper error messages
         project.javaToolchains.launcherFor(jvmSpec).orElse(project.providers.provider {


### PR DESCRIPTION
# What Does This Do

Replace API with non-nullable declaration

# Motivation

Gradle 9 changed the Provider API for handling nullable types. The old code used project.providers.provider<JavaLauncher?> { null } which is no longer compatible.

# Additional Notes

Sub-PR from #10402, #11272