### PR TITLE
Replace `SelfResolvingDependency` by `ExternalModuleDependency`

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -38,7 +38,7 @@ publishing {
               def dependenciesNode = xml.asNode().appendNode('dependencies')
 
               project.configurations.api.allDependencies.each {
-                if ((it instanceof ProjectDependency) || !(it instanceof SelfResolvingDependency)) {
+                if (it instanceof ProjectDependency || it instanceof ExternalModuleDependency) {
                   def dependencyNode = dependenciesNode.appendNode('dependency')
                   dependencyNode.appendNode('groupId', it.group)
                   dependencyNode.appendNode('artifactId', it.name)


### PR DESCRIPTION
# What Does This Do

Replace `!(it instanceof SelfResolvingDependency)` with `it instanceof ExternalModuleDependency` in the POM-generation block of `gradle/publish.gradle`. The filter now explicitly allows only dependencies with Maven coordinates (project deps and external module deps) rather than excluding file deps by the already deprecated and then removed marker interface.

# Motivation

`SelfResolvingDependency` was removed in Gradle 9 as part of the dependency API cleanup, now, as suggested in the deprecation message all resolution happens through a `Configuration`, not through individual dependencies.
The positive check is also safer: a future unknown dependency type without Maven coordinates won't accidentally slip into published POM files, whereas a negative exclusion could let it through.

# Additional Notes

Sub-PR from #10402, #11272
