### PR TITLE
Bump aQute bnd plugin (osgi) to 7.2.3

### DIFF
--- a/dd-smoke-tests/osgi/build.gradle
+++ b/dd-smoke-tests/osgi/build.gradle
@@ -1,7 +1,7 @@
 import aQute.bnd.gradle.Bundle
 
 plugins {
-  id 'biz.aQute.bnd.builder' version '6.4.0' apply true
+  id 'biz.aQute.bnd.builder' version '7.2.3' apply true
 }
 
 repositories {


### PR DESCRIPTION
# What Does This Do

Bumps the `biz.aQute.bnd.builder` Gradle plugin from `6.4.0` to `7.2.3` in
`dd-smoke-tests/osgi/build.gradle`. This is one of the incremental steps toward
Gradle 9 compatibility.

# Motivation

Gradle 9 removed the `Convention` API (`AbstractTask.getConvention()`), which bnd 6.x used internally to register `BundleTaskConvention` on `Jar` tasks. bnd 7.0 replaced this with `BundleTaskExtension` (extensions API), making it Gradle 9-ready.
The `Bundle` task type used in this module is a direct usage with no convention
accessor calls in the build script, so no script changes are required beyond the
version bump.

# Additional Notes

Sub-PR from #10402, #11272