### PR TITLE
Avoid Metadata.key allocations on grpc

### DIFF
--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcInjectAdapter.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcInjectAdapter.java
@@ -1,17 +1,24 @@
 package datadog.trace.instrumentation.armeria.grpc.client;
 
 import datadog.context.propagation.CarrierSetter;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import io.grpc.Metadata;
+import java.util.function.Function;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public final class GrpcInjectAdapter implements CarrierSetter<Metadata> {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
 
   public static final GrpcInjectAdapter SETTER = new GrpcInjectAdapter();
 
   @Override
   public void set(final Metadata carrier, final String key, final String value) {
-    Metadata.Key<String> metadataKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+    Metadata.Key<String> metadataKey = KEY_CACHE.computeIfAbsent(key, KEY_MAKER);
     if (carrier.containsKey(metadataKey)) {
       carrier.removeAll(
           metadataKey); // Remove existing to ensure identical behavior with other carriers

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcExtractAdapter.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcExtractAdapter.java
@@ -1,9 +1,16 @@
 package datadog.trace.instrumentation.armeria.grpc.server;
 
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.grpc.Metadata;
+import java.util.function.Function;
 
 public final class GrpcExtractAdapter implements AgentPropagation.ContextVisitor<Metadata> {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
 
   public static final GrpcExtractAdapter GETTER = new GrpcExtractAdapter();
 
@@ -11,8 +18,7 @@ public final class GrpcExtractAdapter implements AgentPropagation.ContextVisitor
   public void forEachKey(Metadata carrier, AgentPropagation.KeyClassifier classifier) {
     for (String key : carrier.keys()) {
       if (!key.endsWith(Metadata.BINARY_HEADER_SUFFIX) && !key.startsWith(":")) {
-        if (!classifier.accept(
-            key, carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)))) {
+        if (!classifier.accept(key, carrier.get(KEY_CACHE.computeIfAbsent(key, KEY_MAKER)))) {
           return;
         }
       }

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
@@ -12,6 +12,8 @@ import static datadog.trace.instrumentation.armeria.grpc.server.GrpcServerDecora
 import static datadog.trace.instrumentation.armeria.grpc.server.GrpcServerDecorator.SERVER_PATHWAY_EDGE_TAGS;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.function.TriFunction;
 import datadog.trace.api.gateway.CallbackProvider;
@@ -43,6 +45,10 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 public class TracingServerInterceptor implements ServerInterceptor {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
 
   public static final TracingServerInterceptor INSTANCE = new TracingServerInterceptor();
   private static final Set<String> IGNORED_METHODS = Config.get().getGrpcIgnoredInboundMethods();
@@ -294,7 +300,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     }
     for (String key : metadata.keys()) {
       if (!key.endsWith(Metadata.BINARY_HEADER_SUFFIX) && !key.startsWith(":")) {
-        Metadata.Key<String> mdKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key<String> mdKey = KEY_CACHE.computeIfAbsent(key, KEY_MAKER);
         for (String value : metadata.getAll(mdKey)) {
           headerCb.accept(reqCtx, key, value);
         }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
@@ -1,16 +1,24 @@
 package datadog.trace.instrumentation.grpc.client;
 
 import datadog.context.propagation.CarrierSetter;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import io.grpc.Metadata;
+import java.util.function.Function;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public final class GrpcInjectAdapter implements CarrierSetter<Metadata> {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
+
   public static final GrpcInjectAdapter SETTER = new GrpcInjectAdapter();
 
   @Override
   public void set(final Metadata carrier, final String key, final String value) {
-    Metadata.Key<String> metadataKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+    Metadata.Key<String> metadataKey = KEY_CACHE.computeIfAbsent(key, KEY_MAKER);
     if (carrier.containsKey(metadataKey)) {
       carrier.removeAll(
           metadataKey); // Remove existing to ensure identical behavior with other carriers

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcExtractAdapter.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcExtractAdapter.java
@@ -1,9 +1,16 @@
 package datadog.trace.instrumentation.grpc.server;
 
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import io.grpc.Metadata;
+import java.util.function.Function;
 
 public final class GrpcExtractAdapter implements AgentPropagation.ContextVisitor<Metadata> {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
 
   public static final GrpcExtractAdapter GETTER = new GrpcExtractAdapter();
 
@@ -11,8 +18,7 @@ public final class GrpcExtractAdapter implements AgentPropagation.ContextVisitor
   public void forEachKey(Metadata carrier, AgentPropagation.KeyClassifier classifier) {
     for (String key : carrier.keys()) {
       if (!key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        if (!classifier.accept(
-            key, carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)))) {
+        if (!classifier.accept(key, carrier.get(KEY_CACHE.computeIfAbsent(key, KEY_MAKER)))) {
           return;
         }
       }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -13,6 +13,8 @@ import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.GRPC
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.SERVER_PATHWAY_EDGE_TAGS;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.function.TriFunction;
 import datadog.trace.api.gateway.CallbackProvider;
@@ -44,6 +46,10 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 public class TracingServerInterceptor implements ServerInterceptor {
+  private static final Function<String, Metadata.Key<String>> KEY_MAKER =
+      key -> Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+  private static final DDCache<String, Metadata.Key<String>> KEY_CACHE =
+      DDCaches.newFixedSizeCache(64);
 
   public static final TracingServerInterceptor INSTANCE = new TracingServerInterceptor();
   private static final Set<String> IGNORED_METHODS = Config.get().getGrpcIgnoredInboundMethods();
@@ -295,7 +301,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     }
     for (String key : metadata.keys()) {
       if (!key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        Metadata.Key<String> mdKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key<String> mdKey = KEY_CACHE.computeIfAbsent(key, KEY_MAKER);
         for (String value : metadata.getAll(mdKey)) {
           headerCb.accept(reqCtx, key, value);
         }


### PR DESCRIPTION
# What Does This Do

Avoid allocating a Metadata.Key allocation for each grpc call (it's on the hot path). The keys can be cached in a large enough DDCache

# Motivation

### Allocation histogram — instrumented vs baseline (JFR captures)

```
  byte[]                                          instr [██████████████████████]   54   base [████                  ]   10
  java.lang.Object[]                              instr [██████                ]   14   base [████                  ]   11
  java.util.HashMap$Node                          instr [███████               ]   17   base [                      ]    0
  java.lang.String                                instr [██████                ]   15   base [█                     ]    1
  java.util.HashMap$Node[]                        instr [████                  ]    9   base [█                     ]    1
  io.grpc.Metadata$AsciiKey                       instr [████                  ]    9   base [                      ]    0
  ..ChannelStreamProvider$1RetryStream            instr [██                    ]    5   base [█                     ]    2
  ..ConcurrentLinkedQueue$Node                    instr [█                     ]    3   base [█                     ]    3
  io.grpc.internal.ClientCallImpl                 instr [█                     ]    1   base [██                    ]    4
  io.grpc.internal.RetriableStream$State          instr [█                     ]    3   base [█                     ]    2
```

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
