### PR TITLE
Add dd-octo-sts chainguard policy files

### DIFF
--- a/.github/chainguard/self.check-pull-request-labels.sts.yaml
+++ b/.github/chainguard/self.check-pull-request-labels.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/check-pull-request-labels\.yaml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.check-pull-requests.sts.yaml
+++ b/.github/chainguard/self.check-pull-requests.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/check-pull-requests\.yaml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.comment-on-submodule-update.sts.yaml
+++ b/.github/chainguard/self.comment-on-submodule-update.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/comment-on-submodule-update\.yaml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.enforce-groovy-migration.sts.yaml
+++ b/.github/chainguard/self.enforce-groovy-migration.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-java:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/enforce-groovy-migration\.yaml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  contents: read
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.update-issues-on-release.sts.yaml
+++ b/.github/chainguard/self.update-issues-on-release.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-java:ref:refs/(heads|tags)/.*"
+
+claim_pattern:
+  event_name: (release|workflow_dispatch)
+  job_workflow_ref: DataDog/dd-trace-java/\.github/workflows/update-issues-on-release\.yaml@refs/(heads/.*|tags/.*)
+
+permissions:
+  issues: write


### PR DESCRIPTION
# What Does This Do

Add 5 Chainguard policy files under `.github/chainguard/` for the upcoming migration of `secrets.GITHUB_TOKEN` to `DataDog/dd-octo-sts-action`.

# Motivation

These policies must be on the default branch before the corresponding workflow changes can use them. They declare which workflow, event, and ref pattern may request which permissions via the dd-octo-sts OIDC token exchange.

# Additional Notes

Policy files only — no workflow changes. Stacked with #11347.

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [x] Assign the `type:` and (`comp:` or `inst:`) labels

# Jira

- [APMLP-1603](https://datadoghq.atlassian.net/browse/APMLP-1603)


[APMLP-1603]: https://datadoghq.atlassian.net/browse/APMLP-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ