### PR TITLE
Fix NPE in JVMFlagAccess.setValue when getStringFlag returns null

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/Initializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/Initializer.java
@@ -17,6 +17,7 @@ import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public final class Initializer {
     @Override
     public boolean setValue(String flagName, String value) {
       flags.setStringFlag(flagName, value);
-      return flags.getStringFlag(flagName).equals(value);
+      return Objects.equals(flags.getStringFlag(flagName), value);
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Fixes a `NullPointerException` in `JVMFlagAccess.setValue` inside crash tracking initialization.
`setValue` calls `getStringFlag` after `setStringFlag` to verify the write succeeded, but
`getStringFlag` can return `null` on certain platforms where the JVM flag is not accessible via
the native ddprof API. The fix replaces `.equals()` with `Objects.equals` to handle `null` safely.

# Motivation

On Apple Silicon (aarch64) and potentially other platforms, JVM flags like `OnError` and
`OnOutOfMemoryError` are not readable via `JVMAccess.Flags.getStringFlag`, which returns `null`.
This caused a `NullPointerException` logged as a WARN during crash tracking initialization on
every agent startup, polluting logs and causing noise in tests that assert no NPE appears.

# Additional Notes

- Only `JVMFlagAccess` (native path) is affected. `JMXFlagAccess` always returns `true` and is unaffected.
- Returning `false` when `getStringFlag` returns `null` is semantically correct: it signals that
the flag could not be verified as set, which is the expected behavior when the native API does
not support the flag.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors