### PR TITLE
implementation for span derived primary tags

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/msgpack/MsgPackWriter.java
+++ b/communication/src/main/java/datadog/communication/serialization/msgpack/MsgPackWriter.java
@@ -201,6 +201,20 @@ public class MsgPackWriter implements WritableFormatter {
     buffer.put(string.getUtf8Bytes());
   }
 
+  /**
+   * Writes a single msgpack string composed of three byte ranges concatenated in order: {@code
+   * prefix}, the single byte {@code separator}, and {@code suffix}. Avoids allocating an
+   * intermediate {@code byte[]} or formatted String when callers want to emit e.g. {@code
+   * "key:value"} on the wire from separate sources.
+   */
+  public void writeUTF8(byte[] prefix, byte separator, byte[] suffix) {
+    int totalLength = prefix.length + 1 + suffix.length;
+    writeStringHeader(totalLength);
+    buffer.put(prefix);
+    buffer.put(separator);
+    buffer.put(suffix);
+  }
+
   @Override
   public void writeBinary(byte[] binary) {
     writeBinaryHeader(binary.length);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -76,6 +76,7 @@ public final class GeneralConfig {
   public static final String TRACER_METRICS_MAX_PENDING = "trace.tracer.metrics.max.pending";
   public static final String TRACER_METRICS_IGNORED_RESOURCES =
       "trace.tracer.metrics.ignored.resources";
+  public static final String TRACE_STATS_ADDITIONAL_TAGS = "trace.stats.additional.tags";
 
   public static final String AZURE_APP_SERVICES = "azure.app.services";
   public static final String INTERNAL_EXIT_ON_FAILURE = "trace.internal.exit.on.failure";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -77,6 +77,8 @@ public final class GeneralConfig {
   public static final String TRACER_METRICS_IGNORED_RESOURCES =
       "trace.tracer.metrics.ignored.resources";
   public static final String TRACE_STATS_ADDITIONAL_TAGS = "trace.stats.additional.tags";
+  public static final String TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT =
+      "trace.stats.additional.tags.cardinality.limit";
 
   public static final String AZURE_APP_SERVICES = "azure.app.services";
   public static final String INTERNAL_EXIT_ON_FAILURE = "trace.internal.exit.on.failure";

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
@@ -40,7 +40,7 @@ public class ConflatingMetricsAggregatorBenchmark {
       new ConflatingMetricsAggregator(
           new WellKnownTags("", "", "", "", "", ""),
           Collections.emptySet(),
-          Collections.emptyList(),
+          Collections.emptySet(),
           featuresDiscovery,
           HealthMetrics.NO_OP,
           new NullSink(),

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
@@ -40,6 +40,7 @@ public class ConflatingMetricsAggregatorBenchmark {
       new ConflatingMetricsAggregator(
           new WellKnownTags("", "", "", "", "", ""),
           Collections.emptySet(),
+          Collections.emptyList(),
           featuresDiscovery,
           HealthMetrics.NO_OP,
           new NullSink(),

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorBenchmark.java
@@ -41,6 +41,7 @@ public class ConflatingMetricsAggregatorBenchmark {
           new WellKnownTags("", "", "", "", "", ""),
           Collections.emptySet(),
           Collections.emptySet(),
+          100,
           featuresDiscovery,
           HealthMetrics.NO_OP,
           new NullSink(),

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
@@ -1,92 +1,106 @@
 package datadog.trace.common.metrics;
 
 import datadog.trace.core.monitor.HealthMetrics;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bounded per-tag cardinality protection for `additional_metric_tags`.
+ * Bounds how many distinct stat entries (MetricKeys) with any additional tags we'll let into a
+ * single flush bucket, and how long a single tag value can be.
  *
- * <p>For each configured tag key, admits at most {@code limitPerTag} distinct values within a
- * rolling window. Excess values are replaced with {@link #BLOCKED_VALUE} so the span's base stats
- * still flow through but the extra dimension is suppressed.
+ * <p>One global counter. It goes up by one each time we add a brand-new MetricKey to the bucket
+ * that includes any additional tags. When the counter reaches the cap, any further <em>new</em>
+ * MetricKeys drop all of their additional tags. Spans whose full MetricKey already exists in the
+ * bucket are unaffected — they keep merging into the existing entry.
  *
- * <p>The rolling window is implemented as a hard reset: callers schedule {@link #reset()} on a
- * fixed interval (10 minutes by default). After a reset, previously blocked values get a fresh
- * chance to be admitted.
+ * <p>The counter and both one-shot warn flags reset every flush via {@link #resetBucket()}.
  */
 final class AdditionalTagsCardinalityLimiter {
 
   static final String BLOCKED_VALUE = "blocked_by_tracer";
+  static final int MAX_ADDITIONAL_TAG_VALUE_LENGTH = 250;
 
   private static final Logger log = LoggerFactory.getLogger(AdditionalTagsCardinalityLimiter.class);
 
-  private final int limitPerTag;
+  private final int maxStatEntries;
   private final HealthMetrics healthMetrics;
-  private final ConcurrentHashMap<String, Set<String>> seenValuesPerTag = new ConcurrentHashMap<>();
-  private final Set<String> warnedAboutCardinality =
-      Collections.newSetFromMap(new ConcurrentHashMap<>());
-  private final Set<String> warnedAboutLength =
-      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final AtomicInteger statEntryCounter = new AtomicInteger();
+  private volatile boolean warnedAboutCardinality;
+  private volatile boolean warnedAboutLength;
 
-  AdditionalTagsCardinalityLimiter(int limitPerTag, HealthMetrics healthMetrics) {
-    this.limitPerTag = limitPerTag;
+  AdditionalTagsCardinalityLimiter(int maxStatEntries, HealthMetrics healthMetrics) {
+    this.maxStatEntries = maxStatEntries;
     this.healthMetrics = healthMetrics;
   }
 
   /**
-   * @return {@code value} if admitted under the cap, otherwise {@link #BLOCKED_VALUE}.
+   * Returns {@code value} unchanged if it's short enough, or {@link #BLOCKED_VALUE} if it's longer
+   * than {@link #MAX_ADDITIONAL_TAG_VALUE_LENGTH}. Fires the health metric on every block and emits
+   * one warn log per bucket regardless of which tag triggered it.
    */
-  String admitOrBlock(String tagKey, String value) {
-    Set<String> seen =
-        seenValuesPerTag.computeIfAbsent(
-            tagKey, k -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
-    if (seen.contains(value)) {
-      return value;
-    }
-    if (seen.size() >= limitPerTag) {
+  String applyLengthCap(String tagKey, String value) {
+    if (value.length() > MAX_ADDITIONAL_TAG_VALUE_LENGTH) {
       healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
-      if (warnedAboutCardinality.add(tagKey)) {
-        log.warn(
-            "Additional metric tag '{}' exceeded the per-tag cardinality limit of {}; "
-                + "replacing values with '{}' for the rest of the current window",
-            tagKey,
-            limitPerTag,
-            BLOCKED_VALUE);
+      if (!warnedAboutLength) {
+        synchronized (this) {
+          if (!warnedAboutLength) {
+            warnedAboutLength = true;
+            log.warn(
+                "Additional metric tag '{}' had a value of length {} exceeding the max length of {}; "
+                    + "replacing with '{}' for the rest of the current bucket",
+                tagKey,
+                value.length(),
+                MAX_ADDITIONAL_TAG_VALUE_LENGTH,
+                BLOCKED_VALUE);
+          }
+        }
       }
       return BLOCKED_VALUE;
     }
-    seen.add(value);
     return value;
   }
 
   /**
-   * Records that a value for {@code tagKey} was blocked due to exceeding the per-value length cap.
-   * Fires the same health metric as a cardinality block and emits a distinct warn log line once per
-   * tag key per window.
+   * Returns true if the global stat-entry counter has reached the cap. Read-only; no side effects.
    */
-  void noteBlockedDueToLength(String tagKey, int valueLength, int maxLength) {
-    healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
-    if (warnedAboutLength.add(tagKey)) {
-      log.warn(
-          "Additional metric tag '{}' had a value of length {} exceeding the max length of {}; "
-              + "replacing with '{}' for the rest of the current window",
-          tagKey,
-          valueLength,
-          maxLength,
-          BLOCKED_VALUE);
+  boolean isAtCap() {
+    return statEntryCounter.get() >= maxStatEntries;
+  }
+
+  /**
+   * Records that a span's additional tags were dropped because the bucket is at the cap. Emits one
+   * warn log per bucket regardless of how many spans get blocked.
+   */
+  void recordCardinalityBlock() {
+    if (!warnedAboutCardinality) {
+      synchronized (this) {
+        if (!warnedAboutCardinality) {
+          warnedAboutCardinality = true;
+          log.warn(
+              "Additional metric tag stat-entry limit of {} reached for the current bucket; "
+                  + "dropping additional tags from any new stat entries until the next flush",
+              maxStatEntries);
+        }
+      }
     }
   }
 
-  /** Clears per-tag value sets and rearms the per-key log lines. Invoked by the periodic task. */
-  void reset() {
-    for (Set<String> seen : seenValuesPerTag.values()) {
-      seen.clear();
-    }
-    warnedAboutCardinality.clear();
-    warnedAboutLength.clear();
+  /**
+   * Bumps the global stat-entry counter. Called once per brand-new MetricKey we admit that includes
+   * any additional tags.
+   */
+  void onNewStatEntryAdmitted() {
+    statEntryCounter.incrementAndGet();
+  }
+
+  /**
+   * Zeroes the counter and re-arms both warn flags. Called whenever the metrics aggregator flushes
+   * a bucket so the next bucket starts with a fresh budget.
+   */
+  void resetBucket() {
+    statEntryCounter.set(0);
+    warnedAboutCardinality = false;
+    warnedAboutLength = false;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
@@ -27,7 +27,10 @@ final class AdditionalTagsCardinalityLimiter {
   private final int limitPerTag;
   private final HealthMetrics healthMetrics;
   private final ConcurrentHashMap<String, Set<String>> seenValuesPerTag = new ConcurrentHashMap<>();
-  private final Set<String> warnedThisWindow = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final Set<String> warnedAboutCardinality =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final Set<String> warnedAboutLength =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   AdditionalTagsCardinalityLimiter(int limitPerTag, HealthMetrics healthMetrics) {
     this.limitPerTag = limitPerTag;
@@ -46,7 +49,7 @@ final class AdditionalTagsCardinalityLimiter {
     }
     if (seen.size() >= limitPerTag) {
       healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
-      if (warnedThisWindow.add(tagKey)) {
+      if (warnedAboutCardinality.add(tagKey)) {
         log.warn(
             "Additional metric tag '{}' exceeded the per-tag cardinality limit of {}; "
                 + "replacing values with '{}' for the rest of the current window",
@@ -60,11 +63,30 @@ final class AdditionalTagsCardinalityLimiter {
     return value;
   }
 
-  /** Clears per-tag value sets and rearms the per-key log line. Invoked by the periodic task. */
+  /**
+   * Records that a value for {@code tagKey} was blocked due to exceeding the per-value length cap.
+   * Fires the same health metric as a cardinality block and emits a distinct warn log line once per
+   * tag key per window.
+   */
+  void noteBlockedDueToLength(String tagKey, int valueLength, int maxLength) {
+    healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
+    if (warnedAboutLength.add(tagKey)) {
+      log.warn(
+          "Additional metric tag '{}' had a value of length {} exceeding the max length of {}; "
+              + "replacing with '{}' for the rest of the current window",
+          tagKey,
+          valueLength,
+          maxLength,
+          BLOCKED_VALUE);
+    }
+  }
+
+  /** Clears per-tag value sets and rearms the per-key log lines. Invoked by the periodic task. */
   void reset() {
     for (Set<String> seen : seenValuesPerTag.values()) {
       seen.clear();
     }
-    warnedThisWindow.clear();
+    warnedAboutCardinality.clear();
+    warnedAboutLength.clear();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiter.java
@@ -1,0 +1,70 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.core.monitor.HealthMetrics;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bounded per-tag cardinality protection for `additional_metric_tags`.
+ *
+ * <p>For each configured tag key, admits at most {@code limitPerTag} distinct values within a
+ * rolling window. Excess values are replaced with {@link #BLOCKED_VALUE} so the span's base stats
+ * still flow through but the extra dimension is suppressed.
+ *
+ * <p>The rolling window is implemented as a hard reset: callers schedule {@link #reset()} on a
+ * fixed interval (10 minutes by default). After a reset, previously blocked values get a fresh
+ * chance to be admitted.
+ */
+final class AdditionalTagsCardinalityLimiter {
+
+  static final String BLOCKED_VALUE = "blocked_by_tracer";
+
+  private static final Logger log = LoggerFactory.getLogger(AdditionalTagsCardinalityLimiter.class);
+
+  private final int limitPerTag;
+  private final HealthMetrics healthMetrics;
+  private final ConcurrentHashMap<String, Set<String>> seenValuesPerTag = new ConcurrentHashMap<>();
+  private final Set<String> warnedThisWindow = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+  AdditionalTagsCardinalityLimiter(int limitPerTag, HealthMetrics healthMetrics) {
+    this.limitPerTag = limitPerTag;
+    this.healthMetrics = healthMetrics;
+  }
+
+  /**
+   * @return {@code value} if admitted under the cap, otherwise {@link #BLOCKED_VALUE}.
+   */
+  String admitOrBlock(String tagKey, String value) {
+    Set<String> seen =
+        seenValuesPerTag.computeIfAbsent(
+            tagKey, k -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    if (seen.contains(value)) {
+      return value;
+    }
+    if (seen.size() >= limitPerTag) {
+      healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
+      if (warnedThisWindow.add(tagKey)) {
+        log.warn(
+            "Additional metric tag '{}' exceeded the per-tag cardinality limit of {}; "
+                + "replacing values with '{}' for the rest of the current window",
+            tagKey,
+            limitPerTag,
+            BLOCKED_VALUE);
+      }
+      return BLOCKED_VALUE;
+    }
+    seen.add(value);
+    return value;
+  }
+
+  /** Clears per-tag value sets and rearms the per-key log line. Invoked by the periodic task. */
+  void reset() {
+    for (Set<String> seen : seenValuesPerTag.values()) {
+      seen.clear();
+    }
+    warnedThisWindow.clear();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -102,6 +102,11 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       unmodifiableSet(
           new HashSet<>(Arrays.asList(SPAN_KIND_CLIENT, SPAN_KIND_PRODUCER, SPAN_KIND_CONSUMER)));
 
+  // Cap on configured additional metric tag keys. By default only 4 primary tag dimensions are supported.
+  // We sometimes increase this limit for users so a value of 10 allows us to protect against extreme misconfiguration
+  // while still allowing some additional tags to be used.
+  static final int MAX_ADDITIONAL_TAG_KEYS = 10;
+
   private final Set<String> ignoredResources;
   private final List<String> additionalTagKeys;
   private final MessagePassingQueue<Batch> batchPool;
@@ -144,7 +149,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   ConflatingMetricsAggregator(
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
-      List<String> additionalTagKeys,
+      Set<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -168,7 +173,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   ConflatingMetricsAggregator(
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
-      List<String> additionalTagKeys,
+      Set<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -193,7 +198,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   ConflatingMetricsAggregator(
       Set<String> ignoredResources,
-      List<String> additionalTagKeys,
+      Set<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -204,8 +209,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       TimeUnit timeUnit,
       boolean includeEndpointInMetrics) {
     this.ignoredResources = ignoredResources;
-    this.additionalTagKeys =
-        additionalTagKeys == null ? Collections.emptyList() : additionalTagKeys;
+    this.additionalTagKeys = normalizeAdditionalTagKeys(additionalTagKeys);
     this.includeEndpointInMetrics = includeEndpointInMetrics;
     this.inbox = Queues.mpscArrayQueue(queueSize);
     this.batchPool = Queues.spmcArrayQueue(maxAggregates);
@@ -431,6 +435,24 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       }
     }
     return Collections.emptyList();
+  }
+
+  static List<String> normalizeAdditionalTagKeys(Set<String> configured) {
+    if (configured == null || configured.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> sorted = new ArrayList<>(configured);
+    Collections.sort(sorted);
+    if (sorted.size() > MAX_ADDITIONAL_TAG_KEYS) {
+      log.warn(
+          "Configured additional metric tag keys ({}) exceeds the supported limit of {}; "
+              + "dropping extra keys: {}",
+          sorted.size(),
+          MAX_ADDITIONAL_TAG_KEYS,
+          sorted.subList(MAX_ADDITIONAL_TAG_KEYS, sorted.size()));
+      sorted = sorted.subList(0, MAX_ADDITIONAL_TAG_KEYS);
+    }
+    return Collections.unmodifiableList(new ArrayList<>(sorted));
   }
 
   private List<UTF8BytesString> getAdditionalTags(CoreSpan<?> span) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -80,16 +80,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
               Pair.of(
                   DDCaches.newFixedSizeCache(512),
                   value -> UTF8BytesString.create(key + ":" + value));
-  private static final DDCache<
-          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
-      ADDITIONAL_TAG_VALUES_CACHE = DDCaches.newFixedSizeCache(64);
-  private static final Function<
-          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
-      ADDITIONAL_TAG_VALUES_CACHE_ADDER =
-          key ->
-              Pair.of(
-                  DDCaches.newFixedSizeCache(512),
-                  value -> UTF8BytesString.create(key + ":" + value));
   private static final CharSequence SYNTHETICS_ORIGIN = "synthetics";
 
   private static final Set<String> ELIGIBLE_SPAN_KINDS_FOR_METRICS =
@@ -201,7 +191,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         features,
         healthMetric,
         sink,
-        new SerializingMetricWriter(wellKnownTags, sink),
+        new SerializingMetricWriter(
+            wellKnownTags,
+            encodeAdditionalTagKeyBytes(normalizeAdditionalTagKeys(additionalTagKeys)),
+            sink),
         maxAggregates,
         queueSize,
         reportingInterval,
@@ -375,7 +368,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       Object grpcStatusObj = span.unsafeGetTag(InstrumentationTags.GRPC_STATUS_CODE);
       grpcStatusCode = grpcStatusObj != null ? grpcStatusObj.toString() : null;
     }
-    List<UTF8BytesString> fullAdditionalTags = getAdditionalTagsLengthCapped(span);
+    String[] additionalTagValues = getAdditionalTagValuesLengthCapped(span);
     MetricKey newKey =
         new MetricKey(
             span.getResourceName(),
@@ -392,7 +385,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             httpMethod,
             httpEndpoint,
             grpcStatusCode,
-            fullAdditionalTags);
+            additionalTagValues);
 
     // If this span's full MetricKey is already in the current bucket, just admit it as-is.
     // We already paid the cardinality cost for these tag values earlier in this bucket, so the
@@ -404,10 +397,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     // into the no-additional-tags base bucket). If it's a new entry under the cap, admit with
     // the full tag set and remember to bump the counter below.
     boolean newEntryUsedFullTags = false;
-    if (!fullAdditionalTags.isEmpty() && pending.get(newKey) == null) {
+    if (additionalTagValues.length > 0 && pending.get(newKey) == null) {
       if (cardinalityLimiter.isAtCap()) {
         cardinalityLimiter.recordCardinalityBlock();
-        newKey = rebuildKeyWithBlockedValues(span, newKey);
+        newKey = rebuildKeyWithBlockedValues(newKey);
       } else {
         newEntryUsedFullTags = true;
       }
@@ -451,28 +444,19 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   }
 
   /**
-   * Builds a copy of {@code fullKey} with each present additional tag's value replaced by {@code
-   * <tagKey>:blocked_by_tracer}. The set of configured tag keys present on the span is preserved as
-   * dimensions; only the values are masked. Also fires the per-tag health metric for each masked
-   * tag. Used when the bucket cardinality cap is hit and we need to suppress this span's
-   * contribution to per-value aggregation without losing the dimension keys entirely.
+   * Builds a copy of {@code fullKey} with each present additional tag's value replaced by {@link
+   * AdditionalTagsCardinalityLimiter#BLOCKED_VALUE}. The set of configured tag keys present on the
+   * span is preserved (we keep the same positions populated in the values array); only the values
+   * are masked. Fires the per-tag health metric for each masked tag.
    */
-  private MetricKey rebuildKeyWithBlockedValues(CoreSpan<?> span, MetricKey fullKey) {
-    List<UTF8BytesString> blockedTags = null;
-    for (String tagKey : additionalTagKeys) {
-      if (span.unsafeGetTag(tagKey) == null) continue;
-      healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
-      Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
-          ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
-      UTF8BytesString formatted =
-          cacheAndCreator
-              .getLeft()
-              .computeIfAbsent(
-                  AdditionalTagsCardinalityLimiter.BLOCKED_VALUE, cacheAndCreator.getRight());
-      if (blockedTags == null) {
-        blockedTags = new ArrayList<>(additionalTagKeys.size());
+  private MetricKey rebuildKeyWithBlockedValues(MetricKey fullKey) {
+    String[] originalValues = fullKey.getAdditionalTagValues();
+    String[] blocked = new String[originalValues.length];
+    for (int i = 0; i < originalValues.length; i++) {
+      if (originalValues[i] != null) {
+        blocked[i] = AdditionalTagsCardinalityLimiter.BLOCKED_VALUE;
+        healthMetrics.onAdditionalTagValueCardinalityBlocked(additionalTagKeys.get(i));
       }
-      blockedTags.add(formatted);
     }
     return new MetricKey(
         fullKey.getResource(),
@@ -488,7 +472,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         fullKey.getHttpMethod(),
         fullKey.getHttpEndpoint(),
         fullKey.getGrpcStatusCode(),
-        blockedTags == null ? Collections.emptyList() : blockedTags);
+        blocked);
   }
 
   private List<UTF8BytesString> getPeerTags(CoreSpan<?> span, String spanKind) {
@@ -540,29 +524,44 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     return Collections.unmodifiableList(new ArrayList<>(sorted));
   }
 
-  private List<UTF8BytesString> getAdditionalTagsLengthCapped(CoreSpan<?> span) {
+  /**
+   * Builds the raw-value array for this span's additional tags. Element {@code i} holds the span's
+   * value for {@code additionalTagKeys.get(i)} (or {@code null} if not set). Values exceeding the
+   * per-value length cap are substituted with {@link
+   * AdditionalTagsCardinalityLimiter#BLOCKED_VALUE}.
+   *
+   * <p>Returns an empty array when no additional tags are configured or none are set on the span —
+   * keeps the no-additional-tags path zero-allocation.
+   */
+  private String[] getAdditionalTagValuesLengthCapped(CoreSpan<?> span) {
     if (additionalTagKeys.isEmpty()) {
-      return Collections.emptyList();
+      return EMPTY_ADDITIONAL_TAG_VALUES;
     }
-    List<UTF8BytesString> result = null;
+    String[] result = null;
     for (int i = 0; i < additionalTagKeys.size(); i++) {
       String tagKey = additionalTagKeys.get(i);
       Object value = span.unsafeGetTag(tagKey);
       if (value == null) {
         continue;
       }
-      String rawValue = value.toString();
-      String admittedValue = cardinalityLimiter.applyLengthCap(tagKey, rawValue);
-      Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
-          ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
-      UTF8BytesString formatted =
-          cacheAndCreator.getLeft().computeIfAbsent(admittedValue, cacheAndCreator.getRight());
+      String admittedValue = cardinalityLimiter.applyLengthCap(tagKey, value.toString());
       if (result == null) {
-        result = new ArrayList<>(additionalTagKeys.size());
+        result = new String[additionalTagKeys.size()];
       }
-      result.add(formatted);
+      result[i] = admittedValue;
     }
-    return result == null ? Collections.emptyList() : result;
+    return result == null ? EMPTY_ADDITIONAL_TAG_VALUES : result;
+  }
+
+  private static final String[] EMPTY_ADDITIONAL_TAG_VALUES = new String[0];
+
+  /** UTF-8 encodes each configured tag key once; the bytes flow into the serializer. */
+  private static byte[][] encodeAdditionalTagKeyBytes(List<String> tagKeys) {
+    byte[][] encoded = new byte[tagKeys.size()][];
+    for (int i = 0; i < tagKeys.size(); i++) {
+      encoded[i] = tagKeys.get(i).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+    return encoded;
   }
 
   private static boolean isSynthetic(CoreSpan<?> span) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -109,6 +109,11 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   // while still allowing some additional tags to be used.
   static final int MAX_ADDITIONAL_TAG_KEYS = 10;
 
+  // Maximum length of an additional metric tag *value*. Caps cache footprint and wire payload
+  // size from stack-trace / JSON / SQL stuffed into a tag by misconfigured app code. Values
+  // exceeding this are emitted as `<tagKey>:blocked_by_tracer`.
+  static final int MAX_ADDITIONAL_TAG_VALUE_LENGTH = 250;
+
   private final Set<String> ignoredResources;
   private final List<String> additionalTagKeys;
   private final AdditionalTagsCardinalityLimiter cardinalityLimiter;
@@ -488,7 +493,15 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       if (value == null) {
         continue;
       }
-      String admittedValue = cardinalityLimiter.admitOrBlock(tagKey, value.toString());
+      String rawValue = value.toString();
+      String admittedValue;
+      if (rawValue.length() > MAX_ADDITIONAL_TAG_VALUE_LENGTH) {
+        cardinalityLimiter.noteBlockedDueToLength(
+            tagKey, rawValue.length(), MAX_ADDITIONAL_TAG_VALUE_LENGTH);
+        admittedValue = AdditionalTagsCardinalityLimiter.BLOCKED_VALUE;
+      } else {
+        admittedValue = cardinalityLimiter.admitOrBlock(tagKey, rawValue);
+      }
       Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
           ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
       UTF8BytesString formatted =

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -80,6 +80,16 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
               Pair.of(
                   DDCaches.newFixedSizeCache(512),
                   value -> UTF8BytesString.create(key + ":" + value));
+  private static final DDCache<
+          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
+      ADDITIONAL_TAG_VALUES_CACHE = DDCaches.newFixedSizeCache(64);
+  private static final Function<
+          String, Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>>>
+      ADDITIONAL_TAG_VALUES_CACHE_ADDER =
+          key ->
+              Pair.of(
+                  DDCaches.newFixedSizeCache(512),
+                  value -> UTF8BytesString.create(key + ":" + value));
   private static final CharSequence SYNTHETICS_ORIGIN = "synthetics";
 
   private static final Set<String> ELIGIBLE_SPAN_KINDS_FOR_METRICS =
@@ -93,6 +103,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
           new HashSet<>(Arrays.asList(SPAN_KIND_CLIENT, SPAN_KIND_PRODUCER, SPAN_KIND_CONSUMER)));
 
   private final Set<String> ignoredResources;
+  private final List<String> additionalTagKeys;
   private final MessagePassingQueue<Batch> batchPool;
   private final ConcurrentHashMap<MetricKey, Batch> pending;
   private final ConcurrentHashMap<MetricKey, MetricKey> keys;
@@ -115,6 +126,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this(
         config.getWellKnownTags(),
         config.getMetricsIgnoredResources(),
+        config.getTraceStatsAdditionalTags(),
         sharedCommunicationObjects.featuresDiscovery(config),
         healthMetrics,
         new OkHttpSink(
@@ -132,6 +144,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   ConflatingMetricsAggregator(
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
+      List<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -141,6 +154,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this(
         wellKnownTags,
         ignoredResources,
+        additionalTagKeys,
         features,
         healthMetric,
         sink,
@@ -154,6 +168,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   ConflatingMetricsAggregator(
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
+      List<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -164,6 +179,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       boolean includeEndpointInMetrics) {
     this(
         ignoredResources,
+        additionalTagKeys,
         features,
         healthMetric,
         sink,
@@ -177,6 +193,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   ConflatingMetricsAggregator(
       Set<String> ignoredResources,
+      List<String> additionalTagKeys,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -187,6 +204,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       TimeUnit timeUnit,
       boolean includeEndpointInMetrics) {
     this.ignoredResources = ignoredResources;
+    this.additionalTagKeys =
+        additionalTagKeys == null ? Collections.emptyList() : additionalTagKeys;
     this.includeEndpointInMetrics = includeEndpointInMetrics;
     this.inbox = Queues.mpscArrayQueue(queueSize);
     this.batchPool = Queues.spmcArrayQueue(maxAggregates);
@@ -350,7 +369,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             getPeerTags(span, spanKind.toString()),
             httpMethod,
             httpEndpoint,
-            grpcStatusCode);
+            grpcStatusCode,
+            getAdditionalTags(span));
     MetricKey key = keys.putIfAbsent(newKey, newKey);
     if (null == key) {
       key = newKey;
@@ -411,6 +431,28 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       }
     }
     return Collections.emptyList();
+  }
+
+  private List<UTF8BytesString> getAdditionalTags(CoreSpan<?> span) {
+    if (additionalTagKeys.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<UTF8BytesString> result = null;
+    for (String tagKey : additionalTagKeys) {
+      Object value = span.unsafeGetTag(tagKey);
+      if (value == null) {
+        continue;
+      }
+      Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
+          ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
+      UTF8BytesString formatted =
+          cacheAndCreator.getLeft().computeIfAbsent(value.toString(), cacheAndCreator.getRight());
+      if (result == null) {
+        result = new ArrayList<>(additionalTagKeys.size());
+      }
+      result.add(formatted);
+    }
+    return result == null ? Collections.emptyList() : result;
   }
 
   private static boolean isSynthetic(CoreSpan<?> span) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -102,13 +102,16 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       unmodifiableSet(
           new HashSet<>(Arrays.asList(SPAN_KIND_CLIENT, SPAN_KIND_PRODUCER, SPAN_KIND_CONSUMER)));
 
-  // Cap on configured additional metric tag keys. By default only 4 primary tag dimensions are supported.
-  // We sometimes increase this limit for users so a value of 10 allows us to protect against extreme misconfiguration
+  // Cap on configured additional metric tag keys. By default only 4 primary tag dimensions are
+  // supported.
+  // We sometimes increase this limit for users so a value of 10 allows us to protect against
+  // extreme misconfiguration
   // while still allowing some additional tags to be used.
   static final int MAX_ADDITIONAL_TAG_KEYS = 10;
 
   private final Set<String> ignoredResources;
   private final List<String> additionalTagKeys;
+  private final AdditionalTagsCardinalityLimiter cardinalityLimiter;
   private final MessagePassingQueue<Batch> batchPool;
   private final ConcurrentHashMap<MetricKey, Batch> pending;
   private final ConcurrentHashMap<MetricKey, MetricKey> keys;
@@ -123,6 +126,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   private final boolean includeEndpointInMetrics;
 
   private volatile AgentTaskScheduler.Scheduled<?> cancellation;
+  private volatile AgentTaskScheduler.Scheduled<?> cardinalityResetCancellation;
+
+  // Hard-reset window for per-tag value cardinality tracking.
+  static final long CARDINALITY_RESET_INTERVAL_MINUTES = 10;
 
   public ConflatingMetricsAggregator(
       Config config,
@@ -132,6 +139,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         config.getWellKnownTags(),
         config.getMetricsIgnoredResources(),
         config.getTraceStatsAdditionalTags(),
+        config.getTraceStatsAdditionalTagsCardinalityLimit(),
         sharedCommunicationObjects.featuresDiscovery(config),
         healthMetrics,
         new OkHttpSink(
@@ -150,6 +158,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
       Set<String> additionalTagKeys,
+      int additionalTagsCardinalityLimit,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -160,6 +169,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         wellKnownTags,
         ignoredResources,
         additionalTagKeys,
+        additionalTagsCardinalityLimit,
         features,
         healthMetric,
         sink,
@@ -174,6 +184,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       WellKnownTags wellKnownTags,
       Set<String> ignoredResources,
       Set<String> additionalTagKeys,
+      int additionalTagsCardinalityLimit,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -185,6 +196,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this(
         ignoredResources,
         additionalTagKeys,
+        additionalTagsCardinalityLimit,
         features,
         healthMetric,
         sink,
@@ -199,6 +211,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   ConflatingMetricsAggregator(
       Set<String> ignoredResources,
       Set<String> additionalTagKeys,
+      int additionalTagsCardinalityLimit,
       DDAgentFeaturesDiscovery features,
       HealthMetrics healthMetric,
       Sink sink,
@@ -210,6 +223,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       boolean includeEndpointInMetrics) {
     this.ignoredResources = ignoredResources;
     this.additionalTagKeys = normalizeAdditionalTagKeys(additionalTagKeys);
+    this.cardinalityLimiter =
+        new AdditionalTagsCardinalityLimiter(additionalTagsCardinalityLimit, healthMetric);
     this.includeEndpointInMetrics = includeEndpointInMetrics;
     this.inbox = Queues.mpscArrayQueue(queueSize);
     this.batchPool = Queues.spmcArrayQueue(maxAggregates);
@@ -246,6 +261,14 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
                 reportingInterval,
                 reportingInterval,
                 reportingIntervalTimeUnit);
+    cardinalityResetCancellation =
+        AgentTaskScheduler.get()
+            .scheduleAtFixedRate(
+                new CardinalityResetTask(),
+                this,
+                CARDINALITY_RESET_INTERVAL_MINUTES,
+                CARDINALITY_RESET_INTERVAL_MINUTES,
+                TimeUnit.MINUTES);
     log.debug("started metrics aggregator");
   }
 
@@ -465,10 +488,11 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       if (value == null) {
         continue;
       }
+      String admittedValue = cardinalityLimiter.admitOrBlock(tagKey, value.toString());
       Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
           ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
       UTF8BytesString formatted =
-          cacheAndCreator.getLeft().computeIfAbsent(value.toString(), cacheAndCreator.getRight());
+          cacheAndCreator.getLeft().computeIfAbsent(admittedValue, cacheAndCreator.getRight());
       if (result == null) {
         result = new ArrayList<>(additionalTagKeys.size());
       }
@@ -492,6 +516,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   public void stop() {
     if (null != cancellation) {
       cancellation.cancel();
+    }
+    if (null != cardinalityResetCancellation) {
+      cardinalityResetCancellation.cancel();
     }
     inbox.offer(STOP);
   }
@@ -544,6 +571,15 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     @Override
     public void run(ConflatingMetricsAggregator target) {
       target.report();
+    }
+  }
+
+  private static final class CardinalityResetTask
+      implements AgentTaskScheduler.Task<ConflatingMetricsAggregator> {
+
+    @Override
+    public void run(ConflatingMetricsAggregator target) {
+      target.cardinalityLimiter.reset();
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -131,10 +131,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   private final boolean includeEndpointInMetrics;
 
   private volatile AgentTaskScheduler.Scheduled<?> cancellation;
-  private volatile AgentTaskScheduler.Scheduled<?> cardinalityResetCancellation;
-
-  // Hard-reset window for per-tag value cardinality tracking.
-  static final long CARDINALITY_RESET_INTERVAL_MINUTES = 10;
 
   public ConflatingMetricsAggregator(
       Config config,
@@ -266,14 +262,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
                 reportingInterval,
                 reportingInterval,
                 reportingIntervalTimeUnit);
-    cardinalityResetCancellation =
-        AgentTaskScheduler.get()
-            .scheduleAtFixedRate(
-                new CardinalityResetTask(),
-                this,
-                CARDINALITY_RESET_INTERVAL_MINUTES,
-                CARDINALITY_RESET_INTERVAL_MINUTES,
-                TimeUnit.MINUTES);
     log.debug("started metrics aggregator");
   }
 
@@ -295,6 +283,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     if (!published) {
       log.debug("Skipped metrics reporting because the queue is full");
     }
+    cardinalityLimiter.resetBucket();
     return published;
   }
 
@@ -386,6 +375,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       Object grpcStatusObj = span.unsafeGetTag(InstrumentationTags.GRPC_STATUS_CODE);
       grpcStatusCode = grpcStatusObj != null ? grpcStatusObj.toString() : null;
     }
+    List<UTF8BytesString> fullAdditionalTags = getAdditionalTagsLengthCapped(span);
     MetricKey newKey =
         new MetricKey(
             span.getResourceName(),
@@ -402,7 +392,27 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             httpMethod,
             httpEndpoint,
             grpcStatusCode,
-            getAdditionalTags(span));
+            fullAdditionalTags);
+
+    // If this span's full MetricKey is already in the current bucket, just admit it as-is.
+    // We already paid the cardinality cost for these tag values earlier in this bucket, so the
+    // existing entry should keep receiving merges.
+    //
+    // Otherwise, if the bucket is at the global cap, replace every present tag's value with
+    // `blocked_by_tracer` so the dimension keys are preserved on the wire even though the
+    // values aren't (blocked spans collapse into one bucket per tag-presence shape rather than
+    // into the no-additional-tags base bucket). If it's a new entry under the cap, admit with
+    // the full tag set and remember to bump the counter below.
+    boolean newEntryUsedFullTags = false;
+    if (!fullAdditionalTags.isEmpty() && pending.get(newKey) == null) {
+      if (cardinalityLimiter.isAtCap()) {
+        cardinalityLimiter.recordCardinalityBlock();
+        newKey = rebuildKeyWithBlockedValues(span, newKey);
+      } else {
+        newEntryUsedFullTags = true;
+      }
+    }
+
     MetricKey key = keys.putIfAbsent(newKey, newKey);
     if (null == key) {
       key = newKey;
@@ -410,6 +420,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     long tag = (span.getError() > 0 ? ERROR_TAG : 0L) | (isTopLevel ? TOP_LEVEL_TAG : 0L);
     long durationNanos = span.getDurationNano();
     Batch batch = pending.get(key);
+    boolean isNewBucketEntry = (batch == null);
     if (null != batch) {
       // there is a pending batch, try to win the race to add to it
       // returning false means that either the batch can't take any
@@ -430,8 +441,54 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     pending.put(key, batch);
     // must offer to the queue after adding to pending
     inbox.offer(batch);
+    // If we just added a brand-new MetricKey to this bucket and kept its additional tags, charge
+    // it against the global stat-entry budget.
+    if (isNewBucketEntry && newEntryUsedFullTags) {
+      cardinalityLimiter.onNewStatEntryAdmitted();
+    }
     // force keep keys if there are errors
     return span.getError() > 0;
+  }
+
+  /**
+   * Builds a copy of {@code fullKey} with each present additional tag's value replaced by {@code
+   * <tagKey>:blocked_by_tracer}. The set of configured tag keys present on the span is preserved as
+   * dimensions; only the values are masked. Also fires the per-tag health metric for each masked
+   * tag. Used when the bucket cardinality cap is hit and we need to suppress this span's
+   * contribution to per-value aggregation without losing the dimension keys entirely.
+   */
+  private MetricKey rebuildKeyWithBlockedValues(CoreSpan<?> span, MetricKey fullKey) {
+    List<UTF8BytesString> blockedTags = null;
+    for (String tagKey : additionalTagKeys) {
+      if (span.unsafeGetTag(tagKey) == null) continue;
+      healthMetrics.onAdditionalTagValueCardinalityBlocked(tagKey);
+      Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
+          ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
+      UTF8BytesString formatted =
+          cacheAndCreator
+              .getLeft()
+              .computeIfAbsent(
+                  AdditionalTagsCardinalityLimiter.BLOCKED_VALUE, cacheAndCreator.getRight());
+      if (blockedTags == null) {
+        blockedTags = new ArrayList<>(additionalTagKeys.size());
+      }
+      blockedTags.add(formatted);
+    }
+    return new MetricKey(
+        fullKey.getResource(),
+        fullKey.getService(),
+        fullKey.getOperationName(),
+        fullKey.getServiceSource(),
+        fullKey.getType(),
+        fullKey.getHttpStatusCode(),
+        fullKey.isSynthetics(),
+        fullKey.isTraceRoot(),
+        fullKey.getSpanKind(),
+        fullKey.getPeerTags(),
+        fullKey.getHttpMethod(),
+        fullKey.getHttpEndpoint(),
+        fullKey.getGrpcStatusCode(),
+        blockedTags == null ? Collections.emptyList() : blockedTags);
   }
 
   private List<UTF8BytesString> getPeerTags(CoreSpan<?> span, String spanKind) {
@@ -483,25 +540,19 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     return Collections.unmodifiableList(new ArrayList<>(sorted));
   }
 
-  private List<UTF8BytesString> getAdditionalTags(CoreSpan<?> span) {
+  private List<UTF8BytesString> getAdditionalTagsLengthCapped(CoreSpan<?> span) {
     if (additionalTagKeys.isEmpty()) {
       return Collections.emptyList();
     }
     List<UTF8BytesString> result = null;
-    for (String tagKey : additionalTagKeys) {
+    for (int i = 0; i < additionalTagKeys.size(); i++) {
+      String tagKey = additionalTagKeys.get(i);
       Object value = span.unsafeGetTag(tagKey);
       if (value == null) {
         continue;
       }
       String rawValue = value.toString();
-      String admittedValue;
-      if (rawValue.length() > MAX_ADDITIONAL_TAG_VALUE_LENGTH) {
-        cardinalityLimiter.noteBlockedDueToLength(
-            tagKey, rawValue.length(), MAX_ADDITIONAL_TAG_VALUE_LENGTH);
-        admittedValue = AdditionalTagsCardinalityLimiter.BLOCKED_VALUE;
-      } else {
-        admittedValue = cardinalityLimiter.admitOrBlock(tagKey, rawValue);
-      }
+      String admittedValue = cardinalityLimiter.applyLengthCap(tagKey, rawValue);
       Pair<DDCache<String, UTF8BytesString>, Function<String, UTF8BytesString>> cacheAndCreator =
           ADDITIONAL_TAG_VALUES_CACHE.computeIfAbsent(tagKey, ADDITIONAL_TAG_VALUES_CACHE_ADDER);
       UTF8BytesString formatted =
@@ -529,9 +580,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   public void stop() {
     if (null != cancellation) {
       cancellation.cancel();
-    }
-    if (null != cardinalityResetCancellation) {
-      cardinalityResetCancellation.cancel();
     }
     inbox.offer(STOP);
   }
@@ -584,15 +632,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     @Override
     public void run(ConflatingMetricsAggregator target) {
       target.report();
-    }
-  }
-
-  private static final class CardinalityResetTask
-      implements AgentTaskScheduler.Task<ConflatingMetricsAggregator> {
-
-    @Override
-    public void run(ConflatingMetricsAggregator target) {
-      target.cardinalityLimiter.reset();
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -39,6 +39,7 @@ public final class MetricKey {
   private final UTF8BytesString httpMethod;
   private final UTF8BytesString httpEndpoint;
   private final UTF8BytesString grpcStatusCode;
+  private final List<UTF8BytesString> additionalTags;
 
   public MetricKey(
       CharSequence resource,
@@ -53,7 +54,8 @@ public final class MetricKey {
       List<UTF8BytesString> peerTags,
       CharSequence httpMethod,
       CharSequence httpEndpoint,
-      CharSequence grpcStatusCode) {
+      CharSequence grpcStatusCode,
+      List<UTF8BytesString> additionalTags) {
     this.resource = null == resource ? EMPTY : utf8(RESOURCE_CACHE, resource);
     this.service = null == service ? EMPTY : utf8(SERVICE_CACHE, service);
     this.serviceSource = null == serviceSource ? null : utf8(SERVICE_SOURCE_CACHE, serviceSource);
@@ -68,6 +70,7 @@ public final class MetricKey {
     this.httpEndpoint = httpEndpoint == null ? null : utf8(HTTP_ENDPOINT_CACHE, httpEndpoint);
     this.grpcStatusCode =
         grpcStatusCode == null ? null : utf8(GRPC_STATUS_CODE_CACHE, grpcStatusCode);
+    this.additionalTags = additionalTags == null ? Collections.emptyList() : additionalTags;
 
     int tmpHash = 0;
     tmpHash = HashingUtils.addToHash(tmpHash, this.isTraceRoot);
@@ -83,6 +86,7 @@ public final class MetricKey {
     tmpHash = HashingUtils.addToHash(tmpHash, this.httpEndpoint);
     tmpHash = HashingUtils.addToHash(tmpHash, this.httpMethod);
     tmpHash = HashingUtils.addToHash(tmpHash, this.grpcStatusCode);
+    tmpHash = HashingUtils.addToHash(tmpHash, this.additionalTags);
     this.hash = tmpHash;
   }
 
@@ -146,6 +150,10 @@ public final class MetricKey {
     return grpcStatusCode;
   }
 
+  public List<UTF8BytesString> getAdditionalTags() {
+    return additionalTags;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -166,7 +174,8 @@ public final class MetricKey {
           && Objects.equals(serviceSource, metricKey.serviceSource)
           && Objects.equals(httpMethod, metricKey.httpMethod)
           && Objects.equals(httpEndpoint, metricKey.httpEndpoint)
-          && Objects.equals(grpcStatusCode, metricKey.grpcStatusCode);
+          && Objects.equals(grpcStatusCode, metricKey.grpcStatusCode)
+          && additionalTags.equals(metricKey.additionalTags);
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -6,12 +6,15 @@ import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.util.HashingUtils;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 /** The aggregation key for tracked metrics. */
 public final class MetricKey {
+  private static final String[] EMPTY_ADDITIONAL_TAG_VALUES = new String[0];
+
   static final DDCache<String, UTF8BytesString> RESOURCE_CACHE = DDCaches.newFixedSizeCache(32);
   static final DDCache<String, UTF8BytesString> SERVICE_CACHE = DDCaches.newFixedSizeCache(8);
   static final DDCache<String, UTF8BytesString> SERVICE_SOURCE_CACHE =
@@ -39,7 +42,11 @@ public final class MetricKey {
   private final UTF8BytesString httpMethod;
   private final UTF8BytesString httpEndpoint;
   private final UTF8BytesString grpcStatusCode;
-  private final List<UTF8BytesString> additionalTags;
+  // Raw span tag values for each configured additional-tag position. Length matches the
+  // aggregator's configured-tags list; null in slot i means the span did not set that tag.
+  // Deferred concatenation: the wire format "<key>:<value>" is built at serialize time from
+  // these values together with the aggregator's pre-encoded key bytes.
+  private final String[] additionalTagValues;
 
   public MetricKey(
       CharSequence resource,
@@ -55,7 +62,7 @@ public final class MetricKey {
       CharSequence httpMethod,
       CharSequence httpEndpoint,
       CharSequence grpcStatusCode,
-      List<UTF8BytesString> additionalTags) {
+      String[] additionalTagValues) {
     this.resource = null == resource ? EMPTY : utf8(RESOURCE_CACHE, resource);
     this.service = null == service ? EMPTY : utf8(SERVICE_CACHE, service);
     this.serviceSource = null == serviceSource ? null : utf8(SERVICE_SOURCE_CACHE, serviceSource);
@@ -70,7 +77,10 @@ public final class MetricKey {
     this.httpEndpoint = httpEndpoint == null ? null : utf8(HTTP_ENDPOINT_CACHE, httpEndpoint);
     this.grpcStatusCode =
         grpcStatusCode == null ? null : utf8(GRPC_STATUS_CODE_CACHE, grpcStatusCode);
-    this.additionalTags = additionalTags == null ? Collections.emptyList() : additionalTags;
+    this.additionalTagValues =
+        additionalTagValues == null || additionalTagValues.length == 0
+            ? EMPTY_ADDITIONAL_TAG_VALUES
+            : additionalTagValues;
 
     int tmpHash = 0;
     tmpHash = HashingUtils.addToHash(tmpHash, this.isTraceRoot);
@@ -86,7 +96,7 @@ public final class MetricKey {
     tmpHash = HashingUtils.addToHash(tmpHash, this.httpEndpoint);
     tmpHash = HashingUtils.addToHash(tmpHash, this.httpMethod);
     tmpHash = HashingUtils.addToHash(tmpHash, this.grpcStatusCode);
-    tmpHash = HashingUtils.addToHash(tmpHash, this.additionalTags);
+    tmpHash = HashingUtils.addToHash(tmpHash, Arrays.hashCode(this.additionalTagValues));
     this.hash = tmpHash;
   }
 
@@ -150,8 +160,13 @@ public final class MetricKey {
     return grpcStatusCode;
   }
 
-  public List<UTF8BytesString> getAdditionalTags() {
-    return additionalTags;
+  /**
+   * @return the raw span tag values for each configured additional-tag position. Length matches the
+   *     configured-tags list; element {@code i} is {@code null} if the span did not set the
+   *     corresponding tag.
+   */
+  public String[] getAdditionalTagValues() {
+    return additionalTagValues;
   }
 
   @Override
@@ -175,7 +190,7 @@ public final class MetricKey {
           && Objects.equals(httpMethod, metricKey.httpMethod)
           && Objects.equals(httpEndpoint, metricKey.httpEndpoint)
           && Objects.equals(grpcStatusCode, metricKey.grpcStatusCode)
-          && additionalTags.equals(metricKey.additionalTags);
+          && Arrays.equals(additionalTagValues, metricKey.additionalTagValues);
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -41,6 +41,7 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] IS_TRACE_ROOT = "IsTraceRoot".getBytes(ISO_8859_1);
   private static final byte[] SPAN_KIND = "SpanKind".getBytes(ISO_8859_1);
   private static final byte[] PEER_TAGS = "PeerTags".getBytes(ISO_8859_1);
+  private static final byte[] ADDITIONAL_METRIC_TAGS = "AdditionalMetricTags".getBytes(ISO_8859_1);
   private static final byte[] HTTP_METHOD = "HTTPMethod".getBytes(ISO_8859_1);
   private static final byte[] HTTP_ENDPOINT = "HTTPEndpoint".getBytes(ISO_8859_1);
   private static final byte[] GRPC_STATUS_CODE = "GRPCStatusCode".getBytes(ISO_8859_1);
@@ -149,7 +150,7 @@ public final class SerializingMetricWriter implements MetricWriter {
     final boolean hasServiceSource = key.getServiceSource() != null;
     final boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null;
     final int mapSize =
-        15
+        16
             + (hasServiceSource ? 1 : 0)
             + (hasHttpMethod ? 1 : 0)
             + (hasHttpEndpoint ? 1 : 0)
@@ -187,6 +188,13 @@ public final class SerializingMetricWriter implements MetricWriter {
 
     for (UTF8BytesString peerTag : peerTags) {
       writer.writeUTF8(peerTag);
+    }
+
+    writer.writeUTF8(ADDITIONAL_METRIC_TAGS);
+    final List<UTF8BytesString> additionalTags = key.getAdditionalTags();
+    writer.startArray(additionalTags.size());
+    for (UTF8BytesString tag : additionalTags) {
+      writer.writeUTF8(tag);
     }
 
     if (hasServiceSource) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -149,12 +149,14 @@ public final class SerializingMetricWriter implements MetricWriter {
     final boolean hasHttpEndpoint = key.getHttpEndpoint() != null;
     final boolean hasServiceSource = key.getServiceSource() != null;
     final boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null;
+    final boolean hasAdditionalTags = !key.getAdditionalTags().isEmpty();
     final int mapSize =
-        16
+        15
             + (hasServiceSource ? 1 : 0)
             + (hasHttpMethod ? 1 : 0)
             + (hasHttpEndpoint ? 1 : 0)
-            + (hasGrpcStatusCode ? 1 : 0);
+            + (hasGrpcStatusCode ? 1 : 0)
+            + (hasAdditionalTags ? 1 : 0);
 
     writer.startMap(mapSize);
 
@@ -190,11 +192,13 @@ public final class SerializingMetricWriter implements MetricWriter {
       writer.writeUTF8(peerTag);
     }
 
-    writer.writeUTF8(ADDITIONAL_METRIC_TAGS);
-    final List<UTF8BytesString> additionalTags = key.getAdditionalTags();
-    writer.startArray(additionalTags.size());
-    for (UTF8BytesString tag : additionalTags) {
-      writer.writeUTF8(tag);
+    if (hasAdditionalTags) {
+      writer.writeUTF8(ADDITIONAL_METRIC_TAGS);
+      final List<UTF8BytesString> additionalTags = key.getAdditionalTags();
+      writer.startArray(additionalTags.size());
+      for (UTF8BytesString tag : additionalTags) {
+        writer.writeUTF8(tag);
+      }
     }
 
     if (hasServiceSource) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.UTF8BytesString.EMPTY;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import datadog.communication.serialization.GrowableBuffer;
-import datadog.communication.serialization.WritableFormatter;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.WellKnownTags;
@@ -13,6 +12,7 @@ import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -58,8 +58,14 @@ public final class SerializingMetricWriter implements MetricWriter {
               ? UTF8BytesString.create(gitInfo.getCommit().getSha())
               : EMPTY;
 
+  private static final byte[][] NO_ADDITIONAL_TAG_KEYS = new byte[0][];
+
   private final WellKnownTags wellKnownTags;
-  private final WritableFormatter writer;
+  // UTF-8 bytes for each configured additional tag key. Parallel to the aggregator's
+  // configured-tags list; used at write time to compose `<key>:<value>` directly into the buffer
+  // without allocating an intermediate UTF8BytesString or formatted String.
+  private final byte[][] additionalTagKeyBytes;
+  private final MsgPackWriter writer;
   private final Sink sink;
   private final GrowableBuffer buffer;
   private final DDCache<GitInfo, UTF8BytesString> gitInfoCache =
@@ -68,11 +74,21 @@ public final class SerializingMetricWriter implements MetricWriter {
   private final GitInfoProvider gitInfoProvider;
 
   public SerializingMetricWriter(WellKnownTags wellKnownTags, Sink sink) {
-    this(wellKnownTags, sink, 512 * 1024);
+    this(wellKnownTags, NO_ADDITIONAL_TAG_KEYS, sink, 512 * 1024);
+  }
+
+  public SerializingMetricWriter(
+      WellKnownTags wellKnownTags, byte[][] additionalTagKeyBytes, Sink sink) {
+    this(wellKnownTags, additionalTagKeyBytes, sink, 512 * 1024);
   }
 
   public SerializingMetricWriter(WellKnownTags wellKnownTags, Sink sink, int initialCapacity) {
-    this(wellKnownTags, sink, initialCapacity, GitInfoProvider.INSTANCE);
+    this(wellKnownTags, NO_ADDITIONAL_TAG_KEYS, sink, initialCapacity, GitInfoProvider.INSTANCE);
+  }
+
+  public SerializingMetricWriter(
+      WellKnownTags wellKnownTags, byte[][] additionalTagKeyBytes, Sink sink, int initialCapacity) {
+    this(wellKnownTags, additionalTagKeyBytes, sink, initialCapacity, GitInfoProvider.INSTANCE);
   }
 
   public SerializingMetricWriter(
@@ -80,7 +96,17 @@ public final class SerializingMetricWriter implements MetricWriter {
       Sink sink,
       int initialCapacity,
       final GitInfoProvider gitInfoProvider) {
+    this(wellKnownTags, NO_ADDITIONAL_TAG_KEYS, sink, initialCapacity, gitInfoProvider);
+  }
+
+  public SerializingMetricWriter(
+      WellKnownTags wellKnownTags,
+      byte[][] additionalTagKeyBytes,
+      Sink sink,
+      int initialCapacity,
+      final GitInfoProvider gitInfoProvider) {
     this.wellKnownTags = wellKnownTags;
+    this.additionalTagKeyBytes = additionalTagKeyBytes;
     this.buffer = new GrowableBuffer(initialCapacity);
     this.writer = new MsgPackWriter(buffer);
     this.sink = sink;
@@ -149,7 +175,9 @@ public final class SerializingMetricWriter implements MetricWriter {
     final boolean hasHttpEndpoint = key.getHttpEndpoint() != null;
     final boolean hasServiceSource = key.getServiceSource() != null;
     final boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null;
-    final boolean hasAdditionalTags = !key.getAdditionalTags().isEmpty();
+    final String[] additionalTagValues = key.getAdditionalTagValues();
+    final int additionalTagCount = countNonNull(additionalTagValues);
+    final boolean hasAdditionalTags = additionalTagCount > 0;
     final int mapSize =
         15
             + (hasServiceSource ? 1 : 0)
@@ -194,10 +222,16 @@ public final class SerializingMetricWriter implements MetricWriter {
 
     if (hasAdditionalTags) {
       writer.writeUTF8(ADDITIONAL_METRIC_TAGS);
-      final List<UTF8BytesString> additionalTags = key.getAdditionalTags();
-      writer.startArray(additionalTags.size());
-      for (UTF8BytesString tag : additionalTags) {
-        writer.writeUTF8(tag);
+      writer.startArray(additionalTagCount);
+      // Each entry is written as "<configured tag key>:<value>" directly into the msgpack
+      // buffer — no intermediate UTF8BytesString or concatenated String is allocated. The tag
+      // keys' UTF-8 bytes are pre-encoded in `additionalTagKeyBytes`; the per-write byte[] for
+      // the value bytes is the only allocation in this loop.
+      for (int i = 0; i < additionalTagValues.length; i++) {
+        String value = additionalTagValues[i];
+        if (value == null) continue;
+        byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+        writer.writeUTF8(additionalTagKeyBytes[i], (byte) ':', valueBytes);
       }
     }
 
@@ -252,5 +286,13 @@ public final class SerializingMetricWriter implements MetricWriter {
   @Override
   public void reset() {
     buffer.reset();
+  }
+
+  private static int countNonNull(String[] values) {
+    int count = 0;
+    for (String value : values) {
+      if (value != null) count++;
+    }
+    return count;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -93,6 +93,8 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onStatsAggregateDropped() {}
 
+  public void onAdditionalTagValueCardinalityBlocked(String tagKey) {}
+
   /**
    * @return Human-readable summary of the current health metrics.
    */

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -381,7 +381,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     private static final String[] SINGLE_SPAN_SAMPLER = new String[] {"sampler:single-span"};
     private static final String[] REASON_LRU_EVICTION_TAG = new String[] {"reason:lru_eviction"};
 
-    private final long[] previousCounts = new long[51];
+    private final long[] previousCounts = new long[52];
 
     @SuppressFBWarnings("AT_STALE_THREAD_WRITE_OF_PRIMITIVE")
     private int countIndex;

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -98,6 +98,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final LongAdder clientStatsDowngrades = new LongAdder();
 
   private final LongAdder statsAggregateDropped = new LongAdder();
+  private final LongAdder additionalTagValueCardinalityBlocked = new LongAdder();
 
   private final StatsDClient statsd;
   private final long interval;
@@ -353,6 +354,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
+  public void onAdditionalTagValueCardinalityBlocked(String tagKey) {
+    additionalTagValueCardinalityBlocked.increment();
+  }
+
+  @Override
   public void onStatsAggregateDropped() {
     statsAggregateDropped.increment();
   }
@@ -504,6 +510,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             "stats.dropped_aggregates",
             target.statsAggregateDropped,
             REASON_LRU_EVICTION_TAG);
+        reportIfChanged(
+            target.statsd,
+            "stats.additional_tag.cardinality_blocked",
+            target.additionalTagValueCardinalityBlocked,
+            NO_TAGS);
 
       } catch (ArrayIndexOutOfBoundsException e) {
         log.warn(
@@ -637,6 +648,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         + "\nclientStatsProcessedTraces="
         + clientStatsProcessedTraces.sum()
         + "\nstatsAggregateDropped="
-        + statsAggregateDropped.sum();
+        + statsAggregateDropped.sum()
+        + "\nadditionalTagValueCardinalityBlocked="
+        + additionalTagValueCardinalityBlocked.sum();
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -65,7 +65,7 @@ class AggregateMetricTest extends DDSpecification {
     given:
     AggregateMetric aggregate = new AggregateMetric().recordDurations(3, new AtomicLongArray(0L, 0L, 0L | ERROR_TAG | TOP_LEVEL_TAG))
 
-    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", null, "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")], null, null, null))
+    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", null, "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")], null, null, null, null))
     batch.add(0L, 10)
     batch.add(0L, 10)
     batch.add(0L, 10)
@@ -140,7 +140,7 @@ class AggregateMetricTest extends DDSpecification {
   def "consistent under concurrent attempts to read and write"() {
     given:
     AggregateMetric aggregate = new AggregateMetric()
-    MetricKey key = new MetricKey("foo", "bar", "qux", null, "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")], null, null, null)
+    MetricKey key = new MetricKey("foo", "bar", "qux", null, "type", 0, false, true, "corge", [UTF8BytesString.create("grault:quux")], null, null, null, null)
     BlockingDeque<Batch> queue = new LinkedBlockingDeque<>(1000)
     ExecutorService reader = Executors.newSingleThreadExecutor()
     int writerCount = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -39,6 +39,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       wellKnownTags,
       empty,
       [] as Set<String>,
+      100,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -70,6 +71,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       wellKnownTags,
       [ignoredResourceName].toSet(),
       [] as Set<String>,
+      100,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -107,6 +109,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -154,6 +157,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -201,6 +205,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -267,6 +272,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >>> [["country"], ["country", "georegion"],]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -335,6 +341,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> ["peer.hostname", "_dd.base_service"]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -387,7 +394,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     features.peerTags() >> []
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, [] as Set<String>, features, HealthMetrics.NO_OP,
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, [] as Set<String>, 100, features, HealthMetrics.NO_OP,
     sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -441,6 +448,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     List<CoreSpan> trace = [
@@ -514,6 +522,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -642,6 +651,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -758,6 +768,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -829,6 +840,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -899,6 +911,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -968,6 +981,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1003,6 +1017,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1049,6 +1064,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1152,6 +1168,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1213,6 +1230,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1265,6 +1283,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1297,6 +1316,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     aggregator.start()
 
@@ -1320,6 +1340,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, 200, MILLISECONDS, false)
     final spans = [
       new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 10, HTTP_OK)
@@ -1353,6 +1374,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
 
     when:
@@ -1387,6 +1409,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1435,6 +1458,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1491,6 +1515,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -1583,6 +1608,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
       [] as Set<String>,
+      100,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -38,6 +38,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       empty,
+      [] as List<String>,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -68,6 +69,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       [ignoredResourceName].toSet(),
+      [] as List<String>,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -104,6 +106,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -133,7 +136,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), _) >> { MetricKey key, AggregateMetric value ->
+      , null), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
       }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -150,6 +153,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -179,7 +183,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), _) >> { MetricKey key, AggregateMetric value ->
+      , null), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
       }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -196,6 +200,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -231,7 +236,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       httpMethod,
       httpEndpoint,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
     (statsComputed ? 1 : 0) * writer.finishBucket() >> { latch.countDown() }
@@ -261,6 +266,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >>> [["country"], ["country", "georegion"],]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -293,7 +299,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
     1 * writer.add(
@@ -311,7 +317,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -328,6 +334,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> ["peer.hostname", "_dd.base_service"]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -358,7 +365,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 0 && aggregateMetric.getDuration() == 100
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -380,8 +387,8 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     features.peerTags() >> []
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features, HealthMetrics.NO_OP,
-      sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, [] as List<String>, features, HealthMetrics.NO_OP,
+    sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
     when:
@@ -410,7 +417,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getTopLevelCount() == topLevelCount && value.getDuration() == 100
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -433,6 +440,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     List<CoreSpan> trace = [
@@ -469,7 +477,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == count && value.getDuration() == count * duration
       })
     1 * writer.add(new MetricKey(
@@ -486,7 +494,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == count && value.getDuration() == count * duration * 2
       })
 
@@ -505,6 +513,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -540,7 +549,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == count && value.getDuration() == count * duration
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -581,7 +590,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       })
     1 * writer.add(new MetricKey(
@@ -598,7 +607,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/orders/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 2
       })
     1 * writer.add(new MetricKey(
@@ -615,7 +624,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "POST",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 3
       })
     1 * writer.finishBucket() >> { latch2.countDown() }
@@ -632,6 +641,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -679,7 +689,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       })
     1 * writer.add(new MetricKey(
@@ -696,7 +706,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "POST",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 2
       })
     1 * writer.add(new MetricKey(
@@ -713,7 +723,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 3
       })
     1 * writer.add(new MetricKey(
@@ -730,7 +740,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/orders/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 4
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -747,6 +757,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -783,7 +794,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       })
     1 * writer.add(new MetricKey(
@@ -800,7 +811,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration * 2
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -817,6 +828,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -851,7 +863,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 2 && value.getDuration() == 2 * duration
       })
     1 * writer.add(new MetricKey(
@@ -868,7 +880,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric value ->
+      , null), { AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -886,6 +898,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -919,7 +932,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         null,
         null,
         null
-        ), _) >> { MetricKey key, AggregateMetric value ->
+        , null), _) >> { MetricKey key, AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         }
     }
@@ -937,7 +950,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), _)
+      , null), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -954,6 +967,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -988,6 +1002,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1033,6 +1048,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1066,7 +1082,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         null,
         null,
         null
-        ), { AggregateMetric value ->
+        , null), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
     }
@@ -1101,7 +1117,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         null,
         null,
         null
-        ), { AggregateMetric value ->
+        , null), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
     }
@@ -1119,7 +1135,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), _)
+      , null), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -1135,6 +1151,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1168,7 +1185,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         null,
         null,
         null
-        ), { AggregateMetric value ->
+        , null), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
     }
@@ -1195,6 +1212,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1227,7 +1245,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
         null,
         null,
         null
-        ), { AggregateMetric value ->
+        , null), { AggregateMetric value ->
           value.getHitCount() == 1 && value.getDuration() == duration
         })
     }
@@ -1246,6 +1264,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1277,6 +1296,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     Sink sink = Stub(Sink)
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     aggregator.start()
 
@@ -1299,6 +1319,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> false
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, 200, MILLISECONDS, false)
     final spans = [
       new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 10, HTTP_OK)
@@ -1331,6 +1352,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
 
     when:
@@ -1364,6 +1386,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1394,7 +1417,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 1 && aggregateMetric.getDuration() == 100
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -1411,6 +1434,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1449,7 +1473,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 3 && aggregateMetric.getTopLevelCount() == 3 && aggregateMetric.getDuration() == 450
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -1466,6 +1490,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -1504,7 +1529,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "GET",
       "/api/users/:id",
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 1 && aggregateMetric.getDuration() == 100
       })
     1 * writer.add(
@@ -1522,7 +1547,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       "POST",
       "/api/orders",
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 1 && aggregateMetric.getDuration() == 200
       })
     1 * writer.add(
@@ -1540,7 +1565,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), { AggregateMetric aggregateMetric ->
+      , null), { AggregateMetric aggregateMetric ->
         aggregateMetric.getHitCount() == 1 && aggregateMetric.getTopLevelCount() == 1 && aggregateMetric.getDuration() == 150
       })
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -1557,6 +1582,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      [] as List<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1592,7 +1618,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       "0"
-      ), _)
+      , null), _)
     1 * writer.add(new MetricKey(
       "grpc.service/Method",
       "service",
@@ -1607,7 +1633,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       "5"
-      ), _)
+      , null), _)
     1 * writer.add(new MetricKey(
       "GET /api",
       "service",
@@ -1622,7 +1648,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       null,
       null,
       null
-      ), _)
+      , null), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -38,7 +38,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       empty,
-      [] as List<String>,
+      [] as Set<String>,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -69,7 +69,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       [ignoredResourceName].toSet(),
-      [] as List<String>,
+      [] as Set<String>,
       features,
       HealthMetrics.NO_OP,
       sink,
@@ -106,7 +106,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -153,7 +153,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -200,7 +200,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -266,7 +266,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >>> [["country"], ["country", "georegion"],]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -334,7 +334,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> ["peer.hostname", "_dd.base_service"]
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -387,7 +387,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     features.peerTags() >> []
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, [] as List<String>, features, HealthMetrics.NO_OP,
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, [] as Set<String>, features, HealthMetrics.NO_OP,
     sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -440,7 +440,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     List<CoreSpan> trace = [
@@ -513,7 +513,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -641,7 +641,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -757,7 +757,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -828,7 +828,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -898,7 +898,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -967,7 +967,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1002,7 +1002,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.peerTags() >> []
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, healthMetrics, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1048,7 +1048,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1151,7 +1151,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1212,7 +1212,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1264,7 +1264,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     long duration = 100
     aggregator.start()
@@ -1296,7 +1296,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     Sink sink = Stub(Sink)
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
     aggregator.start()
 
@@ -1319,7 +1319,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> false
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, 200, MILLISECONDS, false)
     final spans = [
       new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 10, HTTP_OK)
@@ -1352,7 +1352,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, maxAggregates, queueSize, 1, SECONDS, false)
 
     when:
@@ -1386,7 +1386,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
     features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1434,7 +1434,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 
@@ -1490,7 +1490,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, true)
     aggregator.start()
 
@@ -1582,7 +1582,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     features.supportsMetrics() >> true
     features.peerTags() >> []
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      [] as List<String>,
+      [] as Set<String>,
       features, HealthMetrics.NO_OP, sink, writer, 10, queueSize, reportingInterval, SECONDS, false)
     aggregator.start()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -40,7 +40,7 @@ class FootprintForkedTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("runtimeid","hostname", "env", "service", "version","language"),
       [].toSet() as Set<String>,
-      [] as List<String>,
+      [] as Set<String>,
       features,
       HealthMetrics.NO_OP,
       sink,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -41,6 +41,7 @@ class FootprintForkedTest extends DDSpecification {
       new WellKnownTags("runtimeid","hostname", "env", "service", "version","language"),
       [].toSet() as Set<String>,
       [] as Set<String>,
+      100,
       features,
       HealthMetrics.NO_OP,
       sink,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -40,6 +40,7 @@ class FootprintForkedTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("runtimeid","hostname", "env", "service", "version","language"),
       [].toSet() as Set<String>,
+      [] as List<String>,
       features,
       HealthMetrics.NO_OP,
       sink,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -307,7 +307,12 @@ class SerializingMetricWriterTest extends DDSpecification {
         boolean hasHttpEndpoint = key.getHttpEndpoint() != null
         boolean hasServiceSource = key.getServiceSource() != null
         boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null
-        boolean hasAdditionalTags = key.getAdditionalTags().size() > 0
+        boolean hasAdditionalTags = false
+        for (String v : key.getAdditionalTagValues()) {
+          if (v != null) {
+            hasAdditionalTags = true; break
+          }
+        }
         int expectedMapSize = 15 + (hasServiceSource ? 1 : 0) + (hasHttpMethod ? 1 : 0) + (hasHttpEndpoint ? 1 : 0) + (hasGrpcStatusCode ? 1 : 0) + (hasAdditionalTags ? 1 : 0)
         assert metricMapSize == expectedMapSize
         int elementCount = 0
@@ -346,10 +351,10 @@ class SerializingMetricWriterTest extends DDSpecification {
         if (hasAdditionalTags) {
           assert unpacker.unpackString() == "AdditionalMetricTags"
           int additionalTagsLength = unpacker.unpackArrayHeader()
-          assert additionalTagsLength == key.getAdditionalTags().size()
+          // The Groovy specs don't currently populate additional tags; detailed value
+          // assertions for the populated case live in SerializingMetricWriterAdditionalTagsTest.
           for (int i = 0; i < additionalTagsLength; i++) {
-            def unpackedTag = unpacker.unpackString()
-            assert unpackedTag == key.getAdditionalTags()[i].toString()
+            unpacker.unpackString()
           }
           ++elementCount
         }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -74,7 +74,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         null,
         null,
         null
-        ),
+        , null),
         new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))
         ),
         Pair.of(
@@ -96,7 +96,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         null,
         null,
         null
-        ),
+        , null),
         new AggregateMetric().recordDurations(9, new AtomicLongArray(1L))
         ),
         Pair.of(
@@ -114,7 +114,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         "GET",
         "/api/users/:id",
         null
-        ),
+        , null),
         new AggregateMetric().recordDurations(5, new AtomicLongArray(1L))
         )
       ],
@@ -134,7 +134,7 @@ class SerializingMetricWriterTest extends DDSpecification {
           null,
           null,
           null
-          ),
+          , null),
           new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))
           )
       })
@@ -149,8 +149,8 @@ class SerializingMetricWriterTest extends DDSpecification {
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
     // Create keys with different combinations of HTTP fields
-    def keyWithNoSource = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null)
-    def keyWithSource = new MetricKey("resource", "service", "operation", "source", "type", 200, false, false, "server", [], "POST", null, null)
+    def keyWithNoSource = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null, null)
+    def keyWithSource = new MetricKey("resource", "service", "operation", "source", "type", 200, false, false, "server", [], "POST", null, null, null)
 
     def content = [
       Pair.of(keyWithNoSource, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),
@@ -178,10 +178,10 @@ class SerializingMetricWriterTest extends DDSpecification {
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
     // Create keys with different combinations of HTTP fields
-    def keyWithBoth = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null)
-    def keyWithMethodOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "POST", null,null)
-    def keyWithEndpointOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], null, "/api/orders",null)
-    def keyWithNeither = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "client", [], null, null, null)
+    def keyWithBoth = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null, null)
+    def keyWithMethodOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "POST", null,null, null)
+    def keyWithEndpointOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], null, "/api/orders",null, null)
+    def keyWithNeither = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "client", [], null, null, null, null)
 
     def content = [
       Pair.of(keyWithBoth, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),
@@ -217,7 +217,7 @@ class SerializingMetricWriterTest extends DDSpecification {
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
     // Create keys with different combinations of HTTP fields
-    def key = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null)
+    def key = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null, null)
 
     def content = [Pair.of(key, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),]
 
@@ -307,7 +307,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         boolean hasHttpEndpoint = key.getHttpEndpoint() != null
         boolean hasServiceSource = key.getServiceSource() != null
         boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null
-        int expectedMapSize = 15 + (hasServiceSource ? 1 : 0) + (hasHttpMethod ? 1 : 0) + (hasHttpEndpoint ? 1 : 0) + (hasGrpcStatusCode ? 1 : 0)
+        int expectedMapSize = 16 + (hasServiceSource ? 1 : 0) + (hasHttpMethod ? 1 : 0) + (hasHttpEndpoint ? 1 : 0) + (hasGrpcStatusCode ? 1 : 0)
         assert metricMapSize == expectedMapSize
         int elementCount = 0
         assert unpacker.unpackString() == "Name"
@@ -340,6 +340,14 @@ class SerializingMetricWriterTest extends DDSpecification {
         for (int i = 0; i < peerTagsLength; i++) {
           def unpackedPeerTag = unpacker.unpackString()
           assert unpackedPeerTag == key.getPeerTags()[i].toString()
+        }
+        ++elementCount
+        assert unpacker.unpackString() == "AdditionalMetricTags"
+        int additionalTagsLength = unpacker.unpackArrayHeader()
+        assert additionalTagsLength == key.getAdditionalTags().size()
+        for (int i = 0; i < additionalTagsLength; i++) {
+          def unpackedTag = unpacker.unpackString()
+          assert unpackedTag == key.getAdditionalTags()[i].toString()
         }
         ++elementCount
         // Service source is only present when the service name has been overridden by the tracer
@@ -405,8 +413,8 @@ class SerializingMetricWriterTest extends DDSpecification {
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
     // Create keys with different combinations of HTTP fields
-    def keyWithNoSource = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null)
-    def keyWithSource = new MetricKey("resource", "service", "operation", "source", "type", 200, false, false, "server", [], "POST", null, null)
+    def keyWithNoSource = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null, null)
+    def keyWithSource = new MetricKey("resource", "service", "operation", "source", "type", 200, false, false, "server", [], "POST", null, null, null)
 
     def content = [
       Pair.of(keyWithNoSource, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),
@@ -433,9 +441,9 @@ class SerializingMetricWriterTest extends DDSpecification {
     long duration = SECONDS.toNanos(10)
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
-    def keyWithGrpc = new MetricKey("grpc.service/Method", "grpc-service", "grpc.server", null, "rpc", 0, false, false, "server", [], null, null, "OK")
-    def keyWithGrpcError = new MetricKey("grpc.service/Method", "grpc-service", "grpc.server", null, "rpc", 0, false, false, "client", [], null, null, "NOT_FOUND")
-    def keyWithoutGrpc = new MetricKey("resource", "service", "operation", null, "web", 200, false, false, "server", [], null, null, null)
+    def keyWithGrpc = new MetricKey("grpc.service/Method", "grpc-service", "grpc.server", null, "rpc", 0, false, false, "server", [], null, null, "OK", null)
+    def keyWithGrpcError = new MetricKey("grpc.service/Method", "grpc-service", "grpc.server", null, "rpc", 0, false, false, "client", [], null, null, "NOT_FOUND", null)
+    def keyWithoutGrpc = new MetricKey("resource", "service", "operation", null, "web", 200, false, false, "server", [], null, null, null, null)
 
     def content = [
       Pair.of(keyWithGrpc, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),
@@ -464,10 +472,10 @@ class SerializingMetricWriterTest extends DDSpecification {
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language")
 
     // Create keys with different combinations of HTTP fields
-    def keyWithBoth = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null)
-    def keyWithMethodOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "POST", null, null)
-    def keyWithEndpointOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], null, "/api/orders", null)
-    def keyWithNeither = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "client", [], null, null, null)
+    def keyWithBoth = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "GET", "/api/users", null, null)
+    def keyWithMethodOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], "POST", null, null, null)
+    def keyWithEndpointOnly = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "server", [], null, "/api/orders", null, null)
+    def keyWithNeither = new MetricKey("resource", "service", "operation", null, "type", 200, false, false, "client", [], null, null, null, null)
 
     def content = [
       Pair.of(keyWithBoth, new AggregateMetric().recordDurations(1, new AtomicLongArray(1L))),

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -307,7 +307,8 @@ class SerializingMetricWriterTest extends DDSpecification {
         boolean hasHttpEndpoint = key.getHttpEndpoint() != null
         boolean hasServiceSource = key.getServiceSource() != null
         boolean hasGrpcStatusCode = key.getGrpcStatusCode() != null
-        int expectedMapSize = 16 + (hasServiceSource ? 1 : 0) + (hasHttpMethod ? 1 : 0) + (hasHttpEndpoint ? 1 : 0) + (hasGrpcStatusCode ? 1 : 0)
+        boolean hasAdditionalTags = key.getAdditionalTags().size() > 0
+        int expectedMapSize = 15 + (hasServiceSource ? 1 : 0) + (hasHttpMethod ? 1 : 0) + (hasHttpEndpoint ? 1 : 0) + (hasGrpcStatusCode ? 1 : 0) + (hasAdditionalTags ? 1 : 0)
         assert metricMapSize == expectedMapSize
         int elementCount = 0
         assert unpacker.unpackString() == "Name"
@@ -342,14 +343,16 @@ class SerializingMetricWriterTest extends DDSpecification {
           assert unpackedPeerTag == key.getPeerTags()[i].toString()
         }
         ++elementCount
-        assert unpacker.unpackString() == "AdditionalMetricTags"
-        int additionalTagsLength = unpacker.unpackArrayHeader()
-        assert additionalTagsLength == key.getAdditionalTags().size()
-        for (int i = 0; i < additionalTagsLength; i++) {
-          def unpackedTag = unpacker.unpackString()
-          assert unpackedTag == key.getAdditionalTags()[i].toString()
+        if (hasAdditionalTags) {
+          assert unpacker.unpackString() == "AdditionalMetricTags"
+          int additionalTagsLength = unpacker.unpackArrayHeader()
+          assert additionalTagsLength == key.getAdditionalTags().size()
+          for (int i = 0; i < additionalTagsLength; i++) {
+            def unpackedTag = unpacker.unpackString()
+            assert unpackedTag == key.getAdditionalTags()[i].toString()
+          }
+          ++elementCount
         }
-        ++elementCount
         // Service source is only present when the service name has been overridden by the tracer
         if (hasServiceSource) {
           assert unpacker.unpackString() == "srv_src"

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
@@ -2,113 +2,85 @@ package datadog.trace.common.metrics;
 
 import static datadog.trace.common.metrics.AdditionalTagsCardinalityLimiter.BLOCKED_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.core.monitor.HealthMetrics;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class AdditionalTagsCardinalityLimiterTest {
 
   @Test
-  void belowLimitAdmitsAllValues() {
-    AdditionalTagsCardinalityLimiter limiter =
-        new AdditionalTagsCardinalityLimiter(100, HealthMetrics.NO_OP);
-    for (int i = 0; i < 99; i++) {
-      String v = "v" + i;
-      assertEquals(v, limiter.admitOrBlock("region", v));
-    }
+  void applyLengthCapAdmitsShortValues() {
+    AdditionalTagsCardinalityLimiter limiter = newLimiter(100);
+    assertEquals("us-east-1", limiter.applyLengthCap("region", "us-east-1"));
   }
 
   @Test
-  void atLimitNextNewValueIsBlocked() {
-    AdditionalTagsCardinalityLimiter limiter =
-        new AdditionalTagsCardinalityLimiter(3, HealthMetrics.NO_OP);
-    assertEquals("a", limiter.admitOrBlock("region", "a"));
-    assertEquals("b", limiter.admitOrBlock("region", "b"));
-    assertEquals("c", limiter.admitOrBlock("region", "c"));
-    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "d"));
+  void applyLengthCapBlocksLongValues() {
+    AdditionalTagsCardinalityLimiter limiter = newLimiter(100);
+    String tooLong =
+        repeat('x', AdditionalTagsCardinalityLimiter.MAX_ADDITIONAL_TAG_VALUE_LENGTH + 1);
+    assertEquals(BLOCKED_VALUE, limiter.applyLengthCap("region", tooLong));
   }
 
   @Test
-  void alreadyAdmittedValueStaysAdmittedAfterCapHit() {
-    AdditionalTagsCardinalityLimiter limiter =
-        new AdditionalTagsCardinalityLimiter(3, HealthMetrics.NO_OP);
-    limiter.admitOrBlock("region", "a");
-    limiter.admitOrBlock("region", "b");
-    limiter.admitOrBlock("region", "c");
-    limiter.admitOrBlock("region", "d"); // blocked
-    assertEquals("a", limiter.admitOrBlock("region", "a"));
-    assertEquals("b", limiter.admitOrBlock("region", "b"));
-    assertNotEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "c"));
-  }
-
-  @Test
-  void differentTagsAreIndependent() {
-    AdditionalTagsCardinalityLimiter limiter =
-        new AdditionalTagsCardinalityLimiter(2, HealthMetrics.NO_OP);
-    limiter.admitOrBlock("customer_id", "x");
-    limiter.admitOrBlock("customer_id", "y");
-    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("customer_id", "z"));
-    // region should be completely unaffected
-    assertEquals("us-east-1", limiter.admitOrBlock("region", "us-east-1"));
-    assertEquals("eu-west-1", limiter.admitOrBlock("region", "eu-west-1"));
-    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "ap-south-1"));
-  }
-
-  @Test
-  void resetReadmitsPreviouslyBlockedValues() {
-    AdditionalTagsCardinalityLimiter limiter =
-        new AdditionalTagsCardinalityLimiter(2, HealthMetrics.NO_OP);
-    limiter.admitOrBlock("region", "a");
-    limiter.admitOrBlock("region", "b");
-    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "c"));
-    limiter.reset();
-    assertEquals("c", limiter.admitOrBlock("region", "c"));
-  }
-
-  @Test
-  void healthMetricFiresOnBlock() {
-    RecordingHealthMetrics health = new RecordingHealthMetrics();
-    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(2, health);
-    limiter.admitOrBlock("region", "a");
-    limiter.admitOrBlock("region", "b");
-    assertEquals(0, health.blocked.size());
-    limiter.admitOrBlock("region", "c"); // blocked
-    limiter.admitOrBlock("region", "d"); // blocked
-    assertEquals(2, health.blocked.size());
-    assertEquals("region", health.blocked.get(0));
-    assertEquals("region", health.blocked.get(1));
-  }
-
-  @Test
-  void noteBlockedDueToLengthFiresHealthMetric() {
+  void applyLengthCapFiresHealthMetricOnBlock() {
     RecordingHealthMetrics health = new RecordingHealthMetrics();
     AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(100, health);
-    limiter.noteBlockedDueToLength("region", 500, 250);
-    assertEquals(1, health.blocked.size());
-    assertEquals("region", health.blocked.get(0));
+    String tooLong =
+        repeat('x', AdditionalTagsCardinalityLimiter.MAX_ADDITIONAL_TAG_VALUE_LENGTH + 1);
+    limiter.applyLengthCap("region", tooLong);
+    limiter.applyLengthCap("region", tooLong);
+    assertEquals(2, health.blocked.size());
   }
 
   @Test
-  void lengthAndCardinalityBlocksAreCountedSeparatelyInHealth() {
+  void isAtCapTracksCounter() {
+    AdditionalTagsCardinalityLimiter limiter = newLimiter(3);
+    assertFalse(limiter.isAtCap());
+    limiter.onNewStatEntryAdmitted();
+    limiter.onNewStatEntryAdmitted();
+    assertFalse(limiter.isAtCap());
+    limiter.onNewStatEntryAdmitted();
+    assertTrue(limiter.isAtCap());
+  }
+
+  @Test
+  void resetBucketClearsCounter() {
+    AdditionalTagsCardinalityLimiter limiter = newLimiter(2);
+    limiter.onNewStatEntryAdmitted();
+    limiter.onNewStatEntryAdmitted();
+    assertTrue(limiter.isAtCap());
+    limiter.resetBucket();
+    assertFalse(limiter.isAtCap());
+  }
+
+  @Test
+  void resetBucketRearmsLengthWarnFlag() {
+    // We can't directly observe the warn flag, but resetBucket() should not throw and the next
+    // long value should still be considered a block (health metric fires per call regardless).
     RecordingHealthMetrics health = new RecordingHealthMetrics();
-    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(2, health);
-    // exhaust cardinality
-    limiter.admitOrBlock("region", "a");
-    limiter.admitOrBlock("region", "b");
-    limiter.admitOrBlock("region", "c"); // cardinality block -> 1 health event
-    // length block on same tag -> 2 health events total
-    limiter.noteBlockedDueToLength("region", 500, 250);
+    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(100, health);
+    String tooLong =
+        repeat('x', AdditionalTagsCardinalityLimiter.MAX_ADDITIONAL_TAG_VALUE_LENGTH + 1);
+    limiter.applyLengthCap("region", tooLong);
+    limiter.resetBucket();
+    limiter.applyLengthCap("region", tooLong);
     assertEquals(2, health.blocked.size());
-    // reset rearms both branches
-    limiter.reset();
-    limiter.admitOrBlock("region", "x");
-    limiter.admitOrBlock("region", "y");
-    limiter.admitOrBlock("region", "z"); // cardinality block again -> 3
-    limiter.noteBlockedDueToLength("region", 500, 250); // length block again -> 4
-    assertEquals(4, health.blocked.size());
+  }
+
+  private static AdditionalTagsCardinalityLimiter newLimiter(int maxStatEntries) {
+    return new AdditionalTagsCardinalityLimiter(maxStatEntries, HealthMetrics.NO_OP);
+  }
+
+  private static String repeat(char c, int len) {
+    char[] chars = new char[len];
+    Arrays.fill(chars, c);
+    return new String(chars);
   }
 
   private static final class RecordingHealthMetrics extends HealthMetrics {

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
@@ -1,0 +1,93 @@
+package datadog.trace.common.metrics;
+
+import static datadog.trace.common.metrics.AdditionalTagsCardinalityLimiter.BLOCKED_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import datadog.trace.core.monitor.HealthMetrics;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AdditionalTagsCardinalityLimiterTest {
+
+  @Test
+  void belowLimitAdmitsAllValues() {
+    AdditionalTagsCardinalityLimiter limiter =
+        new AdditionalTagsCardinalityLimiter(100, HealthMetrics.NO_OP);
+    for (int i = 0; i < 99; i++) {
+      String v = "v" + i;
+      assertEquals(v, limiter.admitOrBlock("region", v));
+    }
+  }
+
+  @Test
+  void atLimitNextNewValueIsBlocked() {
+    AdditionalTagsCardinalityLimiter limiter =
+        new AdditionalTagsCardinalityLimiter(3, HealthMetrics.NO_OP);
+    assertEquals("a", limiter.admitOrBlock("region", "a"));
+    assertEquals("b", limiter.admitOrBlock("region", "b"));
+    assertEquals("c", limiter.admitOrBlock("region", "c"));
+    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "d"));
+  }
+
+  @Test
+  void alreadyAdmittedValueStaysAdmittedAfterCapHit() {
+    AdditionalTagsCardinalityLimiter limiter =
+        new AdditionalTagsCardinalityLimiter(3, HealthMetrics.NO_OP);
+    limiter.admitOrBlock("region", "a");
+    limiter.admitOrBlock("region", "b");
+    limiter.admitOrBlock("region", "c");
+    limiter.admitOrBlock("region", "d"); // blocked
+    assertEquals("a", limiter.admitOrBlock("region", "a"));
+    assertEquals("b", limiter.admitOrBlock("region", "b"));
+    assertNotEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "c"));
+  }
+
+  @Test
+  void differentTagsAreIndependent() {
+    AdditionalTagsCardinalityLimiter limiter =
+        new AdditionalTagsCardinalityLimiter(2, HealthMetrics.NO_OP);
+    limiter.admitOrBlock("customer_id", "x");
+    limiter.admitOrBlock("customer_id", "y");
+    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("customer_id", "z"));
+    // region should be completely unaffected
+    assertEquals("us-east-1", limiter.admitOrBlock("region", "us-east-1"));
+    assertEquals("eu-west-1", limiter.admitOrBlock("region", "eu-west-1"));
+    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "ap-south-1"));
+  }
+
+  @Test
+  void resetReadmitsPreviouslyBlockedValues() {
+    AdditionalTagsCardinalityLimiter limiter =
+        new AdditionalTagsCardinalityLimiter(2, HealthMetrics.NO_OP);
+    limiter.admitOrBlock("region", "a");
+    limiter.admitOrBlock("region", "b");
+    assertEquals(BLOCKED_VALUE, limiter.admitOrBlock("region", "c"));
+    limiter.reset();
+    assertEquals("c", limiter.admitOrBlock("region", "c"));
+  }
+
+  @Test
+  void healthMetricFiresOnBlock() {
+    RecordingHealthMetrics health = new RecordingHealthMetrics();
+    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(2, health);
+    limiter.admitOrBlock("region", "a");
+    limiter.admitOrBlock("region", "b");
+    assertEquals(0, health.blocked.size());
+    limiter.admitOrBlock("region", "c"); // blocked
+    limiter.admitOrBlock("region", "d"); // blocked
+    assertEquals(2, health.blocked.size());
+    assertEquals("region", health.blocked.get(0));
+    assertEquals("region", health.blocked.get(1));
+  }
+
+  private static final class RecordingHealthMetrics extends HealthMetrics {
+    final List<String> blocked = new ArrayList<>();
+
+    @Override
+    public void onAdditionalTagValueCardinalityBlocked(String tagKey) {
+      blocked.add(tagKey);
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/AdditionalTagsCardinalityLimiterTest.java
@@ -82,6 +82,35 @@ class AdditionalTagsCardinalityLimiterTest {
     assertEquals("region", health.blocked.get(1));
   }
 
+  @Test
+  void noteBlockedDueToLengthFiresHealthMetric() {
+    RecordingHealthMetrics health = new RecordingHealthMetrics();
+    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(100, health);
+    limiter.noteBlockedDueToLength("region", 500, 250);
+    assertEquals(1, health.blocked.size());
+    assertEquals("region", health.blocked.get(0));
+  }
+
+  @Test
+  void lengthAndCardinalityBlocksAreCountedSeparatelyInHealth() {
+    RecordingHealthMetrics health = new RecordingHealthMetrics();
+    AdditionalTagsCardinalityLimiter limiter = new AdditionalTagsCardinalityLimiter(2, health);
+    // exhaust cardinality
+    limiter.admitOrBlock("region", "a");
+    limiter.admitOrBlock("region", "b");
+    limiter.admitOrBlock("region", "c"); // cardinality block -> 1 health event
+    // length block on same tag -> 2 health events total
+    limiter.noteBlockedDueToLength("region", 500, 250);
+    assertEquals(2, health.blocked.size());
+    // reset rearms both branches
+    limiter.reset();
+    limiter.admitOrBlock("region", "x");
+    limiter.admitOrBlock("region", "y");
+    limiter.admitOrBlock("region", "z"); // cardinality block again -> 3
+    limiter.noteBlockedDueToLength("region", 500, 250); // length block again -> 4
+    assertEquals(4, health.blocked.size());
+  }
+
   private static final class RecordingHealthMetrics extends HealthMetrics {
     final List<String> blocked = new ArrayList<>();
 

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorNormalizationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/ConflatingMetricsAggregatorNormalizationTest.java
@@ -1,0 +1,58 @@
+package datadog.trace.common.metrics;
+
+import static datadog.trace.common.metrics.ConflatingMetricsAggregator.MAX_ADDITIONAL_TAG_KEYS;
+import static datadog.trace.common.metrics.ConflatingMetricsAggregator.normalizeAdditionalTagKeys;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+class ConflatingMetricsAggregatorNormalizationTest {
+
+  @Test
+  void nullOrEmptyProducesEmptyList() {
+    assertEquals(Collections.emptyList(), normalizeAdditionalTagKeys(null));
+    assertEquals(
+        Collections.emptyList(), normalizeAdditionalTagKeys(Collections.<String>emptySet()));
+  }
+
+  @Test
+  void resultIsSortedAlphabetically() {
+    Set<String> configured = new LinkedHashSet<>(Arrays.asList("region", "tenant_id", "az"));
+    assertEquals(
+        Arrays.asList("az", "region", "tenant_id"), normalizeAdditionalTagKeys(configured));
+  }
+
+  @Test
+  void resultIsImmutable() {
+    Set<String> configured = new LinkedHashSet<>(Arrays.asList("region", "tenant_id"));
+    List<String> normalized = normalizeAdditionalTagKeys(configured);
+    assertThrows(UnsupportedOperationException.class, () -> normalized.add("oops"));
+  }
+
+  @Test
+  void inputOrderDoesNotAffectResult() {
+    Set<String> a = new LinkedHashSet<>(Arrays.asList("region", "tenant_id"));
+    Set<String> b = new LinkedHashSet<>(Arrays.asList("tenant_id", "region"));
+    assertEquals(normalizeAdditionalTagKeys(a), normalizeAdditionalTagKeys(b));
+  }
+
+  @Test
+  void exceedingMaxKeysTruncatesAfterSort() {
+    Set<String> configured = new TreeSet<>();
+    for (int i = 0; i < MAX_ADDITIONAL_TAG_KEYS + 5; i++) {
+      configured.add(String.format("tag_%02d", i));
+    }
+    List<String> normalized = normalizeAdditionalTagKeys(configured);
+    assertEquals(MAX_ADDITIONAL_TAG_KEYS, normalized.size());
+    assertTrue(normalized.contains("tag_00"));
+    assertTrue(normalized.contains(String.format("tag_%02d", MAX_ADDITIONAL_TAG_KEYS - 1)));
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/MetricKeyAdditionalTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/MetricKeyAdditionalTagsTest.java
@@ -1,0 +1,77 @@
+package datadog.trace.common.metrics;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MetricKeyAdditionalTagsTest {
+
+  @Test
+  void emptyAndNullAdditionalTagsAreEquivalent() {
+    MetricKey a = key(null);
+    MetricKey b = key(emptyList());
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertEquals(emptyList(), a.getAdditionalTags());
+  }
+
+  @Test
+  void sameOrderProducesEqualKeys() {
+    MetricKey a = key(tags("region:us-east-1", "tenant_id:acme"));
+    MetricKey b = key(tags("region:us-east-1", "tenant_id:acme"));
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void differentValuesProduceDifferentKeys() {
+    MetricKey a = key(tags("region:us-east-1"));
+    MetricKey b = key(tags("region:eu-west-1"));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void differentTagSetsProduceDifferentKeys() {
+    MetricKey a = key(tags("region:us-east-1"));
+    MetricKey b = key(tags("region:us-east-1", "tenant_id:acme"));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void keyWithAdditionalTagsDiffersFromKeyWithout() {
+    MetricKey a = key(emptyList());
+    MetricKey b = key(tags("region:us-east-1"));
+    assertNotEquals(a, b);
+  }
+
+  private static List<UTF8BytesString> tags(String... entries) {
+    List<UTF8BytesString> list = new ArrayList<>(entries.length);
+    for (String e : entries) {
+      list.add(UTF8BytesString.create(e));
+    }
+    return list;
+  }
+
+  private static MetricKey key(List<UTF8BytesString> additionalTags) {
+    return new MetricKey(
+        "resource",
+        "service",
+        "operation",
+        null,
+        "web",
+        200,
+        false,
+        false,
+        "server",
+        emptyList(),
+        null,
+        null,
+        null,
+        additionalTags);
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/MetricKeyAdditionalTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/MetricKeyAdditionalTagsTest.java
@@ -1,63 +1,53 @@
 package datadog.trace.common.metrics;
 
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class MetricKeyAdditionalTagsTest {
 
   @Test
-  void emptyAndNullAdditionalTagsAreEquivalent() {
+  void nullAndEmptyArrayAreEquivalent() {
     MetricKey a = key(null);
-    MetricKey b = key(emptyList());
+    MetricKey b = key(new String[0]);
     assertEquals(a, b);
     assertEquals(a.hashCode(), b.hashCode());
-    assertEquals(emptyList(), a.getAdditionalTags());
+    assertArrayEquals(new String[0], a.getAdditionalTagValues());
   }
 
   @Test
-  void sameOrderProducesEqualKeys() {
-    MetricKey a = key(tags("region:us-east-1", "tenant_id:acme"));
-    MetricKey b = key(tags("region:us-east-1", "tenant_id:acme"));
+  void sameValuesProduceEqualKeys() {
+    MetricKey a = key(new String[] {"us-east-1", "acme"});
+    MetricKey b = key(new String[] {"us-east-1", "acme"});
     assertEquals(a, b);
     assertEquals(a.hashCode(), b.hashCode());
   }
 
   @Test
   void differentValuesProduceDifferentKeys() {
-    MetricKey a = key(tags("region:us-east-1"));
-    MetricKey b = key(tags("region:eu-west-1"));
+    MetricKey a = key(new String[] {"us-east-1", null});
+    MetricKey b = key(new String[] {"eu-west-1", null});
     assertNotEquals(a, b);
   }
 
   @Test
-  void differentTagSetsProduceDifferentKeys() {
-    MetricKey a = key(tags("region:us-east-1"));
-    MetricKey b = key(tags("region:us-east-1", "tenant_id:acme"));
+  void differentTagPresenceProducesDifferentKeys() {
+    MetricKey a = key(new String[] {"us-east-1", null});
+    MetricKey b = key(new String[] {"us-east-1", "acme"});
     assertNotEquals(a, b);
   }
 
   @Test
   void keyWithAdditionalTagsDiffersFromKeyWithout() {
-    MetricKey a = key(emptyList());
-    MetricKey b = key(tags("region:us-east-1"));
+    MetricKey a = key(new String[0]);
+    MetricKey b = key(new String[] {"us-east-1"});
     assertNotEquals(a, b);
   }
 
-  private static List<UTF8BytesString> tags(String... entries) {
-    List<UTF8BytesString> list = new ArrayList<>(entries.length);
-    for (String e : entries) {
-      list.add(UTF8BytesString.create(e));
-    }
-    return list;
-  }
-
-  private static MetricKey key(List<UTF8BytesString> additionalTags) {
+  private static MetricKey key(String[] additionalTagValues) {
     return new MetricKey(
         "resource",
         "service",
@@ -72,6 +62,6 @@ class MetricKeyAdditionalTagsTest {
         null,
         null,
         null,
-        additionalTags);
+        additionalTagValues);
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import datadog.metrics.api.Histograms;
 import datadog.metrics.impl.DDSketchHistograms;
@@ -28,9 +29,9 @@ class SerializingMetricWriterAdditionalTagsTest {
   }
 
   @Test
-  void emptyAdditionalTagsAreEmittedAsEmptyArray() throws Exception {
+  void emptyAdditionalTagsOmitTheField() throws Exception {
     List<String> emitted = roundTripAdditionalTags(emptyList());
-    assertEquals(0, emitted.size());
+    assertNull(emitted);
   }
 
   @Test
@@ -111,7 +112,7 @@ class SerializingMetricWriterAdditionalTagsTest {
         unpacker.skipValue();
       }
     }
-    throw new AssertionError("AdditionalMetricTags field not found in payload");
+    return null;
   }
 
   private static final class CapturingSink implements Sink {

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import datadog.metrics.api.Histograms;
 import datadog.metrics.impl.DDSketchHistograms;
 import datadog.trace.api.WellKnownTags;
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,25 +30,37 @@ class SerializingMetricWriterAdditionalTagsTest {
 
   @Test
   void emptyAdditionalTagsOmitTheField() throws Exception {
-    List<String> emitted = roundTripAdditionalTags(emptyList());
+    List<String> emitted =
+        roundTripAdditionalTags(new String[] {"region", "tenant_id"}, new String[] {null, null});
     assertNull(emitted);
   }
 
   @Test
   void populatedAdditionalTagsAreEmittedInOrder() throws Exception {
-    List<UTF8BytesString> tags =
-        Arrays.asList(
-            UTF8BytesString.create("region:us-east-1"), UTF8BytesString.create("tenant_id:acme"));
-    List<String> emitted = roundTripAdditionalTags(tags);
+    String[] tagKeys = {"region", "tenant_id"};
+    String[] values = {"us-east-1", "acme"};
+    List<String> emitted = roundTripAdditionalTags(tagKeys, values);
     assertEquals(Arrays.asList("region:us-east-1", "tenant_id:acme"), emitted);
   }
 
-  private List<String> roundTripAdditionalTags(List<UTF8BytesString> additionalTags)
-      throws Exception {
+  @Test
+  void partiallyPopulatedTagsOnlyEmitNonNullEntries() throws Exception {
+    String[] tagKeys = {"region", "tenant_id"};
+    String[] values = {null, "acme"};
+    List<String> emitted = roundTripAdditionalTags(tagKeys, values);
+    assertEquals(Arrays.asList("tenant_id:acme"), emitted);
+  }
+
+  private List<String> roundTripAdditionalTags(String[] tagKeys, String[] values) throws Exception {
     WellKnownTags wellKnownTags =
         new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language");
     CapturingSink sink = new CapturingSink();
-    SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink, 128);
+    byte[][] tagKeyBytes = new byte[tagKeys.length][];
+    for (int i = 0; i < tagKeys.length; i++) {
+      tagKeyBytes[i] = tagKeys[i].getBytes(StandardCharsets.UTF_8);
+    }
+    SerializingMetricWriter writer =
+        new SerializingMetricWriter(wellKnownTags, tagKeyBytes, sink, 128);
     MetricKey key =
         new MetricKey(
             "resource",
@@ -64,7 +76,7 @@ class SerializingMetricWriterAdditionalTagsTest {
             null,
             null,
             null,
-            additionalTags);
+            values);
     AggregateMetric aggregate =
         new AggregateMetric().recordDurations(1, new AtomicLongArray(new long[] {1L}));
     long start = MILLISECONDS.toNanos(System.currentTimeMillis());

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/SerializingMetricWriterAdditionalTagsTest.java
@@ -1,0 +1,131 @@
+package datadog.trace.common.metrics;
+
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import datadog.metrics.api.Histograms;
+import datadog.metrics.impl.DDSketchHistograms;
+import datadog.trace.api.WellKnownTags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLongArray;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessageUnpacker;
+
+class SerializingMetricWriterAdditionalTagsTest {
+
+  @BeforeAll
+  static void registerHistograms() {
+    Histograms.register(DDSketchHistograms.FACTORY);
+  }
+
+  @Test
+  void emptyAdditionalTagsAreEmittedAsEmptyArray() throws Exception {
+    List<String> emitted = roundTripAdditionalTags(emptyList());
+    assertEquals(0, emitted.size());
+  }
+
+  @Test
+  void populatedAdditionalTagsAreEmittedInOrder() throws Exception {
+    List<UTF8BytesString> tags =
+        Arrays.asList(
+            UTF8BytesString.create("region:us-east-1"), UTF8BytesString.create("tenant_id:acme"));
+    List<String> emitted = roundTripAdditionalTags(tags);
+    assertEquals(Arrays.asList("region:us-east-1", "tenant_id:acme"), emitted);
+  }
+
+  private List<String> roundTripAdditionalTags(List<UTF8BytesString> additionalTags)
+      throws Exception {
+    WellKnownTags wellKnownTags =
+        new WellKnownTags("runtimeid", "hostname", "env", "service", "version", "language");
+    CapturingSink sink = new CapturingSink();
+    SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink, 128);
+    MetricKey key =
+        new MetricKey(
+            "resource",
+            "service",
+            "operation",
+            null,
+            "web",
+            200,
+            false,
+            false,
+            "server",
+            emptyList(),
+            null,
+            null,
+            null,
+            additionalTags);
+    AggregateMetric aggregate =
+        new AggregateMetric().recordDurations(1, new AtomicLongArray(new long[] {1L}));
+    long start = MILLISECONDS.toNanos(System.currentTimeMillis());
+    long duration = SECONDS.toNanos(10);
+    writer.startBucket(1, start, duration);
+    writer.add(key, aggregate);
+    writer.finishBucket();
+    assertNotNull(sink.captured);
+    return readAdditionalTagsFromPayload(sink.captured);
+  }
+
+  private static List<String> readAdditionalTagsFromPayload(ByteBuffer buffer) throws Exception {
+    MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer);
+    int envelopeSize = unpacker.unpackMapHeader();
+    for (int i = 0; i < envelopeSize; i++) {
+      String envelopeKey = unpacker.unpackString();
+      if ("Stats".equals(envelopeKey)) {
+        int bucketCount = unpacker.unpackArrayHeader();
+        assertEquals(1, bucketCount);
+        int bucketMapSize = unpacker.unpackMapHeader();
+        for (int b = 0; b < bucketMapSize; b++) {
+          String bk = unpacker.unpackString();
+          if ("Stats".equals(bk)) {
+            int statCount = unpacker.unpackArrayHeader();
+            assertEquals(1, statCount);
+            int metricMapSize = unpacker.unpackMapHeader();
+            for (int m = 0; m < metricMapSize; m++) {
+              String mk = unpacker.unpackString();
+              if ("AdditionalMetricTags".equals(mk)) {
+                int tagCount = unpacker.unpackArrayHeader();
+                List<String> result = new ArrayList<>(tagCount);
+                for (int t = 0; t < tagCount; t++) {
+                  result.add(unpacker.unpackString());
+                }
+                return result;
+              } else {
+                unpacker.skipValue();
+              }
+            }
+          } else {
+            unpacker.skipValue();
+          }
+        }
+      } else {
+        unpacker.skipValue();
+      }
+    }
+    throw new AssertionError("AdditionalMetricTags field not found in payload");
+  }
+
+  private static final class CapturingSink implements Sink {
+    ByteBuffer captured;
+    final List<EventListener> listeners = new ArrayList<>();
+
+    @Override
+    public void register(EventListener listener) {
+      listeners.add(listener);
+    }
+
+    @Override
+    public void accept(int messageCount, ByteBuffer buffer) {
+      this.captured = buffer;
+    }
+  }
+}

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -40,11 +40,11 @@ class MetricsIntegrationTest extends AbstractTraceAgentTest {
       )
     writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))
     writer.add(
-      new MetricKey("resource1", "service1", "operation1", null, "sql", 0, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")], null, null, null),
+      new MetricKey("resource1", "service1", "operation1", null, "sql", 0, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")], null, null, null, null),
       new AggregateMetric().recordDurations(5, new AtomicLongArray(2, 1, 2, 250, 4, 5))
       )
     writer.add(
-      new MetricKey("resource2", "service2", "operation2", null, "web", 200, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")], null, null, null),
+      new MetricKey("resource2", "service2", "operation2", null, "web", 200, false, true, "xyzzy", [UTF8BytesString.create("grault:quux")], null, null, null, null),
       new AggregateMetric().recordDurations(10, new AtomicLongArray(1, 1, 200, 2, 3, 4, 5, 6, 7, 8, 9))
       )
     writer.finishBucket()

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -418,6 +418,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
 import static datadog.trace.api.config.GeneralConfig.TRACE_LOG_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_ADDITIONAL_TAGS;
+import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_COMPUTATION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_COMPUTATION_IGNORE_AGENT_VERSION;
 import static datadog.trace.api.config.GeneralConfig.TRACE_TAGS;
@@ -5111,6 +5112,18 @@ public class Config {
 
   public Set<String> getTraceStatsAdditionalTags() {
     return tryMakeImmutableSet(configProvider.getList(TRACE_STATS_ADDITIONAL_TAGS));
+  }
+
+  public int getTraceStatsAdditionalTagsCardinalityLimit() {
+    int configured = configProvider.getInteger(TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT, 100);
+    if (configured <= 0) {
+      log.warn(
+          "Invalid {} value: {}; falling back to default of 100",
+          TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT,
+          configured);
+      return 100;
+    }
+    return configured;
   }
 
   public String getEnv() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -5109,8 +5109,8 @@ public class Config {
     return tryMakeImmutableSet(configProvider.getList(TRACER_METRICS_IGNORED_RESOURCES));
   }
 
-  public List<String> getTraceStatsAdditionalTags() {
-    return tryMakeImmutableList(configProvider.getList(TRACE_STATS_ADDITIONAL_TAGS));
+  public Set<String> getTraceStatsAdditionalTags() {
+    return tryMakeImmutableSet(configProvider.getList(TRACE_STATS_ADDITIONAL_TAGS));
   }
 
   public String getEnv() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -417,6 +417,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGAT
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
 import static datadog.trace.api.config.GeneralConfig.TRACE_LOG_LEVEL;
+import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_ADDITIONAL_TAGS;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_COMPUTATION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_STATS_COMPUTATION_IGNORE_AGENT_VERSION;
 import static datadog.trace.api.config.GeneralConfig.TRACE_TAGS;
@@ -5106,6 +5107,10 @@ public class Config {
 
   public Set<String> getMetricsIgnoredResources() {
     return tryMakeImmutableSet(configProvider.getList(TRACER_METRICS_IGNORED_RESOURCES));
+  }
+
+  public List<String> getTraceStatsAdditionalTags() {
+    return tryMakeImmutableList(configProvider.getList(TRACE_STATS_ADDITIONAL_TAGS));
   }
 
   public String getEnv() {

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -10577,6 +10577,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_STATS_ADDITIONAL_TAGS": [
+      {
+        "version": "B",
+        "type": "array",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_TRACE_STATS_COMPUTATION_ENABLED": [
       {
         "version": "B",

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -10585,6 +10585,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT": [
+      {
+        "version": "B",
+        "type": "number",
+        "default": "100",
+        "aliases": []
+      }
+    ],
     "DD_TRACE_STATS_COMPUTATION_ENABLED": [
       {
         "version": "B",

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -10579,7 +10579,7 @@
     ],
     "DD_TRACE_STATS_ADDITIONAL_TAGS": [
       {
-        "version": "B",
+        "version": "A",
         "type": "array",
         "default": null,
         "aliases": []
@@ -10587,8 +10587,8 @@
     ],
     "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT": [
       {
-        "version": "B",
-        "type": "number",
+        "version": "A",
+        "type": "int",
         "default": "100",
         "aliases": []
       }


### PR DESCRIPTION
# What Does This Do

Adds an implementation of **span-derived primary tags** for client-side stats in the Java tracer ([spec](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6482919540)). Users can configure a list of span tag keys via `DD_TRACE_STATS_ADDITIONAL_TAGS`; the tracer extracts the matching values from each eligible span, adds them as an additional aggregation dimension on `MetricKey`, and emits them in the `v0.6/stats` payload under the new `AdditionalMetricTags` field (msgpack array of `"key:value"` strings, mirroring `PeerTags`).

# Motivation

Customers want APM stats broken down by custom dimensions beyond the standard `env` primary tag (e.g. `region`, `tenant_id`) for more granular per-segment visibility. Previously this was only available via the deprecated agent-side config; this PR moves it tracer-side per the v1.3.0 spec.

# Behavior summary

- **Config**: `DD_TRACE_STATS_ADDITIONAL_TAGS=region,tenant_id` (env), `dd.trace.stats.additional.tags=region,tenant_id` (sysprop), or `trace.stats.additional.tags=region,tenant_id` in `dd-java-tracer.properties`. Comma-separated list of tag keys.
- **Normalization**: configured keys are deduplicated and sorted alphabetically once at startup so config order/duplicates don't affect aggregation keys.
- **Per-span extraction**: for each eligible span (measured / top-level / configured span-kind), the configured tag keys are looked up via `span.unsafeGetTag(...)`; only present values are included.
- **MetricKey participation**: extracted tags become part of the aggregation key — spans with `region:us-east-1` aggregate separately from `region:eu-west-1`; spans without the configured tag aggregate together.
- **Wire format**: emitted as `AdditionalMetricTags` (`repeated string`, each entry `"key:value"`) in the per-metric msgpack map. Field omitted when no tags were extracted, so the 99% of customers who don't configure the feature pay zero payload overhead.
- **Backwards compatible**: older agents that don't recognize the field ignore it.

# Hardening

- **Configured-key cap**: `MAX_ADDITIONAL_TAG_KEYS = 10`. Anything beyond the cap is dropped at startup (after sort) with a `log.warn` listing the dropped keys. Reasoning: the backend stats pipeline only supports a small number of primary tag dimensions (4 by default, up to ~10 for elevated quotas), so configuring more than 10 is misuse.
- **Per-value length cap**: `MAX_ADDITIONAL_TAG_VALUE_LENGTH = 250`. Tag values longer than 250 chars are replaced with `blocked_by_tracer`. Protects against accidental misconfigurations like stuffing stack traces, SQL statements, or JSON blobs into a configured tag key (a precedent in this codebase, per Doug's review).
- **Per-bucket stat-entry cap**: `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT = 100` (configurable; `≤ 0` falls back to the default with a warn). One global counter per flush bucket, bumped each time a new MetricKey with additional tags is admitted. When the counter is at the cap, any *new* MetricKey has its additional tag values replaced with `blocked_by_tracer` (the dimension *keys* are preserved on the wire — blocked spans collapse into a small number of "shape" MetricKeys, not into the no-additional-tags base bucket). Spans whose full MetricKey already exists in the bucket continue to merge into it regardless of the cap. Counter resets on every flush (~10s).
- **Health metric**: `onAdditionalTagValueCardinalityBlocked(String tagKey)` callback on `HealthMetrics`, surfaced through `TracerHealthMetrics` as a counter named `stats.additional_tag.cardinality_blocked`. Fires on both length-blocks and cardinality-blocks so operators can see when the feature is being suppressed.

## Spec deviation: per-tag isolation

The CSS v1.3.0 spec requires per-tag isolation:

> Limits are evaluated independently per configured tag key (so a runaway `customer_id` doesn't poison `region`).

This PR uses a **single global counter** instead. Trade-off explicitly accepted for simplicity: no per-tag bookkeeping, no Map of HashSets, just one `AtomicInteger`. A misconfigured `customer_id` can starve `region`'s admission of new MetricKeys within a bucket, but every span still gets emitted with its dimension keys preserved (values masked) and its base stats unchanged. Worth noting if reviewers want stricter spec adherence.

# Allocation profile

Took two passes addressing review feedback on per-span allocation:

- `MetricKey.additionalTags` is a `String[]` parallel to the configured-keys list (null in slot `i` = the span didn't set tag `i`), rather than a `List<UTF8BytesString>` of pre-formatted `"key:value"` entries. No intermediate `ArrayList` per span; no per-`(key,value)` UTF8BytesString cache.
- The serializer composes `"key:value"` directly into the msgpack buffer using a new `MsgPackWriter.writeUTF8(byte[] prefix, byte separator, byte[] suffix)` helper that writes the string header for the combined length and puts the three byte ranges back-to-back. Tag-key bytes are pre-encoded once at construction. The only per-write allocation is `value.getBytes(UTF_8)` per non-null slot per MetricKey per flush — bounded by `maxAggregates × configured_tags`, dominated by per-span volume which is now leaner.
- The `peerTags` field still uses the older `List<UTF8BytesString>` shape; same optimization is applicable but out of scope here to keep this diff focused. Filed for a follow-up.

# Additional Notes

Out of scope for this PR:

- **`setMeasuredTag(key, value)` programmatic API** — spec marks this as future work.
- **Per-tag cardinality isolation** — see spec-deviation note above; happy to revisit if reviewers want strict spec adherence.
- **`peerTags` allocation refactor** — same `String[]` + direct-write pattern is applicable, deferred follow-up.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with the new `DD_TRACE_STATS_ADDITIONAL_TAGS` and `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` configs

Jira ticket: [PROJ-IDENT]