### PR TITLE
[SLES-2826] Reproducing AAS Restart Named Pipe Overlap Issue [Do Not Merge] 

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
+++ b/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
@@ -25,6 +25,11 @@ public class ExternalAgentLauncher implements Closeable {
   public ExternalAgentLauncher(Config config) {
     if (config.isAzureAppServices()) {
       if (config.getTraceAgentPath() != null) {
+        log.info(
+            "[aas-repro] ExternalAgentLauncher: spawning trace-agent — path={} pipe={} jvm_pid={}",
+            config.getTraceAgentPath(),
+            config.getAgentNamedPipe(),
+            ProcessHandle.current().pid());
         ProcessBuilder traceProcessBuilder = new ProcessBuilder(config.getTraceAgentPath());
         traceProcessBuilder.redirectOutput(DISCARD);
         traceProcessBuilder.redirectError(DISCARD);
@@ -38,6 +43,11 @@ public class ExternalAgentLauncher implements Closeable {
       }
 
       if (config.getDogStatsDPath() != null) {
+        log.info(
+            "[aas-repro] ExternalAgentLauncher: spawning dogstatsd — path={} pipe={} jvm_pid={}",
+            config.getDogStatsDPath(),
+            config.getDogStatsDNamedPipe(),
+            ProcessHandle.current().pid());
         ProcessBuilder dogStatsDProcessBuilder = new ProcessBuilder(config.getDogStatsDPath());
         dogStatsDProcessBuilder.redirectOutput(DISCARD);
         dogStatsDProcessBuilder.redirectError(DISCARD);
@@ -71,6 +81,7 @@ public class ExternalAgentLauncher implements Closeable {
 
   static final class NamedPipeHealthCheck implements ProcessSupervisor.HealthCheck {
     private static final String NAMED_PIPE_PREFIX = "\\\\.\\pipe\\";
+    private static final Logger log = LoggerFactory.getLogger(NamedPipeHealthCheck.class);
 
     private final File pipe;
 
@@ -88,10 +99,15 @@ public class ExternalAgentLauncher implements Closeable {
 
       // first-time round do a more detailed check for existing bound named-pipe
       if (previousHealth == NEVER_CHECKED) {
+        log.info("[aas-repro] NamedPipeHealthCheck first-check pipe={}", pipe);
 
         double delayMillis = 50;
         for (int retries = 0; retries < 7; retries++) {
           if (!pipe.exists()) {
+            log.info(
+                "[aas-repro] NamedPipeHealthCheck pipe={} not found on retry {} → READY_TO_START",
+                pipe,
+                retries);
             return READY_TO_START; // no longer bound, start our own external process
           }
 
@@ -100,6 +116,11 @@ public class ExternalAgentLauncher implements Closeable {
           delayMillis = delayMillis * 1.75;
         }
 
+        // Pipe survived all retries — something already owns it
+        log.warn(
+            "[aas-repro] NamedPipeHealthCheck pipe={} still bound after all retries"
+                + " — assuming existing process is healthy (orphan risk!)",
+            pipe);
         return HEALTHY; // use existing external process
       }
 
@@ -107,6 +128,7 @@ public class ExternalAgentLauncher implements Closeable {
       if (pipe.exists()) {
         return HEALTHY; // keep using external process
       } else {
+        log.info("[aas-repro] NamedPipeHealthCheck pipe={} gone → READY_TO_START", pipe);
         return READY_TO_START; // start our own process
       }
     }

--- a/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
+++ b/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
@@ -70,7 +70,10 @@ public class ProcessSupervisor implements Closeable {
     try {
       while (!stopping) {
         if (currentHealth == FAULTED && ++faults >= MAX_FAULTS) {
-          log.warn("Failed to start process [{}] after {} attempts", imageName, faults);
+          log.warn(
+              "[aas-repro] [{}] Terminal: failed to start after {} faults — supervisor exiting",
+              imageName,
+              faults);
           break;
         }
         try {
@@ -78,14 +81,23 @@ public class ProcessSupervisor implements Closeable {
           if (delayMillis > 0) {
             Thread.sleep(delayMillis);
           }
+          Health prevHealth = currentHealth;
           currentHealth = healthCheck.run(currentHealth);
+          if (currentHealth != prevHealth) {
+            log.info(
+                "[aas-repro] [{}] Health {} → {} (faults={})",
+                imageName,
+                prevHealth,
+                currentHealth,
+                faults);
+          }
           if (currentHealth == READY_TO_START) {
             startProcessAndWait();
           }
         } catch (InterruptedException e) {
           currentHealth = INTERRUPTED;
         } catch (Throwable e) {
-          log.warn("Exception starting process: [{}]", imageName, e);
+          log.warn("[aas-repro] [{}] Exception in supervisor loop", imageName, e);
           currentHealth = FAULTED;
         }
         scheduleNextHealthCheck();
@@ -108,18 +120,29 @@ public class ProcessSupervisor implements Closeable {
 
   private void startProcessAndWait() throws Exception {
     if (currentProcess == null) {
-      log.debug("Starting process: [{}]", imageName);
+      log.info(
+          "[aas-repro] [{}] Spawning — jvm_pid={}",
+          imageName,
+          ProcessHandle.current().pid());
       try (TraceScope ignored = AgentTracer.get().muteTracing()) {
         currentProcess = processBuilder.start();
       }
       currentHealth = HEALTHY;
       faults = 0;
+      log.info(
+          "[aas-repro] [{}] Started — child_pid={} faults_reset_to_0",
+          imageName,
+          currentProcess.pid());
     }
 
     // Block until the process exits
     int code = currentProcess.waitFor();
-    log.debug("Process [{}] has exited with code {}", imageName, code);
     currentHealth = code == 0 ? INTERRUPTED : FAULTED;
+    log.info(
+        "[aas-repro] [{}] Exited — code={} → health={}",
+        imageName,
+        code,
+        currentHealth);
 
     // Process is dead, no longer needs to be tracked
     currentProcess = null;
@@ -127,7 +150,7 @@ public class ProcessSupervisor implements Closeable {
 
   private void stopProcess() {
     if (currentProcess != null) {
-      log.debug("Stopping process: [{}]", imageName);
+      log.info("[aas-repro] [{}] Stopping (supervisor closing)", imageName);
       currentProcess.destroy();
       if (currentProcess.isAlive()) {
         currentProcess.destroyForcibly();


### PR DESCRIPTION
Add ProcessSupervisor and NamedPipeHealthCheck diagnostics for SLES-2826

Adds [aas-repro] INFO-level log lines to make the pipe-collision failure mode observable without DD_TRACE_DEBUG=true:

ProcessSupervisor:
- Health state transitions logged at INFO on every change
- Spawn logged with jvm_pid for cross-process correlation
- Process start logged with child_pid and faults_reset_to_0
- Process exit logged with exit code and resulting health state
- Terminal fault break logged with fault count

ExternalAgentLauncher:
- Supervisor creation logged with path, pipe name, and jvm_pid

NamedPipeHealthCheck (previously silent):
- First-check entry logged with pipe name
- NEVER_CHECKED → READY_TO_START logged with retry count
- NEVER_CHECKED → HEALTHY logged with warning (orphan risk)
- Ongoing HEALTHY → READY_TO_START logged when pipe disappears

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
