### PR TITLE
Test apm-sdks-benchmarks branch changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,8 +43,6 @@ stages:
   - generate-signing-key
 
 variables:
-  # TODO: remove after apm-sdks-benchmarks PR merges
-  APM_SDKS_BENCHMARKS_BRANCH: "sarahchen6/bring-back-comparisons"
   # Gitlab runner features; see https://docs.gitlab.com/runner/configuration/feature-flags.html
   # Fold and time all script sections
   FF_SCRIPT_SECTIONS: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,21 +3,22 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
+  # TODO: revert all refs to 'main' after apm-sdks-benchmarks PR merges
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-spring-petclinic-parallel.yml'
-    ref: 'main'
+    ref: 'sarahchen6/bring-back-comparisons'
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-load-parallel.yml'
-    ref: 'main'
+    ref: 'sarahchen6/bring-back-comparisons'
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-startup-parallel.yml'
-    ref: 'main'
+    ref: 'sarahchen6/bring-back-comparisons'
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-dacapo-parallel.yml'
-    ref: 'main'
+    ref: 'sarahchen6/bring-back-comparisons'
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-java-post-pr-comment.yml'
-    ref: 'main'
+    ref: 'sarahchen6/bring-back-comparisons'
   - local: ".gitlab/java-benchmark-configs.yml"
 
 stages:
@@ -42,6 +43,8 @@ stages:
   - generate-signing-key
 
 variables:
+  # TODO: remove after apm-sdks-benchmarks PR merges
+  APM_SDKS_BENCHMARKS_BRANCH: "sarahchen6/bring-back-comparisons"
   # Gitlab runner features; see https://docs.gitlab.com/runner/configuration/feature-flags.html
   # Fold and time all script sections
   FF_SCRIPT_SECTIONS: 1

--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -38,30 +38,58 @@
     interruptible: true
     allow_failure: true
 
+# TODO: remove APM_SDKS_BENCHMARKS_BRANCH overrides after apm-sdks-benchmarks PR merges.
+# Job-level variables override the template default ("main") which otherwise takes
+# precedence over the pipeline-level variable.
+.benchmark_branch_override: &benchmark_branch_override
+  APM_SDKS_BENCHMARKS_BRANCH: "sarahchen6/bring-back-comparisons"
+
 # Ensure the tracer artifact publish finishes before the benchmark jobs start.
 linux-java-spring-petclinic-parallel:
   needs: ["publish-artifacts-to-s3"]
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-insecure-bank-load-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-spring-petclinic-load-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-insecure-bank-startup-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_startup_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-spring-petclinic-startup-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_startup_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-dacapo-parallel-1:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
 
 linux-java-dacapo-parallel-2:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_benchmark_rules
+  variables:
+    <<: *benchmark_branch_override
+
+java-post-pr-comment-startup:
+  variables:
+    <<: *benchmark_branch_override
+
+java-post-pr-comment-load-dacapo:
+  variables:
+    <<: *benchmark_branch_override


### PR DESCRIPTION
# What Does This Do

This PR tests https://github.com/DataDog/apm-sdks-benchmarks/pull/151 which runs the latest merge-base `master` agent against the same benchmarks that the PR runs, calculates the % change between the results, and reports it in the PR comment.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
