### PR TITLE
fix(llmobs/openai-java): inherit session_id on auto-instrumented openai.request span

### DIFF
--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/CommonTags.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/CommonTags.java
@@ -30,6 +30,7 @@ interface CommonTags {
   String ENV = TAG_PREFIX + "env";
   String SERVICE = TAG_PREFIX + "service";
   String PARENT_ID = TAG_PREFIX + "parent_id";
+  String SESSION_ID = TAG_PREFIX + LLMObsTags.SESSION_ID;
 
   String TOOL_DEFINITIONS = TAG_PREFIX + "tool_definitions";
 

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -115,6 +115,16 @@ public class OpenAiDecorator extends ClientDecorator {
         parentSpanId = String.valueOf(parent.getSpanId());
       }
       span.setTag(CommonTags.PARENT_ID, parentSpanId);
+
+      // Inherit session_id from the active LLMObs parent (e.g. a manual workflow span).
+      // Matches dd-trace-py / dd-trace-js, where auto-instrumented LLM spans inherit
+      // session_id from the workflow root via context propagation. Without this, the
+      // auto-instrumented openai.request span would not appear under its session in
+      // the LLM Trace Explorer's Sessions view.
+      String sessionId = LLMObsContext.currentSessionId();
+      if (sessionId != null && !sessionId.isEmpty()) {
+        span.setTag(CommonTags.SESSION_ID, sessionId);
+      }
     }
     return super.afterStart(span);
   }

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/test/groovy/SessionIdPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/test/groovy/SessionIdPropagationTest.groovy
@@ -1,0 +1,63 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+import datadog.context.ContextScope
+import datadog.trace.api.llmobs.LLMObsContext
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+
+/**
+ * Verifies that auto-instrumented openai.request spans inherit session_id from an active
+ * LLMObs parent context, matching the behavior of dd-trace-py and dd-trace-js.
+ *
+ * Background: customer apps typically set session_id on a manual LLMObs workflow root
+ * via LLMObs.startWorkflowSpan(..., sessionId) and then call OpenAI without manually
+ * wrapping in LLMObs.startLLMSpan. The auto-instrumented LLM span needs to inherit the
+ * session_id from the workflow parent so the trace appears under its session in the
+ * LLM Trace Explorer's Sessions view.
+ *
+ * Note: this test attaches the LLMObsContext directly rather than going through
+ * LLMObs.startWorkflowSpan() — the latter resolves to a no-op factory in this
+ * test module since agent-llmobs isn't loaded here. We're specifically validating
+ * OpenAiDecorator's session_id inheritance behavior, which only depends on
+ * LLMObsContext.currentSessionId() being set.
+ */
+class SessionIdPropagationTest extends OpenAiTest {
+
+  def "openai.request span inherits session_id from active LLMObs context"() {
+    setup:
+    def expectedSessionId = "session-propagation-test-abc"
+
+    when:
+    runUnderTrace("parent") {
+      def parentCtx = AgentTracer.activeSpan().context()
+      ContextScope scope = LLMObsContext.attach(parentCtx, expectedSessionId)
+      try {
+        openAiClient.chat().completions().create(chatCompletionCreateParams(false))
+      } finally {
+        scope.close()
+      }
+    }
+    TEST_WRITER.waitForTraces(1)
+    def openAiSpan = TEST_WRITER.flatten().find {
+      it.operationName.toString() == "openai.request"
+    }
+
+    then:
+    openAiSpan != null
+    expectedSessionId == openAiSpan.getTag("_ml_obs_tag.session_id")
+  }
+
+  def "openai.request span has no session_id when no LLMObs parent context is active"() {
+    when:
+    runUnderTrace("non-llmobs-parent") {
+      openAiClient.chat().completions().create(chatCompletionCreateParams(false))
+    }
+    TEST_WRITER.waitForTraces(1)
+    def openAiSpan = TEST_WRITER.flatten().find {
+      it.operationName.toString() == "openai.request"
+    }
+
+    then:
+    openAiSpan != null
+    null == openAiSpan.getTag("_ml_obs_tag.session_id")
+  }
+}


### PR DESCRIPTION
## Summary

dd-trace-java's openai-java auto-instrumentation (`OpenAiDecorator`) doesn't inherit `session_id` from the active LLMObs parent context. Auto-instrumented `openai.request` spans carry no `_ml_obs_tag.session_id` even when a manual workflow parent has one set.

This PR brings the openai-java integration to parity with dd-trace-py (`ddtrace/llmobs/_llmobs.py:_on_span_start`) and dd-trace-js (`packages/dd-trace/src/llmobs/tagger.js:105-106`), both of which auto-propagate `session_id` from parent context to auto-instrumented LLM spans.

**MLOB tracking:** MLOB-7480


## Stacked on #11371

This PR is **stacked on #11371** (MLOB-7479 — emit session_id as top-level field + propagate via context). It uses `LLMObsContext.currentSessionId()`, an API added in that PR.

Once #11371 merges, the base branch of this PR will be re-pointed to `master`.

## Changes

- `dd-java-agent/instrumentation/openai-java/.../CommonTags.java` — add `SESSION_ID = TAG_PREFIX + LLMObsTags.SESSION_ID` constant, mirroring the existing `PARENT_ID` pattern.
- `dd-java-agent/instrumentation/openai-java/.../OpenAiDecorator.java` — in `afterStart()`, after the existing `parent_id` block, read `LLMObsContext.currentSessionId()` and stamp it on the span as `CommonTags.SESSION_ID` when present.
- `dd-java-agent/instrumentation/openai-java/.../SessionIdPropagationTest.groovy` — **new file**, 2 tests: (1) auto-instrumented `openai.request` span inherits session_id from active LLMObs context; (2) no session_id tag when no LLMObs context is active.

## Test plan

- [x] `./gradlew :dd-java-agent:instrumentation:openai-java:openai-java-3.0:test` — 97 tests pass (2 new + 95 existing, 0 regressions)
- [x] `./gradlew :dd-java-agent:instrumentation:openai-java:openai-java-3.0:spotlessCheck` clean
- [x] End-to-end verified: auto-instrumented `openai.request` now appears under the same Session as its workflow parent in the LLM Trace Explorer

## Future considerations

The openai-java module is currently the only LLMObs auto-instrumentation in dd-trace-java. When additional ones are added (Anthropic, Vertex, Bedrock, etc.), each will need the same `LLMObsContext.currentSessionId()` lookup. A shared helper could consolidate this in a future refactor — out of scope for this PR.