### PR TITLE
Mark check raw file injection as @Flaky on Zulu 8

### DIFF
--- a/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
+++ b/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
@@ -116,13 +116,8 @@ public final class JavaVirtualMachine {
     return isIbm() && isJavaVersion(8);
   }
 
-  /**
-   * Checks whether the current JVM is Azul Zulu 8.
-   *
-   * @return {@code true} if the current JVM is Azul Zulu 8, {@code false} otherwise.
-   */
   public static boolean isZulu8() {
-    return isJavaVersion(8) && runtime.vendor.contains("Azul");
+    return runtime.vendor.contains("Azul") && isJavaVersion(8);
   }
 
   public static boolean isGraalVM() {

--- a/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
+++ b/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
@@ -116,6 +116,15 @@ public final class JavaVirtualMachine {
     return isIbm() && isJavaVersion(8);
   }
 
+  /**
+   * Checks whether the current JVM is Azul Zulu 8.
+   *
+   * @return {@code true} if the current JVM is Azul Zulu 8, {@code false} otherwise.
+   */
+  public static boolean isZulu8() {
+    return isJavaVersion(8) && runtime.vendor.contains("Azul");
+  }
+
   public static boolean isGraalVM() {
     return runtime.vendorVersion.toLowerCase().contains("graalvm");
   }

--- a/components/environment/src/test/java/datadog/environment/JavaVirtualMachineTest.java
+++ b/components/environment/src/test/java/datadog/environment/JavaVirtualMachineTest.java
@@ -138,6 +138,16 @@ class JavaVirtualMachineTest {
     assertTrue(JavaVirtualMachine.isOracleJDK8());
   }
 
+  @Test
+  @EnabledIfSystemProperty(named = "java.vm.vendor", matches = ".*Azul.*")
+  @EnabledOnJre(JAVA_8)
+  void onlyOnZulu8() {
+    assertFalse(JavaVirtualMachine.isGraalVM());
+    assertFalse(JavaVirtualMachine.isIbm8());
+    assertFalse(JavaVirtualMachine.isOracleJDK8());
+    assertTrue(JavaVirtualMachine.isZulu8());
+  }
+
   @ParameterizedTest
   @CsvSource(
       value = {

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -416,7 +416,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     return unmangled.split(" ")[1..2]
   }
 
-  @Flaky(condition = () -> JavaVirtualMachine.isIbm8() || JavaVirtualMachine.isOracleJDK8())
+  @Flaky(condition = () -> JavaVirtualMachine.isIbm8() || JavaVirtualMachine.isOracleJDK8() || JavaVirtualMachine.isZulu8())
   def "check raw file injection"() {
     when:
     def count = waitForTraceCountAlive(2)


### PR DESCRIPTION
# What Does This Do

Adds `JavaVirtualMachine.isZulu8()` and extends the `@Flaky` condition on `LogInjectionSmokeTest.check raw file injection` to include Zulu 8 alongside IBM 8 and Oracle JDK 8.

# Motivation

CI Visibility data for the last 30 days shows 23 failures of `check raw file injection` on master, **all 100% on Zulu 8** (1.8.0_482 and 1.8.0_492). Failure mode: `logLines.size() == 7` got `3`. Spread evenly across the three JUL→Log4j2 backend variants (`JULInterfaceLog4j2{Backend,BackendNoTags,LatestBackend}`).

Root cause analysis: a JDK 8 race between `java.util.logging.LogManager.<clinit>` and `ClassLoader.initSystemClassLoader()` when something during agent premain triggers `LogManager` class loading. On Zulu 8 the trigger is the backported JFR's use of `java.util.logging` from premain code paths. The agent's existing `waitForJUL` guard at [Agent.java:382-396](https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java#L382) mitigates this most of the time, but leaks at ~0.25% — when the leak fires, the user's `-Djava.util.logging.manager` property is silently ignored and JUL falls back to the default `LogManager`, so subsequent `Logger.info(...)` calls don't reach Log4j2's appenders.

The same failure mode already justifies `@Flaky` on Oracle JDK 8 (same JFR backport) and IBM 8 (where OkHttp transitively loads IBMSASL → JUL); Zulu 8 belongs alongside them.

# Additional Notes

- This **suppresses the flaky CI signal** but does NOT fix the underlying agent race. Real-world Zulu 8 users running with a custom `LogManager` (Log4j2 JUL bridge, JBoss LogManager, etc.) plus dd-java-agent still experience the same intermittent JUL routing loss. A proper fix in `Agent.java` (e.g. pre-initializing `LogManager` early in premain, or fully deferring OkHttp/network init out of premain) should follow up.
- Local repro attempts (1000 iter Mac arm64) and CI repro attempts (~140 gradle iter + 300 direct-JVM iter) did NOT capture the failure — bug rate is too low to reliably hit. Diagnosis is from CI Visibility statistical data + agent code analysis (`Agent.java:376-379` explicitly documents this race) + JDK 8 source review of `LogManager.<clinit>` and `ClassLoader.initSystemClassLoader()`.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels — `type: bug`, `comp: logging`, `tag: ai generated`, `tag: no release notes`
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion — N/A (no file additions)
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors — N/A (test-only change)

Jira ticket: N/A