### PR TITLE
fix(muzzle): temporarily excluded broken versions.

### DIFF
--- a/dd-java-agent/instrumentation/confluent-schema-registry/confluent-schema-registry-4.1/build.gradle
+++ b/dd-java-agent/instrumentation/confluent-schema-registry/confluent-schema-registry-4.1/build.gradle
@@ -8,7 +8,20 @@ muzzle {
     versions = "[4.1.0,)"
     // broken POMs: depend on non-existent org.eclipse.jetty:jetty-bom:9.4.59
     // can be fixed after https://github.com/confluentinc/kafka-connect-storage-common/issues/468 is resolved
-    skipVersions += ['7.4.14', '7.5.13', '7.6.10', '7.7.8', '7.8.7', '7.9.6']
+    skipVersions += [
+      '7.4.14',
+      '7.4.15',
+      '7.5.13',
+      '7.5.14',
+      '7.6.10',
+      '7.6.11',
+      '7.7.8',
+      '7.7.9',
+      '7.8.7',
+      '7.8.8',
+      '7.9.6',
+      '7.9.7'
+    ]
     excludeDependency "org.codehaus.jackson:jackson-mapper-asl" // missing on some releases
     assertInverse = true
   }

--- a/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
@@ -9,16 +9,28 @@ muzzle {
     skipVersions += [
       '7.4.14-ce',
       '7.4.14-ccs',
+      '7.4.15-ce',
+      '7.4.15-ccs',
       '7.5.13-ce',
       '7.5.13-ccs',
+      '7.5.14-ce',
+      '7.5.14-ccs',
       '7.6.10-ce',
       '7.6.10-ccs',
+      '7.6.11-ce',
+      '7.6.11-ccs',
       '7.7.8-ce',
       '7.7.8-ccs',
+      '7.7.9-ce',
+      '7.7.9-ccs',
       '7.8.7-ce',
       '7.8.7-ccs',
+      '7.8.8-ce',
+      '7.8.8-ccs',
       '7.9.6-ce',
-      '7.9.6-ccs'
+      '7.9.6-ccs',
+      '7.9.7-ce',
+      '7.9.7-ccs'
     ]
     excludeDependency "io.confluent.cloud:*"
     excludeDependency "io.confluent.observability:*"


### PR DESCRIPTION
# What Does This Do
Add several just-released but broken versions. Same as we did in #10896.

# Motivation
Green CI

# Additional Notes
Again the same issue with broken pom, see https://github.com/DataDog/dd-trace-java/pull/10896
