### PR TITLE
EXPERIMENT: Defer starting DebuggerAgent until shared comms is ready

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -75,7 +75,11 @@ public class DebuggerAgent {
   static final AtomicBoolean symDBEnabled = new AtomicBoolean();
   private static ClassesToRetransformFinder classesToRetransformFinder;
 
-  public static synchronized void run(
+  public static void run(Config config, Instrumentation inst, SharedCommunicationObjects sco) {
+    sco.whenReady(() -> doRun(config, inst, sco));
+  }
+
+  private static synchronized void doRun(
       Config config, Instrumentation inst, SharedCommunicationObjects sco) {
     instrumentation = inst;
     sharedCommunicationObjects = sco;


### PR DESCRIPTION
# Motivation

In certain environments we need to hold back shared-communication over OkHttp because it may trigger early loading of things like JUL which can break apps that expect to set a custom log manager.

At the moment we do this via SharedCommunicationObjects::whenReady - if comms is allowed the call goes ahead immediately, otherwise it is temporarily delayed until we know it is safe to proceed. This mechanism will hopefully be replaced eventually by a run-level style approach, but until then any services that are on by default and might use OkHttp should use this method to co-operate with the overall Agent startup.

The DebuggerAgent has been gradually enabling more and more features by default, including recently source file tracking and symbol uploads. Since these may call out using OkHttp they should use SharedCommunicationObjects::whenReady. Given the current codebase structure the easiest way to apply this was on the main DebuggerAgent::run method.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
