### PR TITLE
Mark PendingTraceBufferTest tests flaky

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/PendingTraceBufferTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/PendingTraceBufferTest.java
@@ -35,6 +35,7 @@ import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.test.util.DDJavaSpecification;
+import datadog.trace.test.util.Flaky;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -195,6 +196,7 @@ public class PendingTraceBufferTest extends DDJavaSpecification {
     assertTrue(metadataChecker.hasSamplingPriority);
   }
 
+  @Flaky("Flaky on ibm8, semeru8, and semeru17 JVMs after migration from Groovy to JUnit")
   @Test
   void bufferFullYieldsImmediateWrite() {
     int capacity = delayingBuffer.getQueue().capacity();
@@ -219,6 +221,7 @@ public class PendingTraceBufferTest extends DDJavaSpecification {
     assertEquals(0, pendingTrace.getIsEnqueued());
   }
 
+  @Flaky("Flaky on ibm8, semeru8, and semeru17 JVMs after migration from Groovy to JUnit")
   @Test
   void longRunningTraceBufferFullDoesNotTriggerWrite() {
     int capacity = delayingBuffer.getQueue().capacity();
@@ -378,6 +381,7 @@ public class PendingTraceBufferTest extends DDJavaSpecification {
     assertEquals(3, counter.get());
   }
 
+  @Flaky("Flaky on semeru17 JVM after migration from Groovy to JUnit")
   @Test
   void samePendingTraceIsNotEnqueuedMultipleTimes() {
     when(tracer.getPartialFlushMinSpans()).thenReturn(10000);


### PR DESCRIPTION
# What Does This Do

Mark PendingTraceBufferTest tests flaky. Specifically:
* `bufferFullYieldsImmediateWrite()`
* `longRunningTraceBufferFullDoesNotTriggerWrite()`
* `samePendingTraceIsNotEnqueuedMultipleTimes()`

# Motivation

After #11362, these tests have been flaky and hurting `master` CI. See [this dashboard](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.status%3A%28fail%29%20%40git.branch%3A%22master%22%20%40test.service%3Add-trace-java%20-%40ci.job.name%3Atest_flaky%2A&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=%40ci.job.name%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A327%2C%40test.name%3A354%2C%40duration%3A183%2C%40test.service%3A124%2C%40git.branch%2C%40ci.job.name&currentTab=overview&eventStack=&fromUser=true&index=citest&refresh_mode=paused&start=1778731200000&end=1778874870562&paused=true) for reference.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
