### PR TITLE
Support @WithConfig on IBM J9 8 / OpenJ9 / Semeru 11 JVMs

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/PendingTraceBufferTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/PendingTraceBufferTest.java
@@ -38,6 +38,8 @@ import datadog.trace.test.util.DDJavaSpecification;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -55,7 +57,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(ThreadDumpOnTimeoutExtension.class)
 @Timeout(5)
 public class PendingTraceBufferTest extends DDJavaSpecification {
 
@@ -604,5 +611,22 @@ public class PendingTraceBufferTest extends DDJavaSpecification {
       }
     }
     return allSpans;
+  }
+}
+
+class ThreadDumpOnTimeoutExtension implements TestExecutionExceptionHandler {
+
+  @Override
+  public void handleTestExecutionException(ExtensionContext ctx, Throwable ex) throws Throwable {
+    if (ex instanceof org.opentest4j.AssertionFailedError
+        && ex.getMessage().contains("exceeded timeout")) {
+      System.err.println("=== TIMEOUT detected — Thread dump ===");
+      ThreadInfo[] infos = ManagementFactory.getThreadMXBean()
+          .dumpAllThreads(true, true);
+      for (ThreadInfo info : infos) {
+        System.err.println(info);
+      }
+    }
+    throw ex; // rethrow so the test still fails
   }
 }

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -9,8 +9,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.environment.EnvironmentVariables;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -18,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +39,11 @@ import org.junit.platform.commons.support.AnnotationSupport;
  * JUnit 5 extension that manages DD config injection for tests. Handles:
  *
  * <ul>
- *   <li>Making {@code Config} and {@code InstrumenterConfig} singletons modifiable via ByteBuddy
+ *   <li>Making {@code Config} and {@code InstrumenterConfig} singletons modifiable. Primary
+ *       strategy: ByteBuddy retransformation to relax the {@code INSTANCE} fields to {@code public
+ *       static volatile}. Fallback strategy (used on JVMs where retransformation silently fails,
+ *       e.g. IBM J9 / OpenJ9 / Semeru): direct field writes via {@code
+ *       sun.misc.Unsafe.putObjectVolatile} accessed reflectively.
  *   <li>Saving/restoring system properties between tests
  *   <li>Managing test environment variables
  *   <li>Applying {@link WithConfig} annotations (class and method level, including composed
@@ -58,10 +61,23 @@ public class WithConfigExtension
   static final String INST_CONFIG = "datadog.trace.api.InstrumenterConfig";
   static final String CONFIG = "datadog.trace.api.Config";
 
+  private enum WriteMode {
+    /** Field has been retransformed to public/volatile — write via {@link Field#set}. */
+    REFLECTION,
+    /** Retransformation failed — write via {@code sun.misc.Unsafe.putObjectVolatile}. */
+    UNSAFE
+  }
+
+  private static WriteMode writeMode;
+
   private static Field instConfigInstanceField;
   private static Constructor<?> instConfigConstructor;
   private static Field configInstanceField;
   private static Constructor<?> configConstructor;
+
+  // Used in UNSAFE mode only.
+  private static UnsafeFieldWriter instConfigUnsafeWriter;
+  private static UnsafeFieldWriter configUnsafeWriter;
 
   private static volatile boolean configTransformerInstalled = false;
   private static volatile boolean isConfigInstanceModifiable = false;
@@ -75,28 +91,15 @@ public class WithConfigExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    /*
-     * Patch config classes to make them modifiable.
-     */
-    // Install config transformer error listener
     if (!configTransformerInstalled) {
       installConfigTransformer();
       configTransformerInstalled = true;
     }
-    // Make config instance modifiable
     makeConfigInstanceModifiable();
-    // Verify that config class transformation succeeded
     assertFalse(configModificationFailed, "Config class modification failed");
-    if (isConfigInstanceModifiable) {
-      checkConfigTransformation();
-    }
-    /*
-     * Back up config and apply class-level config values.
-     */
     if (originalSystemProperties == null) {
       saveProperties();
     }
-    // Apply class-level @WithConfig so config is available before @BeforeAll methods
     applyClassLevelConfig(context);
     if (isConfigInstanceModifiable) {
       rebuildConfig();
@@ -257,7 +260,6 @@ public class WithConfigExtension
     if (isConfigInstanceModifiable || configModificationFailed) {
       return;
     }
-
     try {
       Class<?> instConfigClass = Class.forName(INST_CONFIG);
       instConfigInstanceField = instConfigClass.getDeclaredField("INSTANCE");
@@ -267,6 +269,19 @@ public class WithConfigExtension
       configInstanceField = configClass.getDeclaredField("INSTANCE");
       configConstructor = configClass.getDeclaredConstructor();
       configConstructor.setAccessible(true);
+
+      // Decide write strategy based on whether ByteBuddy retransformation actually relaxed the
+      // INSTANCE fields. On HotSpot it does; on IBM J9 / OpenJ9 / Semeru it can silently fail and
+      // leave the fields as private static final.
+      if (isFieldModifiable(instConfigInstanceField) && isFieldModifiable(configInstanceField)) {
+        writeMode = WriteMode.REFLECTION;
+        instConfigInstanceField.setAccessible(true);
+        configInstanceField.setAccessible(true);
+      } else {
+        writeMode = WriteMode.UNSAFE;
+        instConfigUnsafeWriter = UnsafeFieldWriter.forStaticField(instConfigInstanceField);
+        configUnsafeWriter = UnsafeFieldWriter.forStaticField(configInstanceField);
+      }
 
       isConfigInstanceModifiable = true;
     } catch (ClassNotFoundException e) {
@@ -288,12 +303,86 @@ public class WithConfigExtension
     synchronized (WithConfigExtension.class) {
       try {
         Object newInstConfig = instConfigConstructor.newInstance();
-        instConfigInstanceField.set(null, newInstConfig);
         Object newConfig = configConstructor.newInstance();
-        configInstanceField.set(null, newConfig);
+        if (writeMode == WriteMode.REFLECTION) {
+          instConfigInstanceField.set(null, newInstConfig);
+          configInstanceField.set(null, newConfig);
+        } else {
+          instConfigUnsafeWriter.putVolatile(newInstConfig);
+          configUnsafeWriter.putVolatile(newConfig);
+        }
       } catch (ReflectiveOperationException e) {
         throw new AssertionError("Failed to rebuild config", e);
       }
+    }
+  }
+
+  private static boolean isFieldModifiable(Field field) {
+    int mods = field.getModifiers();
+    return Modifier.isPublic(mods)
+        && Modifier.isStatic(mods)
+        && Modifier.isVolatile(mods)
+        && !Modifier.isFinal(mods);
+  }
+
+  /**
+   * Encapsulates {@code sun.misc.Unsafe}-based volatile writes to a single static field. Used as
+   * the fallback when ByteBuddy retransformation does not relax the field modifiers (IBM J9 /
+   * OpenJ9 / Semeru).
+   *
+   * <p>{@code sun.misc.Unsafe} is accessed entirely via reflection so the module can keep the
+   * default {@code --release} compile setting (the internal {@code sun.misc} package would
+   * otherwise be off-limits to the compiler).
+   */
+  @SuppressForbidden
+  private static final class UnsafeFieldWriter {
+    private static Object unsafe;
+    private static Method staticFieldBase;
+    private static Method staticFieldOffset;
+    private static Method putObjectVolatile;
+
+    private final Object base;
+    private final long offset;
+
+    private UnsafeFieldWriter(Object base, long offset) {
+      this.base = base;
+      this.offset = offset;
+    }
+
+    /**
+     * @throws ReflectiveOperationException if {@code sun.misc.Unsafe} or one of the required
+     *     methods is unavailable on this JVM. Lets the caller mark config modification as failed
+     *     and surface a clean test failure instead of a {@link ExceptionInInitializerError}.
+     */
+    static UnsafeFieldWriter forStaticField(Field staticField) throws ReflectiveOperationException {
+      ensureInitialized();
+      Object fieldBase = staticFieldBase.invoke(unsafe, staticField);
+      long fieldOffset = (long) staticFieldOffset.invoke(unsafe, staticField);
+      return new UnsafeFieldWriter(fieldBase, fieldOffset);
+    }
+
+    void putVolatile(Object value) {
+      try {
+        putObjectVolatile.invoke(unsafe, base, offset, value);
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError("Failed to write static field via Unsafe", e);
+      }
+    }
+
+    private static synchronized void ensureInitialized() throws ReflectiveOperationException {
+      if (unsafe != null) {
+        return;
+      }
+      Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+      Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      Object instance = theUnsafe.get(null);
+      staticFieldBase = unsafeClass.getMethod("staticFieldBase", Field.class);
+      staticFieldOffset = unsafeClass.getMethod("staticFieldOffset", Field.class);
+      putObjectVolatile =
+          unsafeClass.getMethod("putObjectVolatile", Object.class, long.class, Object.class);
+      // Publish `unsafe` last so a partially-initialized state can't fool the early-return guard.
+      unsafe = instance;
     }
   }
 
@@ -312,26 +401,6 @@ public class WithConfigExtension
       copy.putAll(originalSystemProperties);
       System.setProperties(copy);
     }
-  }
-
-  // endregion
-
-  // region Validation
-
-  private static void checkConfigTransformation() {
-    assertTrue(isConfigInstanceModifiable);
-    assertNotNull(instConfigConstructor);
-    checkWritable(instConfigInstanceField);
-    assertNotNull(configConstructor);
-    checkWritable(configInstanceField);
-  }
-
-  private static void checkWritable(Field field) {
-    assertNotNull(field);
-    assertTrue(Modifier.isPublic(field.getModifiers()));
-    assertTrue(Modifier.isStatic(field.getModifiers()));
-    assertTrue(Modifier.isVolatile(field.getModifiers()));
-    assertFalse(Modifier.isFinal(field.getModifiers()));
   }
 
   // endregion
@@ -393,7 +462,10 @@ public class WithConfigExtension
         JavaModule module,
         boolean loaded,
         @NonNull Throwable throwable) {
-      if (CONFIG.equals(typeName)) {
+      if (INST_CONFIG.equals(typeName) || CONFIG.equals(typeName)) {
+        // Note: this only marks failure for ByteBuddy errors that surface as listener errors.
+        // Silent retransformation failures (IBM J9 / Semeru) are detected later in
+        // makeConfigInstanceModifiable() by inspecting the actual field modifiers.
         configModificationFailed = true;
       }
     }


### PR DESCRIPTION
# What Does This Do

Fallback to unsafe when retransformation fail on old IBM J9 / Semeru 11 JVMs.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
