### PR TITLE
Tolerate encoding mix for kafka time in queue headers

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCED_KEY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -46,14 +47,41 @@ public class TextMapExtractAdapter implements ContextVisitor<Headers> {
     Header header = carrier.lastHeader(KAFKA_PRODUCED_KEY);
     if (null != header) {
       try {
-        ByteBuffer buf = ByteBuffer.allocate(8);
-        buf.put(base64 != null ? base64.decode(header.value()) : header.value());
-        buf.flip();
-        return buf.getLong();
+        byte[] value = header.value();
+        if (base64 != null) {
+          long ts = extractBase64Timestamp(value);
+          return ts != 0 ? ts : extractBinaryTimestamp(value);
+        } else {
+          return extractBinaryTimestamp(value);
+        }
       } catch (Exception e) {
         log.debug("Unable to get kafka produced time", e);
       }
     }
     return 0;
+  }
+
+  private long extractBase64Timestamp(byte[] value) {
+    try {
+      ByteBuffer buf = ByteBuffer.allocate(8);
+      buf.put(base64.decode(value));
+      buf.flip();
+      return buf.getLong();
+    } catch (Exception e) {
+      log.debug(EXCLUDE_TELEMETRY, "Unable to extract kafka produced time from base64 header", e);
+      return 0;
+    }
+  }
+
+  private static long extractBinaryTimestamp(byte[] value) {
+    try {
+      ByteBuffer buf = ByteBuffer.allocate(8);
+      buf.put(value);
+      buf.flip();
+      return buf.getLong();
+    } catch (Exception e) {
+      log.debug(EXCLUDE_TELEMETRY, "Unable to extract kafka produced time from binary header", e);
+      return 0;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
@@ -1,11 +1,13 @@
 import com.google.common.io.BaseEncoding
 import datadog.trace.agent.test.InstrumentationSpecification
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
+import datadog.trace.instrumentation.kafka_clients.KafkaDecorator
 import datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.header.internals.RecordHeaders
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 class TextMapExtractAdapterTest extends InstrumentationSpecification {
@@ -31,5 +33,58 @@ class TextMapExtractAdapterTest extends InstrumentationSpecification {
 
     where:
     base64Decode << [true, false]
+  }
+
+  def "extractTimeInQueueStart returns 0 when header is absent"() {
+    given:
+    Headers headers = new RecordHeaders()
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == 0
+  }
+
+  def "extractTimeInQueueStart parses raw binary long (base64 disabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, binaryValue))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart parses base64-encoded binary (base64 enabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    byte[] base64Value = Base64.getEncoder().encode(binaryValue)
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, base64Value))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(true)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart falls back to binary when base64 decode fails (base64 enabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, binaryValue))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(true)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart returns 0 for garbage bytes (base64 disabled)"() {
+    given:
+    byte[] garbage = [1, 2, 3] as byte[]
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, garbage))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == 0
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapExtractAdapter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.trace.api.Config;
@@ -45,14 +46,41 @@ public class TextMapExtractAdapter implements ContextVisitor<Headers> {
     Header header = carrier.lastHeader(KafkaDecorator.KAFKA_PRODUCED_KEY);
     if (null != header) {
       try {
-        ByteBuffer buf = ByteBuffer.allocate(8);
-        buf.put(base64 != null ? base64.decode(header.value()) : header.value());
-        buf.flip();
-        return buf.getLong();
+        byte[] value = header.value();
+        if (base64 != null) {
+          long ts = extractBase64Timestamp(value);
+          return ts != 0 ? ts : extractBinaryTimestamp(value);
+        } else {
+          return extractBinaryTimestamp(value);
+        }
       } catch (Exception e) {
         log.debug("Unable to get kafka produced time", e);
       }
     }
     return 0;
+  }
+
+  private long extractBase64Timestamp(byte[] value) {
+    try {
+      ByteBuffer buf = ByteBuffer.allocate(8);
+      buf.put(base64.decode(value));
+      buf.flip();
+      return buf.getLong();
+    } catch (Exception e) {
+      log.debug(EXCLUDE_TELEMETRY, "Unable to extract kafka produced time from base64 header", e);
+      return 0;
+    }
+  }
+
+  private static long extractBinaryTimestamp(byte[] value) {
+    try {
+      ByteBuffer buf = ByteBuffer.allocate(8);
+      buf.put(value);
+      buf.flip();
+      return buf.getLong();
+    } catch (Exception e) {
+      log.debug(EXCLUDE_TELEMETRY, "Unable to extract kafka produced time from binary header", e);
+      return 0;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/TextMapExtractAdapterTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/groovy/TextMapExtractAdapterTest.groovy
@@ -1,11 +1,13 @@
 import com.google.common.io.BaseEncoding
 import datadog.trace.agent.test.InstrumentationSpecification
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
+import datadog.trace.instrumentation.kafka_clients38.KafkaDecorator
 import datadog.trace.instrumentation.kafka_clients38.TextMapExtractAdapter
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.header.internals.RecordHeaders
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 class TextMapExtractAdapterTest extends InstrumentationSpecification {
@@ -31,5 +33,58 @@ class TextMapExtractAdapterTest extends InstrumentationSpecification {
 
     where:
     base64Decode << [true, false]
+  }
+
+  def "extractTimeInQueueStart returns 0 when header is absent"() {
+    given:
+    Headers headers = new RecordHeaders()
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == 0
+  }
+
+  def "extractTimeInQueueStart parses raw binary long (base64 disabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, binaryValue))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart parses base64-encoded binary (base64 enabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    byte[] base64Value = Base64.getEncoder().encode(binaryValue)
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, base64Value))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(true)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart falls back to binary when base64 decode fails (base64 enabled)"() {
+    given:
+    long ts = 1747587600000L
+    byte[] binaryValue = ByteBuffer.allocate(8).putLong(ts).array()
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, binaryValue))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(true)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == ts
+  }
+
+  def "extractTimeInQueueStart returns 0 for garbage bytes (base64 disabled)"() {
+    given:
+    byte[] garbage = [1, 2, 3] as byte[]
+    Headers headers = new RecordHeaders(new RecordHeader(KafkaDecorator.KAFKA_PRODUCED_KEY, garbage))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(false)
+
+    expect:
+    adapter.extractTimeInQueueStart(headers) == 0
   }
 }


### PR DESCRIPTION
# What Does This Do

The java tracer use the `x_datadog_kafka_produced` header to record the time in queue timestamp. This can be encoded both as a base64 string or as a binary (controlled by a feature flag)

The issue here is that the extract side can receive the header sent by a producer that encodes in base64 but has not the right setting hence treats it as a 8-bytes long and that can overflow.

This PR give a chance to extract that value by falling back to the other method.

Spotted by:

```
java.nio.BufferOverflowException
  at java.base/java.nio.HeapByteBuffer.put(Unknown Source)
  at java.base/java.nio.ByteBuffer.put(Unknown Source)
  at datadog.trace.instrumentation.kafka_clients38.TextMapExtractAdapter.extractTimeInQueueStart(TextMapExtractAdapter.java:49)
  at datadog.trace.instrumentation.kafka_clients38.TracingIterator.startNewRecordSpan(TracingIterator.java:101)
  at 
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
