### PR TITLE
DIAG-BRANCH-ONLY: force jstack diagnostic path to fire in CI (DO NOT MERGE)

### DIFF
--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -461,9 +461,9 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
         // Redirect output to a file to avoid pipe-buffer deadlock — a full thread dump can
         // exceed the OS pipe buffer (typically 64 KB) before waitFor returns.
         Process p = new ProcessBuilder(cmd, String.valueOf(pid))
-          .redirectErrorStream(true)
-          .redirectOutput(tmp)
-          .start()
+        .redirectErrorStream(true)
+        .redirectOutput(tmp)
+        .start()
         if (!p.waitFor(5, SECONDS)) {
           p.destroyForcibly()
           p.waitFor(2, SECONDS)

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -422,12 +422,6 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
       if (jstackOut == null) {
         return "(jstack not available or failed)"
       }
-      // Print the full dump to stdout so it lands in the gradle test report's STANDARD_OUT
-      // section (and the GitLab build log) — Datadog CI Visibility truncates error.message at
-      // ~5000 chars, which would otherwise lose most of the dump.
-      println "=== Full thread dump for pid ${pid} ==="
-      println jstackOut
-      println "=== End thread dump ==="
       return filterThreadDump(jstackOut)
     } catch (Throwable t) {
       // Never let a diagnostic failure mask the original AssertionError.
@@ -435,22 +429,23 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     }
   }
 
-  // Approximate budget for the inline dump in error.message. Leaves room for the
-  // surrounding "Timed out waiting..." prefix to stay under CI Visibility's 5000-char cap.
-  private static final int INLINE_DUMP_CAP = 4200
+  // Approximate budget for the inline dump in error.message. Datadog CI Visibility caps
+  // error.message at ~5000 chars; this leaves a few hundred for the "Timed out waiting..."
+  // prefix and the elision marker.
+  private static final int INLINE_DUMP_CAP = 4700
 
   /**
    * Reduce a jstack thread dump to the threads most likely to explain a hang: the main thread,
    * dd-trace agent threads (dd-*, datadog-*), OkHttp threads, and anything BLOCKED. Drops known
    * JVM boilerplate (compiler/GC/reference handler/etc). Truncates to {@link #INLINE_DUMP_CAP}
-   * with an elision marker. The full dump is always available on stdout.
+   * with an elision marker.
    */
   private String filterThreadDump(String fullDump) {
     int firstBlockIdx = fullDump.indexOf('\n"')
     if (firstBlockIdx < 0) {
       // No recognizable thread blocks — return the original, truncated if needed
       return fullDump.length() > INLINE_DUMP_CAP
-      ? fullDump.substring(0, INLINE_DUMP_CAP) + "\n(truncated; full dump on stdout)"
+      ? fullDump.substring(0, INLINE_DUMP_CAP) + "\n(truncated)"
       : fullDump
     }
     String header = fullDump.substring(0, firstBlockIdx + 1)
@@ -497,7 +492,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
       if (elided > 0) {
         out.append(", elided ${elided} other thread(s) for size")
       }
-      out.append("; full dump on stdout)")
+      out.append(")")
     }
     return out.toString()
   }

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -3,6 +3,7 @@ package datadog.smoketest
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import datadog.environment.JavaVirtualMachine
+import datadog.environment.OperatingSystem
 import datadog.trace.agent.test.server.http.TestHttpServer.HandlerApi.RequestApi
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.test.util.Flaky
@@ -378,13 +379,99 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
       // The default error ("Condition not satisfied after 30s") is useless — enrich with diagnostic state
       def alive = testedProcess?.isAlive()
       def lastLines = tailProcessLog(30)
+      def threadDump = alive ? dumpThreadStacks() : "(process not alive, skipping thread dump)"
       throw new AssertionError(
       "Timed out waiting for ${count} traces after ${defaultPoll.timeout}s. " +
       "traceCount=${traceCount.get()}, process.alive=${alive}, " +
       "RC polls received: ${rcClientMessages.size()}.\n" +
-      "Last process output:\n${lastLines}", e)
+      "Last process output:\n${lastLines}\n" +
+      "Thread dump:\n${threadDump}", e)
     }
     traceCount.get()
+  }
+
+  /**
+   * Capture a thread dump of the forked process via {@code jstack}. jstack's output is captured by
+   * the smoketest JVM directly, bypassing the tested-process output-capture thread that has been
+   * observed to be starved at timeout (which makes the SIGQUIT-via-stderr approach unreliable for
+   * exactly the failures we want to diagnose).
+   *
+   * <p>No raw {@code kill -3} fallback: PID reuse on shared CI hosts could cause us to signal an
+   * unrelated process if the child has exited since the surrounding liveness check.
+   */
+  private String dumpThreadStacks() {
+    if (testedProcess == null) {
+      return "(no tested process)"
+    }
+    if (OperatingSystem.isWindows()) {
+      return "(thread dump not supported on Windows)"
+    }
+    long pid = getTestedProcessPid()
+    if (pid <= 0) {
+      return "(could not determine pid)"
+    }
+    String jstackOut = runJstack(pid)
+    return jstackOut != null ? jstackOut : "(jstack not available or failed)"
+  }
+
+  private long getTestedProcessPid() {
+    try {
+      return (long) testedProcess.getClass().getMethod("pid").invoke(testedProcess)
+    } catch (Throwable ignored) {
+      try {
+        // UNIXProcess's private 'pid' field, for JDK 8 compatibility
+        def field = testedProcess.getClass().getDeclaredField("pid")
+        field.setAccessible(true)
+        return field.getInt(testedProcess) as long
+      } catch (Throwable ignored2) {
+        return -1L
+      }
+    }
+  }
+
+  private String runJstack(long pid) {
+    def candidates = []
+    // java.home is always set by the JVM and points to the active JDK/JRE; prefer it over the
+    // JAVA_HOME env var which is frequently absent in CI runners even when Java is present.
+    String javaHome = System.getProperty("java.home")
+    if (javaHome) {
+      candidates.add(javaHome + "/bin/jstack")
+    }
+    String javaHomeEnv = System.getenv("JAVA_HOME")
+    if (javaHomeEnv && javaHomeEnv != javaHome) {
+      candidates.add(javaHomeEnv + "/bin/jstack")
+    }
+    candidates.add("jstack")
+    for (String cmd : candidates) {
+      File tmp = null
+      try {
+        tmp = File.createTempFile("jstack", ".txt")
+        // Redirect output to a file to avoid pipe-buffer deadlock — a full thread dump can
+        // exceed the OS pipe buffer (typically 64 KB) before waitFor returns.
+        Process p = new ProcessBuilder(cmd, String.valueOf(pid))
+          .redirectErrorStream(true)
+          .redirectOutput(tmp)
+          .start()
+        if (!p.waitFor(5, SECONDS)) {
+          p.destroyForcibly()
+          p.waitFor(2, SECONDS)
+          continue
+        }
+        if (p.exitValue() == 0) {
+          String output = tmp.getText("UTF-8")
+          if (output) {
+            return output
+          }
+        }
+      } catch (Throwable ignored) {
+        // try next candidate
+      } finally {
+        if (tmp != null) {
+          tmp.delete()
+        }
+      }
+    }
+    return null
   }
 
   private String tailProcessLog(int lines) {

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -2,11 +2,9 @@ package datadog.smoketest
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import datadog.environment.JavaVirtualMachine
 import datadog.environment.OperatingSystem
 import datadog.trace.agent.test.server.http.TestHttpServer.HandlerApi.RequestApi
 import datadog.trace.api.config.GeneralConfig
-import datadog.trace.test.util.Flaky
 import java.nio.charset.StandardCharsets
 import java.util.zip.GZIPInputStream
 import spock.lang.AutoCleanup

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -355,6 +355,14 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
    */
   int waitForTraceCountAlive(int count) {
     try {
+      // DIAG-BRANCH-ONLY: force the timeout diagnostic path to fire to validate jstack works in CI.
+      // Sleep 5s so the forked JVM is fully up (post-premain) before we ask jstack to attach.
+      // Throw an AssertionError so the catch block below fires the diagnostic enrichment.
+      // DO NOT MERGE. Revert before merging the PR.
+      if (count == 2) {
+        Thread.sleep(5_000)
+        throw new AssertionError("DIAG-BRANCH-ONLY forced timeout for jstack validation")
+      }
       defaultPoll.eventually {
         if (traceDecodingFailure != null) {
           throw traceDecodingFailure
@@ -515,7 +523,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     return unmangled.split(" ")[1..2]
   }
 
-  @Flaky(condition = () -> JavaVirtualMachine.isIbm8() || JavaVirtualMachine.isOracleJDK8() || JavaVirtualMachine.isZulu8())
+  // DIAG-BRANCH-ONLY: @Flaky removed so the test runs on every matrix cell. DO NOT MERGE.
   def "check raw file injection"() {
     when:
     def count = waitForTraceCountAlive(2)

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -400,18 +400,30 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
    * unrelated process if the child has exited since the surrounding liveness check.
    */
   private String dumpThreadStacks() {
-    if (testedProcess == null) {
-      return "(no tested process)"
+    try {
+      if (testedProcess == null) {
+        return "(no tested process)"
+      }
+      if (OperatingSystem.isWindows()) {
+        return "(thread dump not supported on Windows)"
+      }
+      long pid = getTestedProcessPid()
+      if (pid <= 0) {
+        return "(could not determine pid)"
+      }
+      // Re-check liveness immediately before invoking jstack. The earlier check that gates this
+      // method runs ~1 statement away, but if the child has exited and been reaped since then,
+      // the OS may have reused the PID — jstack-ing the wrong process would attach misleading
+      // diagnostics to the test failure.
+      if (!testedProcess.isAlive()) {
+        return "(process exited between liveness check and dump; skipping to avoid PID reuse)"
+      }
+      String jstackOut = runJstack(pid)
+      return jstackOut != null ? jstackOut : "(jstack not available or failed)"
+    } catch (Throwable t) {
+      // Never let a diagnostic failure mask the original AssertionError.
+      return "(thread dump failed: ${t.getClass().simpleName}: ${t.message})"
     }
-    if (OperatingSystem.isWindows()) {
-      return "(thread dump not supported on Windows)"
-    }
-    long pid = getTestedProcessPid()
-    if (pid <= 0) {
-      return "(could not determine pid)"
-    }
-    String jstackOut = runJstack(pid)
-    return jstackOut != null ? jstackOut : "(jstack not available or failed)"
   }
 
   private long getTestedProcessPid() {

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -144,8 +144,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
 
   @Override
   Closure decodedEvpProxyMessageCallback() {
-    return {
-      String path, RequestApi request ->
+    return { String path, RequestApi request ->
       try {
         boolean isCompressed = request.getHeader("Content-Encoding").contains("gzip")
         byte[] body = request.body

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -419,11 +419,116 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
         return "(process exited between liveness check and dump; skipping to avoid PID reuse)"
       }
       String jstackOut = runJstack(pid)
-      return jstackOut != null ? jstackOut : "(jstack not available or failed)"
+      if (jstackOut == null) {
+        return "(jstack not available or failed)"
+      }
+      // Print the full dump to stdout so it lands in the gradle test report's STANDARD_OUT
+      // section (and the GitLab build log) — Datadog CI Visibility truncates error.message at
+      // ~5000 chars, which would otherwise lose most of the dump.
+      println "=== Full thread dump for pid ${pid} ==="
+      println jstackOut
+      println "=== End thread dump ==="
+      return filterThreadDump(jstackOut)
     } catch (Throwable t) {
       // Never let a diagnostic failure mask the original AssertionError.
       return "(thread dump failed: ${t.getClass().simpleName}: ${t.message})"
     }
+  }
+
+  // Approximate budget for the inline dump in error.message. Leaves room for the
+  // surrounding "Timed out waiting..." prefix to stay under CI Visibility's 5000-char cap.
+  private static final int INLINE_DUMP_CAP = 4200
+
+  /**
+   * Reduce a jstack thread dump to the threads most likely to explain a hang: the main thread,
+   * dd-trace agent threads (dd-*, datadog-*), OkHttp threads, and anything BLOCKED. Drops known
+   * JVM boilerplate (compiler/GC/reference handler/etc). Truncates to {@link #INLINE_DUMP_CAP}
+   * with an elision marker. The full dump is always available on stdout.
+   */
+  private String filterThreadDump(String fullDump) {
+    int firstBlockIdx = fullDump.indexOf('\n"')
+    if (firstBlockIdx < 0) {
+      // No recognizable thread blocks — return the original, truncated if needed
+      return fullDump.length() > INLINE_DUMP_CAP
+      ? fullDump.substring(0, INLINE_DUMP_CAP) + "\n(truncated; full dump on stdout)"
+      : fullDump
+    }
+    String header = fullDump.substring(0, firstBlockIdx + 1)
+    String rest = fullDump.substring(firstBlockIdx + 1)
+
+    List<String> blocks = []
+    int i = 0
+    while (i < rest.length()) {
+      int next = rest.indexOf('\n"', i)
+      if (next < 0) {
+        blocks.add(rest.substring(i))
+        break
+      }
+      blocks.add(rest.substring(i, next + 1))
+      i = next + 1
+    }
+
+    List<String> highPriority = []
+    List<String> lowPriority = []
+    int boilerplateDropped = 0
+    for (String block : blocks) {
+      def m = block =~ /^"([^"]+)"/
+      String name = m.find() ? m.group(1) : ''
+      if (isBoilerplateThread(name)) {
+        boilerplateDropped++
+      } else if (isHighPriorityThread(name, block)) {
+        highPriority.add(block)
+      } else {
+        lowPriority.add(block)
+      }
+    }
+
+    StringBuilder out = new StringBuilder(header)
+    int elided = 0
+    for (String block : highPriority + lowPriority) {
+      if (out.length() + block.length() + 120 > INLINE_DUMP_CAP) {
+        elided++
+        continue
+      }
+      out.append(block)
+    }
+    if (boilerplateDropped > 0 || elided > 0) {
+      out.append("\n(elided ${boilerplateDropped} JVM-boilerplate thread(s)")
+      if (elided > 0) {
+        out.append(", elided ${elided} other thread(s) for size")
+      }
+      out.append("; full dump on stdout)")
+    }
+    return out.toString()
+  }
+
+  private static boolean isBoilerplateThread(String name) {
+    if (name in [
+      "Reference Handler", "Finalizer", "Signal Dispatcher", "Common-Cleaner",
+      "Service Thread", "Monitor Deflation Thread", "Notification Thread",
+      "Attach Listener", "process reaper", "Sweeper thread", "VM Thread", "VM Periodic Task Thread"
+    ]) {
+      return true
+    }
+    return name.startsWith("C1 CompilerThread") ||
+    name.startsWith("C2 CompilerThread") ||
+    name.startsWith("GC Thread") ||
+    name.startsWith("G1 ") ||
+    name.startsWith("ParGC ") ||
+    name.startsWith("CMS ")
+  }
+
+  private static boolean isHighPriorityThread(String name, String block) {
+    if (name == "main") {
+      return true
+    }
+    if (name.startsWith("dd-") || name.startsWith("datadog-")) {
+      return true
+    }
+    if (name.startsWith("OkHttp") || name.contains("okhttp")) {
+      return true
+    }
+    return block.contains("java.lang.Thread.State: BLOCKED")
   }
 
   private long getTestedProcessPid() {

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -144,7 +144,8 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
 
   @Override
   Closure decodedEvpProxyMessageCallback() {
-    return { String path, RequestApi request ->
+    return {
+      String path, RequestApi request ->
       try {
         boolean isCompressed = request.getHeader("Content-Encoding").contains("gzip")
         byte[] body = request.body


### PR DESCRIPTION
# DO NOT MERGE — Diagnostic Experiment

This PR exists purely to trigger CI so I can validate that the `dumpThreadStacks()` path added in #11400 actually captures and propagates a thread dump through to Datadog CI Visibility.

## What it does

On top of #11400's changes:
1. Removes `@Flaky` from `"check raw file injection"` so the test runs on every matrix cell.
2. Forces the timeout catch block to fire after a 5s warmup, so the diagnostic enrichment runs against a real, alive forked JVM.

Expected behavior: every matrix cell will fail the `"check raw file injection"` test with an AssertionError whose message contains the jstack thread dump.

After CI runs once, I'll query the captured `error.message` from CI Visibility, verify the thread dump made it through intact, then close this PR and delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)