### PR TITLE
Tolerate AbstractMethodError for servletRequest remote port

### DIFF
--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.servlet3;
 
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
+
 import datadog.context.Context;
 import datadog.trace.api.ClassloaderConfigurationOverrides;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -10,6 +12,8 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Servlet3Decorator
     extends HttpServerDecorator<
@@ -21,6 +25,7 @@ public class Servlet3Decorator
       UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
+  private static final Logger LOGGER = LoggerFactory.getLogger(Servlet3Decorator.class);
 
   @Override
   protected String[] instrumentationNames() {
@@ -64,7 +69,15 @@ public class Servlet3Decorator
 
   @Override
   protected int peerPort(final HttpServletRequest httpServletRequest) {
-    return httpServletRequest.getRemotePort();
+    try {
+      return httpServletRequest.getRemotePort();
+    } catch (AbstractMethodError e) {
+      LOGGER.debug(
+          EXCLUDE_TELEMETRY,
+          "Method not implemented when trying to get the request remote port",
+          e);
+      return 0; // 0 will be handled as `no port` by the caller
+    }
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

We have telemetry signals like this:

```
java.lang.AbstractMethodError
    at (redacted)
    at datadog.trace.instrumentation.servlet3.Servlet3Decorator.peerPort(Servlet3Decorator.java:67)
    at datadog.trace.instrumentation.servlet3.Servlet3Decorator.peerPort(Servlet3Decorator.java:14)
    at datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.onRequest(HttpServerDecorator.java:331)
    at datadog.trace.instrumentation.servlet3.Servlet3Decorator.onRequest(Servlet3Decorator.java:105)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:618)
    at (redacted: 9 frames)
```

While this decorator works with a servlet 3 that would have bundled this method (`getRemotePort` is available from servlet 2.4 onward) it looks like some underlying request objects have not implemented it.

Muzzle should prevent linkage issues with the *loaded* runtime because (references):

```
datadog.trace.instrumentation.servlet3.Servlet3Instrumentation
  public interface javax.servlet.http.HttpServletRequest
   .....
       Method: public_or_protected non_static getAttribute(Ljava/lang/String;)Ljava/lang/Object;
    Method: public_or_protected non_static setAttribute(Ljava/lang/String;Ljava/lang/Object;)V
    Method: public_or_protected non_static getUserPrincipal()Ljava/security/Principal;
    Method: public_or_protected non_static getServletContext()Ljavax/servlet/ServletContext;
    Method: public_or_protected non_static getMethod()Ljava/lang/String;
    Method: public_or_protected non_static getRemoteAddr()Ljava/lang/String;
    Method: public_or_protected non_static getRemotePort()I
```

Now what can happen (but we cannot prove it) is that the underlying application is wrapping the request with a `ServletRequestWrapper` that's been compiled against an older servlet version. In this case, when the JVM do the `invokeInterface` it may hits the `AbstractMethodError` because not present in the bytecode.

This PR ensure that the error is properly ignored and that the full advice is not interrupted because of this. 

Hence we do not surface the error in the telemetry since now it's handled (but we log in debug in case)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
