### PR TITLE
Stop skipping `"test exception"` test cases, they are not synthetic

### DIFF
--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -66,16 +66,43 @@ final class JUnitReport {
     return changed;
   }
 
+  /// Tags framework-emitted synthetic testcases so Test Optimization does not treat them as
+  /// real failures.
+  ///
+  /// **Criteria for new entries:**
+  /// - Must be a name the framework/runner emits itself — never a name a user-authored test
+  ///   could legitimately have.
+  /// - Must link to the source that emits the literal, pinned to a release tag (not a commit
+  ///   hash).
+  ///
+  /// **Frameworks/libraries to audit before adding a name:** JUnit 4, JUnit Platform engines
+  /// (Vintage / Jupiter), Gradle's JUnit and JUnit Platform adapters, TestNG, Spock, Kotest,
+  /// Maven Surefire/Failsafe. JUnit 5's main sources do not define these literals — Vintage
+  /// forwards `"initializationError"` from JUnit 4 as-is, and `"executionError"` is
+  /// Gradle-specific.
+  ///
+  /// **Do not add** generic English names such as `"test exception"`. Spock feature methods
+  /// (`def "..."()`), JUnit 5 `@DisplayName`, and Kotest specs can all produce them, so the
+  /// tagger would silently mask real pass/fail outcomes.
   void tagSyntheticFailures() {
     Map<String, List<Element>> initializationErrorsByClassname = new LinkedHashMap<>();
     for (var testcase : testcases()) {
-      var name = testcase.getAttribute("name");
-      if ("initializationError".equals(name)) {
-        initializationErrorsByClassname
-            .computeIfAbsent(testcase.getAttribute("classname"), ignored -> new ArrayList<>())
-            .add(testcase);
-      } else if ("executionError".equals(name) || "test exception".equals(name)) {
-        addFinalStatusProperty(testcase, "skip", MissingPropertiesPlacement.APPEND_TO_TESTCASE);
+      switch (testcase.getAttribute("name")) {
+        // JUnit 4 ErrorReportingRunner — initializationError
+        // https://github.com/junit-team/junit4/blob/r4.13.2/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java#L83
+        // Gradle JUnit Platform listener — reuses the same name for synthetic container failures
+        // https://github.com/gradle/gradle/blob/v8.14.5/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L248
+        // https://github.com/gradle/gradle/blob/v9.5.0/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L426
+        case "initializationError" ->
+            initializationErrorsByClassname
+                .computeIfAbsent(testcase.getAttribute("classname"), ignored -> new ArrayList<>())
+                .add(testcase);
+        // Gradle JUnit Platform listener — executionError, used when descendants already started
+        // https://github.com/gradle/gradle/blob/v8.14.5/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L248
+        // https://github.com/gradle/gradle/blob/v9.5.0/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L426
+        case "executionError" ->
+            addFinalStatusProperty(testcase, "skip", MissingPropertiesPlacement.APPEND_TO_TESTCASE);
+        default -> {}
       }
     }
 

--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -70,7 +70,7 @@ final class JUnitReport {
   /// real failures.
   ///
   /// **Criteria for new entries:**
-  /// - Must be a name the framework/runner emits itself — never a name a user-authored test
+  /// - Must be a name the framework/runner emits itself — never use a name that a user-authored test
   ///   could legitimately have.
   /// - Must link to the source that emits the literal, pinned to a release tag (not a commit
   ///   hash).


### PR DESCRIPTION
# What Does This Do

Removes `"test exception"` from being skipped skipped in the JUnit collect result script. It was added in #11259.
They are legitimate synthetic names (`initializationError`, `executionError`), because they are actually coming from framework or libraries. `"test exception"` is not.

Also, the changes documents the criteria for any future entry, i.e. this should be motivated by a proof with a source link where that synthetic test name is added.

# Motivation

**Tagging `"test exception"` name unconditionally will silently skip real tests named that way.**

In fact `"test exception"` isn't a synthetic placeholder emitted by any test framework or runner used with this project:

- **JUnit 4** emits `"initializationError"` from [`ErrorReportingRunner` (r4.13.2 line 83)](https://github.com/junit-team/junit4/blob/r4.13.2/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java#L83) when a test class cannot be loaded, has no runnable methods, or its `@BeforeClass` fails.

- **Gradle's JUnit Platform listener** emits both `"initializationError"` and `"executionError"` from [`JUnitPlatformTestExecutionListener` (v8.14.5)](https://github.com/gradle/gradle/blob/v8.14.5/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L248) (also in later version of Gradle) for synthetic failures.

- **JUnit 5, Spock, Kotest, TestNG, Maven Surefire/Failsafe** — none use the literal `"test exception"` as a synthetic.

A code search across `junit-team/junit4`, `junit-team/junit5`,
`gradle/gradle`, `spockframework/spock`, and `jetbrains/kotlin` confirms this:
the only Gradle hits are unrelated Javadoc on `TestExceptionFormat` plus
user-named retry tests.

The `test exception` entries observed for this repo came from the actual Spock test, [`HttpServerTest.test exception"()`](https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy).

In addition to dropping this case, this PR documents in a code comment that
future synthetic entries must:

1. be names that the framework/runner itself produces (never user-authorable);
2. cite the emitting source file preferring a link with a release tag (rather than a commit hash);
3. consider the full set of frameworks/libraries in the build (JUnit 4, JUnit Platform engines, Gradle adapters, TestNG, Spock, Kotest, Surefire/Failsafe).

# Additional Notes

- The Spock rename from #11259 (from `def "test exception"()` to `def "Instrumentation test exception"()`) is left in place as it makes the test more self-describing.

