### PR TITLE
Fix DDSpan.addThrowable crashing when exception getMessage() throws

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -354,10 +354,10 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
   @Override
   public DDSpan addThrowable(Throwable error, byte errorPriority) {
     if (null != error) {
-      String message = error.getMessage();
+      String message = StackTraces.safeGetMessage(error);
       if (!"broken pipe".equalsIgnoreCase(message)
           && (error.getCause() == null
-              || !"broken pipe".equalsIgnoreCase(error.getCause().getMessage()))) {
+              || !"broken pipe".equalsIgnoreCase(StackTraces.safeGetMessage(error.getCause())))) {
         // broken pipes happen when clients abort connections,
         // which might happen because the application is overloaded
         // or warming up - capturing the stack trace and keeping

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
@@ -64,12 +64,16 @@ public final class StackTraces {
     } catch (Exception ignored) {
       // printStackTrace() failed (e.g. getMessage() throws inside toString()).
       // Reconstruct from getStackTrace() so the call site is still locatable.
-      trace =
-          t.getClass().getName()
-              + System.lineSeparator()
-              + Arrays.stream(t.getStackTrace())
-                  .map(f -> "\tat " + f)
-                  .collect(Collectors.joining(System.lineSeparator()));
+      try {
+        trace =
+            t.getClass().getName()
+                + System.lineSeparator()
+                + Arrays.stream(t.getStackTrace())
+                    .map(f -> "\tat " + f)
+                    .collect(Collectors.joining(System.lineSeparator()));
+      } catch (Exception ignored2) {
+        trace = t.getClass().getName();
+      }
     }
     try {
       return truncate(trace, maxChars);

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
@@ -22,10 +22,9 @@ public final class StackTraces {
    * contains non-integer placeholders.
    *
    * @param t the throwable to retrieve the message from
-   * @return {@code null} if {@code t} is {@code null}; the result of {@link
-   *     Throwable#getMessage()} on success; or a diagnostic string of the form {@code "(Exception
-   *     message unavailable for ClassName: getMessage() threw ExceptionType)"} if {@code
-   *     getMessage()} throws
+   * @return {@code null} if {@code t} is {@code null}; the result of {@link Throwable#getMessage()}
+   *     on success; or a diagnostic string of the form {@code "(Exception message unavailable for
+   *     ClassName: getMessage() threw ExceptionType)"} if {@code getMessage()} throws
    */
   public static String safeGetMessage(Throwable t) {
     if (t == null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
@@ -15,12 +15,17 @@ public final class StackTraces {
   private StackTraces() {}
 
   /**
-   * Safely retrieves the message from a throwable. Returns {@code null} if {@code t} is {@code
-   * null}, or a diagnostic string of the form {@code "(Exception message unavailable for ClassName:
-   * getMessage() threw ExceptionType)"} if {@link Throwable#getMessage()} itself throws.
-   * Third-party exception classes occasionally use formatting utilities (e.g. {@code
+   * Safely retrieves the message from a throwable.
+   *
+   * <p>Third-party exception classes occasionally use formatting utilities (e.g. {@code
    * java.text.MessageFormat}) inside {@code getMessage()}, which can throw when the pattern
    * contains non-integer placeholders.
+   *
+   * @param t the throwable to retrieve the message from
+   * @return {@code null} if {@code t} is {@code null}; the result of {@link
+   *     Throwable#getMessage()} on success; or a diagnostic string of the form {@code "(Exception
+   *     message unavailable for ClassName: getMessage() threw ExceptionType)"} if {@code
+   *     getMessage()} throws
    */
   public static String safeGetMessage(Throwable t) {
     if (t == null) {
@@ -37,6 +42,19 @@ public final class StackTraces {
     }
   }
 
+  /**
+   * Returns the stack trace of {@code t} as a string, truncated to {@code maxChars} characters.
+   *
+   * <p>Uses {@link Throwable#printStackTrace(java.io.PrintWriter)} to produce the full trace
+   * including {@code Caused by} and {@code Suppressed} chains. If {@code printStackTrace} itself
+   * throws (e.g. because {@link Throwable#getMessage()} throws inside {@code toString()}), falls
+   * back to reconstructing the trace from {@link Throwable#getStackTrace()} so the call site
+   * remains locatable.
+   *
+   * @param t the throwable to format
+   * @param maxChars maximum length of the returned string
+   * @return the stack trace string, truncated if necessary
+   */
   public static String getStackTrace(Throwable t, int maxChars) {
     String trace;
     try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/StackTraces.java
@@ -5,6 +5,7 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -13,10 +14,45 @@ import java.util.stream.Collectors;
 public final class StackTraces {
   private StackTraces() {}
 
+  /**
+   * Safely retrieves the message from a throwable. Returns {@code null} if {@code t} is {@code
+   * null}, or a diagnostic string of the form {@code "(Exception message unavailable for ClassName:
+   * getMessage() threw ExceptionType)"} if {@link Throwable#getMessage()} itself throws.
+   * Third-party exception classes occasionally use formatting utilities (e.g. {@code
+   * java.text.MessageFormat}) inside {@code getMessage()}, which can throw when the pattern
+   * contains non-integer placeholders.
+   */
+  public static String safeGetMessage(Throwable t) {
+    if (t == null) {
+      return null;
+    }
+    try {
+      return t.getMessage();
+    } catch (Exception e) {
+      return "(Exception message unavailable for "
+          + t.getClass().getSimpleName()
+          + ": getMessage() threw "
+          + e.getClass().getSimpleName()
+          + ")";
+    }
+  }
+
   public static String getStackTrace(Throwable t, int maxChars) {
-    StringWriter sw = new StringWriter();
-    t.printStackTrace(new PrintWriter(sw));
-    String trace = sw.toString();
+    String trace;
+    try {
+      StringWriter sw = new StringWriter();
+      t.printStackTrace(new PrintWriter(sw));
+      trace = sw.toString();
+    } catch (Exception ignored) {
+      // printStackTrace() failed (e.g. getMessage() throws inside toString()).
+      // Reconstruct from getStackTrace() so the call site is still locatable.
+      trace =
+          t.getClass().getName()
+              + System.lineSeparator()
+              + Arrays.stream(t.getStackTrace())
+                  .map(f -> "\tat " + f)
+                  .collect(Collectors.joining(System.lineSeparator()));
+    }
     try {
       return truncate(trace, maxChars);
     } catch (Exception e) {
@@ -43,6 +79,9 @@ public final class StackTraces {
     /* last-ditch centre cut to guarantee the limit */
     String cutMessage = "\t... trace centre-cut to " + maxChars + " chars ...";
     int retainedLength = maxChars - cutMessage.length() - 2; // 2 for the newlines
+    if (retainedLength <= 0) {
+      return cutMessage + System.lineSeparator();
+    }
     int half = retainedLength / 2;
     return trace.substring(0, half)
         + System.lineSeparator()

--- a/dd-trace-core/src/test/java/datadog/trace/core/DDSpanTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/DDSpanTest.java
@@ -10,6 +10,7 @@ import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MECHANISM_TAG;
 import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_RULE_RATE_TAG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -33,6 +34,7 @@ import datadog.trace.common.sampling.RateByServiceTraceSampler;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.PropagationTags;
+import datadog.trace.core.util.TestThrowables;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -445,6 +447,39 @@ public class DDSpanTest extends DDCoreJavaSpecification {
     span.addThrowable(null);
     assertFalse(span.isError());
     assertNull(span.getTag(DDTags.ERROR_STACK));
+  }
+
+  @Test
+  void addThrowableDoesNotFailWhenGetMessageThrows() {
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "root").start();
+
+    span.addThrowable(TestThrowables.throwingGetMessage());
+
+    assertTrue(span.isError());
+    assertNotNull(span.getTag(DDTags.ERROR_TYPE));
+    assertNotNull(
+        span.getTag(DDTags.ERROR_STACK),
+        "stack trace must be captured even when getMessage() throws");
+    assertTrue(((String) span.getTag(DDTags.ERROR_MSG)).contains("Exception message unavailable"));
+  }
+
+  @Test
+  void addThrowableDoesNotFailWhenGetCauseMessageThrows() {
+    // Outer exception has a normal message, so the broken-pipe check reaches
+    // getCause().getMessage()
+    RuntimeException error =
+        new RuntimeException("outer message", TestThrowables.throwingGetMessage());
+    DDSpan span = (DDSpan) tracer.buildSpan("datadog", "root").start();
+
+    span.addThrowable(error);
+
+    assertTrue(span.isError());
+    assertNotNull(span.getTag(DDTags.ERROR_TYPE));
+    assertNotNull(
+        span.getTag(DDTags.ERROR_STACK),
+        "stack trace must be captured even when cause's getMessage() throws");
+    // Outer getMessage() works normally — message must be recorded
+    assertEquals("outer message", span.getTag(DDTags.ERROR_MSG));
   }
 
   @TableTest({

--- a/dd-trace-core/src/test/java/datadog/trace/core/util/StackTracesTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/util/StackTracesTest.java
@@ -1,9 +1,12 @@
 package datadog.trace.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -63,6 +66,24 @@ class StackTracesTest {
           + "    at com.example.util.FileUtils.readFile(FileUtils.java:22)\n"
           + "    at com.example.util.ResourceManager.close(ResourceManager.java:21)\n"
           + "    ... 3 more\n";
+
+  // --- safeGetMessage ---
+
+  @Test
+  void safeGetMessageReturnsFallbackWhenGetMessageThrows() {
+    String message = StackTraces.safeGetMessage(TestThrowables.throwingGetMessage());
+    assertTrue(
+        message.contains("Exception message unavailable"), "must indicate message is unavailable");
+    assertTrue(
+        message.contains("IllegalArgumentException"), "must include secondary exception type");
+  }
+
+  @Test
+  void safeGetMessageReturnsNullForNullInput() {
+    assertNull(StackTraces.safeGetMessage(null));
+  }
+
+  // --- getStackTrace with broken getMessage ---
 
   @ParameterizedTest(name = "truncation limit {0}")
   @MethodSource("testTruncateArguments")

--- a/dd-trace-core/src/test/java/datadog/trace/core/util/TestThrowables.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/util/TestThrowables.java
@@ -1,0 +1,23 @@
+package datadog.trace.core.util;
+
+import java.text.MessageFormat;
+
+/** Test helpers for throwables with non-standard {@code getMessage()} behaviour. */
+public final class TestThrowables {
+  private TestThrowables() {}
+
+  /**
+   * Returns a {@link RuntimeException} whose {@link Throwable#getMessage()} throws {@link
+   * IllegalArgumentException} via {@link MessageFormat} with non-integer placeholders — simulating
+   * the third-party exception that triggered the production bug in {@code DDSpan.addThrowable}.
+   */
+  public static RuntimeException throwingGetMessage() {
+    return new RuntimeException() {
+      @Override
+      public String getMessage() {
+        return MessageFormat.format(
+            "Timeout after {TotalMilliseconds}ms matching pattern {Pattern}", "arg0", "arg1");
+      }
+    };
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds `StackTraces.safeGetMessage(Throwable)` and uses it in `DDSpan.addThrowable` where `getMessage()` was called directly. Also guards `StackTraces.getStackTrace()` which calls `getMessage()` indirectly via `printStackTrace()` → `toString()`.

**# Motivation**
A third-party exception's `getMessage()` can throw if it internally uses `MessageFormat.format()` with non-integer placeholders (e.g. `{TotalMilliseconds}`). `MessageFormat` tries to parse the placeholder as an argument index via `Integer.parseInt`, which throws `NumberFormatException` → `IllegalArgumentException`

Before the fix:
<img width="1425" height="376" alt="image" src="https://github.com/user-attachments/assets/d5b7b19b-12f7-4c6c-a4d7-982102bfef21" />

**After the fix:**
<img width="1425" height="376" alt="image" src="https://github.com/user-attachments/assets/e62c8b92-ec2b-47be-8290-0e95ef475b17" />


# Additional Notes

- `safeGetMessage` uses `catch (Exception e)` intentionally - `Error` subtypes (`OutOfMemoryError`, `StackOverflowError`) are not caught as masking them would cause more harm than good.
- When `printStackTrace()` fails, the fallback captures frames of the top-level exception via `getStackTrace()[]`. The `Caused by:` chain is lost in this edge case - acceptable given how rarely `getMessage()` throws.
- `ERROR_TYPE` and `ERROR_MSG` (fallback string) are always recorded, giving enough signal to identify the problem even without a full stack trace.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
