### PR TITLE
Introduce early exit on success for repository unshallowing

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitRepoUnshallow.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitRepoUnshallow.java
@@ -28,6 +28,10 @@ public class GitRepoUnshallow {
     long unshallowStart = System.currentTimeMillis();
     try {
       gitClient.unshallow(GitClient.HEAD);
+      LOGGER.debug(
+          "Repository unshallowing via HEAD took {} ms",
+          System.currentTimeMillis() - unshallowStart);
+      return true;
     } catch (ShellCommandExecutor.ShellCommandFailedException e) {
       LOGGER.debug(
           "Could not unshallow using HEAD - assuming HEAD points to a local commit that does not exist in the remote repo",
@@ -37,13 +41,20 @@ public class GitRepoUnshallow {
     try {
       String upstreamBranch = gitClient.getUpstreamBranchSha();
       gitClient.unshallow(upstreamBranch);
+      LOGGER.debug(
+          "Repository unshallowing via upstream branch took {} ms",
+          System.currentTimeMillis() - unshallowStart);
+      return true;
     } catch (ShellCommandExecutor.ShellCommandFailedException e) {
       LOGGER.debug(
           "Could not unshallow using upstream branch - assuming currently checked out local branch does not track any remote branch",
           e);
-      gitClient.unshallow(null);
     }
-    LOGGER.debug("Repository unshallowing took {} ms", System.currentTimeMillis() - unshallowStart);
+
+    gitClient.unshallow(null);
+    LOGGER.debug(
+        "Repository unshallowing via no-ref fetch took {} ms",
+        System.currentTimeMillis() - unshallowStart);
     return true;
   }
 }


### PR DESCRIPTION
# What Does This Do

- Early exit when a repository unshallowing attempt succeeds

# Motivation

The repository unshallowing process makes attempts against `HEAD`, the upstream branch sha, and the remote name. Previously, even if the first attempt against `HEAD` succeeded, another attempt was performed against the upstream branch sha. 

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [PROJ-IDENT]

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
