### PR TITLE
Cache Spotless P2 dependencies in the pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -379,6 +379,7 @@ populate_dep_cache:
         CACHE_TYPE: "smoke"
       - GRADLE_TARGET: "spotlessCheck"
         CACHE_TYPE: "spotless"
+        GRADLE_MEMORY_MAX: "6G"
 
 publish-artifacts-to-s3:
   image: registry.ddbuild.io/images/mirror/amazon/aws-cli:2.4.29

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,6 +229,14 @@ default:
     # replace maven central part by MAVEN_REPOSITORY_PROXY in .mvn/wrapper/maven-wrapper.properties
     - sed -i "s|https://repo.maven.apache.org/maven2/|$MAVEN_REPOSITORY_PROXY|g" .mvn/wrapper/maven-wrapper.properties
     - mkdir -p .mvn/caches
+    # Redirect Spotless's Equo/Solstice P2 cache into the project tree so it is captured by the GitLab cache.
+    # Solstice (https://github.com/equodev/equo-ide) defaults to ~/.m2/repository/dev/equo/p2-data, which is outside $CI_PROJECT_DIR.
+    - |
+      mkdir -p .mvn/caches/equo "$HOME/.m2/repository/dev"
+      if [ ! -L "$HOME/.m2/repository/dev/equo" ]; then
+        rm -rf "$HOME/.m2/repository/dev/equo"
+        ln -s "$(pwd)/.mvn/caches/equo" "$HOME/.m2/repository/dev/equo"
+      fi
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - export GRADLE_ARGS=" --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
@@ -369,6 +377,8 @@ populate_dep_cache:
         CACHE_TYPE: "latestdep"
       - GRADLE_TARGET: ":smokeTest"
         CACHE_TYPE: "smoke"
+      - GRADLE_TARGET: "spotlessCheck"
+        CACHE_TYPE: "spotless"
 
 publish-artifacts-to-s3:
   image: registry.ddbuild.io/images/mirror/amazon/aws-cli:2.4.29
@@ -408,6 +418,7 @@ spotless:
   needs: []
   variables:
     GRADLE_MEMORY_MAX: 6G
+    CACHE_TYPE: "spotless"
   script:
     - ./gradlew --version
     - ./gradlew spotlessCheck $GRADLE_ARGS


### PR DESCRIPTION
## What Does This Do

Makes a pipeline cache for the `spotless` job.

## Motivation

Prevent failure related to re-downloading the groovy formatter

```
* What went wrong:
Execution failed for task ':spotlessInternalRegisterDependencies'.
> java.io.IOException: Failed to provision P2 dependencies
...
Caused by: java.net.SocketTimeoutException: timeout
    at dev.equo.solstice.p2.JarCache.download(JarCache.java:59)
    at dev.equo.solstice.p2.P2Client.download(P2Client.java:76)
    at dev.equo.solstice.p2.P2QueryResult.<init>(P2QueryResult.java:35)
```

Since the groovy formatter don;t change much and that it can't be proxied today by our mirror, having a way to cache this dependency should be a net win.


## Additional Notes

The first run after this lands will still need to download once (no `dependency-spotless` cache exists yet, and the `dependency-base`/`dependency-lib` fallbacks don't carry the P2 data). After the next `populate_dep_cache` schedule, subsequent `spotless` jobs hit the cache.

Done

- [x] Trigger the `populate_dep_cache` pipeline manually.
- [x] Re-run the `spotless` jobs

**Before the cache**

Notice the 4-5 minutes spent after the `:spotlessInternalRegisterDependencies` task
<img width="429" height="36" alt="Screenshot 2026-05-22 at 15 51 50" src="https://github.com/user-attachments/assets/22fbbd90-4a1f-4d7f-a8f4-fcf688a7b529" />

**After**

It takes mere seconds.

<img width="796" height="42" alt="Screenshot 2026-05-22 at 15 55 41" src="https://github.com/user-attachments/assets/6ec05721-a354-48b7-b2a3-48e96900aab4" />