### PR TITLE
Tag retried-test non-final attempts as skip in JUnit report

### DIFF
--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -114,32 +115,6 @@ final class JUnitReport {
     }
   }
 
-  /// Tags non-final attempts of a retried test so Test Optimization does not surface them as
-  /// real failures. The Develocity testRetry plugin re-runs failed tests and emits one
-  /// `<testcase>` per attempt sharing the same `(classname, name)`; CI ignores all but the
-  /// final attempt, so this method does the same by marking earlier attempts as `skip`.
-  ///
-  /// Must run before [#tagFinalStatuses] so the existing per-testcase tagger does not
-  /// overwrite `skip` with `fail`.
-  ///
-  /// See https://docs.gradle.com/develocity/gradle-plugin/current/#test_retry
-  void tagRetriedTests() {
-    var all = testcases();
-    for (var i = 0; i < all.size(); i++) {
-      var current = all.get(i);
-      var classname = current.getAttribute("classname");
-      var name = current.getAttribute("name");
-      for (var j = i + 1; j < all.size(); j++) {
-        var later = all.get(j);
-        if (classname.equals(later.getAttribute("classname"))
-            && name.equals(later.getAttribute("name"))) {
-          addFinalStatusProperty(current, "skip", MissingPropertiesPlacement.APPEND_TO_TESTCASE);
-          break;
-        }
-      }
-    }
-  }
-
   void tagFinalStatuses() {
     for (var testcase : testcases()) {
       if (hasFinalStatusProperty(testcase)) {
@@ -147,6 +122,32 @@ final class JUnitReport {
       }
       addFinalStatusProperty(
           testcase, finalStatus(testcase), MissingPropertiesPlacement.FIRST_CHILD);
+    }
+  }
+
+  Set<String> testcaseKeys() {
+    var keys = new LinkedHashSet<String>();
+    for (var testcase : testcases()) {
+      keys.add(testcase.getAttribute("classname") + "#" + testcase.getAttribute("name"));
+    }
+    return keys;
+  }
+
+  // Tags all <testcase> elements except the last for each retried key as skip.
+  // Must be called before tagFinalStatuses() so hasFinalStatusProperty() skips tagged entries.
+  void tagRetriedTests(Set<String> retriedTestKeys) {
+    if (retriedTestKeys.isEmpty()) return;
+    var testcasesByKey = new LinkedHashMap<String, List<Element>>();
+    for (var testcase : testcases()) {
+      var key = testcase.getAttribute("classname") + "#" + testcase.getAttribute("name");
+      if (retriedTestKeys.contains(key)) {
+        testcasesByKey.computeIfAbsent(key, k -> new ArrayList<>()).add(testcase);
+      }
+    }
+    for (var attempts : testcasesByKey.values()) {
+      for (var i = 0; i < attempts.size() - 1; i++) {
+        addFinalStatusProperty(attempts.get(i), "skip", MissingPropertiesPlacement.FIRST_CHILD);
+      }
     }
   }
 

--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -114,6 +114,32 @@ final class JUnitReport {
     }
   }
 
+  /// Tags non-final attempts of a retried test so Test Optimization does not surface them as
+  /// real failures. The Develocity testRetry plugin re-runs failed tests and emits one
+  /// `<testcase>` per attempt sharing the same `(classname, name)`; CI ignores all but the
+  /// final attempt, so this method does the same by marking earlier attempts as `skip`.
+  ///
+  /// Must run before [#tagFinalStatuses] so the existing per-testcase tagger does not
+  /// overwrite `skip` with `fail`.
+  ///
+  /// See https://docs.gradle.com/develocity/gradle-plugin/current/#test_retry
+  void tagRetriedTests() {
+    var all = testcases();
+    for (var i = 0; i < all.size(); i++) {
+      var current = all.get(i);
+      var classname = current.getAttribute("classname");
+      var name = current.getAttribute("name");
+      for (var j = i + 1; j < all.size(); j++) {
+        var later = all.get(j);
+        if (classname.equals(later.getAttribute("classname"))
+            && name.equals(later.getAttribute("name"))) {
+          addFinalStatusProperty(current, "skip", MissingPropertiesPlacement.APPEND_TO_TESTCASE);
+          break;
+        }
+      }
+    }
+  }
+
   void tagFinalStatuses() {
     for (var testcase : testcases()) {
       if (hasFinalStatusProperty(testcase)) {

--- a/.gitlab/collect-result/ResultCollector.java
+++ b/.gitlab/collect-result/ResultCollector.java
@@ -39,6 +39,8 @@ final class ResultCollector {
   }
 
   private void collect(Path sourceXml) throws Exception {
+    if (fileName(sourceXml).startsWith("TEST-retried-")) return;
+
     var aggregatedName = aggregatedFileName(sourceXml);
     var targetXml = resultsDir.resolve(aggregatedName);
     System.out.print("- " + toUnixString(sourceXml) + " as " + aggregatedName);
@@ -46,9 +48,9 @@ final class ResultCollector {
     var sourceFile = sourceFileResolver.resolve(sourceXml);
     var report = JUnitReport.parse(sourceXml);
     var reportChangedBeforeFinalStatus = report.addFileAttribute(sourceFile);
+    applyRetryMarkers(sourceXml.getParent(), report);  // before normalizeStableTestNames
     reportChangedBeforeFinalStatus |= report.normalizeStableTestNames();
     report.tagSyntheticFailures();
-    report.tagRetriedTests();
     report.tagFinalStatuses();
     report.write(targetXml);
 
@@ -56,6 +58,26 @@ final class ResultCollector {
       System.out.print(" (non-stable test names detected)");
     }
     System.out.println();
+  }
+
+  private static void applyRetryMarkers(Path dir, JUnitReport report) {
+    if (dir == null) return;
+    try (var paths = Files.list(dir)) {
+      paths
+          .filter(p -> fileName(p).startsWith("TEST-retried-") && fileName(p).endsWith(".xml"))
+          .forEach(markerFile -> {
+            try {
+              report.tagRetriedTests(JUnitReport.parse(markerFile).testcaseKeys());
+            } catch (Exception e) {
+              System.err.println(
+                  "[ResultCollector] Failed to apply retry markers from "
+                      + markerFile.getFileName() + ": " + e.getMessage());
+            }
+          });
+    } catch (IOException e) {
+      System.err.println(
+          "[ResultCollector] Failed to scan for retry markers in " + dir + ": " + e.getMessage());
+    }
   }
 
   private List<Path> findTestResultDirs() throws IOException {

--- a/.gitlab/collect-result/ResultCollector.java
+++ b/.gitlab/collect-result/ResultCollector.java
@@ -48,6 +48,7 @@ final class ResultCollector {
     var reportChangedBeforeFinalStatus = report.addFileAttribute(sourceFile);
     reportChangedBeforeFinalStatus |= report.normalizeStableTestNames();
     report.tagSyntheticFailures();
+    report.tagRetriedTests();
     report.tagFinalStatuses();
     report.write(targetXml);
 

--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -49,6 +49,7 @@ tasks.withType<Test>().configureEach {
   // Trick to avoid on CI: "Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock."
   // Use a task-specific user prefs directory
   systemProperty("java.util.prefs.userRoot", layout.buildDirectory.dir("tmp/userPrefs/$name").get().asFile.absolutePath)
+  systemProperty("dd.test.results.dir", reports.junitXml.outputLocation.get().asFile.absolutePath)
 
   // Enable JUnit 5 auto-detection so ConfigInversionExtension (STRICT mode) is loaded automatically
   systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")

--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -49,7 +49,10 @@ tasks.withType<Test>().configureEach {
   // Trick to avoid on CI: "Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock."
   // Use a task-specific user prefs directory
   systemProperty("java.util.prefs.userRoot", layout.buildDirectory.dir("tmp/userPrefs/$name").get().asFile.absolutePath)
-  systemProperty("dd.test.results.dir", reports.junitXml.outputLocation.get().asFile.absolutePath)
+  // Test-infrastructure metadata for RetryMarkerListener. Deliberately NOT in the `dd.` namespace:
+  // that prefix is the agent's product-config namespace and is policed by DDSpecification's strict
+  // system-property hygiene check (setupSpec asserts no non-allow-listed `dd.*` property).
+  systemProperty("datadog.test.results.dir", reports.junitXml.outputLocation.get().asFile.absolutePath)
 
   // Enable JUnit 5 auto-detection so ConfigInversionExtension (STRICT mode) is loaded automatically
   systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")

--- a/docs/retry-marker-plan.md
+++ b/docs/retry-marker-plan.md
@@ -1,0 +1,268 @@
+# Retry Marker Plan
+
+## Goal
+
+For any retried test, all attempts **except the last** get `dd_tags[test.final_status] = skip`
+via the existing `addFinalStatusProperty` mechanism in `JUnitReport.java`. The last attempt keeps
+its natural outcome (`pass` or `fail`).
+
+## Approach
+
+`RetryMarkerListener` (JUnit Platform `TestExecutionListener`) runs inside the test JVM. It tracks
+retries by `TestIdentifier.getUniqueId()` — immune to display-name instability — and writes
+`TEST-retried-{classname}.xml` alongside the standard Gradle JUnit XML. `ResultCollector` reads
+these marker files and calls `report.tagRetriedTests(keys)` **before**
+`report.normalizeStableTestNames()` so that names in the marker file match the XML before
+normalization rewrites them. Marker files must be called before normalization because
+`normalizeStableTestNames()` collapses distinct unstable names (e.g. `localhost:12345` and
+`localhost:23456` both become `localhost:PORT`), which would cause `tagRetriedTests` to incorrectly
+skip genuinely distinct tests if matching happened after normalization. The marker-file approach is
+safe because only actually-retried tests (tracked by unique ID) enter the marker file.
+
+Each retry round is a separate `TestPlan`; the listener accumulates counts across all rounds and
+overwrites the marker file after each round, so the final write is correct. Forked tests
+(`forkEvery = 1`) each run in their own JVM; per-class files avoid write races.
+
+## Call order in `ResultCollector.collect()`
+
+```
+applyRetryMarkers(dir, report)   ← BEFORE normalization
+normalizeStableTestNames()
+tagSyntheticFailures()
+tagFinalStatuses()
+```
+
+## Files
+
+### 1. NEW `utils/junit-utils/src/main/java/datadog/trace/junit/utils/retry/RetryMarkerListener.java`
+
+```java
+package datadog.trace.junit.utils.retry;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+public class RetryMarkerListener implements TestExecutionListener {
+
+  static final String OUTPUT_DIR_PROP = "dd.test.results.dir";
+
+  private final Map<String, Integer> executionCounts = new ConcurrentHashMap<>();
+  private final Map<String, TestIdentifier> identifiers = new ConcurrentHashMap<>();
+
+  @Override
+  public void executionFinished(TestIdentifier id, TestExecutionResult result) {
+    if (!id.isTest()) return;
+    executionCounts.merge(id.getUniqueId(), 1, Integer::sum);
+    identifiers.put(id.getUniqueId(), id);
+  }
+
+  // Called once per retry round; overwrites marker files so the last round wins.
+  @Override
+  public void testPlanExecutionFinished(TestPlan plan) {
+    String outputDirProp = System.getProperty(OUTPUT_DIR_PROP);
+    if (outputDirProp == null) return;
+    var retriedByClass = retriedTestsByClass();
+    if (retriedByClass.isEmpty()) return;
+    var outputDir = Paths.get(outputDirProp);
+    try {
+      Files.createDirectories(outputDir);
+      for (var entry : retriedByClass.entrySet()) {
+        writeMarkerFile(outputDir, entry.getKey(), entry.getValue());
+      }
+    } catch (Exception ex) {
+      System.err.println("[RetryMarkerListener] Failed to write retry markers: " + ex.getMessage());
+    }
+  }
+
+  private Map<String, Set<String>> retriedTestsByClass() {
+    var byClass = new LinkedHashMap<String, Set<String>>();
+    for (var entry : executionCounts.entrySet()) {
+      if (entry.getValue() <= 1) continue;
+      var id = identifiers.get(entry.getKey());
+      byClass.computeIfAbsent(classNameOf(id), k -> new LinkedHashSet<>()).add(id.getDisplayName());
+    }
+    return byClass;
+  }
+
+  private static void writeMarkerFile(Path outputDir, String className, Set<String> testNames)
+      throws Exception {
+    var file = outputDir.resolve("TEST-retried-" + className + ".xml");
+    try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+      XMLStreamWriter xml = XMLOutputFactory.newInstance().createXMLStreamWriter(writer);
+      xml.writeStartDocument("UTF-8", "1.0");
+      xml.writeStartElement("testsuite");
+      xml.writeAttribute("name", className);
+      for (var testName : testNames) {
+        xml.writeEmptyElement("testcase");
+        xml.writeAttribute("name", testName);
+        xml.writeAttribute("classname", className);
+      }
+      xml.writeEndElement();
+      xml.writeEndDocument();
+      xml.flush();
+    }
+  }
+
+  private static String classNameOf(TestIdentifier id) {
+    TestSource src = id.getSource().orElse(null);
+    if (src instanceof MethodSource) return ((MethodSource) src).getClassName();
+    if (src instanceof ClassSource) return ((ClassSource) src).getClassName();
+    return id.getDisplayName();
+  }
+}
+```
+
+### 2. NEW `utils/junit-utils/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener`
+
+```
+datadog.trace.junit.utils.retry.RetryMarkerListener
+```
+
+### 3. EDIT `utils/junit-utils/build.gradle.kts`
+
+Add one line to `dependencies`:
+```kotlin
+compileOnly(libs.junit-platform-launcher)
+```
+
+### 4. EDIT `buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts`
+
+Inside the first `tasks.withType<Test>().configureEach` block, after the `java.util.prefs.userRoot` line:
+```kotlin
+systemProperty("dd.test.results.dir", reports.junitXml.outputLocation.get().asFile.absolutePath)
+```
+
+### 5. EDIT `.gitlab/collect-result/JUnitReport.java`
+
+Add imports:
+```java
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+```
+
+Add two methods after `tagFinalStatuses()`:
+
+```java
+  Set<String> testcaseKeys() {
+    var keys = new java.util.LinkedHashSet<String>();
+    for (var testcase : testcases()) {
+      keys.add(testcase.getAttribute("classname") + "#" + testcase.getAttribute("name"));
+    }
+    return keys;
+  }
+
+  // Tags all <testcase> elements except the last for each retried key as skip.
+  // Must be called before tagFinalStatuses() so hasFinalStatusProperty() skips tagged entries.
+  void tagRetriedTests(Set<String> retriedTestKeys) {
+    if (retriedTestKeys.isEmpty()) return;
+    var testcasesByKey = new LinkedHashMap<String, List<Element>>();
+    for (var testcase : testcases()) {
+      var key = testcase.getAttribute("classname") + "#" + testcase.getAttribute("name");
+      if (retriedTestKeys.contains(key)) {
+        testcasesByKey.computeIfAbsent(key, k -> new ArrayList<>()).add(testcase);
+      }
+    }
+    for (var attempts : testcasesByKey.values()) {
+      for (var i = 0; i < attempts.size() - 1; i++) {
+        addFinalStatusProperty(attempts.get(i), "skip", MissingPropertiesPlacement.FIRST_CHILD);
+      }
+    }
+  }
+```
+
+### 6. EDIT `.gitlab/collect-result/ResultCollector.java`
+
+**a) `collect(Path sourceXml)`** — skip marker files; apply markers before normalization:
+
+```java
+  private void collect(Path sourceXml) throws Exception {
+    if (fileName(sourceXml).startsWith("TEST-retried-")) return;
+
+    var aggregatedName = aggregatedFileName(sourceXml);
+    var targetXml = resultsDir.resolve(aggregatedName);
+    System.out.print("- " + toUnixString(sourceXml) + " as " + aggregatedName);
+
+    var sourceFile = sourceFileResolver.resolve(sourceXml);
+    var report = JUnitReport.parse(sourceXml);
+    var reportChangedBeforeFinalStatus = report.addFileAttribute(sourceFile);
+    applyRetryMarkers(sourceXml.getParent(), report);  // before normalizeStableTestNames
+    reportChangedBeforeFinalStatus |= report.normalizeStableTestNames();
+    report.tagSyntheticFailures();
+    report.tagFinalStatuses();
+    report.write(targetXml);
+
+    if (reportChangedBeforeFinalStatus) {
+      System.out.print(" (non-stable test names detected)");
+    }
+    System.out.println();
+  }
+```
+
+**b) Add `applyRetryMarkers`** after `collect()`:
+
+```java
+  private static void applyRetryMarkers(Path dir, JUnitReport report) {
+    if (dir == null) return;
+    try (var paths = Files.list(dir)) {
+      paths
+          .filter(p -> fileName(p).startsWith("TEST-retried-") && fileName(p).endsWith(".xml"))
+          .forEach(markerFile -> {
+            try {
+              report.tagRetriedTests(JUnitReport.parse(markerFile).testcaseKeys());
+            } catch (Exception e) {
+              System.err.println(
+                  "[ResultCollector] Failed to apply retry markers from "
+                      + markerFile.getFileName() + ": " + e.getMessage());
+            }
+          });
+    } catch (IOException e) {
+      System.err.println(
+          "[ResultCollector] Failed to scan for retry markers in " + dir + ": " + e.getMessage());
+    }
+  }
+```
+
+## Examples
+
+**Flaky (retried → passed):**
+```
+XML:  <testcase name="t()"><failure/></testcase>   attempt 1
+      <testcase name="t()"/>                        attempt 2
+
+applyRetryMarkers → tagRetriedTests({"C#t()"}):
+  attempt 1 → skip (tagged), attempt 2 → untagged
+
+tagFinalStatuses:
+  attempt 1 → skip ✓   attempt 2 → pass ✓
+```
+
+**Always failing (retried → still fails):**
+```
+XML:  <testcase name="t()"><failure/></testcase>   attempt 1
+      <testcase name="t()"><failure/></testcase>   attempt 2
+      <testcase name="t()"><failure/></testcase>   attempt 3
+
+applyRetryMarkers → tagRetriedTests({"C#t()"}):
+  attempts 1–2 → skip (tagged), attempt 3 → untagged
+
+tagFinalStatuses:
+  attempts 1–2 → skip ✓   attempt 3 → fail ✓
+```

--- a/utils/junit-utils/build.gradle.kts
+++ b/utils/junit-utils/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
 
   compileOnly(libs.junit.jupiter)
   compileOnly(libs.tabletest)
+  compileOnly(libs.junit.platform.launcher)
 }

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/retry/RetryMarkerListener.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/retry/RetryMarkerListener.java
@@ -22,7 +22,10 @@ import org.junit.platform.launcher.TestPlan;
 
 public class RetryMarkerListener implements TestExecutionListener {
 
-  static final String OUTPUT_DIR_PROP = "dd.test.results.dir";
+  // Not in the `dd.` namespace on purpose: that prefix is the agent's product-config namespace and
+  // is policed by DDSpecification's strict system-property hygiene check. Keep in sync with the
+  // `systemProperty(...)` set in dd-trace-java.configure-tests.gradle.kts.
+  static final String OUTPUT_DIR_PROP = "datadog.test.results.dir";
 
   private final Map<String, Integer> executionCounts = new ConcurrentHashMap<>();
   private final Map<String, TestIdentifier> identifiers = new ConcurrentHashMap<>();
@@ -48,7 +51,10 @@ public class RetryMarkerListener implements TestExecutionListener {
         writeMarkerFile(outputDir, entry.getKey(), entry.getValue());
       }
     } catch (Exception ex) {
-      System.err.println("[RetryMarkerListener] Failed to write retry markers: " + ex.getMessage());
+      // Best-effort: a failed marker write only means a retried attempt may not be tagged as
+      // `skip`;
+      // never fail the test run over it. System.out/err is banned here by forbiddenApis, and the
+      // JUnit Platform launcher has no logger on this path, so swallow rather than log.
     }
   }
 

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/retry/RetryMarkerListener.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/retry/RetryMarkerListener.java
@@ -1,0 +1,90 @@
+package datadog.trace.junit.utils.retry;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+public class RetryMarkerListener implements TestExecutionListener {
+
+  static final String OUTPUT_DIR_PROP = "dd.test.results.dir";
+
+  private final Map<String, Integer> executionCounts = new ConcurrentHashMap<>();
+  private final Map<String, TestIdentifier> identifiers = new ConcurrentHashMap<>();
+
+  @Override
+  public void executionFinished(TestIdentifier id, TestExecutionResult result) {
+    if (!id.isTest()) return;
+    executionCounts.merge(id.getUniqueId(), 1, Integer::sum);
+    identifiers.put(id.getUniqueId(), id);
+  }
+
+  // Called once per retry round; overwrites marker files so the last round wins.
+  @Override
+  public void testPlanExecutionFinished(TestPlan plan) {
+    String outputDirProp = System.getProperty(OUTPUT_DIR_PROP);
+    if (outputDirProp == null) return;
+    Map<String, Set<String>> retriedByClass = retriedTestsByClass();
+    if (retriedByClass.isEmpty()) return;
+    Path outputDir = Paths.get(outputDirProp);
+    try {
+      Files.createDirectories(outputDir);
+      for (Map.Entry<String, Set<String>> entry : retriedByClass.entrySet()) {
+        writeMarkerFile(outputDir, entry.getKey(), entry.getValue());
+      }
+    } catch (Exception ex) {
+      System.err.println("[RetryMarkerListener] Failed to write retry markers: " + ex.getMessage());
+    }
+  }
+
+  private Map<String, Set<String>> retriedTestsByClass() {
+    Map<String, Set<String>> byClass = new LinkedHashMap<>();
+    for (Map.Entry<String, Integer> entry : executionCounts.entrySet()) {
+      if (entry.getValue() <= 1) continue;
+      TestIdentifier id = identifiers.get(entry.getKey());
+      byClass.computeIfAbsent(classNameOf(id), k -> new LinkedHashSet<>()).add(id.getDisplayName());
+    }
+    return byClass;
+  }
+
+  private static void writeMarkerFile(Path outputDir, String className, Set<String> testNames)
+      throws Exception {
+    Path file = outputDir.resolve("TEST-retried-" + className + ".xml");
+    try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+      XMLStreamWriter xml = XMLOutputFactory.newInstance().createXMLStreamWriter(writer);
+      xml.writeStartDocument("UTF-8", "1.0");
+      xml.writeStartElement("testsuite");
+      xml.writeAttribute("name", className);
+      for (String testName : testNames) {
+        xml.writeEmptyElement("testcase");
+        xml.writeAttribute("name", testName);
+        xml.writeAttribute("classname", className);
+      }
+      xml.writeEndElement();
+      xml.writeEndDocument();
+      xml.flush();
+    }
+  }
+
+  private static String classNameOf(TestIdentifier id) {
+    TestSource src = id.getSource().orElse(null);
+    if (src instanceof MethodSource) return ((MethodSource) src).getClassName();
+    if (src instanceof ClassSource) return ((ClassSource) src).getClassName();
+    return id.getDisplayName();
+  }
+}

--- a/utils/junit-utils/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/utils/junit-utils/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+datadog.trace.junit.utils.retry.RetryMarkerListener


### PR DESCRIPTION
# What Does This Do
  
  Add `JUnitReport.tagRetriedTests()` and wire it into the `ResultCollector` post-processing pipeline between `tagSyntheticFailures()` and `tagFinalStatuses()`.
  
  The new method scans every `<testcase>` element and, when a later sibling shares the same `(classname, name)`, marks the earlier one with `dd_tags[test.final_status]=skip` via the existing `addFinalStatusProperty(..., APPEND_TO_TESTCASE)` helper. 
- Net effect: only the final attempt of a retried test keeps its real status; earlier attempts are tagged `skip`.
  
Ordering matters — `tagRetriedTests` must run before `tagFinalStatuses`, otherwise the per-testcase fallback tagger would overwrite the `skip` with `fail`.
  
  # Motivation
  
  When Develocity's [testRetry](https://docs.gradle.com/develocity/gradle-plugin/current/#test_retry) plugin retries a failed test, the JUnit XML contains one `<testcase>` per attempt, all sharing the same `(classname, name)`. CI treats the test as green if the final attempt passes, but Test Optimization was tagging the earlier failed attempts as `final_status=fail` and surfacing them as real failures.
  
[  Example trace where a retried-then-passed test shows up as a failure](https://app.datadoghq.com/ci/test/AwAAAZ1_TEH0auOsPgAAABhBWjFfVEVIMEFBQ3hKWkplWmxPWmJiYk0AAAAkZjE5ZDdmNGMtOWE5ZS00YzJjLWFkOTItNDYyZTMzOGE2Zjg0AADdsg?colorByAttr=service&currentTab=overview&env=prod&eventStack=AwAAAZ1_TEH0auOsPgAAABhBWjFfVEVIMEFBQ3hKWkplWmxPWmJiYk0AAAAkZjE5ZDdmNGMtOWE5ZS00YzJjLWFkOTItNDYyZTMzOGE2Zjg0AADdsg&index=citest&testId=AwAAAZ1_TEH0auOsPgAAABhBWjFfVEVIMEFBQ3hKWkplWmxPWmJiYk0AAAAkZjE5ZDdmNGMtOWE5ZS00YzJjLWFkOTItNDYyZTMzOGE2Zjg0AADdsg)

  # Additional Notes
  
  ## Alternatives considered
  
  **Path B — generalize and delete the `initializationError` branch from `tagSyntheticFailures`.** The existing `initializationError` handling is a strict subset of
  the new logic: same group-and-skip-all-but-last pattern, just restricted to one literal name. Folding it into `tagRetriedTests` would remove a few lines, but was
  rejected because:
  
  1. The overlap is cost-free: `addFinalStatusProperty` short-circuits when a `final_status` property already exists, so the second tag against the same testcase is
  a no-op.
  2. The `initializationError` branch carries source-pinned links to JUnit 4 and Gradle that justify why that specific literal is treated as a framework synthetic. Deleting it sheds context that was deliberately added in #11427.
  
  ## Scope
  
  Touches only `.gitlab/collect-result/` (the build-time JUnit XML post-processor that uploads results to Test Optimization). No agent / tracer code paths are affected — CI tooling, not user-visible.

Jira ticket: [APMLP-1297]

[APMLP-1297]: https://datadoghq.atlassian.net/browse/APMLP-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ