### PR TITLE
Use FAST_LANE prioritization for OTLP trace export

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
@@ -147,7 +147,7 @@ public class OtlpWriter extends RemoteWriter {
               healthMetrics,
               dispatcher,
               DroppingPolicy.DISABLED,
-              Prioritization.ENSURE_TRACE,
+              Prioritization.FAST_LANE,
               flushIntervalMilliseconds,
               TimeUnit.MILLISECONDS,
               singleSpanSampler);


### PR DESCRIPTION
# What Does This Do

Use `FAST_LANE` prioritization for OTLP trace export, like we use for DD trace export

# Motivation

https://datadoghq.atlassian.net/browse/APMSP-3067

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [APMSP-3067]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMSP-3067]: https://datadoghq.atlassian.net/browse/APMSP-3067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ