### PR TITLE
Disable stable session id propagation until after tracer is registered

### DIFF
--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -12,16 +12,17 @@ class ProcessImplStartAdvice {
   public static AgentSpan beforeStart(
       @Advice.Argument(0) final String[] command,
       @Advice.Argument(1) final Map<String, String> environment) {
+
+    if (!AgentTracer.isRegistered()) {
+      return null;
+    }
+
     String rootSessionId = Config.get().getRootSessionId();
     if (rootSessionId != null && environment != null) {
       environment.put("_DD_ROOT_JAVA_SESSION_ID", rootSessionId);
     }
 
-    if (!ProcessImplInstrumentationHelpers.ONLINE) {
-      return null;
-    }
-
-    if (command.length == 0 || !AgentTracer.isRegistered()) {
+    if (!ProcessImplInstrumentationHelpers.ONLINE || command.length == 0) {
       return null;
     }
 


### PR DESCRIPTION
# What Does This Do

This avoids a potential reentrant situation when tracer debug is enabled:
1. The full `Config` is logged during startup in its constructor
2. This includes any lazy config fields, such as the `hostname`
3. If the host is not available in the environment/host-files then `Config` calls the `hostname` command using `Runtime.exec(...)`
4. The `Runtime.exec(...)` call is intercepted by the process advice
5. The process advice calls `Config.get()` to get the stable session id
6. `Config.get()` returns `null` as the config is still being built

The resulting NPE is caught before it escapes to the application, but it still results in log-spam that could confuse investigations.

# Motivation

Fixes re-appearance of https://github.com/DataDog/dd-trace-java/pull/10088

# Additional Notes

Example stack trace:
```
java.lang.NullPointerException
        at java.lang.ProcessImpl.start(ProcessImpl.java:67)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
        at java.lang.Runtime.exec(Runtime.java:594)
        at java.lang.Runtime.exec(Runtime.java:424)
        at java.lang.Runtime.exec(Runtime.java:321)
        at datadog.trace.api.Config.initHostName(Config.java:5998)
        at datadog.trace.api.Config$HostNameHolder.<clinit>(Config.java:832)
        at datadog.trace.api.Config.getHostName(Config.java:3304)
        at datadog.trace.api.Config.toString(Config.java:6114)
        at datadog.slf4j.helpers.MessageFormatter.safeObjectAppend(MessageFormatter.java:277)
        at datadog.slf4j.helpers.MessageFormatter.deeplyAppendParameter(MessageFormatter.java:249)
        at datadog.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:211)
        at datadog.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:161)
        at datadog.slf4j.helpers.MessageFormatter.format(MessageFormatter.java:124)
        at datadog.trace.logging.ddlogger.DDLogger.formatLog(DDLogger.java:331)
        at datadog.trace.logging.ddlogger.DDTelemetryLogger.formatLog(DDTelemetryLogger.java:18)
        at datadog.trace.logging.ddlogger.DDLogger.debug(DDLogger.java:98)
        at datadog.trace.api.Config.<init>(Config.java:3214)
        at datadog.trace.api.Config.<clinit>(Config.java:6062)
        at datadog.trace.agent.tooling.MeterInstaller.installMeter(MeterInstaller.java:26)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at datadog.trace.bootstrap.Agent.installDatadogMeter(Agent.java:806)
        at datadog.trace.bootstrap.Agent.access$300(Agent.java:88)
        at datadog.trace.bootstrap.Agent$InstallDatadogTracerCallback.<init>(Agent.java:661)
        at datadog.trace.bootstrap.Agent.start(Agent.java:392)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:166)
        at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:73)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at datadog.trace.bootstrap.AgentPreCheck.continueBootstrap(AgentPreCheck.java:171)
        at datadog.trace.bootstrap.AgentPreCheck.agentmain(AgentPreCheck.java:26)
        at datadog.trace.bootstrap.AgentPreCheck.premain(AgentPreCheck.java:19)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
        at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
