### PR TITLE
Request feature flag config on the first RC poll

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -678,11 +678,12 @@ public class Agent {
       maybeStartAppSec(scoClass, sco);
       maybeStartCiVisibility(instrumentation, scoClass, sco);
       maybeStartLLMObs(instrumentation, scoClass, sco);
-      // start debugger before remote config to subscribe to it before starting to poll
+      // Start RC-backed products before remote config so their products and capabilities are
+      // included in the first poll.
       maybeStartDebugger(instrumentation, scoClass, sco);
+      maybeStartFeatureFlagging(scoClass, sco);
       maybeStartRemoteConfig(scoClass, sco);
       maybeStartAiGuard();
-      maybeStartFeatureFlagging(scoClass, sco);
 
       if (telemetryEnabled) {
         startTelemetry(instrumentation, scoClass, sco);

--- a/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
+++ b/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
@@ -51,13 +51,15 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  void 'test remote config'() {
+  void 'test remote config includes feature flags on first poll'() {
     when:
     final rcRequest = waitForRcClientRequest { req ->
-      decodeProducts(req).find { it == Product.FFE_FLAGS } != null
+      return true
     }
 
     then:
+    rcRequest == rcClientMessages.first()
+    decodeProducts(rcRequest).find { it == Product.FFE_FLAGS } != null
     final capabilities = decodeCapabilities(rcRequest)
     hasCapability(capabilities, Capabilities.CAPABILITY_FFE_FLAG_CONFIGURATION_RULES)
   }

--- a/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
+++ b/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
@@ -51,16 +51,18 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  void 'test remote config includes feature flags on first poll'() {
+  void 'test first remote config poll asks agent for feature flags'() {
     when:
-    final rcRequest = waitForRcClientRequest { req ->
+    final firstRcRequest = waitForRcClientRequest { req ->
       return true
     }
 
     then:
-    rcRequest == rcClientMessages.first()
-    decodeProducts(rcRequest).find { it == Product.FFE_FLAGS } != null
-    final capabilities = decodeCapabilities(rcRequest)
+    firstRcRequest == rcClientMessages.first()
+    // An already-running Agent gives a newly-started tracer one new-client cache bypass. If
+    // FFE_FLAGS is missing here and only appears on a later poll, the Agent can miss the fast path.
+    decodeProducts(firstRcRequest).find { it == Product.FFE_FLAGS } != null
+    final capabilities = decodeCapabilities(firstRcRequest)
     hasCapability(capabilities, Capabilities.CAPABILITY_FFE_FLAG_CONFIGURATION_RULES)
   }
 


### PR DESCRIPTION
## Motivation
A customer can hit this even when the Datadog Agent has already been running for hours. The important moment is when the Java tracer starts.

When a new tracer RC client first talks to the Agent, the Agent has a fast path to fetch config for that new client. If Java's first RC request does not ask for `FFE_FLAGS`, the Agent cannot fetch feature flag config on that fast path. Java may ask for `FFE_FLAGS` on a later poll, but by then the Agent already knows that RC client, so the later request can wait for the normal Agent refresh path. That is the startup window where the OpenFeature provider can stay on default values even though the application is already running.

This PR makes Java ask for feature flag config on the first RC request from the tracer. That lets an already-running Agent fetch `FFE_FLAGS` immediately for the newly-started tracer, instead of discovering the product after the new-client fast path was missed.

## Changes
Start the feature flagging subsystem before the shared remote-config poller is started from Agent startup. Feature flagging already registers the `FFE_FLAGS` listener and capability with the shared poller; moving it before `maybeStartRemoteConfig` ensures those fields are present when the immediate first poll is scheduled.

The OpenFeature smoke test now asserts the first captured `/v0.7/config` request already includes `FFE_FLAGS` and `CAPABILITY_FFE_FLAG_CONFIGURATION_RULES`. The test comment calls out why this is the important behavior: for an Agent that is already running, the first request from this newly-started tracer is the request that can use the Agent's new-client cache bypass.

## Decisions
This mirrors the Go tracer early FFE RC subscription pattern without changing provider evaluation semantics, initialization timeout behavior, or the Agent remote-config service. In Go, `startRemoteConfig` calls `internalffe.SubscribeRC()` before starting the RC client when the flagging provider is enabled: https://github.com/DataDog/dd-trace-go/blob/080ee3ab146e57344317a5ac48b2686735bf10fb/ddtrace/tracer/remote_config.go#L510-L512. The OpenFeature subscription helper documents the same first-poll requirement: https://github.com/DataDog/dd-trace-go/blob/080ee3ab146e57344317a5ac48b2686735bf10fb/internal/openfeature/rc_subscription.go#L42-L45.

The smoke test is intentionally tracer-side because it checks the invariant dd-trace-java owns: the tracer must advertise FFE on its first RC request. A full Nasdaq reproduction still belongs in system-tests or Agent coverage: Agent already running with no `FFE_FLAGS` cache, backend able to return FFE only after the new tracer advertises that product, and the first tracer response validated for fast delivery.