### PR TITLE
Reduce wait time for test job to run as soon as their needed build job is finished

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -542,6 +542,9 @@ check_debugger:
 
 muzzle:
   extends: .gradle_build
+  # needs:parallel:matrix limits this job to a specific build_tests combination.
+  # Keep matrix vars exact and in build_tests declaration order:
+  # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
   needs: &needs_build_tests_inst
     - job: build_tests
       parallel:
@@ -736,7 +739,10 @@ agent_integration_tests:
 
 test_base:
   extends: .test_job
-  needs: &needs_build_tests_base
+  # needs:parallel:matrix limits this job to a specific build_tests combination.
+  # Keep matrix vars exact and in build_tests declaration order:
+  # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
+  needs:
     - job: build_tests
       parallel:
         matrix:
@@ -762,7 +768,10 @@ test_inst:
 
 test_inst_latest:
   extends: .test_job_with_test_agent
-  needs: &needs_build_tests_latestdep
+  # needs:parallel:matrix limits this job to a specific build_tests combination.
+  # Keep matrix vars exact and in build_tests declaration order:
+  # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
+  needs:
     - job: build_tests
       parallel:
         matrix:
@@ -813,7 +822,10 @@ test_flaky_inst:
 
 test_profiling:
   extends: .test_job
-  needs: &needs_build_tests_profiling
+  # needs:parallel:matrix limits this job to a specific build_tests combination.
+  # Keep matrix vars exact and in build_tests declaration order:
+  # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
+  needs:
     - job: build_tests
       parallel:
         matrix:
@@ -838,6 +850,9 @@ test_debugger:
 
 test_smoke:
   extends: .test_job
+  # needs:parallel:matrix limits this job to a specific build_tests combination.
+  # Keep matrix vars exact and in build_tests declaration order:
+  # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
   needs: &needs_build_tests_smoke
     - job: build_tests
       parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -542,7 +542,12 @@ check_debugger:
 
 muzzle:
   extends: .gradle_build
-  needs: [ build_tests ]
+  needs: &needs_build_tests_inst
+    - job: build_tests
+      parallel:
+        matrix:
+          - GRADLE_TARGET: ":instrumentationTest"
+            CACHE_TYPE: "inst"
   stage: tests
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
@@ -580,7 +585,7 @@ muzzle:
 
 muzzle-dep-report:
   extends: .gradle_build
-  needs: [ build_tests ]
+  needs: *needs_build_tests_inst
   stage: tests
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
@@ -731,6 +736,12 @@ agent_integration_tests:
 
 test_base:
   extends: .test_job
+  needs: &needs_build_tests_base
+    - job: build_tests
+      parallel:
+        matrix:
+          - GRADLE_TARGET: ":baseTest"
+            CACHE_TYPE: "base"
   variables:
     GRADLE_TARGET: ":baseTest"
     CACHE_TYPE: "base"
@@ -742,6 +753,7 @@ test_base:
 
 test_inst:
   extends: .test_job_with_test_agent
+  needs: *needs_build_tests_inst
   variables:
     GRADLE_TARGET: ":instrumentationTest"
     CACHE_TYPE: "inst"
@@ -750,6 +762,12 @@ test_inst:
 
 test_inst_latest:
   extends: .test_job_with_test_agent
+  needs: &needs_build_tests_latestdep
+    - job: build_tests
+      parallel:
+        matrix:
+          - GRADLE_TARGET: ":instrumentationLatestDepTest"
+            CACHE_TYPE: "latestdep"
   variables:
     GRADLE_TARGET: ":instrumentationLatestDepTest"
     CACHE_TYPE: "latestdep"
@@ -780,6 +798,7 @@ test_flaky:
 
 test_flaky_inst:
   extends: .test_job
+  needs: *needs_build_tests_inst
   variables:
     GRADLE_TARGET: ":instrumentationTest"
     GRADLE_PARAMS: "-PrunFlakyTests"
@@ -794,6 +813,12 @@ test_flaky_inst:
 
 test_profiling:
   extends: .test_job
+  needs: &needs_build_tests_profiling
+    - job: build_tests
+      parallel:
+        matrix:
+          - GRADLE_TARGET: ":profilingTest"
+            CACHE_TYPE: "profiling"
   variables:
     GRADLE_TARGET: ":profilingTest"
     CACHE_TYPE: "profiling"
@@ -813,6 +838,13 @@ test_debugger:
 
 test_smoke:
   extends: .test_job
+  needs: &needs_build_tests_smoke
+    - job: build_tests
+      parallel:
+        matrix:
+          - GRADLE_TARGET: ":smokeTest"
+            CACHE_TYPE: "smoke"
+            MAVEN_OPTS: "-Xms256M -Xmx1024M"
   variables:
     GRADLE_TARGET: "stageMainDist :smokeTest"
     GRADLE_PARAMS: "-PskipFlakyTests"
@@ -822,6 +854,7 @@ test_smoke:
 
 test_ssi_smoke:
   extends: .test_job
+  needs: *needs_build_tests_smoke
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
       when: on_success
@@ -839,6 +872,7 @@ test_ssi_smoke:
 
 test_smoke_graalvm:
   extends: .test_job
+  needs: *needs_build_tests_smoke
   tags: [ "arch:amd64" ]
   variables:
     GRADLE_TARGET: "stageMainDist :dd-smoke-test:spring-boot-3.0-native:test"
@@ -851,6 +885,7 @@ test_smoke_graalvm:
 
 test_smoke_semeru8_debugger:
   extends: .test_job
+  needs: *needs_build_tests_smoke
   tags: [ "arch:amd64" ]
   variables:
     GRADLE_TARGET: "stageMainDist dd-smoke-tests:debugger-integration-tests:test"


### PR DESCRIPTION
# What Does This Do

Narrows selected GitLab `tests`-stage jobs from `needs: [ build_tests ]` to `needs:parallel:matrix` entries that point at the matching `build_tests` matrix row.

This covers the `base`, `profiling`, `instrumentation`, `latest-dependency` `instrumentation`, `smoke`, and `muzzle` jobs that have a build matrix counterpart. Jobs without a direct counterpart keep the inherited default dependency behavior.

<img width="799" height="1189" alt="Screenshot 2026-05-27 at 17 32 24" src="https://github.com/user-attachments/assets/c5e35f0c-856c-43e2-af8c-a435064420ed" />
<img width="809" height="1145" alt="Screenshot 2026-05-27 at 17 34 36" src="https://github.com/user-attachments/assets/1ca59d16-2a78-423d-8811-a77c4366f6fe" />



# Motivation

Test jobs were only started when all tests have been built. Allowing to run test jobs sooner reduces the feedback loop.


Technically a `needs` entry that references a parallel matrix job waits for every generated job in that matrix by default.

Using `needs:parallel:matrix` lets each mapped test job wait only for the build row it actually needs.

Relevant GitLab docs:

- https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
- https://docs.gitlab.com/ci/jobs/job_control/#specify-a-parallelized-job-using-needs-with-multiple-parallelized-jobs

# Additional Notes

Later, we'll run on GitLab 18.6 or later, matrix expressions could reduce the static repetition here in a future cleanup. In particular, `$[[ matrix.IDENTIFIER ]]` can express 1:1 dependencies between parallel matrix jobs at pipeline creation time, if the downstream job matrix carries the same selector identifiers.

Docs: https://docs.gitlab.com/ci/yaml/matrix_expressions/