### PR TITLE
Add VisibleForTesting annotation

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
+++ b/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
@@ -1,5 +1,6 @@
 package datadog.communication.serialization;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.nio.ByteBuffer;
 
 public final class FlushingBuffer implements StreamingBuffer {
@@ -106,7 +107,7 @@ public final class FlushingBuffer implements StreamingBuffer {
     mark = 0;
   }
 
-  // for tests only
+  @VisibleForTesting
   int getMessageCount() {
     return messageCount;
   }

--- a/components/annotations/build.gradle.kts
+++ b/components/annotations/build.gradle.kts
@@ -1,0 +1,1 @@
+apply(from = "$rootDir/gradle/java.gradle")

--- a/components/annotations/src/main/java/datadog/trace/api/internal/VisibleForTesting.java
+++ b/components/annotations/src/main/java/datadog/trace/api/internal/VisibleForTesting.java
@@ -1,0 +1,10 @@
+package datadog.trace.api.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+public @interface VisibleForTesting {}

--- a/components/environment/build.gradle.kts
+++ b/components/environment/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 apply(from = "$rootDir/gradle/java.gradle")
 
+dependencies {
+  compileOnly(project(":components:annotations"))
+}
+
 /*
  * Add an addition gradle configuration to be consumed by bootstrap only.
  * "datadog.trace." prefix is required to be excluded from Jacoco instrumentation.

--- a/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
+++ b/components/environment/src/main/java/datadog/environment/JavaVirtualMachine.java
@@ -1,5 +1,6 @@
 package datadog.environment;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
@@ -212,7 +213,7 @@ public final class JavaVirtualMachine {
           SystemProperties.get("java.vendor.version"));
     }
 
-    // Only visible for testing
+    @VisibleForTesting
     Runtime(String javaVer, String rtVer, String name, String vendor, String vendorVersion) {
       this.name = name == null ? "" : name;
       this.vendor = vendor == null ? "" : vendor;

--- a/components/environment/src/main/java/datadog/environment/JvmOptions.java
+++ b/components/environment/src/main/java/datadog/environment/JvmOptions.java
@@ -5,6 +5,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -93,7 +94,7 @@ class JvmOptions {
 
   // Be aware that when running a native image, the command line in /proc/self/cmdline is just the
   // executable
-  // Visible for testing
+  @VisibleForTesting
   List<String> findVmOptionsFromProcFs(String[] procfsCmdline) {
     // Create the list of VM options
     List<String> vmOptions = new ArrayList<>();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationErrors.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationErrors.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
@@ -30,7 +31,7 @@ public class InstrumentationErrors {
     return error; // keep throwable at top of the stack
   }
 
-  // Visible for testing
+  @VisibleForTesting
   public static void resetErrors() {
     COUNTER.set(0);
     if (detailed) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap;
 
+import datadog.trace.api.internal.VisibleForTesting;
+
 /**
  * Weak {@link ContextStore} that acts as a fall-back when field-injection isn't possible.
  *
@@ -85,7 +87,7 @@ final class WeakMapContextStore<K, V> implements ContextStore<K, V> {
     return (V) map.remove(key);
   }
 
-  // Package reachable for testing
+  @VisibleForTesting
   int size() {
     return map.size();
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
@@ -6,6 +6,7 @@ import static java.lang.ClassLoader.getSystemClassLoader;
 
 import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -187,7 +188,7 @@ public class BlockingActionHelper {
     return mediaRangeMatcher.group(1);
   }
 
-  // public for testing
+  @VisibleForTesting
   public static void reset(Config config) {
     TEMPLATE_HTML = null;
     TEMPLATE_JSON = null;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/dbm/SharedDBCommenter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/dbm/SharedDBCommenter.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 import datadog.trace.api.BaseHash;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.io.UnsupportedEncodingException;
@@ -88,7 +89,7 @@ public class SharedDBCommenter {
     staticPrefixComputed = true;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   public static void resetStaticPrefixForTesting() {
     staticPrefixComputed = false;
   }

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/ConfigManager.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/ConfigManager.java
@@ -8,6 +8,7 @@ import datadog.environment.SystemProperties;
 import datadog.trace.api.Config;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.WellKnownTags;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.util.PidHelper;
 import datadog.trace.util.RandomUtils;
 import java.io.BufferedReader;
@@ -137,7 +138,7 @@ public class ConfigManager {
         return this;
       }
 
-      // @VisibleForTesting
+      @VisibleForTesting
       Builder reportUUID(String reportUUID) {
         this.reportUUID = reportUUID;
         return this;
@@ -170,7 +171,7 @@ public class ConfigManager {
     return filename.substring(0, dotIndex);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   static String getMergedTagsForSerialization(Config config) {
     return config.getMergedCrashTrackingTags().entrySet().stream()
         .filter(e -> e.getValue() != null)
@@ -195,7 +196,7 @@ public class ConfigManager {
     writeConfigToFile(Config.get(), cfgFile, additionalEntries);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   static void writeConfigToFile(Config config, File cfgFile, String... additionalEntries) {
     final WellKnownTags wellKnownTags = config.getWellKnownTags();
 

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
@@ -24,6 +24,7 @@ import datadog.crashtracking.dto.OSInfo;
 import datadog.environment.SystemProperties;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.AgentThreadFactory;
 import datadog.trace.util.PidHelper;
@@ -187,7 +188,7 @@ public final class CrashUploader {
     }
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void sendPingToTelemetry(String error) {
     // send a ping message to the telemetry to notify that the crash report started
     try (Buffer buf = new Buffer();
@@ -207,7 +208,7 @@ public final class CrashUploader {
     }
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void sendPingToErrorTracking(String error) {
     try {
       final CrashLog ping =
@@ -253,7 +254,7 @@ public final class CrashUploader {
     }
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void remoteUpload(
       @Nonnull String fileContent, boolean sendToTelemetry, boolean sendToErrorTracking) {
     final String uuid = storedConfig.reportUUID;
@@ -316,7 +317,7 @@ public final class CrashUploader {
     }
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   @SuppressForbidden
   static String extractErrorKind(String fileContent) {
     Matcher matcher = ERROR_MESSAGE_PATTERN.matcher(fileContent);
@@ -348,7 +349,7 @@ public final class CrashUploader {
               "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
-  // @VisibleForTesting
+  @VisibleForTesting
   @SuppressForbidden
   static String extractErrorMessage(String fileContent) {
     Matcher matcher = ERROR_MESSAGE_PATTERN.matcher(fileContent);

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploaderScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploaderScriptInitializer.java
@@ -8,6 +8,7 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static java.util.Locale.ROOT;
 
 import datadog.environment.SystemProperties;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.util.PidHelper;
 import datadog.trace.util.Strings;
 import java.io.BufferedReader;
@@ -25,12 +26,12 @@ public final class CrashUploaderScriptInitializer {
 
   private CrashUploaderScriptInitializer() {}
 
-  // @VisibleForTests
+  @VisibleForTesting
   static void initialize(String onErrorVal, String onErrorFile) {
     initialize(onErrorVal, onErrorFile, null);
   }
 
-  // @VisibleForTests
+  @VisibleForTesting
   static void initialize(String onErrorVal, String onErrorFile, String javacorePath) {
     if (onErrorVal == null || onErrorVal.isEmpty()) {
       LOG.debug(

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/OOMENotifierScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/OOMENotifierScriptInitializer.java
@@ -8,6 +8,7 @@ import static datadog.crashtracking.Initializer.getScriptPathFromArg;
 import static datadog.crashtracking.Initializer.pidFromSpecialFileName;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.util.PidHelper;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -20,7 +21,7 @@ public final class OOMENotifierScriptInitializer {
 
   private OOMENotifierScriptInitializer() {}
 
-  // @VisibleForTests
+  @VisibleForTesting
   static void initialize(String onOutOfMemoryVal) {
     if (onOutOfMemoryVal == null || onOutOfMemoryVal.isEmpty()) {
       LOG.debug(

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/RedactUtils.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/RedactUtils.java
@@ -1,5 +1,6 @@
 package datadog.crashtracking.parsers;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -215,7 +216,7 @@ public final class RedactUtils {
    * java.lang.Class} oop) use {@link #redactRegisterToMemoryMapping} which detects the oop type
    * automatically.
    */
-  // @VisibleForTesting
+  @VisibleForTesting
   static String redactDottedClassOopRef(String line) {
     return redactStringOopRef(line, false);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -15,6 +15,7 @@ import com.datadog.debugger.util.SpringHelper;
 import datadog.environment.JavaVirtualMachine;
 import datadog.logging.RatelimitedLogger;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
@@ -445,7 +446,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     currentTransformer = null;
   }
 
-  // only visible for tests
+  @VisibleForTesting
   Map<String, ProbeDefinition> getAppliedDefinitions() {
     if (currentTransformer == null) {
       return Collections.emptyMap();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -5,6 +5,7 @@ import com.datadog.debugger.probe.ExceptionProbe;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.debugger.DebuggerContext.SkipCause;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.util.AgentTaskScheduler;
@@ -159,7 +160,7 @@ public class DebuggerSink {
             TimeUnit.MILLISECONDS);
   }
 
-  // visible for testing
+  @VisibleForTesting
   void lowRateFlush(DebuggerSink ignored) {
     symbolSink.flush();
     probeStatusSink.flush(tags);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -7,6 +7,7 @@ import datadog.common.container.ContainerInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.logging.RatelimitedLogger;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.util.AgentThreadFactory;
 import java.io.IOException;
 import java.time.Duration;
@@ -124,7 +125,7 @@ public class BatchUploader {
         ContainerInfo.getEntityId());
   }
 
-  // Visible for testing
+  @VisibleForTesting
   BatchUploader(
       String name,
       Config config,
@@ -220,10 +221,7 @@ public class BatchUploader {
     }
   }
 
-  /**
-   * Note that this method is only visible for testing and should not be used from outside this
-   * class.
-   */
+  @VisibleForTesting
   OkHttpClient getClient() {
     return client;
   }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.logging;
 
 import datadog.environment.OperatingSystem;
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -17,7 +18,7 @@ public class PrintStreamWrapper extends PrintStream {
     super(ps);
   }
 
-  // use for tests only
+  @VisibleForTesting
   public OutputStream getOriginalPrintStream() {
     return super.out;
   }

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/logs/OtelLogRecordBuilder.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/logs/OtelLogRecordBuilder.java
@@ -3,6 +3,7 @@ package datadog.opentelemetry.shim.logs;
 import static datadog.opentelemetry.shim.trace.OtelExtractedContext.extract;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.otel.logs.data.OtelLogRecordProcessor;
@@ -23,8 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 final class OtelLogRecordBuilder implements LogRecordBuilder {
-  // package-visible for testing
-  static TimeSource TIME_SOURCE = SystemTimeSource.INSTANCE;
+  @VisibleForTesting static TimeSource TIME_SOURCE = SystemTimeSource.INSTANCE;
 
   private static final AttributeKey<String> EXCEPTION_TYPE_KEY = stringKey("exception.type");
   private static final AttributeKey<String> EXCEPTION_MESSAGE_KEY = stringKey("exception.message");

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerOngoingRecording.java
@@ -20,6 +20,7 @@ import com.datadog.profiling.controller.ProfilerSettingsSupport;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.ddprof.DatadogProfiler;
 import datadog.environment.JavaVirtualMachine;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.api.profiling.RecordingData;
 import java.time.Instant;
@@ -52,7 +53,7 @@ public class DatadogProfilerOngoingRecording implements OngoingRecording {
     return recording.stop();
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   final RecordingData snapshot(final Instant start) {
     return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -3,6 +3,7 @@ package com.datadog.profiling.controller.openjdk;
 import com.datadog.profiling.controller.ControllerContext;
 import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.utils.ProfilingMode;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
@@ -135,7 +136,7 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     return new OpenJdkRecordingData(recording, ProfilingSnapshot.Kind.PERIODIC);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   final RecordingData snapshot(@Nonnull final Instant start) {
     return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
@@ -15,6 +15,7 @@
  */
 package com.datadog.profiling.controller.openjdk;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.api.profiling.RecordingInputStream;
 import java.io.IOException;
@@ -54,7 +55,7 @@ public class OpenJdkRecordingData extends RecordingData {
     return recording.getName();
   }
 
-  // Visible for testing
+  @VisibleForTesting
   Recording getRecording() {
     return recording;
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCache.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/SmapEntryCache.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.controller.openjdk.events;
 
 import datadog.environment.JavaVirtualMachine;
+import datadog.trace.api.internal.VisibleForTesting;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,7 +61,7 @@ final class SmapEntryCache {
     this.smapsPath = smapsPath;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void invalidate() {
     UPDATER.getAndSet(this, System.nanoTime() - (2 * ttl));
   }
@@ -81,7 +82,7 @@ final class SmapEntryCache {
     return (List<SmapEntryEvent>) events[index];
   }
 
-  // accessible for testing
+  @VisibleForTesting
   static AnnotatedRegion fromAnnotatedEntry(String line, int javaVersion) {
     boolean isRegion = line.startsWith("0x");
     if (isRegion) {
@@ -149,7 +150,7 @@ final class SmapEntryCache {
     return ((firstChar >= '0' && firstChar <= '9') || (firstChar >= 'a' && firstChar <= 'f'));
   }
 
-  // accessible for testing
+  @VisibleForTesting
   static void readEvents(BufferedReader br, List<SmapEntryEvent> events) throws IOException {
     String line = br.readLine();
     while (line != null) {

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.controller.oracle;
 
 import com.datadog.profiling.controller.OngoingRecording;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.IOException;
 import java.time.Duration;
@@ -52,7 +53,7 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
     }
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   final OracleJdkRecordingData snapshot(@Nonnull final Instant start) {
     return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -22,6 +22,7 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.PROFILER_RECORDING_SCHEDULER;
 
 import datadog.environment.JavaVirtualMachine;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilerFlareLogger;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.api.profiling.RecordingData;
@@ -238,7 +239,7 @@ public final class ProfilingSystem {
     return started;
   }
 
-  /** VisibleForTesting */
+  @VisibleForTesting
   final Duration getStartupDelay() {
     return startupDelay;
   }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -38,6 +38,7 @@ import com.datadoghq.profiler.JavaProfiler;
 import datadog.environment.JavaVirtualMachine;
 import datadog.libs.ddprof.DdprofLibraryLoader;
 import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.TaskWrapper;
@@ -115,7 +116,7 @@ public final class DatadogProfiler {
     this(configProvider, getContextAttributes(configProvider));
   }
 
-  // visible for testing
+  @VisibleForTesting
   DatadogProfiler(ConfigProvider configProvider, Set<String> contextAttributes) {
     this.configProvider = configProvider;
     this.profiler = DdprofLibraryLoader.javaProfiler().getComponent();

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerRecording.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.ddprof;
 
 import com.datadog.profiling.controller.OngoingRecording;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.api.profiling.RecordingData;
 import java.io.IOException;
@@ -37,7 +38,7 @@ final class DatadogProfilerRecording implements OngoingRecording {
         recordingFile, started, Instant.now(), ProfilingSnapshot.Kind.ON_SHUTDOWN);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   final RecordingData snapshot(@Nonnull Instant start) {
     return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }
@@ -62,7 +63,7 @@ final class DatadogProfilerRecording implements OngoingRecording {
     }
   }
 
-  // used for tests only
+  @VisibleForTesting
   Path getRecordingFile() {
     return recordingFile;
   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -31,6 +31,7 @@ import datadog.trace.api.Platform;
 import datadog.trace.api.ProcessTags;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.api.profiling.RecordingType;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
@@ -134,10 +135,7 @@ public final class ProfileUploader {
     this(config, configProvider, new IOLogger(log), TERMINATION_TIMEOUT_SEC);
   }
 
-  /**
-   * Note that this method is only visible for testing and should not be used from outside this
-   * class.
-   */
+  @VisibleForTesting
   ProfileUploader(
       final Config config,
       final ConfigProvider configProvider,
@@ -443,10 +441,7 @@ public final class ProfileUploader {
         .collect(Collectors.toList());
   }
 
-  /**
-   * Note that this method is only visible for testing and should not be used from outside this
-   * class.
-   */
+  @VisibleForTesting
   OkHttpClient getClient() {
     return client;
   }

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/CompositeController.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/CompositeController.java
@@ -17,6 +17,7 @@ import datadog.environment.SystemProperties;
 import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilerFlareLogger;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.api.profiling.RecordingData;
@@ -50,7 +51,7 @@ public class CompositeController implements Controller {
     this.controllers = controllers;
   }
 
-  // visible for testing
+  @VisibleForTesting
   public List<Controller> getControllers() {
     return Collections.unmodifiableList(controllers);
   }

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ScrubRecordingDataListener.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ScrubRecordingDataListener.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import com.datadog.profiling.scrubber.DefaultScrubDefinition;
 import com.datadog.profiling.scrubber.JfrScrubber;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.api.profiling.RecordingDataListener;
 import datadog.trace.api.profiling.RecordingInputStream;
@@ -45,7 +46,7 @@ final class ScrubRecordingDataListener implements RecordingDataListener {
     this(delegate, scrubber, failOpen, null);
   }
 
-  // visible for testing
+  @VisibleForTesting
   ScrubRecordingDataListener(
       RecordingDataListener delegate, JfrScrubber scrubber, boolean failOpen, Path tempDir) {
     this.delegate = delegate;

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -60,6 +60,7 @@ tasks.named("compileJava") {
 dependencies {
   implementation sourceSets.main_java11.output
   main_java11CompileOnly libs.forbiddenapis
+  main_java6CompileOnly project(':components:annotations')
   main_java6CompileOnly libs.forbiddenapis
   testImplementation sourceSets.main_java6.output
 }

--- a/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
+++ b/dd-java-agent/src/main/java6/datadog/trace/bootstrap/AgentPreCheck.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -91,9 +92,9 @@ public class AgentPreCheck {
     return compatible(javaVersion, javaHome, System.err);
   }
 
-  // Reachable for testing
   // System.getenv usage is necessary since class is designed to be Java 6 compatible, while
   // Environment component is for Java 8+
+  @VisibleForTesting
   @SuppressForbidden
   static boolean compatible(String javaVersion, String javaHome, PrintStream output) {
     int majorJavaVersion = parseJavaMajorVersion(javaVersion);
@@ -114,7 +115,7 @@ public class AgentPreCheck {
     return false;
   }
 
-  // Reachable for testing
+  @VisibleForTesting
   static int parseJavaMajorVersion(String javaVersion) {
     int major = 0;
     if (javaVersion == null || javaVersion.isEmpty()) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
@@ -3,6 +3,7 @@ package datadog.trace.common.writer;
 import datadog.environment.OperatingSystem;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.core.DDSpan;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.FileOutputStream;
@@ -82,7 +83,7 @@ public class TraceStructureWriter implements Writer {
     return parseArgs(outputFile, OperatingSystem.isWindows());
   }
 
-  // package visibility for testing
+  @VisibleForTesting
   static String[] parseArgs(String outputFile, boolean windows) {
     String[] args = ARGS_DELIMITER.split(outputFile);
     // Check Windows absolute paths (<drive>:<path>) as column is used as arg delimiter

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -9,6 +9,7 @@ import datadog.communication.serialization.WritableFormatter;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.TagMap;
 import datadog.trace.api.TagMap.EntryReader;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.common.writer.Payload;
@@ -125,12 +126,12 @@ public final class TraceMapperV0_5 implements TraceMapper {
     return "v0.5";
   }
 
-  // Visible for tests
+  @VisibleForTesting
   Map<Object, Integer> getEncoding() {
     return encoding;
   }
 
-  // Visible for tests
+  @VisibleForTesting
   GrowableBuffer getDictionary() {
     return dictionary;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -53,6 +53,7 @@ import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.metrics.SpanMetricRegistry;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.api.remoteconfig.ServiceNameCollector;
@@ -1391,7 +1392,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     return "0";
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   TraceInterceptors getInterceptors() {
     return interceptors;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -19,6 +19,7 @@ import datadog.trace.api.TraceConfig;
 import datadog.trace.api.debugger.DebuggerConfigBridge;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.metrics.SpanMetricRegistry;
 import datadog.trace.api.metrics.SpanMetrics;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -125,7 +126,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
    * @param timestampMicro if greater than zero, use this time instead of the current time
    * @param context the context used for the span
    */
-  // @VisibleForTesting
+  @VisibleForTesting
   DDSpan(
       @Nonnull String instrumentationName,
       final long timestampMicro,
@@ -681,7 +682,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
     return durationNano;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void setDurationNano(long duration) {
     DURATION_NANO_UPDATER.set(this, duration);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/LongRunningTracesTracker.java
@@ -3,6 +3,7 @@ package datadog.trace.core;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.core.monitor.HealthMetrics;
 import java.util.ArrayList;
 import java.util.List;
@@ -140,12 +141,12 @@ public class LongRunningTracesTracker {
     expired = 0;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int trackedCount() {
     return traceArray.size();
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getDropped() {
     return dropped;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -2,6 +2,7 @@ package datadog.trace.core;
 
 import datadog.metrics.api.Recording;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.core.CoreTracer.ConfigSnapshot;
@@ -139,7 +140,7 @@ public class PendingTrace extends TraceCollector implements PendingTraceBuffer.E
   private static final AtomicLongFieldUpdater<PendingTrace> LAST_REFERENCED =
       AtomicLongFieldUpdater.newUpdater(PendingTrace.class, "lastReferenced");
 
-  // @VisibleForTesting
+  @VisibleForTesting
   PendingTrace(
       @Nonnull CoreTracer tracer,
       @Nonnull DDTraceId traceId,
@@ -224,37 +225,37 @@ public class PendingTrace extends TraceCollector implements PendingTraceBuffer.E
     return LONG_RUNNING_STATE.compareAndSet(this, expected, newState);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getLongRunningTrackedState() {
     return longRunningTrackedState;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   void setLongRunningTrackedState(int state) {
     LONG_RUNNING_STATE.set(this, state);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getPendingReferenceCount() {
     return pendingReferenceCount;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   PendingTraceBuffer getPendingTraceBuffer() {
     return pendingTraceBuffer;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   DDTraceId getTraceId() {
     return traceId;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   boolean isRootSpanWritten() {
     return rootSpanWritten;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getIsEnqueued() {
     return isEnqueued;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -11,6 +11,7 @@ import datadog.common.queue.Queues;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.flare.TracerFlare;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.common.writer.TraceDumpJsonExporter;
 import datadog.trace.core.monitor.HealthMetrics;
@@ -304,17 +305,17 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
               : null;
     }
 
-    // @VisibleForTesting
+    @VisibleForTesting
     LongRunningTracesTracker getRunningTracesTracker() {
       return runningTracesTracker;
     }
 
-    // @VisibleForTesting
+    @VisibleForTesting
     Thread getWorker() {
       return worker;
     }
 
-    // @VisibleForTesting
+    @VisibleForTesting
     MessagePassingBlockingQueue<Element> getQueue() {
       return queue;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -16,6 +16,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.api.propagation.W3CTraceParent;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -40,10 +41,9 @@ class W3CHttpCodec {
   private static final int TRACE_PARENT_FLAGS_SAMPLED = 1;
   private static final int TRACE_PARENT_LENGTH = TRACE_PARENT_FLAGS_START + 2;
 
-  // Package-protected for testing
-  static final String TRACE_PARENT_KEY = "traceparent";
-  static final String TRACE_STATE_KEY = "tracestate";
-  static final String OT_BAGGAGE_PREFIX = "ot-baggage-";
+  @VisibleForTesting static final String TRACE_PARENT_KEY = "traceparent";
+  @VisibleForTesting static final String TRACE_STATE_KEY = "tracestate";
+  @VisibleForTesting static final String OT_BAGGAGE_PREFIX = "ot-baggage-";
   static final String E2E_START_KEY = OT_BAGGAGE_PREFIX + DDTags.TRACE_START_TIME;
 
   private W3CHttpCodec() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/HttpEndpointPostProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/HttpEndpointPostProcessor.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_URL;
 
 import datadog.trace.api.TagMap;
 import datadog.trace.api.endpoint.EndpointResolver;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.instrumentation.api.AppendableSpanLinks;
 import datadog.trace.core.DDSpanContext;
 import org.slf4j.Logger;
@@ -45,10 +46,9 @@ public class HttpEndpointPostProcessor extends TagsPostProcessor {
   /**
    * Creates a new HttpEndpointPostProcessor with the given endpoint resolver.
    *
-   * <p>Visible for testing.
-   *
    * @param endpointResolver the resolver to use for endpoint inference
    */
+  @VisibleForTesting
   HttpEndpointPostProcessor(EndpointResolver endpointResolver) {
     this.endpointResolver = endpointResolver;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
@@ -3,6 +3,7 @@ package datadog.trace.core.tagprocessor;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.TagMap;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AppendableSpanLinks;
@@ -22,7 +23,7 @@ public final class PeerServiceCalculator extends TagsPostProcessor {
     this(SpanNaming.instance().namingSchema().peerService(), Config.get().getPeerServiceMapping());
   }
 
-  // Visible for testing
+  @VisibleForTesting
   PeerServiceCalculator(
       @Nonnull final NamingSchema.ForPeerService peerServiceNaming,
       @Nonnull final Map<String, String> peerServiceMapping) {

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -260,6 +260,7 @@ dependencies {
   // references TraceScope and Continuation from public api
   api(project(":dd-trace-api"))
   api(libs.slf4j)
+  compileOnlyApi(project(":components:annotations"))
   api(project(":components:context"))
   api(project(":components:environment"))
   api(project(":components:json"))

--- a/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProcessTags.java
@@ -3,6 +3,7 @@ package datadog.trace.api;
 import datadog.environment.EnvironmentVariables;
 import datadog.environment.SystemProperties;
 import datadog.trace.api.env.CapturedEnvironment;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.util.TraceUtils;
 import java.nio.file.Path;
@@ -30,8 +31,7 @@ public class ProcessTags {
   public static final String ENTRYPOINT_BASEDIR = "entrypoint.basedir";
   public static final String ENTRYPOINT_WORKDIR = "entrypoint.workdir";
 
-  // visible for testing
-  static Function<String, String> envGetter = EnvironmentVariables::get;
+  @VisibleForTesting static Function<String, String> envGetter = EnvironmentVariables::get;
 
   private static class Lazy {
     // the tags are used to compute a hash for dsm hence that map must be sorted.
@@ -269,7 +269,7 @@ public class ProcessTags {
     return Lazy.serializedForm;
   }
 
-  /** Visible for testing. */
+  @VisibleForTesting
   static void empty() {
     synchronized (Lazy.TAGS) {
       Lazy.TAGS.clear();
@@ -279,12 +279,12 @@ public class ProcessTags {
     }
   }
 
-  /** Visible for testing. */
+  @VisibleForTesting
   static void reset() {
     reset(Config.get());
   }
 
-  /** Visible for testing. */
+  @VisibleForTesting
   public static void reset(Config config) {
     synchronized (Lazy.TAGS) {
       empty();

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/config/BazelMode.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/config/BazelMode.java
@@ -3,6 +3,7 @@ package datadog.trace.api.civisibility.config;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.config.inversion.ConfigHelper;
 import datadog.trace.util.Strings;
 import java.io.BufferedReader;
@@ -51,7 +52,7 @@ public class BazelMode {
     return INSTANCE;
   }
 
-  // visible for testing
+  @VisibleForTesting
   BazelMode(Config config) {
     String manifestRloc = config.getTestOptimizationManifestFile();
     if (Strings.isNotBlank(manifestRloc)) {
@@ -331,7 +332,7 @@ public class BazelMode {
     return null;
   }
 
-  // visible for testing
+  @VisibleForTesting
   static void reset() {
     INSTANCE = null;
   }

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/TransactionInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/TransactionInfo.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.datastreams;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -71,7 +72,7 @@ public final class TransactionInfo implements InboxItem {
     return buffer.array();
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   static synchronized void resetCache() {
     CACHE.clear();
     CACHE_BYTES = new byte[0];

--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilerFlareLogger.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilerFlareLogger.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.profiling;
 
 import datadog.trace.api.flare.TracerFlare;
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -23,7 +24,7 @@ public final class ProfilerFlareLogger implements TracerFlare.Reporter {
   private final List<String> flareReportLines = new ArrayList<>();
   private int usedReportCapacity = 0;
 
-  // @VisibleForTesting
+  @VisibleForTesting
   ProfilerFlareLogger() {
     TracerFlare.addReporter(this);
   }
@@ -76,17 +77,17 @@ public final class ProfilerFlareLogger implements TracerFlare.Reporter {
     cleanup();
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getUsedReportCapacity() {
     return usedReportCapacity;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int getMaxReportCapacity() {
     return REPORT_CAPACITY;
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   int linesSize() {
     synchronized (flareReportLines) {
       return flareReportLines.size();

--- a/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
@@ -3,6 +3,7 @@ package datadog.trace.api.remoteconfig;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.internal.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -73,7 +74,7 @@ public class ServiceNameCollector {
     services.clear();
   }
 
-  // Visible for testing
+  @VisibleForTesting
   static void setInstance(ServiceNameCollector instance) {
     INSTANCE = instance;
   }

--- a/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
+++ b/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
@@ -7,6 +7,7 @@ import static datadog.trace.util.ProcessSupervisor.Health.HEALTHY;
 import static datadog.trace.util.ProcessSupervisor.Health.INTERRUPTED;
 import static datadog.trace.util.ProcessSupervisor.Health.READY_TO_START;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.context.TraceScope;
 import java.io.Closeable;
@@ -146,7 +147,7 @@ public class ProcessSupervisor implements Closeable {
     }
   }
 
-  // Package reachable for testing
+  @VisibleForTesting
   Process getCurrentProcess() {
     return currentProcess;
   }

--- a/internal-api/src/main/java/datadog/trace/util/TempLocationManager.java
+++ b/internal-api/src/main/java/datadog/trace/util/TempLocationManager.java
@@ -2,6 +2,7 @@ package datadog.trace.util;
 
 import datadog.environment.SystemProperties;
 import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.profiling.ProfilerFlareLogger;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
@@ -307,7 +308,7 @@ public final class TempLocationManager {
     createTempDir(tempDir);
   }
 
-  // @VisibleForTesting
+  @VisibleForTesting
   static String getBaseTempDirName() {
     String userName = SystemProperties.get("user.name");
     // unlikely, but fall-back to system env based user name
@@ -399,7 +400,7 @@ public final class TempLocationManager {
     return false;
   }
 
-  // accessible for tests
+  @VisibleForTesting
   boolean waitForCleanup(long timeout, TimeUnit unit) {
     try {
       return cleanupTask.await(timeout, unit);
@@ -416,7 +417,7 @@ public final class TempLocationManager {
     return false;
   }
 
-  // accessible for tests
+  @VisibleForTesting
   void createDirStructure() throws IOException {
     Files.createDirectories(baseTempDir);
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -112,6 +112,7 @@ include(
 
 include(
   ":communication",
+  ":components:annotations",
   ":components:context",
   ":components:environment",
   ":components:http:http-api",

--- a/utils/config-utils/build.gradle.kts
+++ b/utils/config-utils/build.gradle.kts
@@ -55,6 +55,7 @@ val excludedClassesInstructionCoverage by extra(
 )
 
 dependencies {
+  compileOnly(project(":components:annotations"))
   implementation(project(":components:environment"))
   implementation(project(":dd-trace-api"))
   api(project(":utils:filesystem-utils"))

--- a/utils/config-utils/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/utils/config-utils/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -2,6 +2,7 @@ package datadog.trace.api.env;
 
 import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.config.inversion.ConfigHelper;
 import java.io.File;
 import java.util.HashMap;
@@ -24,12 +25,7 @@ public class CapturedEnvironment {
       mainClass = JavaVirtualMachine.getMainClass();
     }
 
-    /**
-     * Visible for testing
-     *
-     * @param mainClass
-     * @param jarFile
-     */
+    @VisibleForTesting
     ProcessInfo(String mainClass, File jarFile) {
       this.mainClass = mainClass;
       this.jarFile = jarFile;
@@ -55,17 +51,13 @@ public class CapturedEnvironment {
     return processInfo;
   }
 
-  // Testing purposes
+  @VisibleForTesting
   static void useFixedEnv(final Map<String, String> props) {
     INSTANCE.properties.clear();
     INSTANCE.properties.putAll(props);
   }
 
-  /**
-   * For testing purposes.
-   *
-   * @param processInfo
-   */
+  @VisibleForTesting
   static void useFixedProcessInfo(final ProcessInfo processInfo) {
     INSTANCE.processInfo = processInfo;
   }

--- a/utils/logging-utils/src/main/java/datadog/logging/IOLogger.java
+++ b/utils/logging-utils/src/main/java/datadog/logging/IOLogger.java
@@ -2,6 +2,7 @@ package datadog.logging;
 
 import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 
@@ -15,7 +16,7 @@ public class IOLogger {
     this(log, new RatelimitedLogger(log, 5, TimeUnit.MINUTES));
   }
 
-  // Visible for testing
+  @VisibleForTesting
   IOLogger(final Logger log, final RatelimitedLogger ratelimitedLogger) {
     this.log = log;
     this.ratelimitedLogger = ratelimitedLogger;

--- a/utils/logging-utils/src/main/java/datadog/logging/RatelimitedLogger.java
+++ b/utils/logging-utils/src/main/java/datadog/logging/RatelimitedLogger.java
@@ -1,5 +1,6 @@
 package datadog.logging;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
 import java.util.Locale;
@@ -25,7 +26,7 @@ public class RatelimitedLogger {
     this(log, delay, timeUnit, SystemTimeSource.INSTANCE);
   }
 
-  // Visible for testing
+  @VisibleForTesting
   RatelimitedLogger(
       final Logger log, final int delay, final TimeUnit timeUnit, final TimeSource timeSource) {
     this.log = log;


### PR DESCRIPTION
# What Does This Do

Adds a shared `@VisibleForTesting` annotation in `components:annotations`, exposes it through `internal-api`, and replaces testing-visibility comments on loosened members.

# Motivation

Make testing-only visibility explicit and reusable across modules.

# Additional Notes

Validated with `spotlessApply` and focused compile tasks.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`.

Jira ticket: [PROJ-IDENT]
