### PR TITLE
Recover OpenFeature provider after initialization timeout

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -58,7 +58,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   public boolean initialize(
       final long timeout, final TimeUnit unit, final EvaluationContext context) throws Exception {
     FeatureFlaggingGateway.addConfigListener(this);
-    return initializationLatch.await(timeout, unit); // await for initialization
+    return initializationLatch.getCount() == 0;
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -35,7 +35,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -48,17 +47,15 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
 
   private final Runnable configCallback;
   private final AtomicReference<ServerConfiguration> configuration = new AtomicReference<>();
-  private final CountDownLatch initializationLatch = new CountDownLatch(1);
 
   public DDEvaluator(final Runnable configCallback) {
     this.configCallback = configCallback;
   }
 
   @Override
-  public boolean initialize(
-      final long timeout, final TimeUnit unit, final EvaluationContext context) throws Exception {
+  public void initialize(final long timeout, final TimeUnit unit, final EvaluationContext context)
+      throws Exception {
     FeatureFlaggingGateway.addConfigListener(this);
-    return initializationLatch.getCount() == 0;
   }
 
   @Override
@@ -69,7 +66,6 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   @Override
   public void accept(final ServerConfiguration config) {
     configuration.set(config);
-    initializationLatch.countDown();
     configCallback.run();
   }
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -58,7 +58,12 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   public boolean initialize(
       final long timeout, final TimeUnit unit, final EvaluationContext context) throws Exception {
     FeatureFlaggingGateway.addConfigListener(this);
-    return initializationLatch.await(timeout, unit);
+    return initializationLatch.await(timeout, unit) || hasConfiguration();
+  }
+
+  @Override
+  public boolean hasConfiguration() {
+    return configuration.get() != null;
   }
 
   @Override
@@ -70,12 +75,8 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   public void accept(final ServerConfiguration config) {
     configuration.set(config);
     if (config != null) {
-      try {
-        configCallback.run();
-      } finally {
-        // Let OpenFeature emit READY when blocking initialization returns successfully.
-        initializationLatch.countDown();
-      }
+      initializationLatch.countDown();
+      configCallback.run();
     } else if (initializationLatch.getCount() == 0) {
       configCallback.run();
     }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -53,9 +53,10 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   @Override
-  public void initialize(final long timeout, final TimeUnit unit, final EvaluationContext context)
-      throws Exception {
+  public boolean initialize(
+      final long timeout, final TimeUnit unit, final EvaluationContext context) throws Exception {
     FeatureFlaggingGateway.addConfigListener(this);
+    return configuration.get() != null;
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -35,6 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -47,6 +48,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
 
   private final Runnable configCallback;
   private final AtomicReference<ServerConfiguration> configuration = new AtomicReference<>();
+  private final CountDownLatch initializationLatch = new CountDownLatch(1);
 
   public DDEvaluator(final Runnable configCallback) {
     this.configCallback = configCallback;
@@ -56,7 +58,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   public boolean initialize(
       final long timeout, final TimeUnit unit, final EvaluationContext context) throws Exception {
     FeatureFlaggingGateway.addConfigListener(this);
-    return configuration.get() != null;
+    return initializationLatch.await(timeout, unit);
   }
 
   @Override
@@ -67,7 +69,16 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   @Override
   public void accept(final ServerConfiguration config) {
     configuration.set(config);
-    configCallback.run();
+    if (config != null) {
+      try {
+        configCallback.run();
+      } finally {
+        // Let OpenFeature emit READY when blocking initialization returns successfully.
+        initializationLatch.countDown();
+      }
+    } else if (initializationLatch.getCount() == 0) {
+      configCallback.run();
+    }
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
@@ -8,6 +8,8 @@ interface Evaluator {
 
   boolean initialize(long timeout, TimeUnit timeUnit, EvaluationContext context) throws Exception;
 
+  boolean hasConfiguration();
+
   void shutdown();
 
   <T> ProviderEvaluation<T> evaluate(

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 interface Evaluator {
 
-  boolean initialize(long timeout, TimeUnit timeUnit, EvaluationContext context) throws Exception;
+  void initialize(long timeout, TimeUnit timeUnit, EvaluationContext context) throws Exception;
 
   void shutdown();
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Evaluator.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 interface Evaluator {
 
-  void initialize(long timeout, TimeUnit timeUnit, EvaluationContext context) throws Exception;
+  boolean initialize(long timeout, TimeUnit timeUnit, EvaluationContext context) throws Exception;
 
   void shutdown();
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -13,10 +13,12 @@ import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
+import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +30,8 @@ public class Provider extends EventProvider implements Metadata {
   private static final Options DEFAULT_OPTIONS = new Options().initTimeout(30, SECONDS);
   private volatile Evaluator evaluator;
   private final Options options;
+  private final AtomicReference<InitializationState> initializationState =
+      new AtomicReference<>(InitializationState.NOT_STARTED);
   private final FlagEvalMetrics flagEvalMetrics;
   private final FlagEvalHook flagEvalHook;
 
@@ -58,19 +62,40 @@ public class Provider extends EventProvider implements Metadata {
 
   @Override
   public void initialize(final EvaluationContext context) throws Exception {
+    initializationState.set(InitializationState.INITIALIZING);
     try {
       evaluator = buildEvaluator();
       if (!evaluator.initialize(options.getTimeout(), options.getUnit(), context)) {
-        log.debug("OpenFeature provider initialized before initial remote configuration");
+        initializationState.set(InitializationState.ERROR);
+        throw new ProviderNotReadyError(
+            "Provider timed-out while waiting for initial configuration");
       }
+      initializationState.set(InitializationState.READY);
     } catch (final OpenFeatureError e) {
+      initializationState.set(InitializationState.ERROR);
       throw e;
     } catch (final Throwable e) {
+      initializationState.set(InitializationState.ERROR);
       throw new FatalError("Failed to initialize provider, is the tracer configured?", e);
     }
   }
 
   private void onConfigurationChange() {
+    final InitializationState state = initializationState.get();
+    if (state == InitializationState.INITIALIZING) {
+      return;
+    }
+    if (state == InitializationState.ERROR
+        && initializationState.compareAndSet(
+            InitializationState.ERROR, InitializationState.READY)) {
+      emit(
+          ProviderEvent.PROVIDER_READY,
+          ProviderEventDetails.builder().message("Provider ready").build());
+      return;
+    }
+    if (initializationState.get() != InitializationState.READY) {
+      return;
+    }
     emit(
         ProviderEvent.PROVIDER_CONFIGURATION_CHANGED,
         ProviderEventDetails.builder().message("New configuration received").build());
@@ -146,6 +171,13 @@ public class Provider extends EventProvider implements Metadata {
   @SuppressForbidden // Class#forName(String) used to lazy load internal-api dependencies
   protected Class<?> loadEvaluatorClass() throws ClassNotFoundException {
     return Class.forName(EVALUATOR_IMPL);
+  }
+
+  private enum InitializationState {
+    NOT_STARTED,
+    INITIALIZING,
+    READY,
+    ERROR
   }
 
   public static class Options {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -3,6 +3,7 @@ package datadog.trace.api.openfeature;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Hook;
@@ -66,6 +67,21 @@ public class Provider extends EventProvider implements Metadata {
     try {
       evaluator = buildEvaluator();
       if (!evaluator.initialize(options.getTimeout(), options.getUnit(), context)) {
+        final InitializationState state = initializationState.get();
+        if (state == InitializationState.READY
+            || initializationState.compareAndSet(
+                InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.READY)) {
+          return;
+        }
+        if (initializationState.compareAndSet(
+            InitializationState.INITIALIZING, InitializationState.ERROR)) {
+          throw new ProviderNotReadyError(
+              "Provider timed-out while waiting for initial configuration");
+        }
+        if (initializationState.compareAndSet(
+            InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.READY)) {
+          return;
+        }
         initializationState.set(InitializationState.ERROR);
         throw new ProviderNotReadyError(
             "Provider timed-out while waiting for initial configuration");
@@ -80,9 +96,19 @@ public class Provider extends EventProvider implements Metadata {
     }
   }
 
-  private void onConfigurationChange() {
+  void onConfigurationChange() {
+    if (evaluator == null || !evaluator.hasConfiguration()) {
+      onConfigurationUnavailable();
+      return;
+    }
+
     final InitializationState state = initializationState.get();
     if (state == InitializationState.INITIALIZING) {
+      initializationState.compareAndSet(
+          InitializationState.INITIALIZING, InitializationState.INITIAL_CONFIG_RECEIVED);
+      return;
+    }
+    if (state == InitializationState.INITIAL_CONFIG_RECEIVED) {
       return;
     }
     if (state == InitializationState.ERROR
@@ -99,6 +125,22 @@ public class Provider extends EventProvider implements Metadata {
     emit(
         ProviderEvent.PROVIDER_CONFIGURATION_CHANGED,
         ProviderEventDetails.builder().message("New configuration received").build());
+  }
+
+  private void onConfigurationUnavailable() {
+    final InitializationState state = initializationState.get();
+    if (state != InitializationState.READY) {
+      return;
+    }
+    if (!initializationState.compareAndSet(InitializationState.READY, InitializationState.ERROR)) {
+      return;
+    }
+    emit(
+        ProviderEvent.PROVIDER_ERROR,
+        ProviderEventDetails.builder()
+            .message("Configuration unavailable")
+            .errorCode(ErrorCode.PROVIDER_NOT_READY)
+            .build());
   }
 
   private Evaluator buildEvaluator() throws Exception {
@@ -176,6 +218,7 @@ public class Provider extends EventProvider implements Metadata {
   private enum InitializationState {
     NOT_STARTED,
     INITIALIZING,
+    INITIAL_CONFIG_RECEIVED,
     READY,
     ERROR
   }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -13,7 +13,6 @@ import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.List;
@@ -63,12 +62,8 @@ public class Provider extends EventProvider implements Metadata {
   public void initialize(final EvaluationContext context) throws Exception {
     try {
       evaluator = buildEvaluator();
-      final boolean init = evaluator.initialize(options.getTimeout(), options.getUnit(), context);
-      initialized.set(init);
-      if (!init) {
-        throw new ProviderNotReadyError(
-            "Provider timed-out while waiting for initial configuration");
-      }
+      initialized.set(true);
+      evaluator.initialize(options.getTimeout(), options.getUnit(), context);
     } catch (final OpenFeatureError e) {
       throw e;
     } catch (final Throwable e) {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -67,31 +67,23 @@ public class Provider extends EventProvider implements Metadata {
     try {
       evaluator = buildEvaluator();
       if (!evaluator.initialize(options.getTimeout(), options.getUnit(), context)) {
-        final InitializationState state = initializationState.get();
-        if (state == InitializationState.READY
-            || initializationState.compareAndSet(
-                InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.READY)) {
+        if (markInitialConfigReceivedReady()) {
           return;
         }
-        if (initializationState.compareAndSet(
-            InitializationState.INITIALIZING, InitializationState.ERROR)) {
-          throw new ProviderNotReadyError(
-              "Provider timed-out while waiting for initial configuration");
-        }
-        if (initializationState.compareAndSet(
-            InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.READY)) {
-          return;
-        }
-        initializationState.set(InitializationState.ERROR);
+        markInitializationError();
         throw new ProviderNotReadyError(
             "Provider timed-out while waiting for initial configuration");
       }
-      initializationState.set(InitializationState.READY);
+      if (!evaluator.hasConfiguration() || !markSuccessfulInitializationReady()) {
+        markInitializationError();
+        throw new ProviderNotReadyError(
+            "Provider timed-out while waiting for initial configuration");
+      }
     } catch (final OpenFeatureError e) {
-      initializationState.set(InitializationState.ERROR);
+      markInitializationError();
       throw e;
     } catch (final Throwable e) {
-      initializationState.set(InitializationState.ERROR);
+      markInitializationError();
       throw new FatalError("Failed to initialize provider, is the tracer configured?", e);
     }
   }
@@ -128,8 +120,8 @@ public class Provider extends EventProvider implements Metadata {
   }
 
   private void onConfigurationUnavailable() {
-    final InitializationState state = initializationState.get();
-    if (state != InitializationState.READY) {
+    if (initializationState.compareAndSet(
+        InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.ERROR)) {
       return;
     }
     if (!initializationState.compareAndSet(InitializationState.READY, InitializationState.ERROR)) {
@@ -141,6 +133,28 @@ public class Provider extends EventProvider implements Metadata {
             .message("Configuration unavailable")
             .errorCode(ErrorCode.PROVIDER_NOT_READY)
             .build());
+  }
+
+  private boolean markInitialConfigReceivedReady() {
+    return initializationState.get() == InitializationState.READY
+        || initializationState.compareAndSet(
+            InitializationState.INITIAL_CONFIG_RECEIVED, InitializationState.READY);
+  }
+
+  private boolean markSuccessfulInitializationReady() {
+    return markInitialConfigReceivedReady()
+        || initializationState.compareAndSet(
+            InitializationState.INITIALIZING, InitializationState.READY);
+  }
+
+  private void markInitializationError() {
+    InitializationState state = initializationState.get();
+    while (state != InitializationState.READY && state != InitializationState.ERROR) {
+      if (initializationState.compareAndSet(state, InitializationState.ERROR)) {
+        return;
+      }
+      state = initializationState.get();
+    }
   }
 
   private Evaluator buildEvaluator() throws Exception {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +28,6 @@ public class Provider extends EventProvider implements Metadata {
   private static final Options DEFAULT_OPTIONS = new Options().initTimeout(30, SECONDS);
   private volatile Evaluator evaluator;
   private final Options options;
-  private final AtomicBoolean initialized = new AtomicBoolean(false);
   private final FlagEvalMetrics flagEvalMetrics;
   private final FlagEvalHook flagEvalHook;
 
@@ -62,7 +60,6 @@ public class Provider extends EventProvider implements Metadata {
   public void initialize(final EvaluationContext context) throws Exception {
     try {
       evaluator = buildEvaluator();
-      initialized.set(true);
       evaluator.initialize(options.getTimeout(), options.getUnit(), context);
     } catch (final OpenFeatureError e) {
       throw e;
@@ -72,15 +69,9 @@ public class Provider extends EventProvider implements Metadata {
   }
 
   private void onConfigurationChange() {
-    if (initialized.getAndSet(true)) {
-      emit(
-          ProviderEvent.PROVIDER_CONFIGURATION_CHANGED,
-          ProviderEventDetails.builder().message("New configuration received").build());
-    } else {
-      emit(
-          ProviderEvent.PROVIDER_READY,
-          ProviderEventDetails.builder().message("Provider ready").build());
-    }
+    emit(
+        ProviderEvent.PROVIDER_CONFIGURATION_CHANGED,
+        ProviderEventDetails.builder().message("New configuration received").build());
   }
 
   private Evaluator buildEvaluator() throws Exception {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -60,7 +60,9 @@ public class Provider extends EventProvider implements Metadata {
   public void initialize(final EvaluationContext context) throws Exception {
     try {
       evaluator = buildEvaluator();
-      evaluator.initialize(options.getTimeout(), options.getUnit(), context);
+      if (!evaluator.initialize(options.getTimeout(), options.getUnit(), context)) {
+        log.debug("OpenFeature provider initialized before initial remote configuration");
+      }
     } catch (final OpenFeatureError e) {
       throw e;
     } catch (final Throwable e) {

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -12,6 +12,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -79,6 +80,7 @@ public class DDEvaluatorTest {
   @AfterEach
   public void tearDown() {
     FeatureFlaggingGateway.removeExposureListener(exposureListener);
+    FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
   }
 
   private static Arguments[] valueMappingTestCases() {
@@ -146,6 +148,32 @@ public class DDEvaluatorTest {
     assertThat(details.getValue(), equalTo(23));
     assertThat(details.getReason(), equalTo(ERROR.name()));
     assertThat(details.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
+  }
+
+  @Test
+  public void testInitializeTimesOutWithoutConfig() throws Exception {
+    final Runnable configCallback = mock(Runnable.class);
+    final DDEvaluator evaluator = new DDEvaluator(configCallback);
+    evaluator.accept(null);
+    try {
+      assertThat(
+          evaluator.initialize(10, MILLISECONDS, mock(EvaluationContext.class)), equalTo(false));
+      verify(configCallback, times(0)).run();
+    } finally {
+      evaluator.shutdown();
+    }
+  }
+
+  @Test
+  public void testInitializeWaitsForNonNullConfig() throws Exception {
+    FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    try {
+      assertThat(
+          evaluator.initialize(10, MILLISECONDS, mock(EvaluationContext.class)), equalTo(true));
+    } finally {
+      evaluator.shutdown();
+    }
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -13,6 +13,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +54,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -166,12 +170,19 @@ public class DDEvaluatorTest {
 
   @Test
   public void testInitializeWaitsForNonNullConfig() throws Exception {
-    FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
-      assertThat(
-          evaluator.initialize(10, MILLISECONDS, mock(EvaluationContext.class)), equalTo(true));
+      final Future<Boolean> initialized =
+          executor.submit(() -> evaluator.initialize(1, SECONDS, mock(EvaluationContext.class)));
+
+      evaluator.accept(null);
+      assertThat(initialized.isDone(), equalTo(false));
+
+      evaluator.accept(mock(ServerConfiguration.class));
+      assertThat(initialized.get(1, SECONDS), equalTo(true));
     } finally {
+      executor.shutdownNow();
       evaluator.shutdown();
     }
   }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -19,7 +19,6 @@ import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
 import datadog.trace.api.openfeature.Provider.Options;
 import dev.openfeature.sdk.Client;
-import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventDetails;
 import dev.openfeature.sdk.Features;
@@ -31,9 +30,14 @@ import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
+import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,8 +52,16 @@ public class ProviderTest {
 
   @Captor private ArgumentCaptor<EventDetails> eventDetailsCaptor;
 
+  private ExecutorService executor;
+
+  @BeforeEach
+  public void setup() {
+    executor = Executors.newSingleThreadExecutor();
+  }
+
   @AfterEach
   public void tearDown() {
+    executor.shutdownNow();
     OpenFeatureAPI.getInstance().shutdown();
     FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
   }
@@ -60,47 +72,47 @@ public class ProviderTest {
     api.setProvider(new Provider());
 
     final Client client = api.getClient();
-    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
+    assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
   }
 
   @Test
-  public void testSetProviderAndWait() {
+  public void testSetProviderAndWait() throws Exception {
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-    api.setProviderAndWait(new Provider());
+    final Future<?> provider = executor.submit(() -> api.setProviderAndWait(new Provider()));
 
     final Client client = api.getClient();
-    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+    assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
+    provider.get(1, SECONDS);
   }
 
   @Test
-  public void testSetProviderAndWaitWithoutInitialConfiguration() {
-    final Consumer<EventDetails> configChangedEvent = mock(Consumer.class);
+  public void testSetProviderAndWaitTimeoutRecoversWhenConfigurationArrives() {
+    final Consumer<EventDetails> readyEvent = mock(Consumer.class);
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
     final Client client = api.getClient();
-    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent);
+    client.on(ProviderEvent.PROVIDER_READY, readyEvent);
 
-    api.setProviderAndWait(new Provider(new Options().initTimeout(10, MILLISECONDS)));
+    assertThrows(
+        ProviderNotReadyError.class,
+        () -> api.setProviderAndWait(new Provider(new Options().initTimeout(10, MILLISECONDS))));
 
-    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
-    final FlagEvaluationDetails<String> evalDetails = client.getStringDetails("missing", "default");
-    assertThat(evalDetails.getValue(), equalTo("default"));
-    assertThat(evalDetails.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
+    assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
+    verify(readyEvent, times(0)).accept(any());
 
-    // dispatch an initial configuration
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
 
-    // config changed is called after receiving the configuration
     await()
         .atMost(ofSeconds(1))
         .untilAsserted(
             () -> {
-              verify(configChangedEvent, times(1)).accept(eventDetailsCaptor.capture());
+              assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+              verify(readyEvent, times(1)).accept(eventDetailsCaptor.capture());
               final EventDetails eventDetails = eventDetailsCaptor.getValue();
               assertThat(eventDetails.getProviderName(), equalTo(METADATA));
             });
@@ -139,6 +151,7 @@ public class ProviderTest {
   @Test
   public void testShutdownCleansUpMetrics() throws Exception {
     Evaluator evaluator = mock(Evaluator.class);
+    when(evaluator.initialize(eq(10L), eq(MILLISECONDS), any())).thenReturn(true);
     Provider provider = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
     provider.initialize(null);
     provider.shutdown();
@@ -168,6 +181,7 @@ public class ProviderTest {
       final String flag, final E defaultValue, final EvaluateMethod<E> method) throws Exception {
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     final Evaluator evaluator = mock(Evaluator.class);
+    when(evaluator.initialize(eq(10L), eq(SECONDS), any())).thenReturn(true);
     when(evaluator.evaluate(any(), any(), any(), any()))
         .thenAnswer(
             invocation ->

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -19,6 +19,7 @@ import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
 import datadog.trace.api.openfeature.Provider.Options;
 import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventDetails;
 import dev.openfeature.sdk.Features;
@@ -116,6 +117,96 @@ public class ProviderTest {
               final EventDetails eventDetails = eventDetailsCaptor.getValue();
               assertThat(eventDetails.getProviderName(), equalTo(METADATA));
             });
+  }
+
+  @Test
+  public void testSetProviderAndWaitCompletesWhenConfigurationArrivesAtTimeoutBoundary()
+      throws Exception {
+    final Provider[] providerRef = new Provider[1];
+    final Evaluator evaluator =
+        new Evaluator() {
+          private boolean hasConfiguration;
+
+          @Override
+          public boolean initialize(
+              final long timeout,
+              final java.util.concurrent.TimeUnit timeUnit,
+              final EvaluationContext context) {
+            hasConfiguration = true;
+            providerRef[0].onConfigurationChange();
+            return false;
+          }
+
+          @Override
+          public boolean hasConfiguration() {
+            return hasConfiguration;
+          }
+
+          @Override
+          public void shutdown() {}
+
+          @Override
+          public <T> ProviderEvaluation<T> evaluate(
+              final Class<T> target,
+              final String key,
+              final T defaultValue,
+              final EvaluationContext context) {
+            return ProviderEvaluation.<T>builder().value(defaultValue).build();
+          }
+        };
+
+    final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+    providerRef[0] = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
+    api.setProviderAndWait(providerRef[0]);
+
+    final Client client = api.getClient();
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+  }
+
+  @Test
+  public void testNullConfigurationAfterReadyTransitionsToErrorAndRecovers() {
+    final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+    api.setProvider(new Provider());
+    final Client client = api.getClient();
+
+    FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
+    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
+
+    final Consumer<EventDetails> errorEvent = mock(Consumer.class);
+    final Consumer<EventDetails> readyEvent = mock(Consumer.class);
+    final Consumer<EventDetails> configChangedEvent = mock(Consumer.class);
+    client.on(ProviderEvent.PROVIDER_ERROR, errorEvent);
+    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent);
+
+    FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
+    await()
+        .atMost(ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
+              verify(errorEvent, times(1)).accept(eventDetailsCaptor.capture());
+              final EventDetails eventDetails = eventDetailsCaptor.getValue();
+              assertThat(eventDetails.getProviderName(), equalTo(METADATA));
+            });
+
+    final FlagEvaluationDetails<String> evalDetails = client.getStringDetails("missing", "default");
+    assertThat(evalDetails.getValue(), equalTo("default"));
+    assertThat(evalDetails.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
+
+    client.on(ProviderEvent.PROVIDER_READY, readyEvent);
+    FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
+    await()
+        .atMost(ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+              verify(readyEvent, times(1)).accept(any());
+            });
+
+    FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
+    await()
+        .atMost(ofSeconds(1))
+        .untilAsserted(() -> verify(configChangedEvent, times(1)).accept(any()));
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -32,10 +32,12 @@ import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -164,6 +166,99 @@ public class ProviderTest {
   }
 
   @Test
+  public void testSetProviderAndWaitFailsWhenConfigurationIsRemovedBeforeInitializationCompletes() {
+    final Provider[] providerRef = new Provider[1];
+    final Evaluator evaluator =
+        new Evaluator() {
+          private boolean hasConfiguration;
+
+          @Override
+          public boolean initialize(
+              final long timeout,
+              final java.util.concurrent.TimeUnit timeUnit,
+              final EvaluationContext context) {
+            hasConfiguration = true;
+            providerRef[0].onConfigurationChange();
+            hasConfiguration = false;
+            providerRef[0].onConfigurationChange();
+            return true;
+          }
+
+          @Override
+          public boolean hasConfiguration() {
+            return hasConfiguration;
+          }
+
+          @Override
+          public void shutdown() {}
+
+          @Override
+          public <T> ProviderEvaluation<T> evaluate(
+              final Class<T> target,
+              final String key,
+              final T defaultValue,
+              final EvaluationContext context) {
+            return ProviderEvaluation.<T>builder().value(defaultValue).build();
+          }
+        };
+
+    final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+    providerRef[0] = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
+
+    assertThrows(ProviderNotReadyError.class, () -> api.setProviderAndWait(providerRef[0]));
+
+    final Client client = api.getClient();
+    assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
+  }
+
+  @Test
+  public void testInitializationErrorDoesNotOverwriteRecoveredReadyState() throws Exception {
+    final Provider[] providerRef = new Provider[1];
+    final Evaluator evaluator =
+        new Evaluator() {
+          private boolean hasConfiguration;
+
+          @Override
+          public boolean initialize(
+              final long timeout,
+              final java.util.concurrent.TimeUnit timeUnit,
+              final EvaluationContext context) {
+            hasConfiguration = true;
+            providerRef[0].onConfigurationChange();
+            hasConfiguration = false;
+            providerRef[0].onConfigurationChange();
+            hasConfiguration = true;
+            providerRef[0].onConfigurationChange();
+            throw new ProviderNotReadyError(
+                "Provider timed-out while waiting for initial configuration");
+          }
+
+          @Override
+          public boolean hasConfiguration() {
+            return hasConfiguration;
+          }
+
+          @Override
+          public void shutdown() {}
+
+          @Override
+          public <T> ProviderEvaluation<T> evaluate(
+              final Class<T> target,
+              final String key,
+              final T defaultValue,
+              final EvaluationContext context) {
+            return ProviderEvaluation.<T>builder().value(defaultValue).build();
+          }
+        };
+
+    providerRef[0] = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
+
+    assertThrows(ProviderNotReadyError.class, () -> providerRef[0].initialize(null));
+
+    assertThat(initializationState(providerRef[0]), equalTo("READY"));
+  }
+
+  @Test
   public void testNullConfigurationAfterReadyTransitionsToErrorAndRecovers() {
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
     api.setProvider(new Provider());
@@ -243,6 +338,7 @@ public class ProviderTest {
   public void testShutdownCleansUpMetrics() throws Exception {
     Evaluator evaluator = mock(Evaluator.class);
     when(evaluator.initialize(eq(10L), eq(MILLISECONDS), any())).thenReturn(true);
+    when(evaluator.hasConfiguration()).thenReturn(true);
     Provider provider = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
     provider.initialize(null);
     provider.shutdown();
@@ -273,6 +369,7 @@ public class ProviderTest {
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     final Evaluator evaluator = mock(Evaluator.class);
     when(evaluator.initialize(eq(10L), eq(SECONDS), any())).thenReturn(true);
+    when(evaluator.hasConfiguration()).thenReturn(true);
     when(evaluator.evaluate(any(), any(), any(), any()))
         .thenAnswer(
             invocation ->
@@ -289,5 +386,12 @@ public class ProviderTest {
     verify(evaluator, times(1)).initialize(eq(10L), eq(SECONDS), any());
     verify(evaluator, times(1))
         .evaluate(any(), eq(flag), eq(defaultValue), any(EvaluationContext.class));
+  }
+
+  private static String initializationState(final Provider provider) throws Exception {
+    final Field stateField = Provider.class.getDeclaredField("initializationState");
+    stateField.setAccessible(true);
+    final AtomicReference<?> state = (AtomicReference<?>) stateField.get(provider);
+    return state.get().toString();
   }
 }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -140,7 +139,6 @@ public class ProviderTest {
   @Test
   public void testShutdownCleansUpMetrics() throws Exception {
     Evaluator evaluator = mock(Evaluator.class);
-    when(evaluator.initialize(anyLong(), any(), any())).thenReturn(true);
     Provider provider = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
     provider.initialize(null);
     provider.shutdown();
@@ -170,7 +168,6 @@ public class ProviderTest {
       final String flag, final E defaultValue, final EvaluateMethod<E> method) throws Exception {
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     final Evaluator evaluator = mock(Evaluator.class);
-    when(evaluator.initialize(anyLong(), any(), any())).thenReturn(true);
     when(evaluator.evaluate(any(), any(), any(), any()))
         .thenAnswer(
             invocation ->

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -20,6 +20,7 @@ import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
 import datadog.trace.api.openfeature.Provider.Options;
 import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventDetails;
 import dev.openfeature.sdk.Features;
@@ -31,13 +32,9 @@ import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,16 +49,8 @@ public class ProviderTest {
 
   @Captor private ArgumentCaptor<EventDetails> eventDetailsCaptor;
 
-  private ExecutorService executor;
-
-  @BeforeEach
-  public void setup() {
-    executor = Executors.newSingleThreadExecutor();
-  }
-
   @AfterEach
   public void tearDown() {
-    executor.shutdownNow();
     OpenFeatureAPI.getInstance().shutdown();
     FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
   }
@@ -72,7 +61,7 @@ public class ProviderTest {
     api.setProvider(new Provider());
 
     final Client client = api.getClient();
-    assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
+    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
@@ -81,41 +70,40 @@ public class ProviderTest {
   @Test
   public void testSetProviderAndWait() {
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-    executor.submit(() -> api.setProviderAndWait(new Provider()));
+    api.setProviderAndWait(new Provider());
 
     final Client client = api.getClient();
-    assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
   }
 
   @Test
-  public void testSetProviderAndWaitTimeout() {
-    final Consumer<EventDetails> readyEvent = mock(Consumer.class);
+  public void testSetProviderAndWaitWithoutInitialConfiguration() {
+    final Consumer<EventDetails> configChangedEvent = mock(Consumer.class);
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
     final Client client = api.getClient();
-    client.on(ProviderEvent.PROVIDER_READY, readyEvent);
+    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent);
 
-    // we time out after 10 millis without receiving the initial config
-    assertThrows(
-        ProviderNotReadyError.class,
-        () -> api.setProviderAndWait(new Provider(new Options().initTimeout(10, MILLISECONDS))));
+    api.setProviderAndWait(new Provider(new Options().initTimeout(10, MILLISECONDS)));
 
-    // ready has not yet been called
-    verify(readyEvent, times(0)).accept(any());
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+    final FlagEvaluationDetails<String> evalDetails = client.getStringDetails("missing", "default");
+    assertThat(evalDetails.getValue(), equalTo("default"));
+    assertThat(evalDetails.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
 
     // dispatch an initial configuration
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
 
-    // ready is called after receiving the configuration
+    // config changed is called after receiving the configuration
     await()
         .atMost(ofSeconds(1))
         .untilAsserted(
             () -> {
-              verify(readyEvent, times(1)).accept(eventDetailsCaptor.capture());
-              final EventDetails details = eventDetailsCaptor.getValue();
-              assertThat(details.getProviderName(), equalTo(METADATA));
+              verify(configChangedEvent, times(1)).accept(eventDetailsCaptor.capture());
+              final EventDetails eventDetails = eventDetailsCaptor.getValue();
+              assertThat(eventDetails.getProviderName(), equalTo(METADATA));
             });
   }
 


### PR DESCRIPTION
## Motivation

A Java application can start while its Datadog Agent is already running but does not yet have an `FFE_FLAGS` payload cached for that tracer. That is the customer-reported shape we have been investigating: the tracer starts, asks for feature flag configuration, and the OpenFeature provider waits for usable configuration during initialization.

That blocking behavior is intentional. `setProviderAndWait()` should wait until the provider receives usable flag configuration, or fail with the configured timeout. The bug is what happens after the timeout path: the OpenFeature provider transitions to `ERROR`, but when `FFE_FLAGS` arrives later it must transition back to `READY` without requiring an application restart.

There are two edge cases this PR needs to handle correctly. First, a real config can arrive right at the timeout boundary, after the evaluator has received it but before provider initialization has finished deciding whether it timed out. Second, usable config can disappear after the initial config is received but before initialization returns, or after the provider is already `READY`; in either case the provider state should not remain `READY` while evaluations return `PROVIDER_NOT_READY`.

## Changes

This keeps provider initialization blocking. `DDEvaluator.initialize()` registers for Feature Flagging Gateway updates and waits on the initialization latch until a non-null `ServerConfiguration` arrives or the configured timeout expires. A `null` config update means there is still no usable FFE product for the provider, so it does not satisfy initialization.

The provider tracks initialization state explicitly. If real configuration arrives while initialization is still blocked, the provider records that initial config was received and lets the OpenFeature SDK publish `PROVIDER_READY` after `initialize()` returns. If initialization has already timed out and the provider is in `ERROR`, the next real config update moves the provider to `READY` and emits `PROVIDER_READY`. After the provider is ready, later real config updates emit `PROVIDER_CONFIGURATION_CHANGED`.

Nullable config updates are handled as real lifecycle transitions. If config disappears after the initial config was received but before initialization returns, initialization fails instead of advertising readiness without usable config. If the provider was already `READY` and FFE config becomes unavailable, it emits `PROVIDER_ERROR`; evaluations then return the caller default with `PROVIDER_NOT_READY`. A later real config moves the provider back to `READY`.

## Decisions

Blocking is not the problem we are fixing here. Blocking until config or timeout is the Java behavior we want because the provider should not advertise readiness before it has usable flag configuration. The missing piece was recovery after timeout and after losing usable configuration. This PR fixes those recovery paths without changing the public provider API or the caller-facing timeout option.

This also pairs with the first-RC subscription work that landed separately: that work makes the tracer request `FFE_FLAGS` as early as possible from an already-running Agent, while this change makes the Java OpenFeature provider recover correctly if that first attempt still times out. The related Go tracer reference is `SubscribeRC`, which subscribes `FFE_FLAGS` during tracer startup so it is included in the first RC request: https://github.com/DataDog/dd-trace-go/blob/3ded6653e44aeb0d27bd5944e1e8033775473768/internal/openfeature/rc_subscription.go#L40-L44

## Evidence

Dogfooding validation support has now merged to `ffe-dogfooding` main via DataDog/ffe-dogfooding#71. It adds the local Java build path used to run this PR against the full ffe-dogfooding compose stack before the Java artifacts are published.

The local validation built `dd-java-agent-1.63.0-SNAPSHOT.jar` and `dd-openfeature-1.63.0-SNAPSHOT.jar` from this `dd-trace-java` branch, staged the local provider JAR into the Java dogfooding app image, and mounted the local `dd-trace-java` checkout so the Java container started with the local agent JAR.

Commands used for the dogfooding smoke test:

```bash
DD_TRACE_JAVA_PATH=/path/to/dd-trace-java scripts/prepare-local-java.sh
DD_TRACE_JAVA_PATH=/path/to/dd-trace-java docker-compose -f docker-compose.yml -f local/docker-compose.java.yml up --build -d
```

The successful readiness run used the ffe-dogfooding `.env` Remote Config credentials. A dummy API key started the containers but left Java in `PROVIDER_ERROR`, which matched the expected Agent authentication failure rather than a provider startup failure.

The full compose stack started successfully with `app-go`, `app-python`, `app-nodejs`, `app-java`, `app-ruby`, `app-dotnet`, `datadog-agent`, `mock-intake`, `otlp-intake`, and `evaluator` all running. Health checks passed on app ports `8081` through `8086`, and the evaluator `/stats` endpoint responded. The Java container log confirmed the local Java tracer was used:

```text
Using local Java agent: /opt/dd-trace-java/dd-java-agent/build/libs/dd-java-agent-1.63.0-SNAPSHOT.jar
App built with local dd-openfeature JAR
```

## State Transitions

```mermaid
stateDiagram-v2
    [*] --> NOT_STARTED
    NOT_STARTED --> INITIALIZING: initialize()

    INITIALIZING --> INITIALIZING: null config / keep blocking
    INITIALIZING --> INITIAL_CONFIG_RECEIVED: real config arrives before initialize returns
    INITIALIZING --> ERROR: timeout without real config / throw ProviderNotReadyError

    INITIAL_CONFIG_RECEIVED --> READY: initialize returns while config is still present / OpenFeature SDK emits PROVIDER_READY
    INITIAL_CONFIG_RECEIVED --> ERROR: null config before initialize returns / throw ProviderNotReadyError

    ERROR --> READY: later real config / emit PROVIDER_READY
    ERROR --> ERROR: null config / remain unavailable

    READY --> READY: later real config / emit PROVIDER_CONFIGURATION_CHANGED
    READY --> ERROR: null config / emit PROVIDER_ERROR
```



