### PR TITLE
ci(smoke): gate `dd.trace.debug=true` behind opt-in system property.

### DIFF
--- a/dd-java-agent/agent-ci-visibility/civisibility-test-fixtures/src/main/java/datadog/trace/civisibility/CiVisibilitySmokeTest.java
+++ b/dd-java-agent/agent-ci-visibility/civisibility-test-fixtures/src/main/java/datadog/trace/civisibility/CiVisibilitySmokeTest.java
@@ -71,7 +71,6 @@ public abstract class CiVisibilitySmokeTest {
 
   private static Map<String, String> defaultJvmArguments() {
     Map<String, String> argMap = new HashMap<>();
-    argMap.put(GeneralConfig.TRACE_DEBUG, "true");
     argMap.put(GeneralConfig.ENV, TEST_ENVIRONMENT_NAME);
     argMap.put(CiVisibilityConfig.CIVISIBILITY_ENABLED, "true");
     argMap.put(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED, "true");
@@ -116,6 +115,13 @@ public abstract class CiVisibilitySmokeTest {
     }
     if (System.getProperty("datadog.civisibility.smoketest.debug.child") != null) {
       argMap.put(CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT, "5055");
+    }
+
+    // CI-Vis smoke tests produce a lot of logs in debug mode, so it is disabled by default.
+    // Note: GitLab capacity for job logs at 32 MB and truncates the rest, which can fail the job.
+    // Enable full debug via `-Ddatadog.civisibility.smoketest.debug.enabled=true`.
+    if (System.getProperty("datadog.civisibility.smoketest.debug.enabled") != null) {
+      argMap.put(GeneralConfig.TRACE_DEBUG, "true");
     }
 
     String agentArgs =


### PR DESCRIPTION
# What Does This Do
Gates `dd.trace.debug=true` in `CiVisibilitySmokeTest` behind a new opt-in system property `datadog.civisibility.smoketest.debug.enabled`.

# Motivation
The `test_smoke: [semeru17, 8/8]` shard started failing on master with error:
```
Job's log exceeded limit of 33554432 bytes.
Job execution will continue but no more output will be collected.
```

After investigation I found that:
Even if this job passed on CI, it generates `~28Mb` of logs, that is very close to the `32Mb` limit.
So in case of any retry - logs can easily hit `32Mb` limit.

# Additional Notes
Under other JDK vendors this test still produce a lot of logs `~15Mb`, less than `semeru` but still a lot.
After fix log size is `~1Mb`, it is `~15x to 28x` less.


