### PR TITLE
Surface active headless test session and module

### DIFF
--- a/dd-java-agent/agent-ci-visibility/civisibility-instrumentation-test-fixtures/src/main/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/civisibility-instrumentation-test-fixtures/src/main/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
@@ -163,7 +163,8 @@ abstract class CiVisibilityInstrumentationTest extends InstrumentationSpecificat
       executionSettingsFactory.create(JvmInfo.CURRENT_JVM, ""),
       sourcePathResolver,
       linesResolver),
-      capabilities
+      capabilities,
+      component
       )
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -332,7 +332,8 @@ public class CiVisibilitySystem {
           services.linesResolver,
           coverageServices.coverageStoreFactory,
           executionStrategy,
-          capabilities);
+          capabilities,
+          component);
     };
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestModule.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.domain;
 import static datadog.trace.civisibility.Constants.CI_VISIBILITY_INSTRUMENTATION_NAME;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.CIVisibilityEvent;
 import datadog.trace.api.civisibility.execution.TestStatus;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -16,10 +17,11 @@ import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
-public abstract class AbstractTestModule {
+public abstract class AbstractTestModule implements CIVisibilityEvent {
 
   protected final AgentSpan span;
   protected final String moduleName;
@@ -37,6 +39,7 @@ public abstract class AbstractTestModule {
       String moduleName,
       @Nullable Long startTime,
       InstrumentationType instrumentationType,
+      Map<String, Object> inheritedTags,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestDecorator testDecorator,
@@ -79,6 +82,10 @@ public abstract class AbstractTestModule {
     // as we do not know in advance whether the module will have any children
     span.setTag(Tags.TEST_STATUS, TestStatus.skip);
 
+    if (!inheritedTags.isEmpty()) {
+      span.setAllTags(inheritedTags);
+    }
+
     testDecorator.afterStart(span);
 
     metricCollector.add(CiVisibilityCountMetric.EVENT_CREATED, 1, EventType.MODULE);
@@ -88,6 +95,7 @@ public abstract class AbstractTestModule {
     }
   }
 
+  @Override
   public void setTag(String key, Object value) {
     span.setTag(key, value);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
@@ -8,6 +8,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.civisibility.CIConstants;
+import datadog.trace.api.civisibility.CIVisibilityEvent;
 import datadog.trace.api.civisibility.execution.TestStatus;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -40,7 +41,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 
-public abstract class AbstractTestSession {
+public abstract class AbstractTestSession implements CIVisibilityEvent {
 
   protected final Provider ciProvider;
   protected final InstrumentationType instrumentationType;
@@ -144,6 +145,7 @@ public abstract class AbstractTestSession {
     }
   }
 
+  @Override
   public void setTag(String key, Object value) {
     span.setTag(key, value);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/SpanTagsPropagator.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/SpanTagsPropagator.java
@@ -24,6 +24,25 @@ public class SpanTagsPropagator {
     this.parentSpan = parentSpan;
   }
 
+  /**
+   * Snapshots the currently-set values for the given tag keys from {@code source}. Tags that are
+   * not present on {@code source} are omitted from the result. The snapshot reflects the state at
+   * the time of the call; tags set on {@code source} later will not be reflected.
+   */
+  public static Map<String, Object> snapshotTags(AgentSpan source, Collection<String> keys) {
+    if (keys.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Object> snapshot = new HashMap<>();
+    for (String key : keys) {
+      Object value = source.getTag(key);
+      if (value != null) {
+        snapshot.put(key, value);
+      }
+    }
+    return snapshot;
+  }
+
   public void propagateCiVisibilityTags(AgentSpan childSpan) {
     mergeTestFrameworks(getFrameworks(childSpan));
     propagateStatus(childSpan);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -47,6 +47,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionResults;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
@@ -82,6 +83,7 @@ public class TestImpl implements DDTest {
       @Nullable Class<?> testClass,
       @Nullable Method testMethod,
       InstrumentationType instrumentationType,
+      Map<String, Object> inheritedTags,
       TestFrameworkInstrumentation instrumentation,
       Config config,
       CiVisibilityMetricCollector metricCollector,
@@ -155,6 +157,10 @@ public class TestImpl implements DDTest {
 
     for (LibraryCapability capability : capabilities) {
       span.setTag(capability.asTag(), capability.getVersion());
+    }
+
+    if (!inheritedTags.isEmpty()) {
+      span.setAllTags(inheritedTags);
     }
 
     testDecorator.afterStart(span);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
@@ -26,6 +26,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionResults;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -69,6 +70,7 @@ public class TestSuiteImpl implements DDTestSuite {
       @Nullable Long startTime,
       boolean parallelized,
       InstrumentationType instrumentationType,
+      Map<String, Object> inheritedTags,
       TestFrameworkInstrumentation instrumentation,
       Config config,
       CiVisibilityMetricCollector metricCollector,
@@ -133,6 +135,10 @@ public class TestSuiteImpl implements DDTestSuite {
 
     if (config.isCiVisibilitySourceDataEnabled()) {
       populateSourceDataTags(span, testClass, sourcePathResolver, codeowners);
+    }
+
+    if (!inheritedTags.isEmpty()) {
+      span.setAllTags(inheritedTags);
     }
 
     testDecorator.afterStart(span);
@@ -251,6 +257,8 @@ public class TestSuiteImpl implements DDTestSuite {
       @Nullable String testParameters,
       @Nullable Method testMethod,
       @Nullable Long startTime) {
+    Map<String, Object> testInheritedTags =
+        SpanTagsPropagator.snapshotTags(span, config.getCiVisibilityPropagatedTagKeys());
     return new TestImpl(
         moduleSpanContext,
         span.getSpanId(),
@@ -264,6 +272,7 @@ public class TestSuiteImpl implements DDTestSuite {
         testClass,
         testMethod,
         instrumentationType,
+        testInheritedTags,
         instrumentation,
         config,
         metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
@@ -35,6 +35,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,7 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
         moduleName,
         startTime,
         InstrumentationType.BUILD,
+        Collections.emptyMap(),
         config,
         metricCollector,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
@@ -31,6 +31,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionResults;
 import datadog.trace.civisibility.test.ExecutionStrategy;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -204,6 +205,7 @@ public class ProxyTestModule implements TestFrameworkModule {
         startTime,
         parallelized,
         InstrumentationType.BUILD,
+        Collections.emptyMap(),
         instrumentation,
         config,
         metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -48,6 +48,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
   private final ExecutionStrategy executionStrategy;
   private final ExecutionResults executionResults;
   private final Collection<LibraryCapability> capabilities;
+  private final String component;
 
   public HeadlessTestModule(
       AgentSpanContext sessionSpanContext,
@@ -63,6 +64,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       CoverageStore.Factory coverageStoreFactory,
       ExecutionStrategy executionStrategy,
       Collection<LibraryCapability> capabilities,
+      String component,
       Consumer<AgentSpan> onSpanFinish) {
     super(
         sessionSpanContext,
@@ -81,8 +83,9 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
     this.executionStrategy = executionStrategy;
     this.executionResults = new ExecutionResults();
     this.capabilities = capabilities;
+    this.component = component;
 
-    CIVisibility.registerActiveTestModule(this);
+    CIVisibility.registerActiveTestModule(component, this);
   }
 
   @Override
@@ -169,7 +172,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
     try {
       super.end(endTime);
     } finally {
-      CIVisibility.registerActiveTestModule(null);
+      CIVisibility.unregisterActiveTestModule(component, this);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.domain.headless;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.config.LibraryCapability;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
@@ -21,6 +22,7 @@ import datadog.trace.civisibility.config.TestManagementSettings;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestModule;
 import datadog.trace.civisibility.domain.InstrumentationType;
+import datadog.trace.civisibility.domain.SpanTagsPropagator;
 import datadog.trace.civisibility.domain.TestFrameworkModule;
 import datadog.trace.civisibility.domain.TestSuiteImpl;
 import datadog.trace.civisibility.source.LinesResolver;
@@ -28,6 +30,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionResults;
 import datadog.trace.civisibility.test.ExecutionStrategy;
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -50,6 +53,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       AgentSpanContext sessionSpanContext,
       String moduleName,
       @Nullable Long startTime,
+      Map<String, Object> inheritedTags,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestDecorator testDecorator,
@@ -65,6 +69,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
         moduleName,
         startTime,
         InstrumentationType.HEADLESS,
+        inheritedTags,
         config,
         metricCollector,
         testDecorator,
@@ -76,6 +81,8 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
     this.executionStrategy = executionStrategy;
     this.executionResults = new ExecutionResults();
     this.capabilities = capabilities;
+
+    CIVisibility.registerActiveTestModule(this);
   }
 
   @Override
@@ -159,7 +166,11 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       setTag(DDTags.TEST_HAS_FAILED_TEST_REPLAY, true);
     }
 
-    super.end(endTime);
+    try {
+      super.end(endTime);
+    } finally {
+      CIVisibility.registerActiveTestModule(null);
+    }
   }
 
   @Override
@@ -169,6 +180,8 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       @Nullable Long startTime,
       boolean parallelized,
       TestFrameworkInstrumentation instrumentation) {
+    Map<String, Object> suiteInheritedTags =
+        SpanTagsPropagator.snapshotTags(span, config.getCiVisibilityPropagatedTagKeys());
     return new TestSuiteImpl(
         span.context(),
         moduleName,
@@ -179,6 +192,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
         startTime,
         parallelized,
         InstrumentationType.HEADLESS,
+        suiteInheritedTags,
         instrumentation,
         config,
         metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -4,6 +4,7 @@ import static datadog.trace.civisibility.domain.SpanTagsPropagator.TagMergeSpec;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.config.LibraryCapability;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -14,6 +15,7 @@ import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestSession;
 import datadog.trace.civisibility.domain.InstrumentationType;
+import datadog.trace.civisibility.domain.SpanTagsPropagator;
 import datadog.trace.civisibility.domain.TestFrameworkSession;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
@@ -62,6 +64,8 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
     this.executionStrategy = executionStrategy;
     this.coverageStoreFactory = coverageStoreFactory;
     this.capabilities = capabilities;
+
+    CIVisibility.registerActiveTestSession(this);
   }
 
   @Override
@@ -70,6 +74,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         span.context(),
         moduleName,
         startTime,
+        SpanTagsPropagator.snapshotTags(span, config.getCiVisibilityPropagatedTagKeys()),
         config,
         metricCollector,
         testDecorator,
@@ -105,6 +110,10 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
 
   @Override
   public void end(@Nullable Long endTime) {
-    super.end(endTime);
+    try {
+      super.end(endTime);
+    } finally {
+      CIVisibility.registerActiveTestSession(null);
+    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -36,6 +36,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
   private final ExecutionStrategy executionStrategy;
   private final CoverageStore.Factory coverageStoreFactory;
   private final Collection<LibraryCapability> capabilities;
+  private final String component;
 
   public HeadlessTestSession(
       String projectName,
@@ -49,7 +50,8 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
       LinesResolver linesResolver,
       CoverageStore.Factory coverageStoreFactory,
       ExecutionStrategy executionStrategy,
-      @Nonnull Collection<LibraryCapability> capabilities) {
+      @Nonnull Collection<LibraryCapability> capabilities,
+      String component) {
     super(
         projectName,
         startTime,
@@ -64,8 +66,9 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
     this.executionStrategy = executionStrategy;
     this.coverageStoreFactory = coverageStoreFactory;
     this.capabilities = capabilities;
+    this.component = component;
 
-    CIVisibility.registerActiveTestSession(this);
+    CIVisibility.registerActiveTestSession(component, this);
   }
 
   @Override
@@ -84,6 +87,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         coverageStoreFactory,
         executionStrategy,
         capabilities,
+        component,
         this::onModuleFinish);
   }
 
@@ -113,7 +117,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
     try {
       super.end(endTime);
     } finally {
-      CIVisibility.registerActiveTestSession(null);
+      CIVisibility.unregisterActiveTestSession(component, this);
     }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.domain.manualapi;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.DDTestModule;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -13,11 +14,13 @@ import datadog.trace.civisibility.config.ConfigurationErrors;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestModule;
 import datadog.trace.civisibility.domain.InstrumentationType;
+import datadog.trace.civisibility.domain.SpanTagsPropagator;
 import datadog.trace.civisibility.domain.TestSuiteImpl;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.test.ExecutionResults;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -34,6 +37,7 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
       AgentSpanContext sessionSpanContext,
       String moduleName,
       @Nullable Long startTime,
+      Map<String, Object> inheritedTags,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestDecorator testDecorator,
@@ -47,6 +51,7 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
         moduleName,
         startTime,
         InstrumentationType.MANUAL_API,
+        inheritedTags,
         config,
         metricCollector,
         testDecorator,
@@ -55,6 +60,17 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
         linesResolver,
         onSpanFinish);
     this.coverageStoreFactory = coverageStoreFactory;
+
+    CIVisibility.registerActiveTestModule(this);
+  }
+
+  @Override
+  public void end(@Nullable Long endTime) {
+    try {
+      super.end(endTime);
+    } finally {
+      CIVisibility.registerActiveTestModule(null);
+    }
   }
 
   @Override
@@ -74,6 +90,7 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
             startTime,
             parallelized,
             InstrumentationType.MANUAL_API,
+            SpanTagsPropagator.snapshotTags(span, config.getCiVisibilityPropagatedTagKeys()),
             TestFrameworkInstrumentation.OTHER, // for metric purposes, framework is OTHER
             config,
             metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
@@ -1,7 +1,6 @@
 package datadog.trace.civisibility.domain.manualapi;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.DDTestModule;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -60,17 +59,6 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
         linesResolver,
         onSpanFinish);
     this.coverageStoreFactory = coverageStoreFactory;
-
-    CIVisibility.registerActiveTestModule(this);
-  }
-
-  @Override
-  public void end(@Nullable Long endTime) {
-    try {
-      super.end(endTime);
-    } finally {
-      CIVisibility.registerActiveTestModule(null);
-    }
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
@@ -1,7 +1,6 @@
 package datadog.trace.civisibility.domain.manualapi;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.DDTestSession;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -46,17 +45,6 @@ public class ManualApiTestSession extends AbstractTestSession implements DDTestS
         codeowners,
         linesResolver);
     this.coverageStoreFactory = coverageStoreFactory;
-
-    CIVisibility.registerActiveTestSession(this);
-  }
-
-  @Override
-  public void end(@Nullable Long endTime) {
-    try {
-      super.end(endTime);
-    } finally {
-      CIVisibility.registerActiveTestSession(null);
-    }
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.domain.manualapi;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.CIVisibility;
 import datadog.trace.api.civisibility.DDTestSession;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -9,6 +10,7 @@ import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.domain.AbstractTestSession;
 import datadog.trace.civisibility.domain.InstrumentationType;
+import datadog.trace.civisibility.domain.SpanTagsPropagator;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import javax.annotation.Nullable;
@@ -44,6 +46,17 @@ public class ManualApiTestSession extends AbstractTestSession implements DDTestS
         codeowners,
         linesResolver);
     this.coverageStoreFactory = coverageStoreFactory;
+
+    CIVisibility.registerActiveTestSession(this);
+  }
+
+  @Override
+  public void end(@Nullable Long endTime) {
+    try {
+      super.end(endTime);
+    } finally {
+      CIVisibility.registerActiveTestSession(null);
+    }
   }
 
   @Override
@@ -52,6 +65,7 @@ public class ManualApiTestSession extends AbstractTestSession implements DDTestS
         span.context(),
         moduleName,
         startTime,
+        SpanTagsPropagator.snapshotTags(span, config.getCiVisibilityPropagatedTagKeys()),
         config,
         metricCollector,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestImplTest.groovy
@@ -134,6 +134,7 @@ class TestImplTest extends SpanWriterTest {
       null,
       null,
       InstrumentationType.BUILD,
+      [:],
       testFramework,
       config,
       metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestSuiteImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestSuiteImplTest.groovy
@@ -77,6 +77,7 @@ class TestSuiteImplTest extends SpanWriterTest {
       null,
       false,
       InstrumentationType.BUILD,
+      [:],
       testFramework,
       config,
       metricCollector,

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestModuleTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestModuleTest.groovy
@@ -64,6 +64,7 @@ class HeadlessTestModuleTest extends SpanWriterTest {
     Stub(AgentSpanContext),
     "test-module",
     null,
+    [:],
     config,
     Stub(CiVisibilityMetricCollector),
     Stub(TestDecorator),

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestModuleTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestModuleTest.groovy
@@ -74,6 +74,7 @@ class HeadlessTestModuleTest extends SpanWriterTest {
     Stub(CoverageStore.Factory),
     executionStrategy,
     [],
+    "junit",
     (span) -> { }
     )
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
@@ -80,7 +80,8 @@ class HeadlessTestSessionTest extends SpanWriterTest {
       Stub(LinesResolver),
       Stub(CoverageStore.Factory),
       executionStrategy,
-      []
+      [],
+      "junit"
       )
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/headless/HeadlessTestSessionTest.groovy
@@ -20,7 +20,7 @@ class HeadlessTestSessionTest extends SpanWriterTest {
 
   def "test tags are propagated correctly"() {
     setup:
-    def session = givenAHeadlessTestSession()
+    def session = givenAHeadlessTestSession(Stub(Config))
     def module = session.testModuleStart("module-name", null)
 
     when:
@@ -43,17 +43,36 @@ class HeadlessTestSessionTest extends SpanWriterTest {
     })
   }
 
-  private HeadlessTestSession givenAHeadlessTestSession() {
+  def "session tags configured to propagate are inherited by modules"() {
+    setup:
+    def config = Stub(Config) {
+      getCiVisibilityPropagatedTagKeys() >> (["custom.tag"] as Set)
+    }
+    def session = givenAHeadlessTestSession(config)
+    session.setTag("custom.tag", "custom-value")
+    def module = session.testModuleStart("module-name", null)
+
+    when:
+    module.end(null)
+    session.end(null)
+
+    then:
+    def allSpans = TEST_WRITER.toList().flatten()
+    def moduleSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_MODULE_END }
+    moduleSpan.tags["custom.tag"] == "custom-value"
+  }
+
+  private HeadlessTestSession givenAHeadlessTestSession(Config config) {
     def executionSettings = Stub(ExecutionSettings)
     executionSettings.getTestManagementSettings() >> new TestManagementSettings(true, 10)
 
-    def executionStrategy = new ExecutionStrategy(Stub(Config), executionSettings, Stub(SourcePathResolver), Stub(LinesResolver))
+    def executionStrategy = new ExecutionStrategy(config, executionSettings, Stub(SourcePathResolver), Stub(LinesResolver))
 
     new HeadlessTestSession(
       "project-name",
       null,
       Provider.UNSUPPORTED,
-      Stub(Config),
+      config,
       Stub(CiVisibilityMetricCollector),
       Stub(TestDecorator),
       Stub(SourcePathResolver),

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/manualapi/ManualApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/manualapi/ManualApiTest.groovy
@@ -17,7 +17,7 @@ class ManualApiTest extends SpanWriterTest {
   def "test framework tag is set on suite, test, module and session with component info"() {
     setup:
     def component = "my-custom-framework"
-    def session = givenAManualApiSession(component)
+    def session = givenAManualApiSession(component, Stub(Config))
     def module = session.testModuleStart("module-name", null)
     def suite = module.testSuiteStart("suite-name", null, null, false)
     def test = suite.testStart("test-name", null, null)
@@ -49,12 +49,42 @@ class ManualApiTest extends SpanWriterTest {
     testSpan.tags[Tags.TEST_FRAMEWORK] == component
   }
 
-  private ManualApiTestSession givenAManualApiSession(String component) {
+  def "tags configured to propagate are inherited by child events"() {
+    setup:
+    def config = Stub(Config) {
+      getCiVisibilityPropagatedTagKeys() >> (["custom.tag"] as Set)
+    }
+    def session = givenAManualApiSession("my-custom-framework", config)
+    session.setTag("custom.tag", "custom-value")
+    def module = session.testModuleStart("module-name", null)
+    def suite = module.testSuiteStart("suite-name", null, null, false)
+    def test = suite.testStart("test-name", null, null)
+
+    when:
+    test.end(null)
+    suite.end(null)
+    module.end(null)
+    session.end(null)
+
+    then:
+    def allSpans = TEST_WRITER.toList().flatten()
+    def sessionSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_SESSION_END }
+    def moduleSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_MODULE_END }
+    def suiteSpan = allSpans.find { it.spanType == DDSpanTypes.TEST_SUITE_END }
+    def testSpan = allSpans.find { it.spanType == DDSpanTypes.TEST }
+
+    sessionSpan.tags["custom.tag"] == "custom-value"
+    moduleSpan.tags["custom.tag"] == "custom-value"
+    suiteSpan.tags["custom.tag"] == "custom-value"
+    testSpan.tags["custom.tag"] == "custom-value"
+  }
+
+  private ManualApiTestSession givenAManualApiSession(String component, Config config) {
     new ManualApiTestSession(
       "project-name",
       null,
       Provider.UNSUPPORTED,
-      Stub(Config),
+      config,
       Stub(CiVisibilityMetricCollector),
       new TestDecoratorImpl(component, "session-name", "test-command", [:]),
       Stub(SourcePathResolver),

--- a/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibility.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibility.java
@@ -10,6 +10,9 @@ public class CIVisibility {
   private static volatile SessionFactory SESSION_FACTORY =
       (projectName, projectRoot, component, startTime) -> NoOpDDTestSession.INSTANCE;
 
+  @Nullable private static volatile CIVisibilityEvent ACTIVE_TEST_SESSION = null;
+  @Nullable private static volatile CIVisibilityEvent ACTIVE_TEST_MODULE = null;
+
   /**
    * This a hook for injecting SessionFactory implementation. It should only be used internally by
    * the tracer logic
@@ -18,6 +21,42 @@ public class CIVisibility {
    */
   public static void registerSessionFactory(SessionFactory sessionFactory) {
     SESSION_FACTORY = sessionFactory;
+  }
+
+  /**
+   * Hook for the tracer to expose the currently active test session. Pass {@code null} when the
+   * session ends.
+   */
+  public static void registerActiveTestSession(@Nullable CIVisibilityEvent session) {
+    ACTIVE_TEST_SESSION = session;
+  }
+
+  /**
+   * Hook for the tracer to expose the currently active test module. Pass {@code null} when the
+   * module ends.
+   */
+  public static void registerActiveTestModule(@Nullable CIVisibilityEvent module) {
+    ACTIVE_TEST_MODULE = module;
+  }
+
+  /**
+   * Returns a handle to the currently active test session (limited to headless and manual API) so
+   * users can attach custom tags, or {@code null} when no test session is being managed by the
+   * tracer.
+   */
+  @Nullable
+  public static CIVisibilityEvent activeTestSession() {
+    return ACTIVE_TEST_SESSION;
+  }
+
+  /**
+   * Returns a handle to the currently active test module (limited to headless and manual API) so
+   * users can attach custom tags, or {@code null} when no test module is being managed by the
+   * tracer.
+   */
+  @Nullable
+  public static CIVisibilityEvent activeTestModule() {
+    return ACTIVE_TEST_MODULE;
   }
 
   /**

--- a/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibility.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibility.java
@@ -3,6 +3,9 @@ package datadog.trace.api.civisibility;
 import datadog.trace.api.civisibility.noop.NoOpDDTestSession;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 public class CIVisibility {
@@ -10,8 +13,10 @@ public class CIVisibility {
   private static volatile SessionFactory SESSION_FACTORY =
       (projectName, projectRoot, component, startTime) -> NoOpDDTestSession.INSTANCE;
 
-  @Nullable private static volatile CIVisibilityEvent ACTIVE_TEST_SESSION = null;
-  @Nullable private static volatile CIVisibilityEvent ACTIVE_TEST_MODULE = null;
+  private static final Map<String, CIVisibilityEvent> ACTIVE_TEST_SESSIONS =
+      new ConcurrentHashMap<>();
+  private static final Map<String, CIVisibilityEvent> ACTIVE_TEST_MODULES =
+      new ConcurrentHashMap<>();
 
   /**
    * This a hook for injecting SessionFactory implementation. It should only be used internally by
@@ -24,39 +29,44 @@ public class CIVisibility {
   }
 
   /**
-   * Hook for the tracer to expose the currently active test session. Pass {@code null} when the
-   * session ends.
+   * Hook for the tracer to expose an active test session keyed by component. Only used in headless
+   * mode (one session per component).
    */
-  public static void registerActiveTestSession(@Nullable CIVisibilityEvent session) {
-    ACTIVE_TEST_SESSION = session;
+  public static void registerActiveTestSession(String component, CIVisibilityEvent session) {
+    ACTIVE_TEST_SESSIONS.put(component, session);
+  }
+
+  /** Removes a previously registered active test session. */
+  public static void unregisterActiveTestSession(String component, CIVisibilityEvent session) {
+    ACTIVE_TEST_SESSIONS.remove(component, session);
   }
 
   /**
-   * Hook for the tracer to expose the currently active test module. Pass {@code null} when the
-   * module ends.
+   * Hook for the tracer to expose an active test module keyed by component. Only used in headless
+   * mode (one module per component).
    */
-  public static void registerActiveTestModule(@Nullable CIVisibilityEvent module) {
-    ACTIVE_TEST_MODULE = module;
+  public static void registerActiveTestModule(String component, CIVisibilityEvent module) {
+    ACTIVE_TEST_MODULES.put(component, module);
+  }
+
+  /** Removes a previously registered active test module. */
+  public static void unregisterActiveTestModule(String component, CIVisibilityEvent module) {
+    ACTIVE_TEST_MODULES.remove(component, module);
   }
 
   /**
-   * Returns a handle to the currently active test session (limited to headless and manual API) so
-   * users can attach custom tags, or {@code null} when no test session is being managed by the
-   * tracer.
+   * Returns an unmodifiable view of the currently active headless test sessions, keyed by
+   * component.
    */
-  @Nullable
-  public static CIVisibilityEvent activeTestSession() {
-    return ACTIVE_TEST_SESSION;
+  public static Map<String, CIVisibilityEvent> activeTestSessions() {
+    return Collections.unmodifiableMap(ACTIVE_TEST_SESSIONS);
   }
 
   /**
-   * Returns a handle to the currently active test module (limited to headless and manual API) so
-   * users can attach custom tags, or {@code null} when no test module is being managed by the
-   * tracer.
+   * Returns an unmodifiable view of the currently active headless test modules, keyed by component.
    */
-  @Nullable
-  public static CIVisibilityEvent activeTestModule() {
-    return ACTIVE_TEST_MODULE;
+  public static Map<String, CIVisibilityEvent> activeTestModules() {
+    return Collections.unmodifiableMap(ACTIVE_TEST_MODULES);
   }
 
   /**

--- a/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibilityEvent.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibilityEvent.java
@@ -1,0 +1,11 @@
+package datadog.trace.api.civisibility;
+
+/**
+ * Handle to a CI Visibility event (test session or test module) that lets users attach custom tags
+ * from a test framework lifecycle callback. Obtain instances via {@link
+ * CIVisibility#activeTestSession()} or {@link CIVisibility#activeTestModule()}.
+ */
+public interface CIVisibilityEvent {
+
+  void setTag(String key, Object value);
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibilityEvent.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/civisibility/CIVisibilityEvent.java
@@ -3,7 +3,7 @@ package datadog.trace.api.civisibility;
 /**
  * Handle to a CI Visibility event (test session or test module) that lets users attach custom tags
  * from a test framework lifecycle callback. Obtain instances via {@link
- * CIVisibility#activeTestSession()} or {@link CIVisibility#activeTestModule()}.
+ * CIVisibility#activeTestSessions()} or {@link CIVisibility#activeTestModules()}.
  */
 public interface CIVisibilityEvent {
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -83,6 +83,7 @@ public final class CiVisibilityConfig {
   public static final String TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES =
       "test.management.attempt.to.fix.retries";
   public static final String TEST_FAILED_TEST_REPLAY_ENABLED = "test.failed.test.replay.enabled";
+  public static final String CIVISIBILITY_PROPAGATED_TAGS = "civisibility.propagated.tags";
 
   /* Git PR info */
   public static final String GIT_PULL_REQUEST_BASE_BRANCH = "git.pull.request.base.branch";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -280,6 +280,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_JACOCO_PL
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_JVM_INFO_CACHE_SIZE;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_KNOWN_TESTS_REQUEST_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_MODULE_NAME;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_PROPAGATED_TAGS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_REPO_INDEX_DUPLICATE_KEY_CHECK_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_REPO_INDEX_FOLLOW_SYMLINKS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_RESOURCE_FOLDER_NAMES;
@@ -1169,6 +1170,7 @@ public class Config {
   private final String gitPullRequestBaseBranchSha;
   private final String gitCommitHeadSha;
   private final boolean ciVisibilityFailedTestReplayEnabled;
+  private final Set<String> ciVisibilityPropagatedTagKeys;
   private final String testOptimizationManifestFile;
   private final boolean testOptimizationPayloadsInFiles;
 
@@ -2708,6 +2710,8 @@ public class Config {
     gitCommitHeadSha = configProvider.getString(GIT_COMMIT_HEAD_SHA);
     ciVisibilityFailedTestReplayEnabled =
         configProvider.getBoolean(TEST_FAILED_TEST_REPLAY_ENABLED, true);
+    ciVisibilityPropagatedTagKeys =
+        configProvider.getSet(CIVISIBILITY_PROPAGATED_TAGS, Collections.emptySet());
 
     testOptimizationManifestFile = configProvider.getString(TEST_OPTIMIZATION_MANIFEST_FILE);
     testOptimizationPayloadsInFiles =
@@ -4487,6 +4491,10 @@ public class Config {
 
   public boolean isCiVisibilityFailedTestReplayEnabled() {
     return ciVisibilityFailedTestReplayEnabled;
+  }
+
+  public Set<String> getCiVisibilityPropagatedTagKeys() {
+    return ciVisibilityPropagatedTagKeys;
   }
 
   public String getTestOptimizationManifestFile() {

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -777,6 +777,14 @@
         "aliases": []
       }
     ],
+    "DD_CIVISIBILITY_PROPAGATED_TAGS": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_CIVISIBILITY_REMOTE_ENV_VARS_PROVIDER_KEY": [
       {
         "version": "A",

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -780,7 +780,7 @@
     "DD_CIVISIBILITY_PROPAGATED_TAGS": [
       {
         "version": "A",
-        "type": "string",
+        "type": "array",
         "default": null,
         "aliases": []
       }


### PR DESCRIPTION
# What Does This Do

- Surfaces the active headless test sessions and modules through `CIVisibility.activeTestSessions()` and `CIVisibility.activeTestModules()` for users to add custom tags to them. The events are registered per component (framework) because when running in headless mode each framework instrumentation creates its own session and module. 
- Implements top-to-bottom tag propagation configured through an allow-list with `DD_CIVISIBILITY_PROPAGATED_TAGS` (e.g. `DD_CIVISIBILITY_PROPAGATED_TAGS=custom.shard_index,custom.total_shards,build.id`)
	- The configured tags will always be propagated from the test event (e.g. session, module or suite) to its children if they are created after the tag is set. 

# Motivation

These changes allow users to programmatically set custom tags at session and module level. 

Alternative approach to https://github.com/DataDog/dd-trace-java/pull/11366

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [SDTEST-3804]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
