### PR TITLE
Stop leaking Maven subprocess output into JUnit reports

### DIFF
--- a/dd-smoke-tests/maven/src/test/java/datadog/smoketest/MavenSmokeTest.java
+++ b/dd-smoke-tests/maven/src/test/java/datadog/smoketest/MavenSmokeTest.java
@@ -559,10 +559,12 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
         String line;
         while ((line = br.readLine()) != null) {
-          System.out.println(messagePrefix + ": " + line);
+          // DEBUG: logback.xml keeps this logger at INFO, so subprocess output — which may contain
+          // secrets (env vars, agent args) — never reaches JUnit XML reports.
+          LOGGER.debug("{}: {}", messagePrefix, line);
         }
       } catch (IOException e) {
-        e.printStackTrace();
+        LOGGER.warn("Error reading process stream", e);
       }
     }
   }

--- a/dd-smoke-tests/maven/src/test/resources/logback.xml
+++ b/dd-smoke-tests/maven/src/test/resources/logback.xml
@@ -1,3 +1,9 @@
 <configuration>
   <logger name="org.eclipse.jetty" level="INFO"/>
+  <!--
+    MavenSmokeTest.StreamConsumer logs subprocess stdout/stderr at DEBUG.
+    Capped at INFO so Maven's verbose output — which may include CI secrets
+    (env vars, agent args) — never reaches JUnit XML reports.
+  -->
+  <logger name="datadog.smoketest.MavenSmokeTest" level="INFO"/>
 </configuration>


### PR DESCRIPTION
# What Does This Do

Routes `MavenSmokeTest`'s subprocess stdout/stderr through `LOGGER.debug` instead of
`System.out.println`, and caps the logger at `INFO` in `logback.xml`.

# Motivation

JUnit captures `System.out` and embeds it verbatim in XML reports.
`StreamConsumer` was printing every line of the Maven subprocess output there —
producing a **13 MB `<system-out>` block** per run, made up of Maven download
progress bars, tracer `DEBUG` logs, and, crucially, Maven's verbose environment
dump which can include **secrets** from the
subprocess's environment variables.

Routing to `LOGGER.debug` means the output is suppressed at the `INFO` floor set in
`logback.xml` by default, so it never reaches the XML report. Local debugging still
works: drop the logger back to `DEBUG` to see the full subprocess stream.

A comment at the call site and in `logback.xml` explains the contract so future
readers don't accidentally raise the log level without understanding the implications.

# Additional Notes


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

`tag: no release note`
`tag: ai generated`