### PR TITLE
Add instrumentation for quarkus-rest-client-reactive (javax, MicroProfile REST Client 1.0–2.x)

### DIFF
--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/build.gradle
@@ -1,0 +1,33 @@
+muzzle {
+  pass {
+    group = "org.eclipse.microprofile.rest.client"
+    module = "microprofile-rest-client-api"
+    versions = "[1.0, 3.0)"
+    assertInverse = true
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly group: 'org.eclipse.microprofile.rest.client', name: 'microprofile-rest-client-api', version: '2.0'
+  compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1.1'
+  compileOnly group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+  testImplementation group: 'org.eclipse.microprofile.rest.client', name: 'microprofile-rest-client-api', version: '2.0'
+  testImplementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1.1'
+  testImplementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+  // RESTEasy Microprofile client 1.x uses javax namespace and works standalone without Quarkus.
+  testImplementation group: 'org.jboss.resteasy.microprofile', name: 'microprofile-rest-client', version: '1.0.0.Final'
+  testImplementation group: 'org.jboss.resteasy', name: 'resteasy-client', version: '4.7.9.Final'
+  testImplementation group: 'org.jboss.resteasy', name: 'resteasy-jackson2-provider', version: '4.7.9.Final'
+  // MicroProfile Config implementation required by RESTEasy MicroProfile exception mapper at runtime.
+  testImplementation group: 'io.smallrye.config', name: 'smallrye-config', version: '2.13.3'
+
+  latestDepTestImplementation group: 'org.eclipse.microprofile.rest.client', name: 'microprofile-rest-client-api', version: '2.+'
+  latestDepTestImplementation group: 'org.jboss.resteasy.microprofile', name: 'microprofile-rest-client', version: '1.+'
+  latestDepTestImplementation group: 'org.jboss.resteasy', name: 'resteasy-client', version: '4.+'
+  latestDepTestImplementation group: 'org.jboss.resteasy', name: 'resteasy-jackson2-provider', version: '4.+'
+}

--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/InjectAdapter.java
@@ -1,0 +1,17 @@
+package datadog.trace.instrumentation.quarkus_rest_client_reactive_javax;
+
+import datadog.context.propagation.CarrierSetter;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.ws.rs.core.MultivaluedMap;
+
+@ParametersAreNonnullByDefault
+public final class InjectAdapter implements CarrierSetter<MultivaluedMap<String, Object>> {
+
+  public static final InjectAdapter SETTER = new InjectAdapter();
+
+  @Override
+  public void set(
+      final MultivaluedMap<String, Object> headers, final String key, final String value) {
+    headers.putSingle(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxDecorator.java
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxDecorator.java
@@ -1,0 +1,56 @@
+package datadog.trace.instrumentation.quarkus_rest_client_reactive_javax;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
+import java.net.URI;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+
+public class QuarkusRestClientJavaxDecorator
+    extends HttpClientDecorator<ClientRequestContext, ClientResponseContext> {
+
+  public static final CharSequence QUARKUS_REST_CLIENT =
+      UTF8BytesString.create("quarkus-rest-client-reactive");
+  public static final QuarkusRestClientJavaxDecorator DECORATE =
+      new QuarkusRestClientJavaxDecorator();
+  public static final CharSequence QUARKUS_REST_CLIENT_CALL =
+      UTF8BytesString.create(DECORATE.operationName());
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {
+      "quarkus-rest-client-reactive", "quarkus-rest-client", "microprofile-rest-client"
+    };
+  }
+
+  @Override
+  protected CharSequence component() {
+    return QUARKUS_REST_CLIENT;
+  }
+
+  @Override
+  protected String method(final ClientRequestContext request) {
+    return request.getMethod();
+  }
+
+  @Override
+  protected URI url(final ClientRequestContext request) {
+    return request.getUri();
+  }
+
+  @Override
+  protected int status(final ClientResponseContext response) {
+    return response.getStatus();
+  }
+
+  @Override
+  protected String getRequestHeader(final ClientRequestContext request, final String headerName) {
+    return request.getHeaderString(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(
+      final ClientResponseContext response, final String headerName) {
+    return response.getHeaderString(headerName);
+  }
+}

--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxInstrumentation.java
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxInstrumentation.java
@@ -1,0 +1,57 @@
+package datadog.trace.instrumentation.quarkus_rest_client_reactive_javax;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@AutoService(InstrumenterModule.class)
+public final class QuarkusRestClientJavaxInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public QuarkusRestClientJavaxInstrumentation() {
+    super("quarkus-rest-client-reactive", "quarkus-rest-client", "microprofile-rest-client");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.eclipse.microprofile.rest.client.RestClientBuilder";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".QuarkusRestClientJavaxDecorator",
+      packageName + ".QuarkusRestClientJavaxTracingFilter",
+      packageName + ".InjectAdapter",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod().and(named("build")).and(takesArgument(0, Class.class)),
+        QuarkusRestClientJavaxInstrumentation.class.getName() + "$RestClientBuilderAdvice");
+  }
+
+  public static class RestClientBuilderAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void registerFilter(@Advice.This final RestClientBuilder builder) {
+      builder.register(QuarkusRestClientJavaxTracingFilter.class);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxTracingFilter.java
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/main/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxTracingFilter.java
@@ -1,0 +1,48 @@
+package datadog.trace.instrumentation.quarkus_rest_client_reactive_javax;
+
+import static datadog.context.Context.current;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.quarkus_rest_client_reactive_javax.InjectAdapter.SETTER;
+import static datadog.trace.instrumentation.quarkus_rest_client_reactive_javax.QuarkusRestClientJavaxDecorator.DECORATE;
+import static datadog.trace.instrumentation.quarkus_rest_client_reactive_javax.QuarkusRestClientJavaxDecorator.QUARKUS_REST_CLIENT;
+import static datadog.trace.instrumentation.quarkus_rest_client_reactive_javax.QuarkusRestClientJavaxDecorator.QUARKUS_REST_CLIENT_CALL;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+@Priority(Priorities.HEADER_DECORATOR)
+public class QuarkusRestClientJavaxTracingFilter
+    implements ClientRequestFilter, ClientResponseFilter {
+
+  public static final String SPAN_PROPERTY_NAME = "datadog.trace.quarkus-rest-client.span";
+
+  @Override
+  public void filter(final ClientRequestContext requestContext) {
+    final AgentSpan span = startSpan(QUARKUS_REST_CLIENT.toString(), QUARKUS_REST_CLIENT_CALL);
+    try (final AgentScope scope = activateSpan(span)) {
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, requestContext);
+      DECORATE.injectContext(current().with(span), requestContext.getHeaders(), SETTER);
+      requestContext.setProperty(SPAN_PROPERTY_NAME, span);
+    }
+  }
+
+  @Override
+  public void filter(
+      final ClientRequestContext requestContext, final ClientResponseContext responseContext) {
+    final Object spanObj = requestContext.getProperty(SPAN_PROPERTY_NAME);
+    if (spanObj instanceof AgentSpan) {
+      final AgentSpan span = (AgentSpan) spanObj;
+      DECORATE.onResponse(span, responseContext);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/test/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/quarkus/quarkus-rest-client-reactive-2.0/src/test/java/datadog/trace/instrumentation/quarkus_rest_client_reactive_javax/QuarkusRestClientJavaxInstrumentationTest.java
@@ -1,0 +1,97 @@
+package datadog.trace.instrumentation.quarkus_rest_client_reactive_javax;
+
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class QuarkusRestClientJavaxInstrumentationTest extends AbstractInstrumentationTest {
+
+  private static HttpServer server;
+  private static int port;
+  private static final AtomicReference<String> capturedTraceId = new AtomicReference<>();
+  private static final AtomicReference<String> capturedParentId = new AtomicReference<>();
+
+  @RegisterRestClient
+  public interface HelloClient {
+    @GET
+    @Path("/hello")
+    Response hello();
+  }
+
+  @BeforeAll
+  static void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/hello",
+        new HttpHandler() {
+          @Override
+          public void handle(HttpExchange exchange) throws IOException {
+            capturedTraceId.set(exchange.getRequestHeaders().getFirst("x-datadog-trace-id"));
+            capturedParentId.set(exchange.getRequestHeaders().getFirst("x-datadog-parent-id"));
+            byte[] body = "hello".getBytes();
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+          }
+        });
+    server.start();
+    port = server.getAddress().getPort();
+  }
+
+  @AfterAll
+  static void stopServer() {
+    server.stop(0);
+  }
+
+  @Test
+  void propagationHeadersAreInjectedOnRestClientCall() throws Exception {
+    HelloClient client =
+        RestClientBuilder.newBuilder()
+            .baseUri(URI.create("http://localhost:" + port))
+            .build(HelloClient.class);
+
+    try (Response response = client.hello()) {
+      assertEquals(200, response.getStatus());
+    }
+
+    assertNotNull(capturedTraceId.get(), "x-datadog-trace-id header should be injected");
+    assertNotNull(capturedParentId.get(), "x-datadog-parent-id header should be injected");
+
+    assertTraces(trace(span().type("http")));
+  }
+
+  @Test
+  void spanIsCreatedForEachRequest() throws Exception {
+    HelloClient client =
+        RestClientBuilder.newBuilder()
+            .baseUri(URI.create("http://localhost:" + port))
+            .build(HelloClient.class);
+
+    try (Response r1 = client.hello()) {
+      assertEquals(200, r1.getStatus());
+    }
+    try (Response r2 = client.hello()) {
+      assertEquals(200, r2.getStatus());
+    }
+
+    assertTraces(trace(span().type("http")), trace(span().type("http")));
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -530,6 +530,7 @@ include(
   ":dd-java-agent:instrumentation:play:play-appsec-2.7",
   ":dd-java-agent:instrumentation:play:play-appsec-common",
   ":dd-java-agent:instrumentation:protobuf-3.0",
+  ":dd-java-agent:instrumentation:quarkus:quarkus-rest-client-reactive-2.0",
   ":dd-java-agent:instrumentation:quartz-2.0",
   ":dd-java-agent:instrumentation:rabbitmq-amqp-2.7",
   ":dd-java-agent:instrumentation:ratpack-1.5",


### PR DESCRIPTION
## Summary

- Adds `quarkus-rest-client-reactive-2.0` instrumentation for Quarkus 2.x stacks that use the `javax.ws.rs` namespace (MicroProfile REST Client 1.0–2.x)
- Companion to #11495 which covers MicroProfile REST Client 3.0+ (jakarta namespace, Quarkus 3.x)
- Same hook and filter pattern: intercepts `RestClientBuilder.build(Class<?>)`, registers a `ClientRequestFilter` to inject Datadog + W3C propagation headers, creates an HTTP client span per request

## Implementation

Identical to #11495 except all `jakarta.*` imports are replaced with `javax.*`. The muzzle range `[1.0, 3.0)` ensures this module activates only when `microprofile-rest-client-api < 3.0` is on the classpath; the jakarta module activates at `≥ 3.0`. Both can coexist in the agent jar without conflict because they use distinct Java packages (`quarkus_rest_client_reactive_javax` vs `quarkus_rest_client_reactive`).

## Test plan

- [ ] Unit tests pass (`QuarkusRestClientJavaxInstrumentationTest` — 2 JUnit 5 tests using RESTEasy MicroProfile 1.x client + JDK HttpServer): verify `x-datadog-trace-id` / `x-datadog-parent-id` headers are injected and a span is created per request
- [ ] `./gradlew :dd-java-agent:instrumentation:quarkus:quarkus-rest-client-reactive-2.0:test` passes locally
- [ ] Muzzle check configured against `microprofile-rest-client-api [1.0, 3.0)`
- [ ] Manual validation against a Quarkus 2.x app recommended before merge

## Labels

`comp:java-tracer`, `inst:quarkus`, `type:feature`, `tag:ai generated`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)