### PR TITLE
Bump Gradle develocity plugin to 4.4.2

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.4.1"
+  id("com.gradle.develocity") version "4.4.2"
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
# What Does This Do
Bump Gradle develocity plugin to 4.4.2

# Motivation
Latest tools.
