### PR TITLE
Cover documentation for config inversion json checks

### DIFF
--- a/.claude/skills/add-apm-integrations/SKILL.md
+++ b/.claude/skills/add-apm-integrations/SKILL.md
@@ -69,8 +69,7 @@ pattern before writing new code. Use it as a template.
    `DD_TRACE_COUCHBASE_3_ENABLED`). Add a `"type": "boolean"` entry, in alphabetical order, with
    aliases `DD_TRACE_INTEGRATION_<NAME>_ENABLED` and `DD_INTEGRATION_<NAME>_ENABLED`. Set `default`
    to the module's real default — `"true"`, or `"false"` if it overrides `defaultEnabled()` (e.g.
-   OpenTelemetry, Hazelcast); the task won't catch a wrong default, but it ships misleading
-   metadata. Declaring several names (`super("a", "b")`) means one entry each.
+   OpenTelemetry, Hazelcast). Declaring several names (`super("a", "b")`) means one entry each.
 
 ## Step 5 – Write the InstrumenterModule
 

--- a/.claude/skills/add-apm-integrations/SKILL.md
+++ b/.claude/skills/add-apm-integrations/SKILL.md
@@ -63,6 +63,13 @@ pattern before writing new code. Use it as a template.
    - `testImplementation` dependencies for tests
    - `muzzle { pass { } }` directives (see Step 9)
 4. Register the new module in `settings.gradle.kts` in **alphabetical order**
+5. Register the integration name in `metadata/supported-configurations.json`. The name you pass to
+   the `InstrumenterModule` `super(...)` constructor maps to env var `DD_TRACE_<NAME>_ENABLED`
+   (`.` and `-` become `_`, then uppercased — e.g. `couchbase-3` → `DD_TRACE_COUCHBASE_3_ENABLED`).
+   Add a `boolean`/`default: "true"` entry with the two standard aliases
+   `DD_TRACE_INTEGRATION_<NAME>_ENABLED` and `DD_INTEGRATION_<NAME>_ENABLED`, keeping the key in
+   alphabetical order. A module declaring multiple names (`super("a", "b")`) needs **one entry per
+   name**. Omitting this fails the `checkInstrumenterModuleConfigurations` Gradle task.
 
 ## Step 5 – Write the InstrumenterModule
 
@@ -193,10 +200,14 @@ Run these commands in order and fix any failures before proceeding:
 ./gradlew :dd-java-agent:instrumentation:$framework-$version:muzzle
 ./gradlew :dd-java-agent:instrumentation:$framework-$version:test
 ./gradlew :dd-java-agent:instrumentation:$framework-$version:latestDepTest
+./gradlew checkInstrumenterModuleConfigurations
 ./gradlew spotlessCheck
 ```
 
 **If muzzle fails:** check for missing helper class names in `helperClassNames()`.
+
+**If `checkInstrumenterModuleConfigurations` fails:** an integration name from `super(...)` is missing
+(or mismatched) in `metadata/supported-configurations.json` — see Step 4, item 5.
 
 **If tests fail:** verify span lifecycle order (start → activate → error → finish → close), helper registration,
 and `contextStore()` map entries match actual usage.
@@ -208,6 +219,7 @@ and `contextStore()` map entries match actual usage.
 Output this checklist and confirm each item is satisfied:
 
 - [ ] `settings.gradle.kts` entry added in alphabetical order
+- [ ] `metadata/supported-configurations.json` has a `DD_TRACE_<NAME>_ENABLED` entry (+ the two aliases) for every name passed to `super(...)`
 - [ ] `build.gradle` has `compileOnly` deps and `muzzle` directives with `assertInverse = true`
 - [ ] `@AutoService(InstrumenterModule.class)` annotation present on the module class
 - [ ] `helperClassNames()` lists ALL referenced helpers (including inner, anonymous, and enum synthetic classes)

--- a/.claude/skills/add-apm-integrations/SKILL.md
+++ b/.claude/skills/add-apm-integrations/SKILL.md
@@ -63,13 +63,14 @@ pattern before writing new code. Use it as a template.
    - `testImplementation` dependencies for tests
    - `muzzle { pass { } }` directives (see Step 9)
 4. Register the new module in `settings.gradle.kts` in **alphabetical order**
-5. Register the integration name in `metadata/supported-configurations.json`. The name you pass to
-   the `InstrumenterModule` `super(...)` constructor maps to env var `DD_TRACE_<NAME>_ENABLED`
-   (`.` and `-` become `_`, then uppercased — e.g. `couchbase-3` → `DD_TRACE_COUCHBASE_3_ENABLED`).
-   Add a `boolean`/`default: "true"` entry with the two standard aliases
-   `DD_TRACE_INTEGRATION_<NAME>_ENABLED` and `DD_INTEGRATION_<NAME>_ENABLED`, keeping the key in
-   alphabetical order. A module declaring multiple names (`super("a", "b")`) needs **one entry per
-   name**. Omitting this fails the `checkInstrumenterModuleConfigurations` Gradle task.
+5. Register the integration name in `metadata/supported-configurations.json`, or
+   `checkInstrumenterModuleConfigurations` fails. The name in `super(...)` maps to env var
+   `DD_TRACE_<NAME>_ENABLED` (`.` and `-` become `_`, uppercased — `couchbase-3` →
+   `DD_TRACE_COUCHBASE_3_ENABLED`). Add a `"type": "boolean"` entry, in alphabetical order, with
+   aliases `DD_TRACE_INTEGRATION_<NAME>_ENABLED` and `DD_INTEGRATION_<NAME>_ENABLED`. Set `default`
+   to the module's real default — `"true"`, or `"false"` if it overrides `defaultEnabled()` (e.g.
+   OpenTelemetry, Hazelcast); the task won't catch a wrong default, but it ships misleading
+   metadata. Declaring several names (`super("a", "b")`) means one entry each.
 
 ## Step 5 – Write the InstrumenterModule
 

--- a/docs/add_new_instrumentation.md
+++ b/docs/add_new_instrumentation.md
@@ -67,6 +67,17 @@ public class GoogleHttpClientInstrumentation extends InstrumenterModule.Tracing 
 }
 ```
 
+> [!IMPORTANT]
+> **The instrumentation name controls a config flag that must be registered.** The name passed to
+> `super(...)` becomes the config key `dd.trace.<name>.enabled` → environment variable
+> `DD_TRACE_<NAME>_ENABLED` (`.` and `-` become `_`, then uppercased — e.g. `couchbase-3` →
+> `DD_TRACE_COUCHBASE_3_ENABLED`). Every such name must be registered in
+> `metadata/supported-configurations.json` with the two standard aliases
+> (`DD_TRACE_INTEGRATION_<NAME>_ENABLED` and `DD_INTEGRATION_<NAME>_ENABLED`), or the
+> `checkInstrumenterModuleConfigurations` Gradle task fails the build. A module declaring multiple
+> names (`super("a", "b")`) needs **one entry per name**. See
+> [Add new configurations](./add_new_configurations.md) for the JSON entry shape.
+
 ## Match the target class
 
 In this case we target only one known class to instrument. This is the class which contains the method this


### PR DESCRIPTION
# What Does This Do

Add documentation coverage for the configuration inversion json checks (claude + doc)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
