### PR TITLE
Clean up partially-extracted cache after a failed extraction.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,8 @@ variables:
   # Gitlab runner features; see https://docs.gitlab.com/runner/configuration/feature-flags.html
   # Fold and time all script sections
   FF_SCRIPT_SECTIONS: 1
+  # Clean up partially-extracted cache after a failed extraction (mitigates "unexpected EOF" on large cache restores)
+  FF_CLEAN_UP_FAILED_CACHE_EXTRACT: "true"
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   BUILD_JOB_NAME: "build"
   DEPENDENCY_CACHE_POLICY: pull


### PR DESCRIPTION
# What Does This Do
Clean up partially-extracted cache after a failed extraction.

# Motivation
Fix `FATAL: unexpected EOF`. Unblock GitLab PRs and releases.

# Additional Notes
This is a `band-aid`, not a real fix. We need to find a root cause of this `EOF` later.
