### PR TITLE
feat(profiling): add llm.agent.phase profiling feature flag

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -4,6 +4,7 @@ import static com.datadog.profiling.controller.ProfilingSupport.isOldObjectSampl
 import static datadog.environment.JavaVirtualMachine.isJ9;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_LLM_PHASE_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
@@ -394,6 +395,10 @@ public class DatadogProfilerConfig {
 
   public static boolean isResourceNameContextAttributeEnabled(ConfigProvider configProvider) {
     return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED, false);
+  }
+
+  public static boolean isLlmPhaseAttributeEnabled(ConfigProvider configProvider) {
+    return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_LLM_PHASE_ENABLED, true);
   }
 
   public static boolean isTrackingGenerations(ConfigProvider configProvider) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -223,6 +223,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED =
       "profiling.context.attributes.resource.name.enabled";
 
+  public static final String PROFILING_CONTEXT_ATTRIBUTES_LLM_PHASE_ENABLED =
+      "profiling.context.attributes.llm.phase.enabled";
+
   public static final String PROFILING_QUEUEING_TIME_ENABLED = "profiling.queueing.time.enabled";
 
   public static final boolean PROFILING_QUEUEING_TIME_ENABLED_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do

Adds `PROFILING_CONTEXT_ATTRIBUTES_LLM_PHASE_ENABLED` to `ProfilingConfig` and `isLlmPhaseAttributeEnabled(ConfigProvider)` to `DatadogProfilerConfig`.

# Motivation

The `llm.agent.phase` context attribute slot must be registered at profiler startup — `ContextSetter` is built once and `offsetOf()` returns -1 for any name not present at construction time. This flag (default `true`) gates the registration, matching the `PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED` pattern and allowing operators to opt out without disabling the profiler.

Part of PROF-14858 (LLM phase attribution). Stacked: _base (master)_ → [ddt-2-profiler] → [ddt-3-lc4j] → [ddt-4-demo].

# Additional Notes

No behaviour change until the slot registration in the next PR in this stack.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROF-14861]

[PROF-14861]: https://datadoghq.atlassian.net/browse/PROF-14861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ