### PR TITLE
feat(profiling): register llm.agent.phase slot and add phase set/clear API

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -17,6 +17,7 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationPro
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLiveHeapSizeTrackingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isMemoryLeakProfilingEnabled;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLlmPhaseAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isResourceNameContextAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isSpanNameContextAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isTrackingGenerations;
@@ -69,6 +70,7 @@ public final class DatadogProfiler {
 
   private static final String OPERATION = "_dd.trace.operation";
   private static final String RESOURCE = "_dd.trace.resource";
+  private static final String LLM_PHASE = "llm.agent.phase";
 
   private static final int MAX_NUM_ENDPOINTS = 8192;
 
@@ -105,6 +107,7 @@ public final class DatadogProfiler {
   private final Set<ProfilingMode> profilingModes = EnumSet.noneOf(ProfilingMode.class);
 
   private final ContextSetter contextSetter;
+  private final int llmPhaseOffset;
 
   private final List<String> orderedContextAttributes;
 
@@ -150,7 +153,11 @@ public final class DatadogProfiler {
     if (isResourceNameContextAttributeEnabled(configProvider)) {
       orderedContextAttributes.add(RESOURCE);
     }
+    if (isLlmPhaseAttributeEnabled(configProvider)) {
+      orderedContextAttributes.add(LLM_PHASE);
+    }
     this.contextSetter = new ContextSetter(profiler, orderedContextAttributes);
+    this.llmPhaseOffset = contextSetter.offsetOf(LLM_PHASE);
     this.queueTimeThresholdMillis =
         configProvider.getLong(
             PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS,
@@ -406,6 +413,14 @@ public final class DatadogProfiler {
       }
     }
     return false;
+  }
+
+  public boolean setAgentPhase(String phaseToken) {
+    return contextSetter.setContextValue(llmPhaseOffset, phaseToken);
+  }
+
+  public boolean clearAgentPhase() {
+    return contextSetter.clearContextValue(llmPhaseOffset);
   }
 
   private void debugLogging(long localRootSpanId) {


### PR DESCRIPTION
# What Does This Do

Registers `llm.agent.phase` as a context attribute slot in `DatadogProfiler` at startup (when `isLlmPhaseAttributeEnabled` is true) and exposes `setAgentPhase(String phaseToken)` / `clearAgentPhase()` for use by instrumentation modules.

# Motivation

`ContextSetter` is built once; slots not present at construction time have offset -1 (no-op). This change wires the registration into the existing `orderedContextAttributes` pipeline, consuming 1 of the 10 available slots. The named API (`setAgentPhase`/`clearAgentPhase`) hides the raw offset from instrumentation callers.

Part of PROF-14858. Stacked on #11528 (config flag). Next: [ddt-3-lc4j] (LangChain4j hooks).

# Additional Notes

- `llm.agent.phase` appears in the profiler `start` command's `attributes=` parameter when the feature flag is on.
- No change to any sampler hot path; slot lookup and registration happen only at profiler startup.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROF-14862]

[PROF-14862]: https://datadoghq.atlassian.net/browse/PROF-14862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ