### PR TITLE
test: route Tomcat archive through MASS staging (HEAD fix validation)

### DIFF
--- a/dd-smoke-tests/springboot-tomcat/application/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/build.gradle
@@ -29,7 +29,6 @@ ext {
 }
 
 // Route artifact downloads through MASS staging to validate HEAD support.
-// MASS staging: https://mass-read.us1.staging.dog
 // DO NOT MERGE — staging validation only.
 def massArtifactUrl = { String upstreamArtifactUrl ->
   def massReadUrl = 'https://mass-read.us1.staging.dog'
@@ -66,3 +65,32 @@ dependencies {
 
 tasks.register("unzip", Copy) {
   def zipFileNamePrefix = "tomcat"
+  def serverZipTree = providers.provider {
+    // eager access
+    def zipPath = project.configurations.serverFile.find {
+      it.name.startsWith(zipFileNamePrefix)
+    }
+    if (zipPath == null) {
+      throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
+    }
+    zipTree(zipPath)
+  }
+
+  from serverZipTree
+  into layout.buildDirectory
+
+  // When tests are disabled this would still be run, so disable this manually
+  onlyIf { !project.rootProject.hasProperty("skipTests") }
+}
+
+tasks.named('bootWar') {
+  dependsOn 'unzip'
+}
+
+tasks.named('bootWarMainClassName') {
+  dependsOn 'unzip'
+}
+
+tasks.named('war') {
+  dependsOn 'unzip'
+}

--- a/dd-smoke-tests/springboot-tomcat/application/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/build.gradle
@@ -28,9 +28,17 @@ ext {
   serverExtension = 'zip'
 }
 
+// Route artifact downloads through MASS staging to validate HEAD support.
+// MASS staging: https://mass-read.us1.staging.dog
+// DO NOT MERGE — staging validation only.
+def massArtifactUrl = { String upstreamArtifactUrl ->
+  def massReadUrl = 'https://mass-read.us1.staging.dog'
+  return "${massReadUrl}/internal/artifact/${upstreamArtifactUrl}"
+}
+
 repositories {
   ivy {
-    url = 'https://dlcdn.apache.org'
+    url = massArtifactUrl('dlcdn.apache.org')
     patternLayout {
       artifact '/[organisation]/[module]/v[revision]/bin/apache-[organisation]-[revision].[ext]'
     }
@@ -58,32 +66,3 @@ dependencies {
 
 tasks.register("unzip", Copy) {
   def zipFileNamePrefix = "tomcat"
-  def serverZipTree = providers.provider {
-    // eager access
-    def zipPath = project.configurations.serverFile.find {
-      it.name.startsWith(zipFileNamePrefix)
-    }
-    if (zipPath == null) {
-      throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
-    }
-    zipTree(zipPath)
-  }
-
-  from serverZipTree
-  into layout.buildDirectory
-
-  // When tests are disabled this would still be run, so disable this manually
-  onlyIf { !project.rootProject.hasProperty("skipTests") }
-}
-
-tasks.named('bootWar') {
-  dependsOn 'unzip'
-}
-
-tasks.named('bootWarMainClassName') {
-  dependsOn 'unzip'
-}
-
-tasks.named('war') {
-  dependsOn 'unzip'
-}


### PR DESCRIPTION
## What Does This Do

Routes the Spring Boot Tomcat archive download through MASS staging (`https://mass-read.us1.staging.dog`) to validate that Gradle HEAD probes work correctly after the MASS pull-through HEAD fix.

## Motivation

MASS previously returned `405 Method Not Allowed` for HEAD requests on artifact routes. A fix was deployed to staging that adds proper HEAD support, including a pull-through fallback so uncached artifacts return `200` (not `404`) when Gradle probes before downloading.

This PR exercises that exact path: Gradle sends `HEAD /internal/artifact/dlcdn.apache.org/...` before the GET, MASS should return `200`, and the download should complete.

## Additional Notes

**DO NOT MERGE** — staging validation only. Once validated, the production version of this routing should use `MASS_READ_URL` env var (as in #11525) rather than a hardcoded staging URL.

Depends on: DataDog/dd-source#455913