### PR TITLE
Fix Gradle custom test task wiring

### DIFF
--- a/dd-java-agent/instrumentation/scala/scala-2.10.7/build.gradle
+++ b/dd-java-agent/instrumentation/scala/scala-2.10.7/build.gradle
@@ -68,7 +68,9 @@ final testTasks = scalaVersions.collect { scalaLibrary ->
   }
 
   return tasks.register("test$version", Test) {
-    classpath = classpath
+    testClassesDirs = sourceSets.test.output.classesDirs
+      .minus(files(sourceSets.test.scala.classesDirectory))
+    classpath = sourceSets.test.runtimeClasspath
       .filter { !it.toString().contains('scala-library') }   // exclude default scala-library
       .minus(files(sourceSets.test.scala.classesDirectory))  // exclude default /build/classes/scala/test folder
       .plus(customSourceSet.output.classesDirs)              // add /build/classes/scala/${version} folder
@@ -83,4 +85,3 @@ tasks.named('test', Test) {
   systemProperty('uses.java.concat', false) // version 2.10.7 does not use java concatenation
   finalizedBy(testTasks)
 }
-

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -134,6 +134,8 @@ tasks.register('forkedTest', Test) {
   classpath = sourceSets.test.runtimeClasspath
 }
 
+// testRuntimeActivation is registered in individual module build files after this convention is
+// applied, so tasks.named() won't work here — use a lazy hook that intercepts it on registration.
 tasks.withType(Test).configureEach {
   if (name == 'testRuntimeActivation') {
     testClassesDirs = sourceSets.test.output.classesDirs

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -130,6 +130,15 @@ ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainers
 tasks.register('forkedTest', Test) {
   group = LifecycleBasePlugin.VERIFICATION_GROUP
   useJUnitPlatform()
+  testClassesDirs = sourceSets.test.output.classesDirs
+  classpath = sourceSets.test.runtimeClasspath
+}
+
+tasks.withType(Test).configureEach {
+  if (name == 'testRuntimeActivation') {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+  }
 }
 
 def applyCodeCoverage = !(


### PR DESCRIPTION
# What Does This Do

Wires custom `Test` tasks explicitly to their intended source set outputs:

- shared `forkedTest` -> `sourceSets.test`
- shared `testRuntimeActivation` -> `sourceSets.test`
- Scala cross-version tasks -> regular test classes plus version-specific Scala support classes

# Motivation

After moving to `Gradle 9.5.1`, these custom `Test` tasks no longer inherited the implicit `test` source set wiring that made them run under `Gradle 8.14.4`; without explicit `testClassesDirs`/`classpath`, they were skipped as `NO-SOURCE`.

# Additional Notes

Checked custom `Test` task wiring across the repo. The only remaining empty task is the parent `:dd-java-agent:instrumentation:latestDepTest` placeholder.

Follow up to 
* #11436 