### PR TITLE
[codex] Remove no-discovered-test override

### DIFF
--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -63,17 +63,6 @@ tasks.withType<Test>().configureEach {
     onlyIf("skipForkedTests are undefined or false") { !skipForkedTestsProvider.isPresent }
   } else {
     exclude("**/*ForkedTest*")
-    // Starting from Gradle 9.3, Gradle will fail if a test task has no discovered tests.
-    // While this can be a misconfiguration, dd-trace-java test suite conventions allow suites
-    // to contain abstract base classes that are extended by concrete forked test suites.
-    //
-    // Many instrumentation suites indeed only ship *ForkedTest concrete classes
-    // (the non-forked peer task created by `addTestSuiteExtendingForDir` exists only
-    // to host shared configurations/sources). Those test tasks won't have executable tests
-    // by design under the `**/*ForkedTest*` exclude rule above. So let's allow them.
-    //
-    // Related but not the issue here https://github.com/gradle/gradle/issues/36508
-    failOnNoDiscoveredTests = false
   }
 
   // Set test timeout for 20 minutes. Default job timeout is 1h (configured on CI level).


### PR DESCRIPTION
## What changed

Removes the `failOnNoDiscoveredTests = false` override from the shared Gradle test-task convention.

## Why

This is an experiment after #11538 restored explicit `testClassesDirs`/`classpath` wiring for custom `Test` tasks. CI should show whether the no-discovered-tests override is still required after the custom task wiring fix.

## Validation

- `./gradlew :buildSrc:compileKotlin`