### PR TITLE
Tolerate servlet 2.x wrappers used on servlet-3 classpath for isAsyncStarted calls

### DIFF
--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -158,7 +158,7 @@ public class Servlet3Advice {
 
       final AgentSpan span = spanFromContext(scope.context());
 
-      if (request.isAsyncStarted()) {
+      if (DECORATE.safeIsAsyncStarted(request)) {
         AtomicBoolean activated = new AtomicBoolean();
         FinishAsyncDispatchListener asyncListener =
             new FinishAsyncDispatchListener(scope, activated, !isDispatch);
@@ -166,11 +166,11 @@ public class Servlet3Advice {
         request.setAttribute(DD_FIN_DISP_LIST_SPAN_ATTRIBUTE, asyncListener);
         try {
           request.getAsyncContext().addListener(asyncListener);
-        } catch (final IllegalStateException e) {
+        } catch (final IllegalStateException | AbstractMethodError ignored) {
           // org.eclipse.jetty.server.Request may throw an exception here if request became
           // finished after check above. We just ignore that exception and move on.
         }
-        if (!request.isAsyncStarted() && activated.compareAndSet(false, true)) {
+        if (!DECORATE.safeIsAsyncStarted(request) && activated.compareAndSet(false, true)) {
           if (!isDispatch) {
             DECORATE.onResponse(span, resp);
           }

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
@@ -126,5 +127,20 @@ public class Servlet3Decorator
       super.onError(span, throwable);
     }
     return span;
+  }
+
+  /**
+   * Safely calls ServletRequest#isAsyncStarted. Some 2.x wrappers might be dangling in the 3.x
+   * classpath and produce an AbstractMethodError
+   *
+   * @param servletRequest the servlet request.
+   * @return the real call result or false when the method does not exist in the provided object.
+   */
+  public boolean safeIsAsyncStarted(final ServletRequest servletRequest) {
+    try {
+      return servletRequest.isAsyncStarted();
+    } catch (AbstractMethodError ignored) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

When servlet 2.x wrappers are used along with a servlet3 classpath the issue is that those wrappers are not implementing methods that are expected to be there by the servlet 3 spec.

One example is `isAsyncStarted`. In those cases we see issues like:

```
java.lang.AbstractMethodError
  at javax.servlet.ServletRequestWrapper.isAsyncStarted(ServletRequestWrapper.java:479)
  at javax.servlet.ServletRequestWrapper.isAsyncStarted(ServletRequestWrapper.java:479)
  at (redacted: 18 frames)
```

or even:

```
java.lang.AbstractMethodError
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
  at (redacted: 14 frames)
```

This PR makes sure that access to this method tolerates this case

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
