### PR TITLE
Refine Baggage test migration

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/baggage/BaggagePropagatorTest.java
@@ -15,6 +15,7 @@ import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.tabletest.junit.TableTest;
@@ -28,6 +29,7 @@ class BaggagePropagatorTest extends DDJavaSpecification {
   private Map<String, String> carrier;
   private Context context;
 
+  @ParametersAreNonnullByDefault
   static class MapCarrierAccessor
       implements CarrierSetter<Map<String, String>>, CarrierVisitor<Map<String, String>> {
     @Override
@@ -78,7 +80,7 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     "third entry dropped | [key1: val1, key2: val2, key3: val3] | 'key1=val1,key2=val2'"
   })
   void testBaggageInjectItemLimit(Map<String, String> baggage, String baggageHeader) {
-    // creating a new instance after injecting config
+    // Creating propagator with test item limit
     propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES);
     context = Baggage.create(baggage).storeInto(context);
 
@@ -94,7 +96,7 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     "single entry exceeds bytes once encoded | [abcdefg: 'hijklmnopq♥']            | ''                    "
   })
   void testBaggageInjectBytesLimit(Map<String, String> baggage, String baggageHeader) {
-    // creating a new instance after injecting config
+    // Creating propagator with test bytes limit
     propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20);
     context = Baggage.create(baggage).storeInto(context);
 
@@ -113,7 +115,9 @@ class BaggagePropagatorTest extends DDJavaSpecification {
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
-    assertEquals(baggageMap, Baggage.fromContext(context).asMap());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(baggageMap, baggage.asMap());
   }
 
   @Test
@@ -123,7 +127,7 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
     Baggage baggage = Baggage.fromContext(context);
 
-    // non ASCII values data are still accessible as part of the API
+    // non-ASCII values data are still accessible as part of the API
     assertNotNull(baggage);
     assertEquals("vallée", baggage.asMap().get("key1"));
     assertEquals("value", baggage.asMap().get("clé2"));
@@ -163,8 +167,9 @@ class BaggagePropagatorTest extends DDJavaSpecification {
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
-    Baggage baggageContext = Baggage.fromContext(context);
-    assertEquals(cachedString, baggageContext.getW3cHeader());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(cachedString, baggage.getW3cHeader());
   }
 
   @TableTest({
@@ -180,8 +185,9 @@ class BaggagePropagatorTest extends DDJavaSpecification {
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
-    Baggage baggageContext = Baggage.fromContext(context);
-    assertEquals(cachedString, baggageContext.getW3cHeader());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(cachedString, baggage.getW3cHeader());
   }
 
   @TableTest({
@@ -189,15 +195,16 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     "limit not reached     | 'key1=val1,key2=val2'           | 'key1=val1,key2=val2'",
     "third entry truncates | 'key1=val1,key2=val2,key3=val3' | 'key1=val1,key2=val2'"
   })
-  void testBaggageCacheBytesLimit(String scenario, String baggageHeader, String cachedString) {
-    // creating a new instance after injecting config
+  void testBaggageCacheBytesLimit(String baggageHeader, String cachedString) {
+    // Creating propagator with test bytes limit
     propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20);
     Map<String, String> headers = singletonMap(BAGGAGE_KEY, baggageHeader);
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
-    Baggage baggageContext = Baggage.fromContext(context);
-    assertEquals(cachedString, baggageContext.getW3cHeader());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(cachedString, baggage.getW3cHeader());
   }
 
   @TableTest({
@@ -207,14 +214,16 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     "third entry dropped | 'key1=val1,key2=val2,key3=val3' | [key1: val1, key2: val2]"
   })
   void testBaggageExtractItemsLimit(String baggageHeader, Map<String, String> baggageMap) {
-    // creating a new instance after injecting config
+    // Creating propagator with test item limit
     propagator = new BaggagePropagator(true, true, 2, DEFAULT_TRACE_BAGGAGE_MAX_BYTES);
     Map<String, String> headers = singletonMap(BAGGAGE_KEY, baggageHeader);
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
     // parsing stops once the item limit is exceeded
-    assertEquals(baggageMap, Baggage.fromContext(context).asMap());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(baggageMap, baggage.asMap());
   }
 
   @TableTest({
@@ -224,14 +233,16 @@ class BaggagePropagatorTest extends DDJavaSpecification {
     "third entry dropped | 'key1=val1,key2=val2,key3=val3' | [key1: val1, key2: val2]"
   })
   void testBaggageExtractBytesLimit(String baggageHeader, Map<String, String> baggageMap) {
-    // creating a new instance after injecting config
+    // Creating propagator with test bytes limit
     propagator = new BaggagePropagator(true, true, DEFAULT_TRACE_BAGGAGE_MAX_ITEMS, 20);
     Map<String, String> headers = singletonMap(BAGGAGE_KEY, baggageHeader);
 
     context = this.propagator.extract(context, headers, ContextVisitors.stringValuesMap());
 
     // parsing stops once the byte limit is exceeded
-    assertEquals(baggageMap, Baggage.fromContext(context).asMap());
+    Baggage baggage = Baggage.fromContext(context);
+    assertNotNull(baggage);
+    assertEquals(baggageMap, baggage.asMap());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Minor changes following the migration to JUnit.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
