### PR TITLE
Fix JDBC URL parsing crash when no port specified

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -85,9 +85,13 @@ public enum JDBCConnectionUrlParser {
       if (type.equals("db2") || type.equals("as400")) {
         if (jdbcUrl.contains("=")) {
           paramLoc = jdbcUrl.lastIndexOf(':');
-          urlPart1 = jdbcUrl.substring(0, paramLoc);
-          urlPart2 = jdbcUrl.substring(paramLoc + 1);
-
+          if (paramLoc > hostIndex + 2) {
+            urlPart1 = jdbcUrl.substring(0, paramLoc);
+            urlPart2 = jdbcUrl.substring(paramLoc + 1);
+          } else {
+            urlPart1 = jdbcUrl;
+            urlPart2 = null;
+          }
         } else {
           urlPart1 = jdbcUrl;
           urlPart2 = null;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -81,6 +81,7 @@ public enum JDBCConnectionUrlParser {
       final String urlPart1;
       final String urlPart2;
       final int paramLoc;
+      char paramSeparator = ';';
 
       if (type.equals("db2") || type.equals("as400")) {
         if (jdbcUrl.contains("=")) {
@@ -89,8 +90,16 @@ public enum JDBCConnectionUrlParser {
             urlPart1 = jdbcUrl.substring(0, paramLoc);
             urlPart2 = jdbcUrl.substring(paramLoc + 1);
           } else {
-            urlPart1 = jdbcUrl;
-            urlPart2 = null;
+            // No ':' past '://': fall back to '?' query-string params
+            final int queryLoc = jdbcUrl.indexOf('?');
+            if (queryLoc >= 0) {
+              urlPart1 = jdbcUrl.substring(0, queryLoc);
+              urlPart2 = jdbcUrl.substring(queryLoc + 1);
+              paramSeparator = '&';
+            } else {
+              urlPart1 = jdbcUrl;
+              urlPart2 = null;
+            }
           }
         } else {
           urlPart1 = jdbcUrl;
@@ -103,7 +112,7 @@ public enum JDBCConnectionUrlParser {
       }
 
       if (urlPart2 != null) {
-        final Map<String, String> props = splitQuery(urlPart2, ';');
+        final Map<String, String> props = splitQuery(urlPart2, paramSeparator);
         populateStandardProperties(builder, props);
         if (props.containsKey("servername")) {
           serverName = props.get("servername");

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
@@ -1,0 +1,42 @@
+package datadog.trace.bootstrap.instrumentation.jdbc;
+
+import static datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.extractDBInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Regression tests for StringIndexOutOfBoundsException in MODIFIED_URL_LIKE.doParse() (line 109)
+ * when parsing DB2/AS400 URLs that contain '=' but have no explicit port number.
+ *
+ * <p>Root cause: {@code lastIndexOf(':')} returns the scheme colon (e.g. position 3 in
+ * {@code "db2://..."}) when there is no port in the URL. This makes {@code urlPart1} shorter than
+ * {@code hostIndex + 3}, causing the subsequent {@code urlPart1.substring(hostIndex + 3)} call to
+ * throw.
+ *
+ * <p>Triggering condition: type is {@code db2} or {@code as400}, URL contains {@code =} (e.g.
+ * query-string parameters), and there is no explicit port.
+ */
+class JDBCConnectionUrlParserDB2Test {
+
+  @ParameterizedTest
+  @CsvSource({
+    // DB2: path present, query-string params, no port — last ':' is the scheme colon
+    "jdbc:db2://db2.host/mydb?user=db2user,       db2,   db2.host",
+    // AS400: same pattern
+    "jdbc:as400://ashost/asdb?user=asuser,         as400, ashost",
+    // DB2: multiple query params
+    "jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30, db2, db2.host",
+  })
+  void db2UrlWithEqualsAndNoPortShouldParseHostCorrectly(
+      String url, String expectedType, String expectedHost) {
+    DBInfo info = extractDBInfo(url.trim(), null);
+
+    // Before the fix, MODIFIED_URL_LIKE.doParse() throws StringIndexOutOfBoundsException.
+    // The exception is swallowed by the catch in JDBCConnectionUrlParser.parse(), but host
+    // is never set, so info.getHost() returns null.
+    assertEquals(expectedType, info.getType());
+    assertEquals(expectedHost, info.getHost());
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
@@ -7,16 +7,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Regression tests for StringIndexOutOfBoundsException in MODIFIED_URL_LIKE.doParse() (line 109)
- * when parsing DB2/AS400 URLs that contain '=' but have no explicit port number.
+ * Tests for DB2/AS400 JDBC URL parsing when the URL contains '=' but no explicit port.
  *
- * <p>Root cause: {@code lastIndexOf(':')} returns the scheme colon (e.g. position 3 in
- * {@code "db2://..."}) when there is no port in the URL. This makes {@code urlPart1} shorter than
- * {@code hostIndex + 3}, causing the subsequent {@code urlPart1.substring(hostIndex + 3)} call to
- * throw.
- *
- * <p>Triggering condition: type is {@code db2} or {@code as400}, URL contains {@code =} (e.g.
- * query-string parameters), and there is no explicit port.
+ * <p>Without a port, {@code lastIndexOf(':')} returns the scheme colon, making {@code urlPart1}
+ * too short for the subsequent {@code substring()} call and causing a
+ * {@code StringIndexOutOfBoundsException}.
  */
 class JDBCConnectionUrlParserDB2Test {
 
@@ -33,9 +28,7 @@ class JDBCConnectionUrlParserDB2Test {
       String url, String expectedType, String expectedHost) {
     DBInfo info = extractDBInfo(url.trim(), null);
 
-    // Before the fix, MODIFIED_URL_LIKE.doParse() throws StringIndexOutOfBoundsException.
-    // The exception is swallowed by the catch in JDBCConnectionUrlParser.parse(), but host
-    // is never set, so info.getHost() returns null.
+    // Without the fix, host was never extracted due to StringIndexOutOfBoundsException.
     assertEquals(expectedType, info.getType());
     assertEquals(expectedHost, info.getHost());
   }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
@@ -9,27 +9,52 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Tests for DB2/AS400 JDBC URL parsing when the URL contains '=' but no explicit port.
  *
- * <p>Without a port, {@code lastIndexOf(':')} returns the scheme colon, making {@code urlPart1}
- * too short for the subsequent {@code substring()} call and causing a
- * {@code StringIndexOutOfBoundsException}.
+ * <p>Without a port, {@code lastIndexOf(':')} returns the scheme colon, making {@code urlPart1} too
+ * short for the subsequent {@code substring()} call and causing a {@code
+ * StringIndexOutOfBoundsException}.
  */
 class JDBCConnectionUrlParserDB2Test {
 
   @ParameterizedTest
   @CsvSource({
     // DB2: path present, query-string params, no port — last ':' is the scheme colon
-    "jdbc:db2://db2.host/mydb?user=db2user,       db2,   db2.host",
+    "jdbc:db2://db2.host/mydb?user=db2user,                       db2,   db2.host, mydb, db2user",
     // AS400: same pattern
-    "jdbc:as400://ashost/asdb?user=asuser,         as400, ashost",
+    "jdbc:as400://ashost/asdb?user=asuser,                         as400, ashost,   asdb, asuser",
     // DB2: multiple query params
-    "jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30, db2, db2.host",
+    "jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30,  db2,   db2.host, mydb, db2user",
   })
   void db2UrlWithEqualsAndNoPortShouldParseHostCorrectly(
-      String url, String expectedType, String expectedHost) {
+      String url,
+      String expectedType,
+      String expectedHost,
+      String expectedInstance,
+      String expectedUser) {
     DBInfo info = extractDBInfo(url.trim(), null);
 
     // Without the fix, host was never extracted due to StringIndexOutOfBoundsException.
     assertEquals(expectedType, info.getType());
     assertEquals(expectedHost, info.getHost());
+    assertEquals(expectedInstance, info.getInstance());
+    assertEquals(expectedUser, info.getUser());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    // databasename param in query string should be parsed into db field
+    "jdbc:db2://db2.host/mydb?user=db2user&databasename=otherdb, db2, db2.host, db2user, otherdb",
+  })
+  void db2UrlWithDatabasenameQueryParamShouldParseDbCorrectly(
+      String url,
+      String expectedType,
+      String expectedHost,
+      String expectedUser,
+      String expectedDb) {
+    DBInfo info = extractDBInfo(url.trim(), null);
+
+    assertEquals(expectedType, info.getType());
+    assertEquals(expectedHost, info.getHost());
+    assertEquals(expectedUser, info.getUser());
+    assertEquals(expectedDb, info.getDb());
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
@@ -3,8 +3,7 @@ package datadog.trace.bootstrap.instrumentation.jdbc;
 import static datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.extractDBInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.tabletest.junit.TableTest;
 
 /**
  * Tests for DB2/AS400 JDBC URL parsing when the URL contains '=' but no explicit port.
@@ -15,46 +14,20 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 class JDBCConnectionUrlParserDB2Test {
 
-  @ParameterizedTest
-  @CsvSource({
-    // DB2: path present, query-string params, no port — last ':' is the scheme colon
-    "jdbc:db2://db2.host/mydb?user=db2user,                       db2,   db2.host, mydb, db2user",
-    // AS400: same pattern
-    "jdbc:as400://ashost/asdb?user=asuser,                         as400, ashost,   asdb, asuser",
-    // DB2: multiple query params
-    "jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30,  db2,   db2.host, mydb, db2user",
+  @TableTest({
+    "scenario                             | url                                                        | type  | host     | instance | user    | db     ",
+    "DB2 with user param, no port         | jdbc:db2://db2.host/mydb?user=db2user                      | db2   | db2.host | mydb     | db2user | mydb   ",
+    "AS400 with user param, no port       | jdbc:as400://ashost/asdb?user=asuser                       | as400 | ashost   | asdb     | asuser  | asdb   ",
+    "DB2 with multiple params, no port    | jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30 | db2   | db2.host | mydb     | db2user | mydb   ",
+    "DB2 with databasename param, no port | jdbc:db2://db2.host/mydb?user=db2user&databasename=otherdb | db2   | db2.host | mydb     | db2user | otherdb"
   })
-  void db2UrlWithEqualsAndNoPortShouldParseHostCorrectly(
-      String url,
-      String expectedType,
-      String expectedHost,
-      String expectedInstance,
-      String expectedUser) {
-    DBInfo info = extractDBInfo(url.trim(), null);
-
-    // Without the fix, host was never extracted due to StringIndexOutOfBoundsException.
-    assertEquals(expectedType, info.getType());
-    assertEquals(expectedHost, info.getHost());
-    assertEquals(expectedInstance, info.getInstance());
-    assertEquals(expectedUser, info.getUser());
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    // databasename param in query string should be parsed into db field
-    "jdbc:db2://db2.host/mydb?user=db2user&databasename=otherdb, db2, db2.host, db2user, otherdb",
-  })
-  void db2UrlWithDatabasenameQueryParamShouldParseDbCorrectly(
-      String url,
-      String expectedType,
-      String expectedHost,
-      String expectedUser,
-      String expectedDb) {
-    DBInfo info = extractDBInfo(url.trim(), null);
-
-    assertEquals(expectedType, info.getType());
-    assertEquals(expectedHost, info.getHost());
-    assertEquals(expectedUser, info.getUser());
-    assertEquals(expectedDb, info.getDb());
+  void db2UrlWithEqualsAndNoPortShouldParseCorrectly(
+      String url, String type, String host, String instance, String user, String db) {
+    DBInfo info = extractDBInfo(url, null);
+    assertEquals(type, info.getType());
+    assertEquals(host, info.getHost());
+    assertEquals(instance, info.getInstance());
+    assertEquals(user, info.getUser());
+    assertEquals(db, info.getDb());
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserDB2Test.java
@@ -19,7 +19,9 @@ class JDBCConnectionUrlParserDB2Test {
     "DB2 with user param, no port         | jdbc:db2://db2.host/mydb?user=db2user                      | db2   | db2.host | mydb     | db2user | mydb   ",
     "AS400 with user param, no port       | jdbc:as400://ashost/asdb?user=asuser                       | as400 | ashost   | asdb     | asuser  | asdb   ",
     "DB2 with multiple params, no port    | jdbc:db2://db2.host/mydb?user=db2user&connectionTimeout=30 | db2   | db2.host | mydb     | db2user | mydb   ",
-    "DB2 with databasename param, no port | jdbc:db2://db2.host/mydb?user=db2user&databasename=otherdb | db2   | db2.host | mydb     | db2user | otherdb"
+    "DB2 with databasename param, no port | jdbc:db2://db2.host/mydb?user=db2user&databasename=otherdb | db2   | db2.host | mydb     | db2user | otherdb",
+    "DB2 with port and colon params       | jdbc:db2://db2.host:50000/mydb:user=db2user                | db2   | db2.host | mydb     | db2user | mydb   ",
+    "DB2 no params                        | jdbc:db2://db2.host/mydb                                   | db2   | db2.host | mydb     |         | mydb   "
   })
   void db2UrlWithEqualsAndNoPortShouldParseCorrectly(
       String url, String type, String host, String instance, String user, String db) {


### PR DESCRIPTION
# What Does This Do
Guards the `lastIndexOf(':')` split in `MODIFIED_URL_LIKE.doParse()` so it only splits on a colon that appears after `://`. If no such colon exists, the full URL is used as-is.

# Motivation
DB2/AS400 JDBC URLs without an explicit port that contain `=` caused a crash in the agent:

```
java.lang.StringIndexOutOfBoundsException
    at java.lang.String.substring(String.java:1841)
    at datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser$2.doParse(JDBCConnectionUrlParser.java:109)
    at datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser$9.doParse(JDBCConnectionUrlParser.java:344)
    at datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.parse(JDBCConnectionUrlParser.java:871)
```

The root cause: when a URL like `jdbc:db2://host/db?user=foo` is parsed, the code uses `lastIndexOf(':')` to find the parameter section separator. With no explicit port, the only `:` is the scheme colon (position 3), so `urlPart1` is cut to just `"db2"`. The subsequent `urlPart1.substring(hostIndex + 3)` - i.e. `"db2".substring(6)` - throws

URLs that trigger the bug:
- jdbc:db2://myhost/mydb?user=admin
- jdbc:db2://myhost/mydb?user=admin&connectionTimeout=30
- jdbc:as400://myhost/mydb?user=admin

URLs that work fine (explicit port puts a `:` past `://`):
- jdbc:db2://myhost:50000/mydb:user=admin;password=secret;

# Additional Notes
- The exception was swallowed by the parser's catch block, so the app didn't crash - but host and user were silently lost from the span.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
