### PR TITLE
Fixed GitLab cache key for Gradle dependencies.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ variables:
   BUILD_JOB_NAME: "build"
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
-  GRADLE_VERSION: "8.14.5" # must match gradle-wrapper.properties
+  GRADLE_VERSION: "9.5.1" # must match gradle-wrapper.properties
   MASS_READ_URL: "https://mass-read.us1.ddbuild.io"
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"


### PR DESCRIPTION
# What Does This Do
Update GitLab cache key.

# Motivation
This key should be in sync with actual Gradle version we are using to build project.

# Additional Notes
We should re-populate caches once merged.
