### PR TITLE
Avoid leaking continuations on jdk-http-client

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -184,8 +184,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
-    transformer.applyAdvice(
-        namedOneOf("send", "sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
+    transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
   }
 
   public static class DisableAsyncAdvice {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -47,6 +47,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       namedOneOf("reactor.core.scheduler.SchedulerTask", "reactor.core.scheduler.WorkerTask");
   private static final ElementMatcher<TypeDescription> RXJAVA2_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
+  private static final ElementMatcher<TypeDescription> JAVA_HTTP_CLIENT =
+      extendsClass(named("java.net.http.HttpClient"));
 
   @Override
   public boolean onlyMatchKnownTypes() {
@@ -80,7 +82,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "org.springframework.jms.listener.DefaultMessageListenerContainer",
       "org.apache.activemq.broker.TransactionBroker",
       "com.mongodb.internal.connection.DefaultConnectionPool$AsyncWorkManager",
-      "io.reactivex.internal.schedulers.AbstractDirectTask"
+      "io.reactivex.internal.schedulers.AbstractDirectTask",
+      "jdk.internal.net.http.HttpClientImpl"
     };
   }
 
@@ -94,7 +97,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     return RX_WORKERS
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
-        .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS);
+        .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
+        .or(JAVA_HTTP_CLIENT);
   }
 
   @Override
@@ -180,6 +184,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
+    transformer.applyAdvice(
+        namedOneOf("send", "sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
   }
 
   public static class DisableAsyncAdvice {

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/main/java11/datadog/trace/instrumentation/httpclient/BodyHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/main/java11/datadog/trace/instrumentation/httpclient/BodyHandlerWrapper.java
@@ -1,6 +1,9 @@
 package datadog.trace.instrumentation.httpclient;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.ResponseInfo;
@@ -11,20 +14,21 @@ import java.util.concurrent.Flow;
 
 public class BodyHandlerWrapper<T> implements BodyHandler<T> {
   private final BodyHandler<T> delegate;
-  private final AgentScope.Continuation continuation;
+  private final AgentSpan span;
 
-  public BodyHandlerWrapper(BodyHandler<T> delegate, AgentScope.Continuation context) {
+  public BodyHandlerWrapper(BodyHandler<T> delegate, AgentSpan span) {
     this.delegate = delegate;
-    this.continuation = context;
+    this.span = span;
   }
 
   @Override
   public BodySubscriber<T> apply(ResponseInfo responseInfo) {
+    // Capture the continuation lazily here rather than at sendAsync() call time.
     BodySubscriber<T> subscriber = delegate.apply(responseInfo);
     if (subscriber instanceof BodySubscriberWrapper) {
       return subscriber;
     }
-    return new BodySubscriberWrapper<>(subscriber, continuation);
+    return new BodySubscriberWrapper<>(subscriber, captureSpan(span));
   }
 
   static class BodySubscriberWrapper<T> implements BodySubscriber<T> {

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/main/java11/datadog/trace/instrumentation/httpclient/SendAsyncAdvice.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.httpclient;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.httpclient.JavaNetClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.httpclient.JavaNetClientDecorator.INSTRUMENTATION_NAME;
@@ -38,7 +37,10 @@ public class SendAsyncAdvice {
       final AgentSpan span = startSpan(INSTRUMENTATION_NAME, OPERATION_NAME);
       final AgentScope scope = activateSpan(span);
       if (bodyHandler != null) {
-        bodyHandler = new BodyHandlerWrapper<>(bodyHandler, captureSpan(span));
+        // Pass span directly — BodyHandlerWrapper captures the continuation lazily in apply(),
+        // only once response headers arrive. This avoids leaking a continuation when the
+        // connection fails before headers are received.
+        bodyHandler = new BodyHandlerWrapper<>(bodyHandler, span);
       }
 
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-net/java-net-11.0/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientTest.groovy
@@ -10,11 +10,6 @@ import java.net.http.HttpResponse
 import java.time.Duration
 
 abstract class JavaHttpClientTest extends HttpClientTest {
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
 
   def client = HttpClient.newBuilder()
   .connectTimeout(Duration.ofMillis(CONNECT_TIMEOUT_MS))


### PR DESCRIPTION
# What Does This Do

This PR applies several fixes on the jdk http client instrumentation. 

* Disable capturing continuations on send/sendAsync to avoid being captured on the underlying fork-join used for scheduling
* Lazy capture continuations on the BodyHandlerWrapper to avoid having cases when the handler is not called and the continuation not used/canceled

The tests confirm that everything now works as expected. Before was failing when enabling the strictTraceWrite

Now the async disable has been added to the "catch-all" disable instrumentation. Thoughts on it since it's becoming a bit big in terms of matchers and I don't know if we should think about a refactoring/split

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
