### PR TITLE
Avoid reactor netty continuation leakage

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -49,8 +49,6 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
   private static final ElementMatcher<TypeDescription> JAVA_HTTP_CLIENT =
       extendsClass(named("java.net.http.HttpClient"));
-  private static final ElementMatcher<TypeDescription> REACTOR_NETTY_HTTP_CONNECT =
-      named("reactor.netty.http.client.HttpClientConnect$MonoHttpConnect");
 
   @Override
   public boolean onlyMatchKnownTypes() {
@@ -85,8 +83,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "org.apache.activemq.broker.TransactionBroker",
       "com.mongodb.internal.connection.DefaultConnectionPool$AsyncWorkManager",
       "io.reactivex.internal.schedulers.AbstractDirectTask",
-      "jdk.internal.net.http.HttpClientImpl",
-      "reactor.netty.http.client.HttpClientConnect$MonoHttpConnect"
+      "jdk.internal.net.http.HttpClientImpl"
     };
   }
 
@@ -101,8 +98,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
         .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
-        .or(JAVA_HTTP_CLIENT)
-        .or(REACTOR_NETTY_HTTP_CONNECT);
+        .or(JAVA_HTTP_CLIENT);
   }
 
   @Override
@@ -189,10 +185,6 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
-    // Avoid leaking continuations on the netty event loop that initiates the tasks that handle the
-    // request lifecycle
-    transformer.applyAdvice(
-        named("subscribe").and(isDeclaredBy(REACTOR_NETTY_HTTP_CONNECT)), advice);
   }
 
   public static class DisableAsyncAdvice {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -49,6 +49,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
   private static final ElementMatcher<TypeDescription> JAVA_HTTP_CLIENT =
       extendsClass(named("java.net.http.HttpClient"));
+  private static final ElementMatcher<TypeDescription> REACTOR_NETTY_HTTP_CONNECT =
+      named("reactor.netty.http.client.HttpClientConnect$MonoHttpConnect");
 
   @Override
   public boolean onlyMatchKnownTypes() {
@@ -83,7 +85,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "org.apache.activemq.broker.TransactionBroker",
       "com.mongodb.internal.connection.DefaultConnectionPool$AsyncWorkManager",
       "io.reactivex.internal.schedulers.AbstractDirectTask",
-      "jdk.internal.net.http.HttpClientImpl"
+      "jdk.internal.net.http.HttpClientImpl",
+      "reactor.netty.http.client.HttpClientConnect$MonoHttpConnect"
     };
   }
 
@@ -98,7 +101,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
         .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
-        .or(JAVA_HTTP_CLIENT);
+        .or(JAVA_HTTP_CLIENT)
+        .or(REACTOR_NETTY_HTTP_CONNECT);
   }
 
   @Override
@@ -185,6 +189,10 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
+    // Avoid leaking continuations on the netty event loop that initiates the tasks that handle the
+    // request lifecycle
+    transformer.applyAdvice(
+        named("subscribe").and(isDeclaredBy(REACTOR_NETTY_HTTP_CONNECT)), advice);
   }
 
   public static class DisableAsyncAdvice {

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -18,6 +18,7 @@ import datadog.context.Context;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -54,8 +55,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     }
 
     AgentScope parentScope = null;
-    final AgentScope.Continuation continuation =
-        ctx.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    final AgentScope.Continuation continuation = takeConnectContinuation(ctx.channel());
     if (continuation != null) {
       parentScope = continuation.activate();
     }
@@ -110,5 +110,17 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
         parentScope.close();
       }
     }
+  }
+
+  private static AgentScope.Continuation takeConnectContinuation(final Channel channel) {
+    AgentScope.Continuation continuation =
+        channel.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    if (continuation == null) {
+      final Channel parent = channel.parent();
+      if (parent != null) {
+        continuation = parent.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+      }
+    }
+    return continuation;
   }
 }

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/ConnectSpanSubscriber.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/ConnectSpanSubscriber.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.reactor.netty;
+
+import static datadog.trace.instrumentation.reactor.netty.CaptureConnectSpan.CONNECT_SPAN;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.netty.Connection;
+import reactor.util.context.Context;
+
+public final class ConnectSpanSubscriber implements CoreSubscriber<Connection> {
+
+  private final CoreSubscriber<? super Connection> actual;
+  private final AgentSpan span;
+
+  public ConnectSpanSubscriber(
+      final CoreSubscriber<? super Connection> actual, final AgentSpan span) {
+    this.actual = actual;
+    this.span = span;
+  }
+
+  @Override
+  public void onSubscribe(final Subscription subscription) {
+    actual.onSubscribe(subscription);
+  }
+
+  @Override
+  public void onNext(final Connection connection) {
+    actual.onNext(connection);
+  }
+
+  @Override
+  public void onError(final Throwable throwable) {
+    actual.onError(throwable);
+  }
+
+  @Override
+  public void onComplete() {
+    actual.onComplete();
+  }
+
+  @Override
+  public Context currentContext() {
+    return actual.currentContext().put(CONNECT_SPAN, span);
+  }
+}

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/MonoHttpConnectInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/MonoHttpConnectInstrumentation.java
@@ -1,0 +1,82 @@
+package datadog.trace.instrumentation.reactor.netty;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
+import reactor.core.CoreSubscriber;
+import reactor.netty.Connection;
+
+/**
+ * Suppresses generic async captures created while Reactor Netty subscribes to connection setup.
+ *
+ * <p>The subscriber is wrapped first so the active span is still available from Reactor context;
+ * {@link TransferConnectSpan} later turns that context value into the continuation consumed by
+ * Netty request tracing.
+ */
+@AutoService(InstrumenterModule.class)
+public class MonoHttpConnectInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public MonoHttpConnectInstrumentation() {
+    super("reactor-netty", "reactor-netty-1");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // Avoid matching pre-1.0 releases which are not compatible.
+    return hasClassNamed("reactor.netty.transport.AddressUtils");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ConnectSpanSubscriber",
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "reactor.netty.http.client.HttpClientConnect$MonoHttpConnect";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("subscribe").and(takesArgument(0, named("reactor.core.CoreSubscriber"))),
+        getClass().getName() + "$SubscribeAdvice");
+  }
+
+  public static class SubscribeAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static boolean before(
+        @Advice.Argument(value = 0, readOnly = false)
+            CoreSubscriber<? super Connection> subscriber) {
+      final AgentSpan span = activeSpan();
+      if (span != null) {
+        subscriber = new ConnectSpanSubscriber(subscriber, span);
+      }
+      if (isAsyncPropagationEnabled()) {
+        setAsyncPropagationEnabled(false);
+        return true;
+      }
+      return false;
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void after(@Advice.Enter final boolean wasDisabled) {
+      if (wasDisabled) {
+        setAsyncPropagationEnabled(true);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
@@ -24,10 +24,9 @@ public class TransferConnectSpan implements BiConsumer<HttpClientRequest, Connec
         current.cancel();
       }
 
-      // A http2 channel (Http2StreamChannel, H2C prior-knowledge), operates a child stream level by
-      // design.
-      // ConnectAdvice stores a continuation on the parent TCP channel at connect time hence this
-      // will be never canceled
+      // HTTP/2 requests operate on stream channels. Netty captures the TCP connect continuation on
+      // the parent channel, but request tracing consumes the request-specific continuation from the
+      // stream channel, so the parent copy must not keep the trace open.
       final Channel parent = channel.parent();
       if (parent != null) {
         final Continuation parentCurrent =

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/main/java/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
@@ -6,6 +6,7 @@ import static datadog.trace.instrumentation.reactor.netty.CaptureConnectSpan.CON
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope.Continuation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.netty.channel.Channel;
 import java.util.function.BiConsumer;
 import reactor.netty.Connection;
 import reactor.netty.http.client.HttpClientRequest;
@@ -16,13 +17,24 @@ public class TransferConnectSpan implements BiConsumer<HttpClientRequest, Connec
     final AgentSpan span = httpClientRequest.currentContextView().getOrDefault(CONNECT_SPAN, null);
     final Continuation continuation = null == span ? null : captureSpan(span);
     if (null != continuation) {
-      Continuation current =
-          connection
-              .channel()
-              .attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY)
-              .getAndSet(continuation);
+      final Channel channel = connection.channel();
+      final Continuation current =
+          channel.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndSet(continuation);
       if (null != current) {
         current.cancel();
+      }
+
+      // A http2 channel (Http2StreamChannel, H2C prior-knowledge), operates a child stream level by
+      // design.
+      // ConnectAdvice stores a continuation on the parent TCP channel at connect time hence this
+      // will be never canceled
+      final Channel parent = channel.parent();
+      if (parent != null) {
+        final Continuation parentCurrent =
+            parent.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+        if (null != parentCurrent) {
+          parentCurrent.cancel();
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
@@ -25,11 +25,6 @@ class ReactorNettyHttp2ClientTest extends InstrumentationSpecification {
   .bindNow()
 
   @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
-  @Override
   def cleanupSpec() {
     server?.disposeNow()
   }

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -1,5 +1,6 @@
 import datadog.environment.JavaVirtualMachine
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.netty.handler.codec.http.HttpMethod
@@ -68,6 +69,40 @@ class ReactorNettyHttpClientTest extends HttpClientTest implements TestingNettyH
   @Override
   boolean testConnectionFailure() {
     false
+  }
+
+  def "connection error produces netty.connect error span"() {
+    given:
+    def uri = new URI("http://localhost:${PortUtils.UNUSABLE_PORT}/")
+
+    when:
+    runUnderTrace("parent") {
+      httpClient.get()
+        .uri(uri)
+        .responseSingle({ r, b -> b.asString() })
+        .block()
+    }
+
+    then:
+    def ex = thrown(Exception)
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent", null, ex)
+        span {
+          operationName "netty.connect"
+          resourceName "netty.connect"
+          childOf span(0)
+          errored true
+          tags {
+            "component" "netty"
+            "error.type" String
+            "error.message" String
+            "error.stack" String
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -53,11 +53,6 @@ class SpringWebfluxTest extends InstrumentationSpecification {
 
   WebClient client = WebClient.builder().clientConnector(new ReactorClientHttpConnector()).build()
 
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
   def "Basic GET test #testName"() {
     setup:
     String url = "http://localhost:$port$urlPath"

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -21,12 +21,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
   abstract WebClient createClient(CharSequence component)
 
   abstract void check()

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
@@ -22,12 +22,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
   abstract WebClient createClient(CharSequence component)
 
   abstract void check()


### PR DESCRIPTION
# What Does This Do

This PR fixes some scope propagation leakage happening on netty-reactor. This also impacts the spring-webflux client since it's based on this last one.

A couple of different fixes:
1. Add propagation barrier on HttpClientConnect$MonoHttpConnect.subscribe(). During the http client subscription, the  event-loop tasks are submitted while the span scope is active; hence the concurrent instrumentation would capture that continuation that survives when the span finishes and it's not needed
2. Fix the TransferConnectSpan for http2: In a http2 context the channel is multiplexed. We previously captured the connect span but in case of http2 the parent context is not used hence the continuation was dangling. This PR ensures that we properly cancel it

Please note that removeStrictTraces has been successfully removed from the concerned tests that are now passing OK (without this PR they are timing out as expected)


Note: Perhaps a broader re-evaluation of reactor context propagation is needed to avoid doing defensive fixes like this one

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
