### PR TITLE
Improve isolation for nested Gradle runs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,6 +224,7 @@ default:
       org.gradle.java.installations.auto-detect=false
       org.gradle.java.installations.auto-download=false
       org.gradle.java.installations.fromEnv=$JAVA_HOMES
+      org.gradle.console=colored
       EOF
     - mkdir -p .gradle
     - export GRADLE_USER_HOME=$(pwd)/.gradle
@@ -244,7 +245,7 @@ default:
         ln -s "$(pwd)/.mvn/caches/equo" "$HOME/.m2/repository/dev/equo"
       fi
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-    - export GRADLE_ARGS=" --console=colored --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
+    - export GRADLE_ARGS=" --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
     # GitLab's cache helper restores .gradle as root, but we run as non-root-user (uid 1001),
     # and Gradle does `chmod 700 .gradle` on startup which requires user ownership.
@@ -436,7 +437,7 @@ check-instrumentation-naming:
   needs: [ ]
   script:
     - ./gradlew --version
-    - ./gradlew checkInstrumentationNaming --console=colored
+    - ./gradlew checkInstrumentationNaming
 
 config-inversion-linter:
   extends: .gradle_build
@@ -444,7 +445,7 @@ config-inversion-linter:
   needs: []
   script:
     - ./gradlew --version
-    - ./gradlew checkConfigurations --console=colored
+    - ./gradlew checkConfigurations
 
 test_published_artifacts:
   extends: .gradle_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,6 @@ variables:
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
   GRADLE_VERSION: "9.5.1" # must match gradle-wrapper.properties
-  GRADLE_CONSOLE_ARGS: "--console=colored"
   MASS_READ_URL: "https://mass-read.us1.ddbuild.io"
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
@@ -245,7 +244,7 @@ default:
         ln -s "$(pwd)/.mvn/caches/equo" "$HOME/.m2/repository/dev/equo"
       fi
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-    - export GRADLE_ARGS=" $GRADLE_CONSOLE_ARGS --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
+    - export GRADLE_ARGS=" --console=colored --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
     # GitLab's cache helper restores .gradle as root, but we run as non-root-user (uid 1001),
     # and Gradle does `chmod 700 .gradle` on startup which requires user ownership.
@@ -437,7 +436,7 @@ check-instrumentation-naming:
   needs: [ ]
   script:
     - ./gradlew --version
-    - ./gradlew checkInstrumentationNaming $GRADLE_CONSOLE_ARGS
+    - ./gradlew checkInstrumentationNaming --console=colored
 
 config-inversion-linter:
   extends: .gradle_build
@@ -445,7 +444,7 @@ config-inversion-linter:
   needs: []
   script:
     - ./gradlew --version
-    - ./gradlew checkConfigurations $GRADLE_CONSOLE_ARGS
+    - ./gradlew checkConfigurations --console=colored
 
 test_published_artifacts:
   extends: .gradle_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,6 +462,7 @@ test_published_artifacts:
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms2G -Xmx2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew publishToMavenLocal $GRADLE_ARGS
     - cd test-published-dependencies
+    - printf '\norg.gradle.console=colored\n' >> gradle.properties
     - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms1G -Xmx1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew --version
     - ./gradlew check --info $GRADLE_ARGS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ variables:
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
   GRADLE_VERSION: "9.5.1" # must match gradle-wrapper.properties
-  GRADLE_CONSOLE_OPTS: "-Dorg.gradle.console=colored"
+  GRADLE_CONSOLE_ARGS: "--console=colored"
   MASS_READ_URL: "https://mass-read.us1.ddbuild.io"
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
@@ -244,8 +244,8 @@ default:
         rm -rf "$HOME/.m2/repository/dev/equo"
         ln -s "$(pwd)/.mvn/caches/equo" "$HOME/.m2/repository/dev/equo"
       fi
-    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-    - export GRADLE_ARGS=" --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_ARGS=" $GRADLE_CONSOLE_ARGS --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
     # GitLab's cache helper restores .gradle as root, but we run as non-root-user (uid 1001),
     # and Gradle does `chmod 700 .gradle` on startup which requires user ownership.
@@ -437,7 +437,7 @@ check-instrumentation-naming:
   needs: [ ]
   script:
     - ./gradlew --version
-    - ./gradlew checkInstrumentationNaming
+    - ./gradlew checkInstrumentationNaming $GRADLE_CONSOLE_ARGS
 
 config-inversion-linter:
   extends: .gradle_build
@@ -445,7 +445,7 @@ config-inversion-linter:
   needs: []
   script:
     - ./gradlew --version
-    - ./gradlew checkConfigurations
+    - ./gradlew checkConfigurations $GRADLE_CONSOLE_ARGS
 
 test_published_artifacts:
   extends: .gradle_build
@@ -459,10 +459,10 @@ test_published_artifacts:
     - rm -rf "${mvn_local_repo}/com/datadoghq"
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
-    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms2G -Xmx2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms2G -Xmx2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew publishToMavenLocal $GRADLE_ARGS
     - cd test-published-dependencies
-    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms1G -Xmx1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms1G -Xmx1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew --version
     - ./gradlew check --info $GRADLE_ARGS
   after_script:
@@ -670,7 +670,7 @@ muzzle-dep-report:
       export PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/${CI_JOB_NAME_SLUG}.jfr,dumponexit=true";
       fi
     - *prepare_test_env
-    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.util.prefs.userRoot=/tmp/.java/.userPrefs-${CI_JOB_ID}' -Ddatadog.forkedMinHeapSize=128M -Ddatadog.forkedMaxHeapSize=1024M"
+    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.util.prefs.userRoot=/tmp/.java/.userPrefs-${CI_JOB_ID}' -Ddatadog.forkedMinHeapSize=128M -Ddatadog.forkedMaxHeapSize=1024M"
     - ./gradlew --version
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PtestJvm=$testJvm -Pslot=$CI_NODE_INDEX/$CI_NODE_TOTAL $GRADLE_ARGS --continue || $CONTINUE_ON_FAILURE
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,7 @@ variables:
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
   GRADLE_VERSION: "9.5.1" # must match gradle-wrapper.properties
+  GRADLE_CONSOLE_OPTS: "-Dorg.gradle.console=colored"
   MASS_READ_URL: "https://mass-read.us1.ddbuild.io"
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
@@ -243,7 +244,7 @@ default:
         rm -rf "$HOME/.m2/repository/dev/equo"
         ln -s "$(pwd)/.mvn/caches/equo" "$HOME/.m2/repository/dev/equo"
       fi
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - export GRADLE_ARGS=" --build-cache --stacktrace --no-daemon --parallel --max-workers=$GRADLE_WORKERS"
     - *normalize_node_index
     # GitLab's cache helper restores .gradle as root, but we run as non-root-user (uid 1001),
@@ -458,10 +459,10 @@ test_published_artifacts:
     - rm -rf "${mvn_local_repo}/com/datadoghq"
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms2G -Xmx2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms2G -Xmx2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew publishToMavenLocal $GRADLE_ARGS
     - cd test-published-dependencies
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms1G -Xmx1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms1G -Xmx1G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
     - ./gradlew --version
     - ./gradlew check --info $GRADLE_ARGS
   after_script:
@@ -669,7 +670,7 @@ muzzle-dep-report:
       export PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/${CI_JOB_NAME_SLUG}.jfr,dumponexit=true";
       fi
     - *prepare_test_env
-    - export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.util.prefs.userRoot=/tmp/.java/.userPrefs-${CI_JOB_ID}' -Ddatadog.forkedMinHeapSize=128M -Ddatadog.forkedMaxHeapSize=1024M"
+    - export GRADLE_OPTS="$GRADLE_CONSOLE_OPTS -Dorg.gradle.jvmargs='-Xms$GRADLE_MEMORY_MIN -Xmx$GRADLE_MEMORY_MAX $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.util.prefs.userRoot=/tmp/.java/.userPrefs-${CI_JOB_ID}' -Ddatadog.forkedMinHeapSize=128M -Ddatadog.forkedMaxHeapSize=1024M"
     - ./gradlew --version
     - ./gradlew $GRADLE_TARGET $GRADLE_PARAMS -PtestJvm=$testJvm -Pslot=$CI_NODE_INDEX/$CI_NODE_TOTAL $GRADLE_ARGS --continue || $CONTINUE_ON_FAILURE
   after_script:

--- a/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
+++ b/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
@@ -28,6 +28,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.tooling.GradleConnector
 import java.io.File
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -187,9 +188,71 @@ abstract class NestedGradleBuild @Inject constructor(
           .run()
       }
     } finally {
+      stopGradleDaemon(appDir, gradleUserHomeDir, daemonJavaHome, mergedEnv)
       deleteGradleUserHome(gradleUserHomeDir)
     }
   }
+
+  private fun stopGradleDaemon(
+    appDir: File,
+    gradleUserHomeDir: File,
+    daemonJavaHome: File,
+    environment: Map<String, String>,
+  ) {
+    val gradleExecutable = findGradleExecutable(gradleUserHomeDir)
+    if (gradleExecutable == null) {
+      logger.warn(
+        "Could not find nested Gradle executable under {} to stop its daemon",
+        gradleUserHomeDir.absolutePath,
+      )
+      return
+    }
+
+    try {
+      val processBuilder = ProcessBuilder(gradleExecutable.absolutePath, "--stop")
+        .directory(appDir)
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+      processBuilder.environment().apply {
+        clear()
+        putAll(environment)
+        put("JAVA_HOME", daemonJavaHome.absolutePath)
+      }
+
+      val process = processBuilder.start()
+      if (!process.waitFor(GRADLE_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        logger.warn("Timed out while stopping nested Gradle daemon")
+        return
+      }
+      val exitCode = process.exitValue()
+      if (exitCode != 0) {
+        logger.warn("Nested Gradle daemon stop exited with code {}", exitCode)
+      }
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      logger.warn(
+        "Interrupted while stopping nested Gradle daemon before deleting its user home",
+        e,
+      )
+    } catch (e: Exception) {
+      logger.warn("Could not stop nested Gradle daemon before deleting its user home", e)
+    }
+  }
+
+  private fun findGradleExecutable(gradleUserHomeDir: File): File? =
+    gradleUserHomeDir.walkTopDown().firstOrNull { file ->
+      file.isFile &&
+        file.name == gradleExecutableName() &&
+        file.parentFile?.name == "bin"
+    }
+
+  private fun gradleExecutableName(): String =
+    if (System.getProperty("os.name").lowercase().contains("windows")) {
+      "gradle.bat"
+    } else {
+      "gradle"
+    }
 
   private fun createGradleUserHome(): File {
     val directory = temporaryDir.resolve("gradle-user-home")
@@ -206,5 +269,9 @@ abstract class NestedGradleBuild @Inject constructor(
     if (directory.exists() && !directory.deleteRecursively()) {
       logger.warn("Could not delete nested Gradle user home: {}", directory.absolutePath)
     }
+  }
+
+  private companion object {
+    const val GRADLE_STOP_TIMEOUT_SECONDS = 30L
   }
 }

--- a/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
+++ b/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
@@ -104,8 +104,9 @@ abstract class NestedGradleBuild @Inject constructor(
 
   /**
    * Extra environment variables for the nested Gradle daemon. Merged on top of the outer
-   * process environment — set a key to override an inherited value. The nested build script
-   * sees these via `System.getenv()` like any normal environment variable.
+   * process environment after clearing Gradle launcher variables — set a key to override an
+   * inherited value. The nested build script sees these via `System.getenv()` like any normal
+   * environment variable.
    */
   @get:Input
   abstract val environment: MapProperty<String, String>
@@ -161,16 +162,20 @@ abstract class NestedGradleBuild @Inject constructor(
         }
       }
 
-    val extraEnv = environment.get()
-    val mergedEnv: Map<String, String>? =
-      if (extraEnv.isEmpty()) null else System.getenv() + extraEnv
+    val mergedEnv =
+      System.getenv() +
+        mapOf(
+          "GRADLE_ARGS" to "",
+          "GRADLE_OPTS" to "",
+        ) +
+        environment.get()
 
     connector.connect().use { connection ->
       connection.newBuild()
         .forTasks(*tasksToRun.get().toTypedArray())
         .withArguments(args)
         .setJavaHome(daemonJavaHome)
-        .apply { if (mergedEnv != null) setEnvironmentVariables(mergedEnv) }
+        .setEnvironmentVariables(mergedEnv)
         .setStandardOutput(System.out)
         .setStandardError(System.err)
         .run()

--- a/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
+++ b/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/NestedGradleBuild.kt
@@ -2,6 +2,7 @@ package datadog.buildlogic.smoketest
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
@@ -26,6 +27,7 @@ import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.tooling.GradleConnector
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -103,10 +105,10 @@ abstract class NestedGradleBuild @Inject constructor(
   abstract val buildCacheEnabled: Property<Boolean>
 
   /**
-   * Extra environment variables for the nested Gradle daemon. Merged on top of the outer
-   * process environment after clearing Gradle launcher variables — set a key to override an
-   * inherited value. The nested build script sees these via `System.getenv()` like any normal
-   * environment variable.
+   * Extra environment variables for the nested Gradle daemon. Merged on top of the outer process
+   * environment; Gradle launcher variables are reserved by this task so nested builds do not
+   * inherit incompatible outer-build settings. The nested build script sees these via
+   * `System.getenv()` like any normal environment variable.
    */
   @get:Input
   abstract val environment: MapProperty<String, String>
@@ -139,6 +141,7 @@ abstract class NestedGradleBuild @Inject constructor(
     val appDir = applicationDir.get().asFile
     val appBuildDirFile = applicationBuildDir.get().asFile
     val daemonJavaHome = javaLauncher.get().metadata.installationPath.asFile
+    val gradleUserHomeDir = createGradleUserHome()
 
     val args = buildList {
       add(if (buildCacheEnabled.get()) "--build-cache" else "--no-build-cache")
@@ -151,6 +154,7 @@ abstract class NestedGradleBuild @Inject constructor(
 
     val connector = GradleConnector.newConnector()
       .forProjectDirectory(appDir)
+      .useGradleUserHomeDir(gradleUserHomeDir)
       .apply {
         val distributionBaseUrl = gradleDistributionBaseUrl.orNull
         if (distributionBaseUrl.isNullOrBlank()) {
@@ -164,21 +168,43 @@ abstract class NestedGradleBuild @Inject constructor(
 
     val mergedEnv =
       System.getenv() +
+        environment.get() +
         mapOf(
           "GRADLE_ARGS" to "",
           "GRADLE_OPTS" to "",
-        ) +
-        environment.get()
+          "GRADLE_USER_HOME" to gradleUserHomeDir.absolutePath,
+        )
 
-    connector.connect().use { connection ->
-      connection.newBuild()
-        .forTasks(*tasksToRun.get().toTypedArray())
-        .withArguments(args)
-        .setJavaHome(daemonJavaHome)
-        .setEnvironmentVariables(mergedEnv)
-        .setStandardOutput(System.out)
-        .setStandardError(System.err)
-        .run()
+    try {
+      connector.connect().use { connection ->
+        connection.newBuild()
+          .forTasks(*tasksToRun.get().toTypedArray())
+          .withArguments(args)
+          .setJavaHome(daemonJavaHome)
+          .setEnvironmentVariables(mergedEnv)
+          .setStandardOutput(System.out)
+          .setStandardError(System.err)
+          .run()
+      }
+    } finally {
+      deleteGradleUserHome(gradleUserHomeDir)
+    }
+  }
+
+  private fun createGradleUserHome(): File {
+    val directory = temporaryDir.resolve("gradle-user-home")
+    deleteGradleUserHome(directory)
+    if (!directory.mkdirs()) {
+      throw GradleException(
+        "Could not create nested Gradle user home: ${directory.absolutePath}",
+      )
+    }
+    return directory
+  }
+
+  private fun deleteGradleUserHome(directory: File) {
+    if (directory.exists() && !directory.deleteRecursively()) {
+      logger.warn("Could not delete nested Gradle user home: {}", directory.absolutePath)
     }
   }
 }

--- a/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/SmokeTestAppExtension.kt
+++ b/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/SmokeTestAppExtension.kt
@@ -214,10 +214,10 @@ abstract class ApplicationSpec @Inject constructor() {
   abstract val buildArguments: ListProperty<String>
 
   /**
-   * Extra environment variables exposed to the nested Gradle daemon. Merged on top of the
-   * outer process environment after clearing Gradle launcher variables — entries here override
-   * any inherited values with the same key. Use this for nested tooling that reads `JAVA_HOME`,
-   * `GRAALVM_HOME`, etc. from the env.
+   * Extra environment variables exposed to the nested Gradle daemon. Merged on top of the outer
+   * process environment; Gradle launcher variables are reserved by the nested build task so CI
+   * settings do not leak into pinned Gradle versions. Use this for nested tooling that reads
+   * `JAVA_HOME`, `GRAALVM_HOME`, etc. from the env.
    */
   abstract val environment: MapProperty<String, String>
 

--- a/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/SmokeTestAppExtension.kt
+++ b/build-logic/smoke-test/src/main/kotlin/datadog/buildlogic/smoketest/SmokeTestAppExtension.kt
@@ -215,8 +215,9 @@ abstract class ApplicationSpec @Inject constructor() {
 
   /**
    * Extra environment variables exposed to the nested Gradle daemon. Merged on top of the
-   * outer process environment — entries here override any inherited values with the same key.
-   * Use this for nested tooling that reads `JAVA_HOME`, `GRAALVM_HOME`, etc. from the env.
+   * outer process environment after clearing Gradle launcher variables — entries here override
+   * any inherited values with the same key. Use this for nested tooling that reads `JAVA_HOME`,
+   * `GRAALVM_HOME`, etc. from the env.
    */
   abstract val environment: MapProperty<String, String>
 

--- a/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
+++ b/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
@@ -163,6 +163,63 @@ class SmokeTestAppEndToEndTest {
     assertThat(result.task(":customBuild")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }
 
+  @Test
+  fun `nested build clears inherited Gradle launcher environment`() {
+    writeOuterSettings()
+    outerBuild.writeText(
+      """
+      plugins {
+        java
+        id("dd-trace-java.smoke-test-app")
+      }
+
+      smokeTestApp {
+        javaLauncher.set(
+          javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(${currentMajorJdk()})) }
+        )
+        application {
+          taskName.set("recordGradleEnvironment")
+          artifactPath.set("gradle-env.txt")
+          sysProperty.set("gradle.env.path")
+        }
+      }
+      """.trimIndent(),
+    )
+    writeInnerSettings()
+    writeInnerBuild(
+      """
+      tasks.register("recordGradleEnvironment") {
+        val out = layout.buildDirectory.file("gradle-env.txt")
+        outputs.file(out)
+        doLast {
+          out.get().asFile.writeText(
+            listOf("GRADLE_ARGS", "GRADLE_OPTS")
+              .joinToString(System.lineSeparator()) { key ->
+                "${'$'}key=${'$'}{System.getenv(key) ?: "<null>"}"
+              }
+          )
+        }
+      }
+      """.trimIndent(),
+    )
+
+    val result = runner(
+      "recordGradleEnvironment",
+      environment = mapOf(
+        "GRADLE_ARGS" to "--console=colored",
+        "GRADLE_OPTS" to "-Dorg.gradle.console=colored",
+      ),
+    ).build()
+
+    assertThat(result.task(":recordGradleEnvironment")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    val envFile = File(projectDir.toFile(), "build/application/gradle-env.txt")
+    assertThat(envFile).exists()
+    assertThat(envFile.readLines()).containsExactly(
+      "GRADLE_ARGS=",
+      "GRADLE_OPTS=",
+    )
+  }
+
   /**
    * `buildCacheEnabled` defaults to `false` and is plumbed through to the nested daemon as
    * an explicit `--no-build-cache` / `--build-cache` argument. The inner build records
@@ -336,11 +393,15 @@ class SmokeTestAppEndToEndTest {
     )
   }
 
-  private fun runner(vararg args: String): GradleRunner =
+  private fun runner(
+    vararg args: String,
+    environment: Map<String, String>? = null,
+  ): GradleRunner =
     GradleRunner.create()
       .withProjectDir(projectDir.toFile())
       .withPluginClasspath()
       .withArguments(*args, "--stacktrace")
+      .apply { if (environment != null) withEnvironment(System.getenv() + environment) }
       .forwardOutput()
 
   private fun currentMajorJdk(): Int =

--- a/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
+++ b/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
@@ -166,6 +166,8 @@ class SmokeTestAppEndToEndTest {
   @Test
   fun `nested build clears inherited Gradle launcher environment`() {
     writeOuterSettings()
+    val inheritedGradleUserHome = projectDir.resolve("inherited-gradle-user-home").toFile()
+    inheritedGradleUserHome.mkdirs()
     outerBuild.writeText(
       """
       plugins {
@@ -193,10 +195,12 @@ class SmokeTestAppEndToEndTest {
         outputs.file(out)
         doLast {
           out.get().asFile.writeText(
-            listOf("GRADLE_ARGS", "GRADLE_OPTS")
-              .joinToString(System.lineSeparator()) { key ->
-                "${'$'}key=${'$'}{System.getenv(key) ?: "<null>"}"
-              }
+            listOf(
+              "GRADLE_ARGS=${'$'}{System.getenv("GRADLE_ARGS") ?: "<null>"}",
+              "GRADLE_OPTS=${'$'}{System.getenv("GRADLE_OPTS") ?: "<null>"}",
+              "GRADLE_USER_HOME=${'$'}{System.getenv("GRADLE_USER_HOME") ?: "<null>"}",
+              "gradleUserHomeDir=${'$'}{gradle.gradleUserHomeDir.absolutePath}",
+            ).joinToString(System.lineSeparator())
           )
         }
       }
@@ -208,16 +212,25 @@ class SmokeTestAppEndToEndTest {
       environment = mapOf(
         "GRADLE_ARGS" to "--console=colored",
         "GRADLE_OPTS" to "-Ddd.test.gradle.opts=inherited",
+        "GRADLE_USER_HOME" to inheritedGradleUserHome.absolutePath,
       ),
     ).build()
 
     assertThat(result.task(":recordGradleEnvironment")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     val envFile = File(projectDir.toFile(), "build/application/gradle-env.txt")
     assertThat(envFile).exists()
-    assertThat(envFile.readLines()).containsExactly(
+    val lines = envFile.readLines()
+    assertThat(lines).contains(
       "GRADLE_ARGS=",
       "GRADLE_OPTS=",
     )
+    val gradleUserHomeEnv = lines.single { it.startsWith("GRADLE_USER_HOME=") }
+      .substringAfter("=")
+    val gradleUserHomeDir = lines.single { it.startsWith("gradleUserHomeDir=") }
+      .substringAfter("=")
+    assertThat(gradleUserHomeEnv).isEqualTo(gradleUserHomeDir)
+    assertThat(gradleUserHomeDir).isNotEqualTo(inheritedGradleUserHome.absolutePath)
+    assertThat(File(gradleUserHomeDir)).doesNotExist()
   }
 
   /**

--- a/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
+++ b/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
@@ -210,7 +210,7 @@ class SmokeTestAppEndToEndTest {
     val result = runner(
       "recordGradleEnvironment",
       environment = mapOf(
-        "GRADLE_ARGS" to "--console=colored",
+        "GRADLE_ARGS" to "--info",
         "GRADLE_OPTS" to "-Ddd.test.gradle.opts=inherited",
         "GRADLE_USER_HOME" to inheritedGradleUserHome.absolutePath,
       ),

--- a/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
+++ b/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
@@ -207,7 +207,7 @@ class SmokeTestAppEndToEndTest {
       "recordGradleEnvironment",
       environment = mapOf(
         "GRADLE_ARGS" to "--console=colored",
-        "GRADLE_OPTS" to "-Dorg.gradle.console=colored",
+        "GRADLE_OPTS" to "-Ddd.test.gradle.opts=inherited",
       ),
     ).build()
 
@@ -401,8 +401,18 @@ class SmokeTestAppEndToEndTest {
       .withProjectDir(projectDir.toFile())
       .withPluginClasspath()
       .withArguments(*args, "--stacktrace")
-      .apply { if (environment != null) withEnvironment(System.getenv() + environment) }
+      .withEnvironment(sanitizedGradleEnvironment(environment))
       .forwardOutput()
+
+  private fun sanitizedGradleEnvironment(
+    overrides: Map<String, String>? = null,
+  ): Map<String, String> =
+    System.getenv() +
+      mapOf(
+        "GRADLE_ARGS" to "",
+        "GRADLE_OPTS" to "",
+      ) +
+      (overrides ?: emptyMap())
 
   private fun currentMajorJdk(): Int =
     System.getProperty("java.specification.version").let {

--- a/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
+++ b/build-logic/smoke-test/src/test/kotlin/datadog/buildlogic/smoketest/SmokeTestAppEndToEndTest.kt
@@ -3,6 +3,7 @@ package datadog.buildlogic.smoketest
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -424,6 +426,7 @@ class SmokeTestAppEndToEndTest {
       mapOf(
         "GRADLE_ARGS" to "",
         "GRADLE_OPTS" to "",
+        "GRADLE_USER_HOME" to outerGradleUserHome.absolutePath,
       ) +
       (overrides ?: emptyMap())
 
@@ -433,6 +436,19 @@ class SmokeTestAppEndToEndTest {
     }
 
   companion object {
+    private val outerGradleUserHome: File by lazy {
+      Files.createTempDirectory("smoke-test-app-gradle-user-home-").toFile().also { dir ->
+        Runtime.getRuntime().addShutdownHook(Thread {
+          try {
+            DefaultGradleConnector.close()
+          } catch (_: Exception) {
+            // best effort
+          }
+          dir.deleteRecursively()
+        })
+      }
+    }
+
     @JvmStatic
     fun buildCacheFlagCases(): List<Arguments> = listOf(
       // (scenario name, DSL line added to the `application { … }` block, expected

--- a/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
+++ b/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
@@ -25,7 +25,6 @@ import org.gradle.testkit.runner.TaskOutcome;
 import org.gradle.tooling.internal.consumer.DefaultGradleConnector;
 import org.gradle.util.GradleVersion;
 import org.gradle.wrapper.Download;
-import org.gradle.wrapper.GradleUserHomeLookup;
 import org.gradle.wrapper.Install;
 import org.gradle.wrapper.PathAssembler;
 import org.gradle.wrapper.WrapperConfiguration;
@@ -286,7 +285,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
               GradleVersion.current().getVersion(),
               GRADLE_DISTRIBUTION_NETWORK_TIMEOUT);
 
-      java.io.File userHomeDir = GradleUserHomeLookup.gradleUserHome();
+      java.io.File userHomeDir = testKitFolder.toFile();
       java.io.File projectDir = projectFolder.toFile();
       Install install = new Install(logger, download, new PathAssembler(userHomeDir, projectDir));
 
@@ -308,6 +307,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
     Map<String, String> buildEnv = new HashMap<>();
     buildEnv.put("GRADLE_ARGS", "");
     buildEnv.put("GRADLE_OPTS", "");
+    buildEnv.put("GRADLE_USER_HOME", testKitFolder.toString());
     buildEnv.put("GRADLE_VERSION", gradleVersion);
     buildEnv.put(
         GradleDistribution.GRADLE_DISTRIBUTION_URL_ENV,

--- a/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
+++ b/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
@@ -306,6 +306,8 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
   private BuildResult runGradle(
       String gradleVersion, List<String> arguments, boolean successExpected) throws IOException {
     Map<String, String> buildEnv = new HashMap<>();
+    buildEnv.put("GRADLE_ARGS", "");
+    buildEnv.put("GRADLE_OPTS", "");
     buildEnv.put("GRADLE_VERSION", gradleVersion);
     buildEnv.put(
         GradleDistribution.GRADLE_DISTRIBUTION_URL_ENV,

--- a/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleLauncherSmokeTest.java
+++ b/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleLauncherSmokeTest.java
@@ -99,6 +99,7 @@ class GradleLauncherSmokeTest extends AbstractGradleTest {
     Map<String, String> env = new HashMap<>();
     env.put("JAVA_HOME", JAVA_HOME);
     env.put("GRADLE_USER_HOME", gradleUserHome.toString());
+    env.put("GRADLE_ARGS", "");
     env.put("GRADLE_OPTS", "");
     ShellCommandExecutor shellCommandExecutor =
         new ShellCommandExecutor(projectFolder.toFile(), GRADLE_STOP_TIMEOUT_MILLIS, env);
@@ -114,7 +115,8 @@ class GradleLauncherSmokeTest extends AbstractGradleTest {
     Map<String, String> env = new HashMap<>();
     env.put("JAVA_HOME", JAVA_HOME);
     env.put("GRADLE_USER_HOME", gradleUserHome.toString());
-    // Avoid inheriting CI's GRADLE_OPTS which might be incompatible with the tested JVM.
+    // Avoid inheriting CI Gradle launcher settings that might be incompatible with this wrapper.
+    env.put("GRADLE_ARGS", "");
     env.put("GRADLE_OPTS", "");
     ShellCommandExecutor shellCommandExecutor =
         new ShellCommandExecutor(projectFolder.toFile(), GRADLE_BUILD_TIMEOUT_MILLIS, env);
@@ -139,6 +141,7 @@ class GradleLauncherSmokeTest extends AbstractGradleTest {
     Map<String, String> env = new HashMap<>();
     env.put("JAVA_HOME", JAVA_HOME);
     env.put("GRADLE_USER_HOME", gradleUserHome.toString());
+    env.put("GRADLE_ARGS", "");
     env.put("GRADLE_OPTS", "-javaagent:" + AGENT_JAR);
     env.put("DD_CIVISIBILITY_ENABLED", "true");
     env.put("DD_CIVISIBILITY_AGENTLESS_ENABLED", "true");

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/coverages.ftl
@@ -1,6 +1,6 @@
 [ {
   "files" : [ {
-    "bitmap" : "AAAAfOxv",
+    "bitmap" : "AAAA8LF/8wE=",
     "filename" : "src/test/java/datadog/smoke/HelloPluginFunctionalTest.java"
   } ],
   "span_id" : ${content_span_id_4},

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/events.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/events.ftl
@@ -216,8 +216,8 @@
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
-      "test.source.end" : 47,
-      "test.source.start" : 18
+      "test.source.end" : 58,
+      "test.source.start" : 20
     },
     "name" : "junit5.test_suite",
     "resource" : "datadog.smoke.HelloPluginFunctionalTest",
@@ -278,8 +278,8 @@
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
-      "test.source.end" : 46,
-      "test.source.start" : 34
+      "test.source.end" : 49,
+      "test.source.start" : 36
     },
     "name" : "junit5.test",
     "parent_id" : ${content_parent_id},

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
@@ -9,6 +9,8 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,9 +41,17 @@ class HelloPluginFunctionalTest {
             .withPluginClasspath()
             .withGradleDistribution(URI.create(gradleDistributionUrl))
             .withArguments("hello", "--stacktrace")
+            .withEnvironment(sanitizedGradleEnvironment())
             .forwardOutput()
             .build();
 
     assertTrue(result.getOutput().contains("Hello from my plugin!"));
+  }
+
+  private static Map<String, String> sanitizedGradleEnvironment() {
+    Map<String, String> environment = new HashMap<>(System.getenv());
+    environment.put("GRADLE_ARGS", "");
+    environment.put("GRADLE_OPTS", "");
+    return environment;
   }
 }

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-gradle-plugin-test/src/test/java/datadog/smoke/HelloPluginFunctionalTest.java
@@ -41,17 +41,18 @@ class HelloPluginFunctionalTest {
             .withPluginClasspath()
             .withGradleDistribution(URI.create(gradleDistributionUrl))
             .withArguments("hello", "--stacktrace")
-            .withEnvironment(sanitizedGradleEnvironment())
+            .withEnvironment(sanitizedGradleEnvironment(testProjectDir.resolve("gradle-user-home")))
             .forwardOutput()
             .build();
 
     assertTrue(result.getOutput().contains("Hello from my plugin!"));
   }
 
-  private static Map<String, String> sanitizedGradleEnvironment() {
+  private static Map<String, String> sanitizedGradleEnvironment(Path gradleUserHomeDir) {
     Map<String, String> environment = new HashMap<>(System.getenv());
     environment.put("GRADLE_ARGS", "");
     environment.put("GRADLE_OPTS", "");
+    environment.put("GRADLE_USER_HOME", gradleUserHomeDir.toString());
     return environment;
   }
 }


### PR DESCRIPTION
# What Does This Do

Isolates nested Gradle invocations used by smoke-test application builds and Gradle TestKit fixtures from CI-provided Gradle launcher environment variables.

The main changes are:

- Clear inherited `GRADLE_OPTS` and `GRADLE_ARGS` before nested Tooling API and TestKit Gradle builds run.
- Give nested smoke-test application builds a task-local `GRADLE_USER_HOME`, stop nested Gradle daemons, and delete that user home after the build.

# Motivation

GitLab CI exports Gradle launcher settings for the root Gradle 9 build. Those settings can be inherited by nested Gradle builds launched through the Tooling API or Gradle TestKit, including smoke-test applications pinned to older Gradle versions. That inheritance caused nested Gradle 8.14.5 builds to reject unsupported console settings before the application build could run.

The fix keeps nested builds isolated from root-build launcher state while preserving the CI root build behavior.

# Additional Notes

Colored output uses Gradle's colored plain-console support introduced in [Gradle 9.1.0](https://docs.gradle.org/9.1.0/release-notes.html#plain-console-with-colors) (`--console=colored`):

<img width="707" height="592" alt="Screenshot 2026-06-04 at 14 33 40" src="https://github.com/user-attachments/assets/f17458c9-4264-40e2-9549-9c4a89836f24" />
<img width="482" height="97" alt="Screenshot 2026-06-04 at 14 35 39" src="https://github.com/user-attachments/assets/f1f78c00-c8a8-4901-9903-d9a14eab8634" />

At this time, I chose not to clear these variables as they are not explicitly set in the gitlab ci at this time.

* GRADLE_OPTS
* GRADLE_ARGS
* JAVA_HOME
* JAVA_OPTS
* JAVA_TOOL_OPTIONS
* JDK_JAVA_OPTIONS
* _JAVA_OPTIONS

Nor do I choose to filter on `ORG_GRADLE_PROJECT_` because some are _intentionnaly_ needed in the nested build, in particular for the `repositories.gradle` script plugin.


# Contributor Checklist

- [ ] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- [ ] Add your completed PR to the merge queue by commenting `/merge`.

Jira ticket: [PROJ-IDENT]
