### PR TITLE
Update byte-buddy dependency to 1.18.10

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -77,7 +77,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.18.8")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.18.9")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -77,7 +77,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.18.9")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.18.10")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/csi/CallSiteInstrumentationPluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/csi/CallSiteInstrumentationPluginTest.kt
@@ -30,7 +30,7 @@ class CallSiteInstrumentationPluginTest : GradleFixture() {
     }
 
     dependencies {
-      implementation("net.bytebuddy:byte-buddy:1.18.9")
+      implementation("net.bytebuddy:byte-buddy:1.18.10")
       implementation("com.google.auto.service:auto-service-annotations:1.1.1")
     }
   """

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/csi/CallSiteInstrumentationPluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/csi/CallSiteInstrumentationPluginTest.kt
@@ -30,7 +30,7 @@ class CallSiteInstrumentationPluginTest : GradleFixture() {
     }
 
     dependencies {
-      implementation("net.bytebuddy:byte-buddy:1.18.8")
+      implementation("net.bytebuddy:byte-buddy:1.18.9")
       implementation("com.google.auto.service:auto-service-annotations:1.1.1")
     }
   """

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPluginTest.kt
@@ -30,7 +30,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
     }
 
     dependencies {
-      compileOnly("net.bytebuddy:byte-buddy:1.18.9") // just to build TestPlugin
+      compileOnly("net.bytebuddy:byte-buddy:1.18.10") // just to build TestPlugin
     }
 
     buildTimeInstrumentation.plugins.set(listOf("TestPlugin"))
@@ -71,7 +71,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
       }
 
       dependencies {
-        compileOnly("net.bytebuddy:byte-buddy:1.18.9")
+        compileOnly("net.bytebuddy:byte-buddy:1.18.10")
       }
 
       buildTimeInstrumentation {
@@ -112,7 +112,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
       }
 
       dependencies {
-        compileOnly("net.bytebuddy:byte-buddy:1.18.9")
+        compileOnly("net.bytebuddy:byte-buddy:1.18.10")
       }
 
       buildTimeInstrumentation {

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPluginTest.kt
@@ -30,7 +30,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
     }
 
     dependencies {
-      compileOnly("net.bytebuddy:byte-buddy:1.18.8") // just to build TestPlugin
+      compileOnly("net.bytebuddy:byte-buddy:1.18.9") // just to build TestPlugin
     }
 
     buildTimeInstrumentation.plugins.set(listOf("TestPlugin"))
@@ -71,7 +71,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
       }
 
       dependencies {
-        compileOnly("net.bytebuddy:byte-buddy:1.18.8")
+        compileOnly("net.bytebuddy:byte-buddy:1.18.9")
       }
 
       buildTimeInstrumentation {
@@ -112,7 +112,7 @@ class BuildTimeInstrumentationPluginTest : GradleFixture() {
       }
 
       dependencies {
-        compileOnly("net.bytebuddy:byte-buddy:1.18.8")
+        compileOnly("net.bytebuddy:byte-buddy:1.18.9")
       }
 
       buildTimeInstrumentation {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -162,7 +162,7 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
       })
       )
       .make()
-      .load(Thread.currentThread().contextClassLoader, ClassLoadingStrategy.Default.INJECTION)
+      .load(Thread.currentThread().contextClassLoader, ClassLoadingStrategy.Default.WRAPPER)
     return Tuple.tuple(newType.loaded, newType.bytes)
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ scala33 = "3.3.0"
 # Bytecode manipulations & codegen
 autoservice = "1.1.1"
 asm = "9.9.1"
-byte-buddy = "1.18.8"
+byte-buddy = "1.18.9"
 instrument-java = "0.0.3"
 
 # Benchmarks

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ scala33 = "3.3.0"
 # Bytecode manipulations & codegen
 autoservice = "1.1.1"
 asm = "9.9.1"
-byte-buddy = "1.18.9"
+byte-buddy = "1.18.10"
 instrument-java = "0.0.3"
 
 # Benchmarks


### PR DESCRIPTION
# Motivation

- Disable use of Unsafe by default when Java 25 or newer is discovered.
- Avoid null pointer on missing annotation types.

https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.9

Updated to pull in 1.18.10 which just got released with a small improvement:
- https://github.com/raphw/byte-buddy/commit/5821cccc552b2c03cea37fc54cec27740a9a60c3

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
