### PR TITLE
Fix password leak from JDBC URL

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -36,9 +36,11 @@ public enum JDBCConnectionUrlParser {
 
         populateStandardProperties(builder, splitQuery(uri.getQuery(), '&'));
 
-        final String user = uri.getUserInfo();
-        if (user != null) {
-          builder.user(user);
+        final String userInfo = uri.getUserInfo();
+        if (userInfo != null) {
+          // getUserInfo() returns "user:password" — strip the password
+          final int colonLoc = userInfo.indexOf(':');
+          builder.user(colonLoc >= 0 ? userInfo.substring(0, colonLoc) : userInfo);
         }
 
         String path = uri.getPath();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -36,11 +36,17 @@ public enum JDBCConnectionUrlParser {
 
         populateStandardProperties(builder, splitQuery(uri.getQuery(), '&'));
 
-        final String userInfo = uri.getUserInfo();
-        if (userInfo != null) {
-          // getUserInfo() returns "user:password" — strip the password
-          final int colonLoc = userInfo.indexOf(':');
-          builder.user(colonLoc >= 0 ? userInfo.substring(0, colonLoc) : userInfo);
+        final String rawUserInfo = uri.getRawUserInfo();
+        if (rawUserInfo != null) {
+          // getRawUserInfo() avoids decoding %3A in the username before splitting on the unescaped
+          // ':'
+          final int colonLoc = rawUserInfo.indexOf(':');
+          final String rawUser = colonLoc >= 0 ? rawUserInfo.substring(0, colonLoc) : rawUserInfo;
+          try {
+            builder.user(URLDecoder.decode(rawUser, "UTF-8"));
+          } catch (final UnsupportedEncodingException e) {
+            builder.user(rawUser);
+          }
         }
 
         String path = uri.getPath();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -38,8 +38,7 @@ public enum JDBCConnectionUrlParser {
 
         final String rawUserInfo = uri.getRawUserInfo();
         if (rawUserInfo != null) {
-          // getRawUserInfo() avoids decoding %3A in the username before splitting on the unescaped
-          // ':'
+          // rawUserInfo keeps %3A encoded, so indexOf(':') only matches the password separator
           final int colonLoc = rawUserInfo.indexOf(':');
           final String rawUser = colonLoc >= 0 ? rawUserInfo.substring(0, colonLoc) : rawUserInfo;
           try {

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
@@ -5,21 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.tabletest.junit.TableTest;
 
-/**
- * Tests that passwords embedded in JDBC URL userinfo (user:password@host) do not leak into the
- * {@code db.user} span tag.
- *
- * <p>{@link java.net.URI#getUserInfo()} returns the full userinfo component, including the
- * password. Without sanitization, {@code builder.user("myuser:secret")} stores the password in
- * {@code DBInfo.user}, which is then set as the {@code db.user} span tag.
- */
 class JDBCConnectionUrlParserPasswordLeakTest {
 
   @TableTest({
-    "scenario                                       | url                                             | type       | host    | user        ",
-    "PostgreSQL userinfo with password              | jdbc:postgresql://myuser:secret123@pg.host/mydb | postgresql | pg.host | myuser      ",
-    "PostgreSQL userinfo without password           | jdbc:postgresql://myuser@pg.host/mydb           | postgresql | pg.host | myuser      ",
-    "PostgreSQL userinfo with percent-encoded colon | jdbc:postgresql://tenant%3Aalice@pg.host/mydb   | postgresql | pg.host | tenant:alice"
+    "scenario                                       | url                                             | type       | host     | user        ",
+    "PostgreSQL userinfo with password              | jdbc:postgresql://myuser:secret123@pg.host/mydb | postgresql | pg.host  | myuser      ",
+    "PostgreSQL userinfo without password           | jdbc:postgresql://myuser@pg.host/mydb           | postgresql | pg.host  | myuser      ",
+    "PostgreSQL userinfo with percent-encoded colon | jdbc:postgresql://tenant%3Aalice@pg.host/mydb   | postgresql | pg.host  | tenant:alice",
+    "SAP userinfo with password                     | jdbc:sap://myuser:secret@sap.host/sapdb         | sap        | sap.host | myuser      "
   })
   void passwordShouldNotLeakIntoUserTag(String url, String type, String host, String user) {
     DBInfo info = extractDBInfo(url, null);

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
@@ -16,9 +16,10 @@ import org.tabletest.junit.TableTest;
 class JDBCConnectionUrlParserPasswordLeakTest {
 
   @TableTest({
-    "scenario                             | url                                             | type       | host    | user  ",
-    "PostgreSQL userinfo with password    | jdbc:postgresql://myuser:secret123@pg.host/mydb | postgresql | pg.host | myuser",
-    "PostgreSQL userinfo without password | jdbc:postgresql://myuser@pg.host/mydb           | postgresql | pg.host | myuser"
+    "scenario                                       | url                                             | type       | host    | user        ",
+    "PostgreSQL userinfo with password              | jdbc:postgresql://myuser:secret123@pg.host/mydb | postgresql | pg.host | myuser      ",
+    "PostgreSQL userinfo without password           | jdbc:postgresql://myuser@pg.host/mydb           | postgresql | pg.host | myuser      ",
+    "PostgreSQL userinfo with percent-encoded colon | jdbc:postgresql://tenant%3Aalice@pg.host/mydb   | postgresql | pg.host | tenant:alice"
   })
   void passwordShouldNotLeakIntoUserTag(String url, String type, String host, String user) {
     DBInfo info = extractDBInfo(url, null);

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParserPasswordLeakTest.java
@@ -1,0 +1,29 @@
+package datadog.trace.bootstrap.instrumentation.jdbc;
+
+import static datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.extractDBInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.tabletest.junit.TableTest;
+
+/**
+ * Tests that passwords embedded in JDBC URL userinfo (user:password@host) do not leak into the
+ * {@code db.user} span tag.
+ *
+ * <p>{@link java.net.URI#getUserInfo()} returns the full userinfo component, including the
+ * password. Without sanitization, {@code builder.user("myuser:secret")} stores the password in
+ * {@code DBInfo.user}, which is then set as the {@code db.user} span tag.
+ */
+class JDBCConnectionUrlParserPasswordLeakTest {
+
+  @TableTest({
+    "scenario                             | url                                             | type       | host    | user  ",
+    "PostgreSQL userinfo with password    | jdbc:postgresql://myuser:secret123@pg.host/mydb | postgresql | pg.host | myuser",
+    "PostgreSQL userinfo without password | jdbc:postgresql://myuser@pg.host/mydb           | postgresql | pg.host | myuser"
+  })
+  void passwordShouldNotLeakIntoUserTag(String url, String type, String host, String user) {
+    DBInfo info = extractDBInfo(url, null);
+    assertEquals(type, info.getType());
+    assertEquals(host, info.getHost());
+    assertEquals(user, info.getUser());
+  }
+}


### PR DESCRIPTION
# What Does This Do
Strips the password from JDBC URL credentials before storing the username in the db.user span tag.

`jdbc:postgresql://myuser:secret123@pg.host/mydb`

**Before:**
db.user = "myuser:secret123"  ← password leaks into the tag

**After:**
db.user = "myuser" 

# Motivation
JDBC URLs can embed credentials directly in the URL (user:password@host). Java's URI.getUserInfo() returns the full string including the password.
Without sanitization, this password ends up in the db.user span tag sent to Datadog.

# Additional Notes
- Only affects the GENERIC_URL_LIKE parser (PostgreSQL, SAP, Redshift, Snowflake, IRIS, Sybase TDS)
- Other parsers (Oracle, DB2, MSSQL) use different URL formats and were already correct

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
