### PR TITLE
Consolidate MASS artifact URL handling

### DIFF
--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+  `kotlin-dsl`
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+  }
+}

--- a/build-logic/conventions/src/main/kotlin/datadog/buildlogic/mass/MassExtension.kt
+++ b/build-logic/conventions/src/main/kotlin/datadog/buildlogic/mass/MassExtension.kt
@@ -1,0 +1,19 @@
+package datadog.buildlogic.mass
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+
+open class MassExtension
+@Inject
+constructor(objects: ObjectFactory, providers: ProviderFactory) {
+  val readUrl: Property<String> =
+    objects.property(String::class.java).convention(providers.environmentVariable("MASS_READ_URL"))
+
+  fun artifactUrl(upstreamArtifactUrl: String): String {
+    val massReadUrl = readUrl.orNull ?: return "https://$upstreamArtifactUrl"
+    val baseUrl = if (massReadUrl.endsWith("/")) massReadUrl else "$massReadUrl/"
+    return "${baseUrl}internal/artifact/$upstreamArtifactUrl"
+  }
+}

--- a/build-logic/conventions/src/main/kotlin/dd-trace-java.mass.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/dd-trace-java.mass.gradle.kts
@@ -1,0 +1,4 @@
+import datadog.buildlogic.mass.MassExtension
+import org.gradle.kotlin.dsl.create
+
+extensions.create<MassExtension>("mass")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -47,4 +47,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "build-logic"
 
+include(":conventions")
 include(":smoke-test")

--- a/dd-java-agent/instrumentation/cics-9.1/build.gradle
+++ b/dd-java-agent/instrumentation/cics-9.1/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'dd-trace-java.mass'
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 // Configuration for downloading CICS SDK from IBM
@@ -6,18 +10,9 @@ ext {
   cicsSdkName = 'CICS_TG_SDK_91_Unix'
 }
 
-def massArtifactUrl = { String upstreamArtifactUrl ->
-  def massReadUrl = providers.environmentVariable('MASS_READ_URL').orNull
-  if (massReadUrl == null) {
-    return "https://${upstreamArtifactUrl}"
-  }
-  def baseUrl = massReadUrl.endsWith('/') ? massReadUrl : "${massReadUrl}/"
-  return "${baseUrl}internal/artifact/${upstreamArtifactUrl}"
-}
-
 repositories {
   ivy {
-    url = massArtifactUrl('public.dhe.ibm.com/software/htp/cics/support/supportpacs/individual/')
+    url = mass.artifactUrl('public.dhe.ibm.com/software/htp/cics/support/supportpacs/individual/')
     patternLayout {
       artifact '[module].[ext]'
     }

--- a/dd-smoke-tests/rum/wildfly-15/build.gradle
+++ b/dd-smoke-tests/rum/wildfly-15/build.gradle
@@ -2,6 +2,7 @@ import datadog.buildlogic.smoketest.NestedGradleBuild
 
 plugins {
   id 'dd-trace-java.smoke-test-app'
+  id 'dd-trace-java.mass'
 }
 
 ext {
@@ -12,18 +13,9 @@ ext {
   serverExtension = 'zip'
 }
 
-def massArtifactUrl = { String upstreamArtifactUrl ->
-  def massReadUrl = providers.environmentVariable('MASS_READ_URL').orNull
-  if (massReadUrl == null) {
-    return "https://${upstreamArtifactUrl}"
-  }
-  def baseUrl = massReadUrl.endsWith('/') ? massReadUrl : "${massReadUrl}/"
-  return "${baseUrl}internal/artifact/${upstreamArtifactUrl}"
-}
-
 repositories {
   ivy {
-    url = massArtifactUrl('github.com/wildfly/wildfly/releases/download/')
+    url = mass.artifactUrl('github.com/wildfly/wildfly/releases/download/')
     // Restrict this repository to WildFly distribution artifacts only.
     // Without this filter, Gradle may probe this host for unrelated dependencies
     // (for example JUnit/Mockito), which makes the build flaky when the host is unreachable.

--- a/dd-smoke-tests/springboot-tomcat/application/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'war'
   id 'org.springframework.boot' version '2.5.12'
+  id 'dd-trace-java.mass'
 }
 
 def sharedRootDir = "$rootDir/../../../"
@@ -28,18 +29,9 @@ ext {
   serverExtension = 'zip'
 }
 
-def massArtifactUrl = { String upstreamArtifactUrl ->
-  def massReadUrl = providers.environmentVariable('MASS_READ_URL').orNull
-  if (massReadUrl == null) {
-    return "https://${upstreamArtifactUrl}"
-  }
-  def baseUrl = massReadUrl.endsWith('/') ? massReadUrl : "${massReadUrl}/"
-  return "${baseUrl}internal/artifact/${upstreamArtifactUrl}"
-}
-
 repositories {
   ivy {
-    url = massArtifactUrl('dlcdn.apache.org')
+    url = mass.artifactUrl('dlcdn.apache.org')
     patternLayout {
       artifact '/[organisation]/[module]/v[revision]/bin/apache-[organisation]-[revision].[ext]'
     }

--- a/dd-smoke-tests/springboot-tomcat/application/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/build.gradle
@@ -1,7 +1,6 @@
 plugins {
   id 'war'
   id 'org.springframework.boot' version '2.5.12'
-  id 'dd-trace-java.mass'
 }
 
 def sharedRootDir = "$rootDir/../../../"
@@ -22,69 +21,7 @@ java {
   sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
-ext {
-  serverName = 'tomcat'
-  serverModule = 'tomcat-9'
-  serverVersion = '9.0.117'
-  serverExtension = 'zip'
-}
-
-repositories {
-  ivy {
-    url = mass.artifactUrl('dlcdn.apache.org')
-    patternLayout {
-      artifact '/[organisation]/[module]/v[revision]/bin/apache-[organisation]-[revision].[ext]'
-    }
-    metadataSources {
-      it.artifact()
-    }
-  }
-}
-
-configurations {
-  serverFile {
-    extendsFrom implementation
-    canBeResolved = true
-  }
-}
-
 dependencies {
-  // uses the ivy repository url to download the tomcat server
-  // organisation = serverName, revision = serverVersion, module = serverModule, ext = serverExtension
-  serverFile "${serverName}:${serverModule}:${serverVersion}@${serverExtension}"
-
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.5.12'
-  providedRuntime group: 'org.springframework.boot', name: 'spring-boot-starter-tomcat', version: '2.5.12'
-}
-
-tasks.register("unzip", Copy) {
-  def zipFileNamePrefix = "tomcat"
-  def serverZipTree = providers.provider {
-    // eager access
-    def zipPath = project.configurations.serverFile.find {
-      it.name.startsWith(zipFileNamePrefix)
-    }
-    if (zipPath == null) {
-      throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
-    }
-    zipTree(zipPath)
-  }
-
-  from serverZipTree
-  into layout.buildDirectory
-
-  // When tests are disabled this would still be run, so disable this manually
-  onlyIf { !project.rootProject.hasProperty("skipTests") }
-}
-
-tasks.named('bootWar') {
-  dependsOn 'unzip'
-}
-
-tasks.named('bootWarMainClassName') {
-  dependsOn 'unzip'
-}
-
-tasks.named('war') {
-  dependsOn 'unzip'
+  implementation 'org.springframework.boot:spring-boot-starter-web:2.5.12'
+  providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat:2.5.12'
 }

--- a/dd-smoke-tests/springboot-tomcat/application/settings.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/settings.gradle
@@ -1,6 +1,4 @@
 pluginManagement {
-  includeBuild("$settingsDir/../../../build-logic")
-
   repositories {
     mavenLocal()
     if (settings.hasProperty("gradlePluginProxy")) {

--- a/dd-smoke-tests/springboot-tomcat/application/settings.gradle
+++ b/dd-smoke-tests/springboot-tomcat/application/settings.gradle
@@ -1,4 +1,6 @@
 pluginManagement {
+  includeBuild("$settingsDir/../../../build-logic")
+
   repositories {
     mavenLocal()
     if (settings.hasProperty("gradlePluginProxy")) {

--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'dd-trace-java.smoke-test-app'
+  id 'dd-trace-java.mass'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -7,20 +8,87 @@ apply from: "$rootDir/gradle/java.gradle"
 description = 'SpringBoot Tomcat Smoke Tests.'
 
 def serverName = 'tomcat'
+def serverModule = 'tomcat-9'
 def serverVersion = '9.0.117'
+def serverExtension = 'zip'
+
+repositories {
+  ivy {
+    url = mass.artifactUrl('dlcdn.apache.org')
+    content {
+      includeGroup serverName
+    }
+    patternLayout {
+      artifact '/[organisation]/[module]/v[revision]/bin/apache-[organisation]-[revision].[ext]'
+    }
+    metadataSources {
+      it.artifact()
+    }
+  }
+}
+
+configurations {
+  register('serverFile') {
+    canBeConsumed = false
+    canBeResolved = true
+  }
+}
 
 smokeTestApp {
   application {
     taskName = 'bootWar'
     artifactPath = 'libs/springboot-tomcat-smoketest.war'
     sysProperty = 'datadog.smoketest.springboot.war.path'
-    additionalSystemProperties.put('datadog.smoketest.tomcatDir', "apache-${serverName}-${serverVersion}")
   }
 }
 
 dependencies {
+  // Uses the ivy repository url to download the Tomcat server zip.
+  // organisation = serverName, module = serverModule, revision = serverVersion,
+  // ext = serverExtension
+  serverFile "${serverName}:${serverModule}:${serverVersion}@${serverExtension}"
+
   testImplementation project(':dd-smoke-tests')
   testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+}
+
+def serverDirectory = layout.buildDirectory.dir("server")
+
+tasks.register("unzip", Copy) {
+  def zipFileNamePrefix = "tomcat"
+  def serverZipTree = providers.provider {
+    // eager access
+    def zipPath = project.configurations.serverFile.find {
+      it.name.startsWith(zipFileNamePrefix)
+    }
+    if (zipPath == null) {
+      throw new GradleException("Can't find server zip file that starts with: " + zipFileNamePrefix)
+    }
+    zipTree(zipPath)
+  }
+
+  from serverZipTree
+  into serverDirectory
+
+  // When tests are disabled this would still be run, so disable this manually
+  onlyIf { !project.rootProject.hasProperty("skipTests") }
+}
+
+def tomcatDir = serverDirectory.map {
+  it.dir("apache-${serverName}-${serverVersion}")
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn 'unzip'
+
+  jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+      @Override
+      Iterable<String> asArguments() {
+        return tomcatDir.map {
+          ["-Ddatadog.smoketest.tomcatDir=${it.asFile.absolutePath}"]
+        }.get()
+      }
+    })
 }
 
 spotless {

--- a/dd-smoke-tests/springboot-tomcat/gradle.lockfile
+++ b/dd-smoke-tests/springboot-tomcat/gradle.lockfile
@@ -109,4 +109,5 @@ org.spockframework:spock-core:2.4-groovy-3.0=testCompileClasspath,testRuntimeCla
 org.tabletest:tabletest-junit:1.2.1=testCompileClasspath,testRuntimeClasspath
 org.tabletest:tabletest-parser:1.2.0=testCompileClasspath,testRuntimeClasspath
 org.xmlresolver:xmlresolver:5.3.3=spotbugs
+tomcat:tomcat-9:9.0.117=serverFile
 empty=annotationProcessor,runtimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -2,6 +2,7 @@ import datadog.buildlogic.smoketest.NestedGradleBuild
 
 plugins {
   id 'dd-trace-java.smoke-test-app'
+  id 'dd-trace-java.mass'
 }
 
 ext {
@@ -12,18 +13,9 @@ ext {
   serverExtension = 'zip'
 }
 
-def massArtifactUrl = { String upstreamArtifactUrl ->
-  def massReadUrl = providers.environmentVariable('MASS_READ_URL').orNull
-  if (massReadUrl == null) {
-    return "https://${upstreamArtifactUrl}"
-  }
-  def baseUrl = massReadUrl.endsWith('/') ? massReadUrl : "${massReadUrl}/"
-  return "${baseUrl}internal/artifact/${upstreamArtifactUrl}"
-}
-
 repositories {
   ivy {
-    url = massArtifactUrl('github.com/wildfly/wildfly/releases/download/')
+    url = mass.artifactUrl('github.com/wildfly/wildfly/releases/download/')
     // Restrict this repository to WildFly distribution artifacts only.
     // Without this filter, Gradle may probe this host for unrelated dependencies
     // (for example JUnit/Mockito), which makes the build flaky when the host is unreachable.


### PR DESCRIPTION
# What Does This Do

Adds a `dd-trace-java.mass` Kotlin DSL convention plugin.

The plugin exposes `mass.artifactUrl(...)`, which maps upstream archive URLs through `MASS_READ_URL` when CI provides it. CICS, WildFly, RUM WildFly, and the standalone Tomcat smoke app now use that shared helper instead of carrying local closures.

# Motivation

Three recent archive downloads were routed through MASS independently. The URL behavior should live in one checked-in build convention, with each relevant project opting in through its `plugins` block.

* #11524
* #11525
* #11526

# Additional Notes

The Spring Boot Tomcat smoke test now resolves the Tomcat archive from the outer smoke-test project. This keeps the nested application isolated from the repository `build-logic` included build.

The outer project already participates in the main build and can apply the MASS convention plugin directly. The WildFly smoke test already keeps its application-server download in the outer smoke-test build, so Tomcat now follows the same pattern.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`.

Jira ticket: [APMLP-1405], [APMLP-1406], [APMLP-1407]

[APMLP-1405]: https://datadoghq.atlassian.net/browse/APMLP-1405
[APMLP-1406]: https://datadoghq.atlassian.net/browse/APMLP-1406
[APMLP-1407]: https://datadoghq.atlassian.net/browse/APMLP-1407
