### PR TITLE
Exchange test statistics through S3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ variables:
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   BUILDER_IMAGE_REPO: "registry.ddbuild.io/images/mirror/dd-trace-java-docker-build" # images are pinned in images/mirror.lock.yaml in the DataDog/images repo
   BUILDER_IMAGE_VERSION_PREFIX: "ci-" # use either an empty string (e.g. "") for latest images or a version followed by a hyphen (e.g. "ci-" or "123_merge-")
+  TEST_COUNTS_S3_BUCKET: "dd-trace-java-ci-test-reports"
   REPO_NOTIFICATION_CHANNEL: "#apm-java-escalations"
   DEFAULT_TEST_JVMS: /^(8|11|17|21|25|tip)$/ # the latest "tip" version is 26
   PROFILE_TESTS:
@@ -686,6 +687,11 @@ muzzle-dep-report:
     - .gitlab/upload_ciapp.sh $CACHE_TYPE $testJvm
     - gitlab_section_end "collect-reports"
     - .gitlab/count_tests.sh "$GRADLE_TARGET" "$testJvm" "./results" "./test_counts_${CI_JOB_ID}.json"
+    - export TEST_COUNTS_S3_PREFIX="test-counts/${CI_PIPELINE_ID}"
+    - export TEST_COUNTS_FILE="./test_counts_${CI_JOB_ID}.json"
+    - export TEST_COUNTS_S3_URI="s3://${TEST_COUNTS_S3_BUCKET}/${TEST_COUNTS_S3_PREFIX}/test_counts_${CI_JOB_ID}.json"
+    - echo "Uploading ${TEST_COUNTS_FILE} to ${TEST_COUNTS_S3_URI}"
+    - aws s3 cp "$TEST_COUNTS_FILE" "$TEST_COUNTS_S3_URI" --only-show-errors
     - URL_ENCODED_JOB_NAME=$(jq -rn --arg x "$CI_JOB_NAME" '$x|@uri')
     - echo -e "${TEXT_BOLD}${TEXT_YELLOW}See test results in Datadog:${TEXT_CLEAR} https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A${CI_PIPELINE_ID}%20%40ci.job.name%3A%22${URL_ENCODED_JOB_NAME}%22"
   artifacts:
@@ -918,9 +924,8 @@ test_smoke_semeru8_debugger:
 aggregate_test_counts:
   image: ${BUILDER_IMAGE_REPO}:${BUILDER_IMAGE_VERSION_PREFIX}base
   stage: test-summary
-  # Note: No explicit 'needs' or 'dependencies' required
-  # By default, GitLab CI automatically downloads artifacts from ALL jobs in previous stages
-  # This job collects test_counts_*.json files from all test/check jobs via stage ordering
+  # Keep stage ordering, but prevent GitLab from downloading all previous-stage artifacts.
+  dependencies: []
   rules:
     - if: '$POPULATE_CACHE'
       when: never
@@ -932,10 +937,16 @@ aggregate_test_counts:
       when: on_success
   script:
     - *set_datadog_api_keys
-    - .gitlab/aggregate_test_counts.sh
+    - export TEST_COUNTS_S3_PREFIX="test-counts/${CI_PIPELINE_ID}"
+    - mkdir -p ./test_counts_aggregate
+    - echo "Downloading test count files from s3://${TEST_COUNTS_S3_BUCKET}/${TEST_COUNTS_S3_PREFIX}/"
+    - aws s3 cp "s3://${TEST_COUNTS_S3_BUCKET}/${TEST_COUNTS_S3_PREFIX}/" ./test_counts_aggregate/ --recursive --exclude "*" --include "test_counts_*.json" --only-show-errors
+    - find ./test_counts_aggregate -name 'test_counts_*.json' -type f -print | sort
+    - .gitlab/aggregate_test_counts.sh ./test_counts_aggregate
   artifacts:
     when: always
     paths:
+      - test_counts_aggregate/test_counts_*.json
       - test_counts_summary.json
       - test_counts_report.md
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -935,6 +935,8 @@ aggregate_test_counts:
       when: on_success
     - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
       when: on_success
+    - if: '$CI_COMMIT_BRANCH'
+      when: on_success
   script:
     - *set_datadog_api_keys
     - export TEST_COUNTS_S3_PREFIX="test-counts/${CI_PIPELINE_ID}"

--- a/.gitlab/aggregate_test_counts.sh
+++ b/.gitlab/aggregate_test_counts.sh
@@ -471,7 +471,7 @@ done <<-EOF  # <<- strips leading tabs
 	EOF
 
 # Find and validate test count files
-mapfile -t VALID_FILES < <(find_and_validate_test_files "." "$OUTPUT_FILE")
+mapfile -t VALID_FILES < <(find_and_validate_test_files "$AGGREGATE_DIR" "$OUTPUT_FILE")
 if [ ${#VALID_FILES[@]} -eq 0 ]; then
     exit 0
 fi


### PR DESCRIPTION
# What Does This Do

Uploads each CI test job's test statistics JSON report to S3 under a pipeline-specific prefix, then has the aggregate job download those files before building the summary report.

This replaces the previous mechanism relying on GitLab artifacts, that was performing a _sequential_ download of every test job artifacts content (including things useless here). And it re-enables test count aggregation for branch pipelines.

And a PR branch the job should now take ~52 seconds (with ~50 seconds setting up container), while it was ~10 minutes (on merge queue it could be longer)

# Motivation

The aggregate job needs test count files from many test jobs, but relying on GitLab's default artifact download is very long, in merge queue it can take as long as 20 minutes, also this job is on the critical path. Using S3 keeps the aggregate input explicit and lets branch pipelines produce the same test count summary.

# Additional Notes

Follow-up
* #11580

Jira ticket: [PROJ-IDENT]