### PR TITLE
Prevent test statistics duplication

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -689,7 +689,9 @@ muzzle-dep-report:
     - .gitlab/count_tests.sh "$GRADLE_TARGET" "$testJvm" "./results" "./test_counts_${CI_JOB_ID}.json"
     - export TEST_COUNTS_S3_PREFIX="test-counts/${CI_PIPELINE_ID}"
     - export TEST_COUNTS_FILE="./test_counts_${CI_JOB_ID}.json"
-    - export TEST_COUNTS_S3_URI="s3://${TEST_COUNTS_S3_BUCKET}/${TEST_COUNTS_S3_PREFIX}/test_counts_${CI_JOB_ID}.json"
+    # Use logical job identity in S3 so retried jobs overwrite stale attempts.
+    - export TEST_COUNTS_S3_FILE="test_counts_${CI_JOB_NAME_SLUG}_${CI_NODE_INDEX}-${CI_NODE_TOTAL}.json"
+    - export TEST_COUNTS_S3_URI="s3://${TEST_COUNTS_S3_BUCKET}/${TEST_COUNTS_S3_PREFIX}/${TEST_COUNTS_S3_FILE}"
     - echo "Uploading ${TEST_COUNTS_FILE} to ${TEST_COUNTS_S3_URI}"
     - aws s3 cp "$TEST_COUNTS_FILE" "$TEST_COUNTS_S3_URI" --only-show-errors
     - URL_ENCODED_JOB_NAME=$(jq -rn --arg x "$CI_JOB_NAME" '$x|@uri')


### PR DESCRIPTION
# What Does This Do

Uploads test count JSON files to S3 with a stable logical job key based on the GitLab job slug and split index instead of the retry-specific `CI_JOB_ID`.

# Motivation

This follows up on review feedback from #11579. Retried GitLab jobs keep the same pipeline prefix but get a new job ID, so using `CI_JOB_ID` in the S3 object name can leave stale attempts for `aggregate_test_counts` to download and count.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]