### PR TITLE
feat(spring): add Spring Boot 4 / Spring Framework 7 support to spring-webmvc-6.0

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/build.gradle
@@ -4,7 +4,7 @@ muzzle {
     module = 'spring-webmvc'
     versions = "[6,)"
     javaVersion = "17"
-    extraDependency "jakarta.servlet:jakarta.servlet-api:5.0.0"
+    extraDependency "jakarta.servlet:jakarta.servlet-api:6.1.0"
   }
 }
 
@@ -55,10 +55,10 @@ dependencies {
 
   testImplementation(libs.spock.spring)
 
-  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.+'
-  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.+'
-  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '3.+'
-  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-websocket', version: '3.+'
+  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '4.+'
+  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '4.+'
+  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '4.+'
+  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-websocket', version: '4.+'
 }
 
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -101,6 +101,11 @@ public class SpringWebHttpServerDecorator
     return httpServletResponse.getStatus();
   }
 
+  // TODO Switch to HandlerMapping.API_VERSION_ATTRIBUTE once compile baseline moves to Spring
+  // Framework 7.
+  private static final String API_VERSION_ATTRIBUTE =
+      "org.springframework.web.servlet.HandlerMapping.apiVersion";
+
   @Override
   public AgentSpan onRequest(
       final AgentSpan span,
@@ -116,6 +121,10 @@ public class SpringWebHttpServerDecorator
       if (method != null && bestMatchingPattern != null && !bestMatchingPattern.equals("/**")) {
         request.setAttribute(DD_FILTERED_SPRING_ROUTE_ALREADY_APPLIED, true);
         HTTP_RESOURCE_DECORATOR.withRoute(span, method, bestMatchingPattern.toString());
+      }
+      final Object apiVersion = request.getAttribute(API_VERSION_ATTRIBUTE);
+      if (apiVersion instanceof String && !((String) apiVersion).isEmpty()) {
+        span.setTag("http.api_version", (String) apiVersion);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/java/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/java/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.java
@@ -1,0 +1,54 @@
+package datadog.trace.instrumentation.springweb6;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+class SpringWebHttpServerDecoratorTest {
+
+  private static final String API_VERSION_ATTRIBUTE =
+      "org.springframework.web.servlet.HandlerMapping.apiVersion";
+
+  @Test
+  void setsHttpApiVersionTagWhenAttributePresent() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    AgentSpan span = mock(AgentSpan.class);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getAttribute(API_VERSION_ATTRIBUTE)).thenReturn("v1");
+
+    SpringWebHttpServerDecorator.DECORATE.onRequest(span, request, request, null);
+
+    verify(span).setTag("http.api_version", "v1");
+  }
+
+  @Test
+  void doesNotSetHttpApiVersionTagWhenAttributeAbsent() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    AgentSpan span = mock(AgentSpan.class);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getAttribute(API_VERSION_ATTRIBUTE)).thenReturn(null);
+
+    SpringWebHttpServerDecorator.DECORATE.onRequest(span, request, request, null);
+
+    verify(span, never()).setTag(eq("http.api_version"), anyString());
+  }
+
+  @Test
+  void doesNotSetHttpApiVersionTagWhenAttributeEmpty() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    AgentSpan span = mock(AgentSpan.class);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getAttribute(API_VERSION_ATTRIBUTE)).thenReturn("");
+
+    SpringWebHttpServerDecorator.DECORATE.onRequest(span, request, request, null);
+
+    verify(span, never()).setTag(eq("http.api_version"), anyString());
+  }
+}


### PR DESCRIPTION
🤖 Generated with [APM Instrumentation Toolkit](https://github.com/DataDog/apm-instrumentation-toolkit)

## Summary

- Bumps `latestDepTestImplementation` spring-boot-starter-* from `3.+` to `4.+` for Spring Boot 4 / Spring Framework 7 test coverage
- Bumps muzzle `extraDependency jakarta.servlet-api` from `5.0.0` to `6.1.0` (SF7 requires Servlet 6.1 / Jakarta EE 11)
- Adds `http.api_version` span tag: reads `HandlerMapping.API_VERSION_ATTRIBUTE` (`"org.springframework.web.servlet.HandlerMapping.apiVersion"`) set by SF7's API versioning strategies (path, header, query-param, media-type). Read as a String literal since compile baseline is spring-webmvc:6.0.0; constant was verified from the SF7 jar.

## Test plan

- [x] `compileJava` — BUILD SUCCESSFUL
- [x] `test` — all tests pass (new `SpringWebHttpServerDecoratorTest.java` covers 3 cases)
- [x] `spotlessApply/Check` — clean
- [ ] `latestDepTest` against spring-boot-starter-*:4.+ (CI)

## Related

Part of Spring Boot 4 instrumentation: https://github.com/DataDog/apm-instrumentation-toolkit/issues/437
Depends on: #11584 (jakarta-servlet-6.0)

🤖 Generated with [APM Instrumentation Toolkit](https://github.com/DataDog/apm-instrumentation-toolkit)