### PR TITLE
Fixed queue-utils Javadoc toolchain.

### DIFF
--- a/utils/queue-utils/build.gradle.kts
+++ b/utils/queue-utils/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+
 plugins {
   `java-library`
 }
@@ -7,4 +10,13 @@ apply(from = "$rootDir/gradle/java.gradle")
 dependencies {
   api(project(":internal-api"))
   api(libs.jctools)
+}
+
+// jctools-core-jdk11 contains Java 11 class files; JDK 8 javadoc cannot read them.
+tasks.named<Javadoc>("javadoc") {
+  javadocTool.set(
+    javaToolchains.javadocToolFor {
+      languageVersion.set(JavaLanguageVersion.of(11))
+    }
+  )
 }


### PR DESCRIPTION
# What Does This Do
  Configures `utils:queue-utils:javadoc` to use a Java 11 `javadocTool`.

# Motivation
  `jctools-core-jdk11` contains Java 11 class files, which JDK 8 `javadoc` cannot read. This broke after the JCTools 4.0.6 upgrade in #10691.

# Additional Notes
Found it when executed `./gradlew assemble` on repository with stale cache.
Can be reproduced as `./gradlew assemble --rerun-tasks --no-build-cache`.

No production code changes.
