### PR TITLE
Fix continuation leakage on netty http2 client pipeline

### DIFF
--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/Http2ConnectContinuationListener.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/Http2ConnectContinuationListener.java
@@ -1,0 +1,34 @@
+package datadog.trace.instrumentation.netty41;
+
+import static datadog.trace.instrumentation.netty41.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+
+public final class Http2ConnectContinuationListener implements ChannelFutureListener {
+  public static final ChannelFutureListener INSTANCE = new Http2ConnectContinuationListener();
+
+  private Http2ConnectContinuationListener() {}
+
+  @Override
+  public void operationComplete(final ChannelFuture future) {
+    if (future.isSuccess() || future.isCancelled()) {
+      cancel(future.channel());
+    }
+    // Failed connects are left for ChannelFutureListenerInstrumentation, which creates the
+    // netty.connect error span under this continuation.
+  }
+
+  public static void cancel(final Channel channel) {
+    if (channel == null) {
+      return;
+    }
+    final AgentScope.Continuation continuation =
+        channel.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    if (continuation != null) {
+      continuation.cancel();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -30,6 +30,7 @@ import datadog.trace.instrumentation.netty41.server.MaybeBlockResponseHandler;
 import datadog.trace.instrumentation.netty41.server.websocket.WebSocketServerInboundTracingHandler;
 import datadog.trace.instrumentation.netty41.server.websocket.WebSocketServerOutboundTracingHandler;
 import datadog.trace.instrumentation.netty41.server.websocket.WebSocketServerTracingHandler;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpClientCodec;
@@ -91,6 +92,7 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
       packageName + ".server.websocket.WebSocketServerTracingHandler",
       packageName + ".server.websocket.WebSocketServerOutboundTracingHandler",
       packageName + ".server.websocket.WebSocketServerInboundTracingHandler",
+      packageName + ".Http2ConnectContinuationListener",
       packageName + ".NettyHttp2Helper",
       packageName + ".NettyPipelineHelper",
     };
@@ -253,18 +255,33 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
 
   public static class ConnectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      if (Boolean.TRUE.equals(
-          pipeline.channel().attr(HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY).get())) {
-        return;
-      }
+    public static boolean addParentSpan(@Advice.This final ChannelPipeline pipeline) {
       AgentScope.Continuation continuation = captureActiveSpan();
       if (continuation != noopContinuation()) {
         final Attribute<AgentScope.Continuation> attribute =
             pipeline.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY);
         if (!attribute.compareAndSet(null, continuation)) {
           continuation.cancel();
+          return false;
         }
+        return Boolean.TRUE.equals(
+            pipeline.channel().attr(HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY).get());
+      }
+      return false;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void cleanupHttp2ConnectParentContinuation(
+        @Advice.Enter final boolean cleanupHttp2Continuation,
+        @Advice.This final ChannelPipeline pipeline,
+        @Advice.Return final ChannelFuture future) {
+      if (!cleanupHttp2Continuation) {
+        return;
+      }
+      if (future == null) {
+        Http2ConnectContinuationListener.cancel(pipeline.channel());
+      } else {
+        future.addListener(Http2ConnectContinuationListener.INSTANCE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureActiveSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopContinuation;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
+import static datadog.trace.instrumentation.netty41.AttributeKeys.HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -175,6 +176,9 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
           handler2 instanceof ChannelHandler ? (ChannelHandler) handler2 : handler3;
 
       try {
+        if (NettyHttp2Helper.isHttp2ConnectionCodec(handler)) {
+          pipeline.channel().attr(HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY).set(Boolean.TRUE);
+        }
         // Server pipeline handlers
         if (handler instanceof HttpServerCodec) {
           NettyPipelineHelper.addHandlerAfter(
@@ -250,6 +254,10 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
   public static class ConnectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
+      if (Boolean.TRUE.equals(
+          pipeline.channel().attr(HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY).get())) {
+        return;
+      }
       AgentScope.Continuation continuation = captureActiveSpan();
       if (continuation != noopContinuation()) {
         final Attribute<AgentScope.Continuation> attribute =

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyHttp2Helper.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyHttp2Helper.java
@@ -10,11 +10,13 @@ import org.slf4j.LoggerFactory;
 
 public class NettyHttp2Helper {
   private static final Class HTTP2_CODEC_CLS;
+  private static final Class HTTP2_FRAME_CODEC_CLS;
   private static final MethodHandle IS_SERVER_FIELD;
   private static final Logger LOGGER = LoggerFactory.getLogger(NettyHttp2Helper.class);
 
   static {
     Class codecClass;
+    Class frameCodecClass;
     MethodHandle isServerField;
     try {
       codecClass =
@@ -38,12 +40,31 @@ public class NettyHttp2Helper {
       isServerField = null;
       LOGGER.debug("Unable to setup netty http2 instrumentation", t);
     }
+    try {
+      frameCodecClass =
+          Class.forName(
+              "io.netty.handler.codec.http2.Http2FrameCodec",
+              false,
+              NettyHttp2Helper.class.getClassLoader());
+    } catch (final ClassNotFoundException cnfe) {
+      // can be expected
+      frameCodecClass = null;
+    } catch (Throwable t) {
+      // unexpected
+      frameCodecClass = null;
+      LOGGER.debug("Unable to setup netty http2 connection detection", t);
+    }
     HTTP2_CODEC_CLS = codecClass;
+    HTTP2_FRAME_CODEC_CLS = frameCodecClass;
     IS_SERVER_FIELD = isServerField;
   }
 
   public static boolean isHttp2FrameCodec(final ChannelHandler handler) {
     return HTTP2_CODEC_CLS != null && HTTP2_CODEC_CLS.isInstance(handler);
+  }
+
+  public static boolean isHttp2ConnectionCodec(final ChannelHandler handler) {
+    return HTTP2_FRAME_CODEC_CLS != null && HTTP2_FRAME_CODEC_CLS.isInstance(handler);
   }
 
   public static boolean isServer(final ChannelHandler handler) {

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyHttp2Helper.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyHttp2Helper.java
@@ -9,8 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NettyHttp2Helper {
-  private static final Class HTTP2_CODEC_CLS;
-  private static final Class HTTP2_FRAME_CODEC_CLS;
+  private static final Class HTTP2_STREAM_FRAME_CODEC_CLS;
+  private static final Class HTTP2_CONNECTION_CODEC_CLS;
   private static final MethodHandle IS_SERVER_FIELD;
   private static final Logger LOGGER = LoggerFactory.getLogger(NettyHttp2Helper.class);
 
@@ -54,17 +54,17 @@ public class NettyHttp2Helper {
       frameCodecClass = null;
       LOGGER.debug("Unable to setup netty http2 connection detection", t);
     }
-    HTTP2_CODEC_CLS = codecClass;
-    HTTP2_FRAME_CODEC_CLS = frameCodecClass;
+    HTTP2_STREAM_FRAME_CODEC_CLS = codecClass;
+    HTTP2_CONNECTION_CODEC_CLS = frameCodecClass;
     IS_SERVER_FIELD = isServerField;
   }
 
   public static boolean isHttp2FrameCodec(final ChannelHandler handler) {
-    return HTTP2_CODEC_CLS != null && HTTP2_CODEC_CLS.isInstance(handler);
+    return HTTP2_STREAM_FRAME_CODEC_CLS != null && HTTP2_STREAM_FRAME_CODEC_CLS.isInstance(handler);
   }
 
   public static boolean isHttp2ConnectionCodec(final ChannelHandler handler) {
-    return HTTP2_FRAME_CODEC_CLS != null && HTTP2_FRAME_CODEC_CLS.isInstance(handler);
+    return HTTP2_CONNECTION_CODEC_CLS != null && HTTP2_CONNECTION_CODEC_CLS.isInstance(handler);
   }
 
   public static boolean isServer(final ChannelHandler handler) {

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -18,6 +18,7 @@ import datadog.context.Context;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -54,8 +55,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     }
 
     AgentScope parentScope = null;
-    final AgentScope.Continuation continuation =
-        ctx.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    final AgentScope.Continuation continuation = takeConnectParentContinuation(ctx);
     if (continuation != null) {
       parentScope = continuation.activate();
     }
@@ -110,5 +110,17 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
         parentScope.close();
       }
     }
+  }
+
+  private static AgentScope.Continuation takeConnectParentContinuation(
+      final ChannelHandlerContext ctx) {
+    final Channel channel = ctx.channel();
+    AgentScope.Continuation continuation =
+        channel.attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    if (continuation == null && channel.parent() != null) {
+      continuation =
+          channel.parent().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
+    }
+    return continuation;
   }
 }

--- a/dd-java-agent/instrumentation/netty/netty-common/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty/netty-common/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -27,6 +27,9 @@ public final class AttributeKeys {
       CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY =
           attributeKey("datadog.connect.parent.continuation");
 
+  public static final AttributeKey<Boolean> HTTP2_CONNECTION_CODEC_ATTRIBUTE_KEY =
+      attributeKey("datadog.http2.connection.codec");
+
   public static final AttributeKey<Context> PARENT_CONTEXT_ATTRIBUTE_KEY =
       attributeKey("datadog.server.parent-context");
 

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
@@ -9,6 +9,7 @@ import reactor.netty.http.server.HttpServer
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
@@ -27,6 +28,45 @@ class ReactorNettyHttp2ClientTest extends InstrumentationSpecification {
   @Override
   def cleanupSpec() {
     server?.disposeNow()
+  }
+
+  def "test http2 prior knowledge failed connect creates connect error span"() {
+    setup:
+    HttpClient httpClient = HttpClient.create()
+      .disableRetry(true)
+      .protocol(HttpProtocol.H2C)
+
+    when:
+    runUnderTrace("parent", {
+      httpClient.baseUrl("http://127.0.0.1:${UNUSABLE_PORT}")
+        .get()
+        .uri("/")
+        .response()
+        .block()
+    })
+
+    then:
+    def ex = thrown(Exception)
+    (ex instanceof ConnectException) || (ex.cause instanceof ConnectException)
+
+    and:
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent", null, ex)
+
+        span {
+          operationName "netty.connect"
+          resourceName "netty.connect"
+          childOf span(0)
+          errored true
+          tags {
+            "$Tags.COMPONENT" "netty"
+            errorTags Throwable, ~"Connection refused"
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 
   def "test http2 client/server propagation"() {

--- a/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1.0/src/test/groovy/ReactorNettyHttp2ClientTest.groovy
@@ -25,11 +25,6 @@ class ReactorNettyHttp2ClientTest extends InstrumentationSpecification {
   .bindNow()
 
   @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
-  @Override
   def cleanupSpec() {
     server?.disposeNow()
   }


### PR DESCRIPTION
# What Does This Do

Fixes an orphaned async continuation in Netty 4.1 HTTP/2 client flows.

For HTTP/1, the connect continuation captured in ConnectAdvice is later consumed by the request handler. In HTTP/2 prior-knowledge mode, the continuation is captured on the connection channel but requests are written on stream channels, so the continuation was never consumed or canceled.

This change marks channels that have an HTTP/2 connection codec as HTTP/2 connections and skips capturing the connect continuation for them. This avoids creating a continuation with no consumer. The request handler now also checks the parent channel for an existing connect continuation, covering stream-channel request paths where a parent-channel continuation is valid.

Issue spotted using an experimental continuation lifecycle tracker that gave:

```
continuation #35 captured-never-activated-or-canceled
    captured by: captureActiveSpan
    span: parent trace_id=9 span_id=8
    capture thread: reactor-http-nio-6
    activations=0, closed_scopes=0, cancels=0
    capture stack:
      at io.netty.channel.DefaultChannelPipeline.connect(DefaultChannelPipeline.java:978)
      at io.netty.channel.AbstractChannel.connect(AbstractChannel.java:253)
      at reactor.netty.transport.TransportConnector.lambda$doConnect$3(TransportConnector.java:149)
      at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
```
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
