### PR TITLE
Fix waf.updates metric success:N/A tag from sequential counter metric values

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -320,15 +320,23 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         }
       }
     } catch (InvalidRuleSetException e) {
-      log.debug(
+      log.warn(
           "Invalid rule during waf config update for config key {}: {}",
           configKey,
           e.wafDiagnostics);
       if (e.wafDiagnostics.getNumConfigError() > 0) {
         WafMetricCollector.get().addWafConfigError(e.wafDiagnostics.getNumConfigError());
       }
-      // TODO: Propagate diagostics back to remote config apply_error
-
+      // TODO: Propagate diagnostics back to remote config apply_error
+      if (e.wafDiagnostics.rulesetVersion != null
+          && !e.wafDiagnostics.rulesetVersion.isEmpty()
+          && (!defaultConfigActivated || currentRuleVersion == null)) {
+        currentRuleVersion = e.wafDiagnostics.rulesetVersion;
+        statsReporter.setRulesVersion(currentRuleVersion);
+        if (modulesToUpdateVersionIn != null) {
+          modulesToUpdateVersionIn.forEach(module -> module.setRuleVersion(currentRuleVersion));
+        }
+      }
       initReporter.setReportForPublication(e.wafDiagnostics);
       throw new RuntimeException(e);
     } catch (UnclassifiedWafException e) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -332,7 +332,9 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
           && !e.wafDiagnostics.rulesetVersion.isEmpty()
           && (!defaultConfigActivated || currentRuleVersion == null)) {
         currentRuleVersion = e.wafDiagnostics.rulesetVersion;
-        statsReporter.setRulesVersion(currentRuleVersion);
+        if (!e.wafDiagnostics.rules.getLoaded().isEmpty()) {
+          statsReporter.setRulesVersion(currentRuleVersion);
+        }
         if (modulesToUpdateVersionIn != null) {
           modulesToUpdateVersionIn.forEach(module -> module.setRuleVersion(currentRuleVersion));
         }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -1,5 +1,6 @@
 package com.datadog.appsec.config
 
+import com.datadog.appsec.AppSecModule
 import com.datadog.appsec.AppSecSystem
 import com.datadog.appsec.util.AbortStartupException
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_EXTENDED_DATA_COLLECTION
@@ -701,6 +702,49 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
 
     then:
     noExceptionThrown()
+  }
+
+  void 'currentRuleVersion is updated from diagnostics when InvalidRuleSetException is thrown on RC update'() {
+    setup:
+    final key = new ParsedConfigKey('Test', '1234', 1, 'ASM_DD', 'ID')
+    final service = new AppSecConfigServiceImpl(config, poller, reconf)
+    AppSecSystem.active = true
+    config.getAppSecActivation() >> ProductActivation.FULLY_ENABLED
+    AppSecModule wafModule = Mock()
+    wafModule.isWafBuilderSet() >> false
+    service.modulesToUpdateVersionIn([wafModule])
+
+    when:
+    service.maybeSubscribeConfigPolling()
+
+    then:
+    1 * poller.addListener(Product.ASM_DD, _) >> {
+      listeners.savedWafDataChangesListener = it[1]
+    }
+
+    when:
+    listeners.savedWafDataChangesListener.accept(
+      key,
+      '''{
+        "version": "2.2",
+        "metadata": {"rules_version": "1.99.0"},
+        "rules": [{
+          "id": "invalid-rule",
+          "name": "Invalid Rule",
+          "tags": {"type": "attack_attempt", "category": "attack_attempt"},
+          "conditions": [{
+            "operator": "invalid_operator",
+            "parameters": {"inputs": [{"address": "server.request.query"}]}
+          }]
+        }]
+      }'''.getBytes(),
+      NOOP)
+
+    then:
+    thrown RuntimeException
+    service.getCurrentRuleVersion() == '1.99.0'
+    1 * wafModule.setWafBuilder(_)
+    1 * wafModule.setRuleVersion('1.99.0')
   }
 
   void 'config keys are added and removed to the set when receiving ASM_DD payloads'() {

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -33,9 +33,6 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   private static final BlockingQueue<WafMetric> rawMetricsQueue =
       new ArrayBlockingQueue<>(RAW_QUEUE_SIZE);
 
-  private static final AtomicInteger wafInitCounter = new AtomicInteger();
-  private static final AtomicInteger wafUpdatesCounter = new AtomicInteger();
-
   private static final int WAF_REQUEST_COMBINATIONS = 128; // 2^7
   private final AtomicLongArray wafRequestCounter = new AtomicLongArray(WAF_REQUEST_COMBINATIONS);
 
@@ -80,14 +77,11 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
   public void wafInit(final String wafVersion, final String rulesVersion, final boolean success) {
     WafMetricCollector.wafVersion = wafVersion;
     WafMetricCollector.rulesVersion = rulesVersion;
-    rawMetricsQueue.offer(
-        new WafInitRawMetric(wafInitCounter.incrementAndGet(), wafVersion, rulesVersion, success));
+    rawMetricsQueue.offer(new WafInitRawMetric(1L, wafVersion, rulesVersion, success));
   }
 
   public void wafUpdates(final String rulesVersion, final boolean success) {
-    rawMetricsQueue.offer(
-        new WafUpdatesRawMetric(
-            wafUpdatesCounter.incrementAndGet(), wafVersion, rulesVersion, success));
+    rawMetricsQueue.offer(new WafUpdatesRawMetric(1L, wafVersion, rulesVersion, success));
 
     // Flush request metrics to get the new version.
     if (rulesVersion != null

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -67,7 +67,7 @@ class WafMetricCollectorTest extends DDSpecification {
 
     def updateMetric2 = (WafMetricCollector.WafUpdatesRawMetric) metrics[2]
     updateMetric2.type == 'count'
-    updateMetric2.value == 2
+    updateMetric2.value == 1
     updateMetric2.namespace == 'appsec'
     updateMetric2.metricName == 'waf.updates'
     updateMetric2.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.3', 'success:false'].toSet()

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/WafMetricPeriodicActionSpecification.groovy
@@ -34,7 +34,7 @@ class WafMetricPeriodicActionSpecification extends DDSpecification {
     1 * telemetryService.addMetric( { Metric metric ->
       metric.namespace == 'appsec' &&
         metric.metric == 'waf.updates' &&
-        metric.points[0][1] == 2 &&
+        metric.points[0][1] == 1 &&
         metric.tags == ['waf_version:0.0.0', 'event_rules_version:rules_ver_3', 'success:true']
     } )
     0 * _._


### PR DESCRIPTION
# What Does This Do

- Removes static `AtomicInteger` counters (`wafInitCounter`, `wafUpdatesCounter`) from `WafMetricCollector` and uses `1L` as the metric value for both `wafInit()` and `wafUpdates()`, matching RFC semantics (COUNT-1-per-event)
- In `AppSecConfigServiceImpl.handleWafUpdateResultReport()`, updates `currentRuleVersion` from `e.wafDiagnostics.rulesetVersion` in the `InvalidRuleSetException` catch block so `wafUpdates()` emits with the correct `event_rules_version` even when a partial WAF config error occurs
- Changes log level for `InvalidRuleSetException` during WAF config updates from `debug` to `warn`
- Adds a regression test verifying `currentRuleVersion` is populated from diagnostics when `InvalidRuleSetException` is thrown during a remote config update

# Motivation

`appsec.waf.updates` was reporting `success:N/A` for approximately 10% of events.

The root cause was the use of sequential `AtomicInteger` counters (`1, 2, 3, ...`) as the metric value. The telemetry backend aggregates metrics with the same tags across polling windows. When the `rawMetricsQueue` (capacity 1024) is full and a metric offer is dropped, the counter has already been incremented — the next successful emission sends value `N+1` with no preceding `N`, creating a gap the backend interprets as `success:N/A`.

The RFC specifies `waf.init` and `waf.updates` as COUNT-1-per-event metrics: each emission should carry value `1`, not a cumulative count.

The secondary fix ensures `currentRuleVersion` is set from WAF diagnostics even when `InvalidRuleSetException` is thrown, so `wafUpdates()` carries the correct `event_rules_version` tag in error scenarios.

# Additional Notes

The condition `(!defaultConfigActivated || currentRuleVersion == null)` in the error path mirrors the guard used in the success path: it prevents overwriting a user-customized rule version with a default config version, while still allowing the version to be set on the first update or when the default config is active.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APPSEC-62740](https://datadoghq.atlassian.net/browse/APPSEC-62740)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

[APPSEC-62740]: https://datadoghq.atlassian.net/browse/APPSEC-62740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ