### PR TITLE
Avoid leaking continuations on google pubsub instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/GooglePubSubModule.java
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/main/java/datadog/trace/instrumentation/googlepubsub/GooglePubSubModule.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.googlepubsub;
 
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.EXECUTOR;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
@@ -11,6 +10,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +35,16 @@ public class GooglePubSubModule extends InstrumenterModule.Tracing
 
   @Override
   public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
-    return singletonMap(RUNNABLE, singletonList("com.google.api.gax.rpc.Watchdog"));
+    final List<String> gaxInternalRunnables =
+        asList(
+            "com.google.api.gax.rpc.Watchdog",
+            "com.google.api.gax.retrying.BasicRetryingFuture$CompletionListener",
+            "com.google.api.gax.retrying.CallbackChainRetryingFuture$AttemptCompletionListener");
+    final Map<ExcludeFilter.ExcludeType, Collection<String>> excluded =
+        new EnumMap<>(ExcludeFilter.ExcludeType.class);
+    excluded.put(RUNNABLE, gaxInternalRunnables);
+    excluded.put(EXECUTOR, gaxInternalRunnables);
+    return excluded;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/test/groovy/PubSubTest.groovy
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/test/groovy/PubSubTest.groovy
@@ -69,11 +69,6 @@ abstract class PubSubTest extends VersionedNamingTestBase {
     null
   }
 
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
   boolean shadowGrpcSpans() {
     true
   }


### PR DESCRIPTION
# What Does This Do

Fix Pub/Sub strict trace writes by avoiding async continuation capture for internal GAX/PubSub callbacks that do not represent application work. The Pub/Sub tests no longer need `useStrictTraceWrites() == false`: strict mode was failing because internal retry/listener callbacks could capture continuations from the publish span and resolve too late, or never resolve, leaving the writer waiting on orphaned work.

This has been detected with an experimental (unreleased) diagnostic tool to track continuation leakage. The diagnostic message was

```
- span: `google-pubsub.produce`
  - state: `captured-never-activated-or-canceled`
  - capture thread: `Gax-*`
  - capture stack included:
    - `State.captureAndSetContinuation`
    - `ExecutorInstrumentationUtils.setupState`
    - `AbstractFuture.addListener`
    - `CallbackChainRetryingFuture.setAttemptFuture`
    - `AttemptCallable.call`
    - `Publisher.publishOutstandingBatch`
 ```

That showed the continuation was captured by GAX retry/listener machinery, not by user-visible async work.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
