### PR TITLE
Enable secure random ID generation for AWS Lambda MicroVM environments

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1516,7 +1516,9 @@ public class Config {
         configProvider.getBoolean(WRITER_BAGGAGE_INJECT, isDatadogTraceWriter);
     injectLinksAsTagsEnabled = configProvider.getBoolean(WRITER_LINKS_INJECT, isDatadogTraceWriter);
     String lambdaInitType = getEnv("AWS_LAMBDA_INITIALIZATION_TYPE");
-    if (lambdaInitType != null && lambdaInitType.equals("snap-start")) {
+    String lambdaMicrovmImageArn = ConfigHelper.env("AWS_LAMBDA_MICROVM_IMAGE_ARN");
+    if ((lambdaInitType != null && lambdaInitType.equals("snap-start"))
+        || (lambdaMicrovmImageArn != null && !lambdaMicrovmImageArn.isEmpty())) {
       secureRandom = true;
     } else {
       secureRandom = configProvider.getBoolean(SECURE_RANDOM, DEFAULT_SECURE_RANDOM);

--- a/internal-api/src/test/java/datadog/trace/api/ConfigSecureRandomTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/ConfigSecureRandomTest.java
@@ -1,0 +1,46 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import datadog.trace.junit.utils.config.WithConfig;
+import datadog.trace.junit.utils.config.WithConfigExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WithConfigExtension.class)
+class ConfigSecureRandomTest {
+
+  @Test
+  void defaultStrategyIsRandom() {
+    assertNotEquals("SRandom", Config.get().getIdGenerationStrategy().getClass().getSimpleName());
+  }
+
+  @Test
+  void snapStartEnablesSecureRandom() {
+    WithConfigExtension.injectEnvConfig("AWS_LAMBDA_INITIALIZATION_TYPE", "snap-start", false);
+
+    assertEquals("SRandom", Config.get().getIdGenerationStrategy().getClass().getSimpleName());
+  }
+
+  @Test
+  void microvmImageArnEnablesSecureRandom() {
+    WithConfigExtension.injectEnvConfig(
+        "AWS_LAMBDA_MICROVM_IMAGE_ARN", "arn:aws:lambda:us-east-1::runtime:microvm", false);
+
+    assertEquals("SRandom", Config.get().getIdGenerationStrategy().getClass().getSimpleName());
+  }
+
+  @Test
+  void emptyMicrovmImageArnDoesNotEnableSecureRandom() {
+    WithConfigExtension.injectEnvConfig("AWS_LAMBDA_MICROVM_IMAGE_ARN", "", false);
+
+    assertNotEquals("SRandom", Config.get().getIdGenerationStrategy().getClass().getSimpleName());
+  }
+
+  @Test
+  @WithConfig(key = "trace.secure-random", value = "true")
+  void configPropertyEnablesSecureRandom() {
+    assertEquals("SRandom", Config.get().getIdGenerationStrategy().getClass().getSimpleName());
+  }
+}


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-9287

## Background

For Firecracker-based container technology, in order to reduce cold-start latency, the system snapshots the entire process memory of a warmed-up instance and reuses it to launch new ones. Every resumed instance starts from the same frozen memory image — including any userspace state that was initialized before the snapshot was taken.

## Summary
- Extends the existing `secureRandom` logic to also activate when running in AWS Lambda MicroVM environments (detected via the `AWS_LAMBDA_MICROVM_IMAGE_ARN` environment variable)
- MicroVM environments, like SnapStart, benefit from `SecureRandom`-based ID generation because memory snapshots can cause ID collisions with standard random sources
- Adds `ConfigSecureRandomTest` with 5 JUnit 5 tests covering all activation paths (default, SnapStart, MicroVM ARN, empty ARN, config property)

## Test plan
- [ ] `./gradlew :internal-api:test --tests datadog.trace.api.ConfigSecureRandomTest` passes
- [ ] Verify `secureRandom = true` when `AWS_LAMBDA_MICROVM_IMAGE_ARN` is set to a non-empty value
- [ ] Verify `secureRandom = false` (default) when `AWS_LAMBDA_MICROVM_IMAGE_ARN` is empty or unset
- [ ] Integration shows `secureRandom = true`
<img width="1474" height="204" alt="image" src="https://github.com/user-attachments/assets/82da20fc-f0f4-464e-9dc0-9979abcb490c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)