### PR TITLE
Apply main forbidden APIs to instrumentation modules

### DIFF
--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -44,7 +44,9 @@ subprojects { Project subProj ->
 
     // Add instrumentation-specific forbiddenApi rules
     subProj.tasks.withType(CheckForbiddenApis).configureEach {
-      signaturesFiles += subProj.files("$rootDir/gradle/forbiddenApiFilters/instrumentation.txt")
+      signaturesFiles = subProj.files(
+        "$rootDir/gradle/forbiddenApiFilters/main.txt",
+        "$rootDir/gradle/forbiddenApiFilters/instrumentation.txt")
     }
 
 

--- a/dd-java-agent/instrumentation/datadog/dynamic-instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/datadog/dynamic-instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
@@ -1,13 +1,12 @@
 package datadog.trace.instrumentation.codeorigin;
 
-import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
-import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule.Tracing;
-import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.OneOf;
 import datadog.trace.api.InstrumenterConfig;
@@ -16,7 +15,6 @@ import java.util.Set;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public abstract class CodeOriginInstrumentation extends Tracing
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
@@ -44,28 +42,20 @@ public abstract class CodeOriginInstrumentation extends Tracing
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     ElementMatcher.Junction<TypeDescription> matcher =
-        HierarchyMatchers.declaresMethod(HierarchyMatchers.isAnnotatedWith(this.matcher));
+        declaresMethod(isAnnotatedWith(this.matcher));
     if (InstrumenterConfig.get().isCodeOriginInterfaceSupport()) {
-      matcher =
-          matcher.or(
-              HierarchyMatchers.implementsInterface(
-                  HierarchyMatchers.declaresMethod(
-                      HierarchyMatchers.isAnnotatedWith(this.matcher))));
+      matcher = matcher.or(implementsInterface(declaresMethod(isAnnotatedWith(this.matcher))));
     }
     return matcher;
   }
 
   @Override
-  @SuppressForbidden // Existing direct ElementMatchers usage differs from HierarchyMatchers
-  // behavior
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        HierarchyMatchers.isAnnotatedWith(matcher),
-        "datadog.trace.instrumentation.codeorigin.EntrySpanOriginAdvice");
+        isAnnotatedWith(matcher), "datadog.trace.instrumentation.codeorigin.EntrySpanOriginAdvice");
     if (InstrumenterConfig.get().isCodeOriginInterfaceSupport()) {
       transformer.applyAdvice(
-          ElementMatchers.isDeclaredBy(
-              hasSuperType(isInterface().and(declaresMethod(isAnnotatedWith(matcher))))),
+          isDeclaredBy(implementsInterface(declaresMethod(isAnnotatedWith(matcher)))),
           "datadog.trace.instrumentation.codeorigin.EntrySpanOriginAdvice");
     }
   }

--- a/dd-java-agent/instrumentation/datadog/dynamic-instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/datadog/dynamic-instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
@@ -56,6 +56,8 @@ public abstract class CodeOriginInstrumentation extends Tracing
   }
 
   @Override
+  @SuppressForbidden // Existing direct ElementMatchers usage differs from HierarchyMatchers
+  // behavior
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         HierarchyMatchers.isAnnotatedWith(matcher),

--- a/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/PartHelper.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/PartHelper.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.liberty20;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,6 +49,7 @@ public class PartHelper {
     }
   }
 
+  @SuppressForbidden // split on single-character uses a fast path
   private static String getFilenameFromContentDisposition(Method getHeader, Object part) {
     if (getHeader == null) {
       return null;

--- a/dd-java-agent/instrumentation/spring/spring-core-3.2.2/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-core-3.2.2/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springcore;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -56,7 +57,7 @@ public final class StreamUtilsInstrumentation extends InstrumenterModule.Iast
 
     private static void muzzleCheck() throws IOException {
       StreamUtils.copyToString(
-          new ByteArrayInputStream("test".getBytes()), Charset.defaultCharset());
+          new ByteArrayInputStream("test".getBytes(UTF_8)), Charset.defaultCharset());
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Restores the intended forbidden-apis signature set for instrumentation modules: `main.txt` plus `instrumentation.txt`.

The stricter check surfaced a few existing calls that were previously leaking through:

- `String#split(String)` in Liberty filename parsing, kept with a narrow `@SuppressForbidden` because this is the existing one-character split fast-path pattern used elsewhere in the repo.
- `String#getBytes()` in Spring Core muzzle code, changed to `getBytes(UTF_8)`.
- direct Byte Buddy `ElementMatchers` usage in Code Origin support, I kept as-is with because the existing matcher expression intentionally differs from the available `HierarchyMatchers`.

# Motivation

~~Follow-up to https://github.com/DataDog/dd-trace-java/pull/11620.~~ Actually it can be merged before.

Instrumentation forbidden-apis tasks were not properly configured to use `main.txt`. 
This was already true on `master`, and it surfaced while working on #11620: 
1. the forbidden-api task setup configures `main.txt`, 
2. then `dd-java-agent/instrumentation/build.gradle` mutates each `CheckForbiddenApis` task with `signaturesFiles += instrumentation.txt`, 
 
...but it's not working as expected.

With the forbidden-apis Gradle plugin task property/convention wiring, that task-level **`+=`** did not _merge_ with the extension's "default" in the way it was _supposedly_ (as far as I understand) intended. In practice, that means that forbidden api instrumentation tasks such as `:dd-java-agent:instrumentation:liberty:liberty-20.0:forbiddenApisMain` only read `instrumentation.txt`.

This means that APIs covered only by `main.txt` were not checked in instrumentation modules.

This PR makes the task-level configuration explicit by assigning both files together.

# Additional Details

* By using `--info` to the `forbiddenApisMain` task, once can see what signature file are used.

* The `CodeOriginInstrumentation` change is now using tracer's `HierarchyMatchers`. In particular the change should keep the #11017.

  The API is a bit different on the surface, but should behave the same way

  ```diff
  - isDeclaredBy(hasSuperType(isInterface().and(declaresMethod(isAnnotatedWith(matcher)))))
  + isDeclaredBy(implementsInterface(declaresMethod(isAnnotatedWith(matcher))))
  ```


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [N/A]
