### PR TITLE
Avoid final field mutations in JUnit 5, Weaver and Karate instrumentations

### DIFF
--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5ExecutionInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5ExecutionInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.junit5.execution;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
@@ -27,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.ModifierAdjustment;
+import net.bytebuddy.description.modifier.FieldManifestation;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService;
@@ -35,7 +38,9 @@ import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 @AutoService(InstrumenterModule.class)
 public class JUnit5ExecutionInstrumentation extends InstrumenterModule.CiVisibility
-    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForSingleType,
+        Instrumenter.HasTypeAdvice,
+        Instrumenter.HasMethodAdvice {
 
   private final String parentPackageName =
       Strings.getPackageName(JUnitPlatformUtils.class.getName());
@@ -82,6 +87,20 @@ public class JUnit5ExecutionInstrumentation extends InstrumenterModule.CiVisibil
             .withMethod(new String[0], 0, "execute", "V")
             .build());
     return additionalReferences.toArray(new Reference[0]);
+  }
+
+  /**
+   * Strips the {@code final} modifier from the fields that {@link TestTaskHandle} mutates when
+   * setting up test retries. Mutating final fields via reflection or method handles is forbidden by
+   * <a href="https://openjdk.org/jeps/500">JEP 500</a>, while mutating non-final fields remains
+   * legal. The modifier is stripped when the class is loaded, before any instance is created, so
+   * the JVM never relies on the fields being final.
+   */
+  @Override
+  public void typeAdvice(TypeTransformer transformer) {
+    transformer.applyAdvice(
+        new ModifierAdjustment()
+            .withFieldModifiers(namedOneOf("testDescriptor", "node"), FieldManifestation.PLAIN));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5TestDescriptorInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/execution/JUnit5TestDescriptorInstrumentation.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.junit5.execution;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.Config;
+import net.bytebuddy.asm.ModifierAdjustment;
+import net.bytebuddy.description.modifier.FieldManifestation;
+
+/**
+ * Strips the {@code final} modifier from {@code AbstractTestDescriptor#uniqueId} when the class is
+ * loaded. {@link TestDescriptorHandle} overwrites this field on cloned descriptors to give each
+ * test retry a distinct unique ID, and mutating final fields via reflection or method handles is
+ * forbidden by <a href="https://openjdk.org/jeps/500">JEP 500</a>. Mutating non-final fields
+ * remains legal, and since the modifier is stripped before any instance of the class is created,
+ * the JVM never relies on the field being final.
+ */
+@AutoService(InstrumenterModule.class)
+public class JUnit5TestDescriptorInstrumentation extends InstrumenterModule.CiVisibility
+    implements Instrumenter.ForSingleType, Instrumenter.HasTypeAdvice {
+
+  public JUnit5TestDescriptorInstrumentation() {
+    super("ci-visibility", "junit-5", "test-retry");
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled() && Config.get().isCiVisibilityExecutionPoliciesEnabled();
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.junit.platform.engine.support.descriptor.AbstractTestDescriptor";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return TestDescriptorHandle.MuzzleHelper.compileReferences().toArray(new Reference[0]);
+  }
+
+  @Override
+  public void typeAdvice(TypeTransformer transformer) {
+    transformer.applyAdvice(
+        new ModifierAdjustment()
+            .withFieldModifiers(NameMatchers.named("uniqueId"), FieldManifestation.PLAIN));
+  }
+}

--- a/dd-java-agent/instrumentation/karate-1.0/src/main/java/datadog/trace/instrumentation/karate/KarateExecutionInstrumentation.java
+++ b/dd-java-agent/instrumentation/karate-1.0/src/main/java/datadog/trace/instrumentation/karate/KarateExecutionInstrumentation.java
@@ -21,10 +21,14 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.ModifierAdjustment;
+import net.bytebuddy.description.modifier.FieldManifestation;
 
 @AutoService(InstrumenterModule.class)
 public class KarateExecutionInstrumentation extends InstrumenterModule.CiVisibility
-    implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
+    implements Instrumenter.ForKnownTypes,
+        Instrumenter.HasTypeAdvice,
+        Instrumenter.HasMethodAdvice {
 
   public KarateExecutionInstrumentation() {
     super("ci-visibility", "karate", "test-retry");
@@ -56,6 +60,21 @@ public class KarateExecutionInstrumentation extends InstrumenterModule.CiVisibil
   public Map<String, String> contextStore() {
     return Collections.singletonMap(
         "com.intuit.karate.core.Scenario", packageName + ".ExecutionContext");
+  }
+
+  /**
+   * Strips the {@code final} modifier from {@code ScenarioRuntime#result} when the class is loaded
+   * ({@code ScenarioResult} has no field with that name, so this is a no-op there). {@link
+   * KarateUtils#setResult(ScenarioRuntime, ScenarioResult)} overwrites the field after retries so
+   * that the last execution result is reported, and mutating final fields via reflection or method
+   * handles is forbidden by <a href="https://openjdk.org/jeps/500">JEP 500</a>. Mutating non-final
+   * fields remains legal, and since the modifier is stripped before any instance of the class is
+   * created, the JVM never relies on the field being final.
+   */
+  @Override
+  public void typeAdvice(TypeTransformer transformer) {
+    transformer.applyAdvice(
+        new ModifierAdjustment().withFieldModifiers(named("result"), FieldManifestation.PLAIN));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
+++ b/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
@@ -1,12 +1,12 @@
 package datadog.trace.instrumentation.weaver;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.lang.reflect.Field;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import net.bytebuddy.asm.Advice;
@@ -36,36 +36,42 @@ public class WeaverInstrumentation extends InstrumenterModule.CiVisibility
     };
   }
 
+  /**
+   * The suite event queue is wrapped by replacing the constructor argument before the constructor
+   * body assigns it to the {@code queue} field. The field is final, so it cannot be overwritten
+   * after construction: mutating final fields via reflection or method handles is forbidden by <a
+   * href="https://openjdk.org/jeps/500">JEP 500</a>.
+   */
   @Override
   public void methodAdvice(MethodTransformer transformer) {
+    // typelevel's implementation (0.9+) uses a LinkedBlockingQueue
     transformer.applyAdvice(
-        isConstructor(), WeaverInstrumentation.class.getName() + "$SbtTaskCreationAdvice");
+        isConstructor().and(takesArgument(5, named("java.util.concurrent.LinkedBlockingQueue"))),
+        WeaverInstrumentation.class.getName() + "$LinkedBlockingQueueAdvice");
+    // disney's implementation (0.8.4+) uses a ConcurrentLinkedQueue
+    transformer.applyAdvice(
+        isConstructor().and(takesArgument(5, named("java.util.concurrent.ConcurrentLinkedQueue"))),
+        WeaverInstrumentation.class.getName() + "$ConcurrentLinkedQueueAdvice");
   }
 
-  public static class SbtTaskCreationAdvice {
-    // TODO: JEP 500 - avoid mutating final fields
-    @SuppressForbidden
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onTaskCreation(
-        @Advice.This Object sbtTask, @Advice.FieldValue("taskDef") TaskDef taskDef) {
-      try {
-        Field queueField = sbtTask.getClass().getDeclaredField("queue");
-        queueField.setAccessible(true);
-        Object queue = queueField.get(sbtTask);
-        if (queue instanceof ConcurrentLinkedQueue) {
-          // disney's implementation (0.8.4+) uses a ConcurrentLinkedQueue for the field
-          queueField.set(
-              sbtTask,
-              new TaskDefAwareConcurrentLinkedQueueProxy<SuiteEvent>(
-                  taskDef, (ConcurrentLinkedQueue<SuiteEvent>) queue));
-        } else if (queue instanceof LinkedBlockingQueue) {
-          // typelevel's implementation (0.9+) uses a LinkedBlockingQueue for the field
-          queueField.set(
-              sbtTask,
-              new TaskDefAwareLinkedBlockingQueueProxy<SuiteEvent>(
-                  taskDef, (LinkedBlockingQueue<SuiteEvent>) queue));
-        }
-      } catch (Exception ignored) {
+  public static class LinkedBlockingQueueAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrapQueue(
+        @Advice.Argument(0) TaskDef taskDef,
+        @Advice.Argument(value = 5, readOnly = false) LinkedBlockingQueue<SuiteEvent> queue) {
+      if (!(queue instanceof TaskDefAwareLinkedBlockingQueueProxy)) {
+        queue = new TaskDefAwareLinkedBlockingQueueProxy<>(taskDef, queue);
+      }
+    }
+  }
+
+  public static class ConcurrentLinkedQueueAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrapQueue(
+        @Advice.Argument(0) TaskDef taskDef,
+        @Advice.Argument(value = 5, readOnly = false) ConcurrentLinkedQueue<SuiteEvent> queue) {
+      if (!(queue instanceof TaskDefAwareConcurrentLinkedQueueProxy)) {
+        queue = new TaskDefAwareConcurrentLinkedQueueProxy<>(taskDef, queue);
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/UnsafeUtils.java
@@ -1,6 +1,5 @@
 package datadog.trace.util;
 
-import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import org.slf4j.Logger;
@@ -58,16 +57,39 @@ public abstract class UnsafeUtils {
     }
   }
 
-  // TODO: JEP 500 - avoid mutating final fields
-  @SuppressForbidden
-  private static void cloneFields(Class<?> clazz, Object original, Object clone) throws Exception {
+  /**
+   * Copies field values using {@link Unsafe} field offsets instead of core reflection or method
+   * handles: mutating final fields with those APIs is forbidden by <a
+   * href="https://openjdk.org/jeps/500">JEP 500</a>, while Unsafe memory access is not affected by
+   * it (and the clone is a fresh, unpublished instance allocated with {@link
+   * Unsafe#allocateInstance(Class)}, so the writes are safe).
+   */
+  private static void cloneFields(Class<?> clazz, Object original, Object clone) {
     for (Field field : clazz.getDeclaredFields()) {
       if ((field.getModifiers() & Modifier.STATIC) != 0) {
         continue;
       }
-      field.setAccessible(true);
-      Object fieldValue = field.get(original);
-      field.set(clone, fieldValue);
+      long offset = UNSAFE.objectFieldOffset(field);
+      Class<?> type = field.getType();
+      if (!type.isPrimitive()) {
+        UNSAFE.putObject(clone, offset, UNSAFE.getObject(original, offset));
+      } else if (type == int.class) {
+        UNSAFE.putInt(clone, offset, UNSAFE.getInt(original, offset));
+      } else if (type == long.class) {
+        UNSAFE.putLong(clone, offset, UNSAFE.getLong(original, offset));
+      } else if (type == boolean.class) {
+        UNSAFE.putBoolean(clone, offset, UNSAFE.getBoolean(original, offset));
+      } else if (type == byte.class) {
+        UNSAFE.putByte(clone, offset, UNSAFE.getByte(original, offset));
+      } else if (type == char.class) {
+        UNSAFE.putChar(clone, offset, UNSAFE.getChar(original, offset));
+      } else if (type == short.class) {
+        UNSAFE.putShort(clone, offset, UNSAFE.getShort(original, offset));
+      } else if (type == float.class) {
+        UNSAFE.putFloat(clone, offset, UNSAFE.getFloat(original, offset));
+      } else if (type == double.class) {
+        UNSAFE.putDouble(clone, offset, UNSAFE.getDouble(original, offset));
+      }
     }
   }
 }


### PR DESCRIPTION
## What Does This Do

Removes final-field mutation from the JUnit 5, Weaver and Karate CI Visibility instrumentations and from `UnsafeUtils.tryShallowClone`, so test retries / EFD / quarantine / attempt-to-fix keep working when [JEP 500](https://openjdk.org/jeps/500) flips `--illegal-final-field-mutation` to `deny` (warns in JDK 26, denied by default later).

Per mutation site:

- **JUnit 5** — `NodeTestTask.testDescriptor` / `NodeTestTask.node` (mutated by `TestTaskHandle` on retries) and `AbstractTestDescriptor.uniqueId` (mutated by `TestDescriptorHandle` to give each retry a distinct ID): the `final` modifier is now stripped from these specific fields at class load via ByteBuddy `ModifierAdjustment` type advice. The existing MethodHandle setters are unchanged — JEP 500 only forbids mutating fields that are final at runtime, and the modifier is removed before any instance of the class exists, so the JVM never relies on these fields being final. `AbstractTestDescriptor.uniqueId` is covered by a new `JUnit5TestDescriptorInstrumentation` since it lives in a different type than the one `JUnit5ExecutionInstrumentation` matches.
- **Weaver** — `SbtTask.queue` is no longer overwritten after construction. The advice now intercepts the constructor and replaces the queue *argument* (`@Advice.Argument(readOnly = false)`) before it is assigned to the final field, so no field mutation happens at all. The queue is constructor parameter 5 with a stable signature across disney 0.8.4 → typelevel main; the two advices (LinkedBlockingQueue vs ConcurrentLinkedQueue) select via the argument type and only one matches per weaver version.
- **Karate** — `ScenarioRuntime.result` (overwritten by `KarateUtils.setResult` after retries so the final result is reported): same final-stripping type advice as JUnit 5.
- **`UnsafeUtils.tryShallowClone`** — field copying switched from `Field.setAccessible`/`Field.set` (forbidden by JEP 500 for final fields) to `Unsafe` field offsets (`objectFieldOffset` + `put*`), which JEP 500 does not cover. The clone target is a fresh unpublished instance from `Unsafe.allocateInstance`, so the offset writes are safe. This keeps cloning *all* fields (including finals) of arbitrary test descriptor classes, which the JUnit 5 retry path depends on.

## Motivation

JEP 500 (integrity by default) makes final-field mutation via core reflection and `MethodHandles.Lookup.unreflectSetter` illegal: JDK 26 warns, and a future release flips the default to `deny`, at which point these instrumentations break (`IllegalAccessException`). Verified with the released 1.63.0 agent under `--illegal-final-field-mutation=deny`: agent install fails before any test runs.

Part of SDTEST-3576.

## Additional Notes

- `Unsafe` memory access is itself deprecated for removal (JEP 498), so the `UnsafeUtils` change is a stopgap that buys time on the JEP 500 timeline; eliminating `Unsafe.allocateInstance`-based cloning entirely requires a per-descriptor-class copy-constructor approach and is left for a follow-up.
- The JUnit console standalone runner (shaded picocli) itself mutates final fields and crashes under `deny` before any test executes — independent of the tracer.

## Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefule labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits)

## Testing

- `:internal-api:test --tests UnsafeUtilsTest` ✅
- `:dd-java-agent:instrumentation:karate-1.0:test` ✅ (10/10, includes flaky retries / EFD / quarantine / attempt-to-fix cases)
- `:dd-java-agent:instrumentation:weaver-0.9:test`, `:weaver084Test`, `:latestDepTest` ✅ (29/29 — covers both queue types and latest weaver)
- `:dd-java-agent:instrumentation:junit:junit-5:junit-5.3:test` fails identically on my machine **on clean master** (62/63 JSON-mismatch failures, pre-existing local toolchain issue) — deferring to CI for this module.
- forbiddenApis + spotless clean on all touched modules.
