### PR TITLE
Use env to prevent injection from parameters

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -21,11 +21,13 @@ jobs:
     steps:
       - name: Determine tag
         id: determine-tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            TAG=${{ github.event.inputs.tag }}
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG=${GITHUB_REF#refs/tags/}
+            TAG="${GITHUB_REF#refs/tags/}"
           fi
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo "Error: Tag $TAG is not in the expected format: vX.Y.0"
@@ -35,8 +37,9 @@ jobs:
 
       - name: Define release branch name from tag
         id: define-release-branch
+        env:
+          TAG: ${{ steps.determine-tag.outputs.tag }}
         run: |
-          TAG=${{ steps.determine-tag.outputs.tag }}
           echo "branch=release/${TAG%.0}.x" >> "$GITHUB_OUTPUT"
 
       - name: Check out repo at tag
@@ -46,8 +49,9 @@ jobs:
 
       - name: Check if branch already exists
         id: check-release-branch
+        env:
+          BRANCH: ${{ steps.define-release-branch.outputs.branch }}
         run: |
-          BRANCH=${{ steps.define-release-branch.outputs.branch }}
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
             echo "creating_new_branch=false" >> "$GITHUB_OUTPUT"
             echo "Branch $BRANCH already exists - skipping creation"
@@ -58,9 +62,11 @@ jobs:
 
       - name: Create and push release branch
         if: steps.check-release-branch.outputs.creating_new_branch == 'true'
+        env:
+          BRANCH: ${{ steps.define-release-branch.outputs.branch }}
         run: |
-          git checkout -b "${{ steps.define-release-branch.outputs.branch }}"
-          git push -u origin "${{ steps.define-release-branch.outputs.branch }}"
+          git checkout -b "$BRANCH"
+          git push -u origin "$BRANCH"
 
   pin-system-tests:
     needs: create-release-branch
@@ -91,8 +97,9 @@ jobs:
 
       - name: Check if pin-system-tests branch already exists
         id: check-pin-branch
+        env:
+          BRANCH: ${{ steps.define-pin-branch.outputs.branch }}
         run: |
-          BRANCH=${{ steps.define-pin-branch.outputs.branch }}
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
             echo "ERROR: Branch $BRANCH already exists - please delete it and re-run the workflow."
             exit 1
@@ -132,10 +139,12 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          BASE_BRANCH: ${{ needs.create-release-branch.outputs.release-branch-name }}
+          HEAD_BRANCH: ${{ steps.define-pin-branch.outputs.branch }}
         run: |
           gh pr create --title "Pin system tests for release branch" \
-            --base ${{ needs.create-release-branch.outputs.release-branch-name }} \
-            --head ${{ steps.define-pin-branch.outputs.branch }} \
+            --base "$BASE_BRANCH" \
+            --head "$HEAD_BRANCH" \
             --label "tag: dependencies" \
             --label "tag: no release notes" \
             --body "This PR pins the system-tests reference for the release branch."


### PR DESCRIPTION
# What Does This Do

Use env to prevent injection from GitHub workflow run.

# Motivation

# Additional Notes

Injection limited to project maintainers but worth using the good practices.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
