### PR TITLE
Support proper async propagation for GAX retrying futures

### DIFF
--- a/dd-java-agent/instrumentation/gax-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/gax-1.4/build.gradle
@@ -1,0 +1,21 @@
+muzzle {
+  pass {
+    group = "com.google.api"
+    module = "gax"
+    // CallbackChainRetryingFuture (with setAttemptFuture + attemptFutureCompletionListener) first
+    // appears in gax 1.4.0. No need to assert the low bound hence since the instrumentation is not applied.
+    versions = "[1.4.0,]"
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly group: 'com.google.api', name: 'gax', version: '1.4.0'
+  testImplementation project(":dd-java-agent:instrumentation:guava-10.0")
+  testImplementation group: 'com.google.api', name: 'gax', version: '1.4.0'
+
+  latestDepTestImplementation group: 'com.google.api', name: 'gax', version: '+'
+}

--- a/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
@@ -1,0 +1,76 @@
+package datadog.trace.instrumentation.gax;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Cancels the trace continuation captured on a gax retry attempt's completion listener when that
+ * listener is superseded.
+ *
+ * <p>{@code AttemptCallable.call()} calls {@code setAttemptFuture} twice per attempt: first with a
+ * {@code NonCancellableFuture} placeholder (a reservation that is never completed), then with the
+ * real RPC future. {@code CallbackChainRetryingFuture.setAttemptFuture} registers a fresh {@code
+ * AttemptCompletionListener} each time and stores it in {@code attemptFutureCompletionListener}.
+ * The guava {@code AbstractFuture} instrumentation captures a continuation onto each listener. The
+ * placeholder's listener never runs (its future never completes), so its continuation would never
+ * be activated or canceled.
+ *
+ * <p>Each {@code setAttemptFuture} overwrites the previous listener: that overwrite is the
+ * abandonment signal. On method entry, before the field is reassigned, we read the previous
+ * listener and cancel its continuation. This is a no-op for a listener that already ran (its
+ * continuation was reset on execution) and only ever cancels the superseded placeholder, so the
+ * real RPC listener keeps its continuation and resolves normally.
+ */
+@AutoService(InstrumenterModule.class)
+public class CallbackChainRetryingFutureInstrumentation extends InstrumenterModule.ContextTracking
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public CallbackChainRetryingFutureInstrumentation() {
+    super("gax");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.google.api.gax.retrying.CallbackChainRetryingFuture";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap(Runnable.class.getName(), State.class.getName());
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("setAttemptFuture")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("com.google.api.core.ApiFuture"))),
+        CallbackChainRetryingFutureInstrumentation.class.getName() + "$SetAttemptFutureAdvice");
+  }
+
+  public static class SetAttemptFutureAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void cancelSuperseded(
+        @Advice.FieldValue("attemptFutureCompletionListener") final Runnable previousListener) {
+      if (previousListener != null) {
+        final ContextStore<Runnable, State> contextStore =
+            InstrumentationContext.get(Runnable.class, State.class);
+        final State state = contextStore.remove(previousListener);
+        if (state != null) {
+          state.closeContinuation();
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
@@ -27,10 +27,9 @@ import net.bytebuddy.asm.Advice;
  * be activated or canceled.
  *
  * <p>Each {@code setAttemptFuture} overwrites the previous listener: that overwrite is the
- * abandonment signal. On method entry, before the field is reassigned, we read the previous
- * listener and cancel its continuation. This is a no-op for a listener that already ran (its
- * continuation was reset on execution) and only ever cancels the superseded placeholder, so the
- * real RPC listener keeps its continuation and resolves normally.
+ * abandonment signal. We capture the previous listener on entry but cancel its continuation on
+ * exit, once the field has actually been replaced, so a listener GAX still treats as active (early
+ * return, or a completion racing the overwrite) keeps its continuation.
  */
 @AutoService(InstrumenterModule.class)
 public class CallbackChainRetryingFutureInstrumentation extends InstrumenterModule.ContextTracking
@@ -61,9 +60,18 @@ public class CallbackChainRetryingFutureInstrumentation extends InstrumenterModu
 
   public static class SetAttemptFutureAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void cancelSuperseded(
+    public static Runnable capturePrevious(
         @Advice.FieldValue("attemptFutureCompletionListener") final Runnable previousListener) {
-      if (previousListener != null) {
+      return previousListener;
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void cancelSuperseded(
+        @Advice.Enter final Runnable previousListener,
+        @Advice.FieldValue("attemptFutureCompletionListener") final Runnable newListener) {
+      // Only cancel once the field has actually been replaced: GAX may return early without
+      // reassigning, and a listener still treated as active must keep its continuation.
+      if (previousListener != null && previousListener != newListener) {
         final ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
         final State state = contextStore.remove(previousListener);

--- a/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/gax-1.4/src/main/java/datadog/trace/instrumentation/gax/CallbackChainRetryingFutureInstrumentation.java
@@ -36,7 +36,7 @@ public class CallbackChainRetryingFutureInstrumentation extends InstrumenterModu
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
 
   public CallbackChainRetryingFutureInstrumentation() {
-    super("gax");
+    super("gax", "gax-1.4");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/gax-1.4/src/test/java/datadog/trace/instrumentation/gax/GaxRetryContinuationTest.java
+++ b/dd-java-agent/instrumentation/gax-1.4/src/test/java/datadog/trace/instrumentation/gax/GaxRetryContinuationTest.java
@@ -1,7 +1,12 @@
 package datadog.trace.instrumentation.gax;
 
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.NanoClock;
@@ -15,8 +20,12 @@ import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import datadog.trace.agent.test.AbstractInstrumentationTest;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.Duration;
 
@@ -27,7 +36,7 @@ class GaxRetryContinuationTest extends AbstractInstrumentationTest {
     ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     try {
       ScheduledRetryingExecutor<String> executor =
-          new ScheduledRetryingExecutor<>(retryAlgorithm(), scheduler);
+          new ScheduledRetryingExecutor<>(retryAlgorithm(1), scheduler);
       RetryingFuture<String> retryingFuture = executor.createFuture(() -> "ok");
 
       AgentSpan span = startSpan("gax", "publish");
@@ -42,24 +51,140 @@ class GaxRetryContinuationTest extends AbstractInstrumentationTest {
         attempt.set("ok");
       }
       span.finish();
-      // expect one trace that will be dropped if this instrumentation is not working
-      writer.waitForTraces(1);
+      // one trace that will be dropped if the placeholder's continuation is never cancelled
+      assertTraces(trace(span().root().operationName("publish")));
     } finally {
       scheduler.shutdownNow();
     }
   }
 
-  private static RetryAlgorithm<String> retryAlgorithm() {
+  @Test
+  void singleAttemptSucceedsAndContextNotLeaked() throws Exception {
+    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      ScheduledRetryingExecutor<String> executor =
+          new ScheduledRetryingExecutor<>(retryAlgorithm(3), scheduler);
+      AgentSpan parent = startSpan("gax", "publish");
+      CountDownLatch allAttemptsDone = new CountDownLatch(1);
+      RetryingFuture<String> future =
+          executor.createFuture(
+              () -> {
+                AgentSpan attempt = startSpan("gax", "attempt");
+                try {
+                  return "ok";
+                } finally {
+                  attempt.finish();
+                  allAttemptsDone.countDown();
+                }
+              });
+
+      try (AgentScope scope = activateSpan(parent)) {
+        future.setAttemptFuture(executor.submit(future));
+        assertEquals("ok", future.get(5, TimeUnit.SECONDS));
+      }
+      allAttemptsDone.await(5, TimeUnit.SECONDS);
+      parent.finish();
+      assertTraces(
+          trace(
+              SORT_BY_START_TIME,
+              span().root().operationName("publish"),
+              span().childOf(parent.getSpanId()).operationName("attempt")));
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  @Test
+  void retriedAttemptsSucceedAndContextNotLeaked() throws Exception {
+    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      ScheduledRetryingExecutor<String> executor =
+          new ScheduledRetryingExecutor<>(retryAlgorithm(3), scheduler);
+      AtomicInteger count = new AtomicInteger(0);
+      AgentSpan parent = startSpan("gax", "publish");
+      CountDownLatch allAttemptsDone = new CountDownLatch(3);
+      RetryingFuture<String> future =
+          executor.createFuture(
+              () -> {
+                AgentSpan attempt = startSpan("gax", "attempt");
+                try {
+                  if (count.incrementAndGet() < 3) {
+                    throw new RuntimeException("transient");
+                  }
+                  return "ok";
+                } finally {
+                  attempt.finish();
+                  allAttemptsDone.countDown();
+                }
+              });
+
+      try (AgentScope scope = activateSpan(parent)) {
+        future.setAttemptFuture(executor.submit(future));
+        assertEquals("ok", future.get(5, TimeUnit.SECONDS));
+      }
+      allAttemptsDone.await(5, TimeUnit.SECONDS);
+      parent.finish();
+      assertTraces(
+          trace(
+              SORT_BY_START_TIME,
+              span().root().operationName("publish"),
+              span().childOf(parent.getSpanId()).operationName("attempt"),
+              span().childOf(parent.getSpanId()).operationName("attempt"),
+              span().childOf(parent.getSpanId()).operationName("attempt")));
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  @Test
+  void exhaustedRetriesContextNotLeaked() throws Exception {
+    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      ScheduledRetryingExecutor<String> executor =
+          new ScheduledRetryingExecutor<>(retryAlgorithm(3), scheduler);
+      AgentSpan parent = startSpan("gax", "publish");
+      CountDownLatch allAttemptsDone = new CountDownLatch(3);
+      RetryingFuture<String> future =
+          executor.createFuture(
+              () -> {
+                AgentSpan attempt = startSpan("gax", "attempt");
+                try {
+                  throw new RuntimeException("always fails");
+                } finally {
+                  attempt.finish();
+                  allAttemptsDone.countDown();
+                }
+              });
+
+      try (AgentScope scope = activateSpan(parent)) {
+        future.setAttemptFuture(executor.submit(future));
+        assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+      }
+      allAttemptsDone.await(5, TimeUnit.SECONDS);
+      parent.finish();
+      assertTraces(
+          trace(
+              SORT_BY_START_TIME,
+              span().root().operationName("publish"),
+              span().childOf(parent.getSpanId()).operationName("attempt"),
+              span().childOf(parent.getSpanId()).operationName("attempt"),
+              span().childOf(parent.getSpanId()).operationName("attempt")));
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  private static RetryAlgorithm<String> retryAlgorithm(int maxAttempts) {
     RetrySettings settings =
         RetrySettings.newBuilder()
-            .setMaxAttempts(1)
+            .setMaxAttempts(maxAttempts)
             .setInitialRetryDelay(Duration.ofMillis(1))
             .setRetryDelayMultiplier(1.0)
-            .setMaxRetryDelay(Duration.ofMillis(1))
-            .setInitialRpcTimeout(Duration.ofMillis(10))
+            .setMaxRetryDelay(Duration.ofMillis(10))
+            .setInitialRpcTimeout(Duration.ofSeconds(5))
             .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(Duration.ofMillis(10))
-            .setTotalTimeout(Duration.ofMillis(10))
+            .setMaxRpcTimeout(Duration.ofSeconds(5))
+            .setTotalTimeout(Duration.ofSeconds(30))
             .build();
     ApiClock clock = NanoClock.getDefaultClock();
     return new RetryAlgorithm<>(

--- a/dd-java-agent/instrumentation/gax-1.4/src/test/java/datadog/trace/instrumentation/gax/GaxRetryContinuationTest.java
+++ b/dd-java-agent/instrumentation/gax-1.4/src/test/java/datadog/trace/instrumentation/gax/GaxRetryContinuationTest.java
@@ -1,0 +1,68 @@
+package datadog.trace.instrumentation.gax;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
+import com.google.api.core.ApiClock;
+import com.google.api.core.NanoClock;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
+import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
+import com.google.api.gax.retrying.RetryAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.ScheduledRetryingExecutor;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+import org.threeten.bp.Duration;
+
+class GaxRetryContinuationTest extends AbstractInstrumentationTest {
+
+  @Test
+  void supersededAttemptListenerDoesNotLeak() throws Exception {
+    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      ScheduledRetryingExecutor<String> executor =
+          new ScheduledRetryingExecutor<>(retryAlgorithm(), scheduler);
+      RetryingFuture<String> retryingFuture = executor.createFuture(() -> "ok");
+
+      AgentSpan span = startSpan("gax", "publish");
+      try (AgentScope scope = activateSpan(span)) {
+        // reserve the attempt slot with a placeholder that is never completed
+        SettableApiFuture<String> placeholder = SettableApiFuture.create();
+        retryingFuture.setAttemptFuture(placeholder);
+        // supersede it with the real attempt future -> must cancel the placeholder's continuation
+        SettableApiFuture<String> attempt = SettableApiFuture.create();
+        retryingFuture.setAttemptFuture(attempt);
+        // real attempt completes -> its listener runs -> resolves normally
+        attempt.set("ok");
+      }
+      span.finish();
+      // expect one trace that will be dropped if this instrumentation is not working
+      writer.waitForTraces(1);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  private static RetryAlgorithm<String> retryAlgorithm() {
+    RetrySettings settings =
+        RetrySettings.newBuilder()
+            .setMaxAttempts(1)
+            .setInitialRetryDelay(Duration.ofMillis(1))
+            .setRetryDelayMultiplier(1.0)
+            .setMaxRetryDelay(Duration.ofMillis(1))
+            .setInitialRpcTimeout(Duration.ofMillis(10))
+            .setRpcTimeoutMultiplier(1.0)
+            .setMaxRpcTimeout(Duration.ofMillis(10))
+            .setTotalTimeout(Duration.ofMillis(10))
+            .build();
+    ApiClock clock = NanoClock.getDefaultClock();
+    return new RetryAlgorithm<>(
+        new BasicResultRetryAlgorithm<>(), new ExponentialRetryAlgorithm(settings, clock));
+  }
+}

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/build.gradle
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   testImplementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.116.0'
   testImplementation project(":dd-java-agent:instrumentation:grpc-1.5")
   testImplementation project(":dd-java-agent:instrumentation:guava-10.0")
+  testImplementation project(":dd-java-agent:instrumentation:gax-1.4")
   latestDepTestImplementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '+'
 }
 

--- a/dd-java-agent/instrumentation/google-pubsub-1.116/src/test/groovy/PubSubTest.groovy
+++ b/dd-java-agent/instrumentation/google-pubsub-1.116/src/test/groovy/PubSubTest.groovy
@@ -67,11 +67,6 @@ abstract class PubSubTest extends VersionedNamingTestBase {
     null
   }
 
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
   boolean shadowGrpcSpans() {
     true
   }

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5777,6 +5777,14 @@
         "aliases": ["DD_TRACE_INTEGRATION_FREEMARKER_ENABLED", "DD_INTEGRATION_FREEMARKER_ENABLED"]
       }
     ],
+    "DD_TRACE_GAX_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": ["DD_TRACE_INTEGRATION_GAX_ENABLED", "DD_INTEGRATION_GAX_ENABLED"]
+      }
+    ],
     "DD_TRACE_GIT_METADATA_ENABLED": [
       {
         "version": "A",

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5777,6 +5777,14 @@
         "aliases": ["DD_TRACE_INTEGRATION_FREEMARKER_ENABLED", "DD_INTEGRATION_FREEMARKER_ENABLED"]
       }
     ],
+    "DD_TRACE_GAX_1_4_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": ["DD_TRACE_INTEGRATION_GAX_1_4_ENABLED", "DD_INTEGRATION_GAX_1_4_ENABLED"]
+      }
+    ],
     "DD_TRACE_GAX_ENABLED": [
       {
         "version": "A",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -359,6 +359,7 @@ include(
   ":dd-java-agent:instrumentation:finatra-2.9",
   ":dd-java-agent:instrumentation:freemarker:freemarker-2.3.24",
   ":dd-java-agent:instrumentation:freemarker:freemarker-2.3.9",
+  ":dd-java-agent:instrumentation:gax-1.4",
   ":dd-java-agent:instrumentation:glassfish-3.0",
   ":dd-java-agent:instrumentation:google-http-client-1.19",
   ":dd-java-agent:instrumentation:google-pubsub-1.116",


### PR DESCRIPTION
# What Does This Do

This PR is a result of investigating why the PubSub instrumentation was leaking continuation.
It appeared that we have futures that are retriable and in fact the guava-concurrent was capturing continuations on those futures as soon as a listener was set. 
Now, for retriable futures, gax retry calls setAttemptFuture twice per attempt:
* first with a NonCancellableFuture placeholder (never completed)
* then the real RPC future. 

The guava AbstractFuture.addListener instrumentation captures a trace continuation on each attempt-completion listener. The placeholder's listener never runs and its continuation is never resolved 

In this PR we introduce a new module to deal with those gax specific futures.  Since there are no signals to hook on to know if the first future will be run or not, we just simply cancel the previously taken continuation when the second is captured.
In any case the first continuation won't be run when the second fire so the fix seems safe to me.

That approach also solves continuation leakage issues in the pubsub instrumentation so that the strictTraceWrites hack is now removed

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
