### PR TITLE
Only check AgentJarIndex consistency after all entries have been recorded

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -15,10 +15,8 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
@@ -101,9 +99,11 @@ public final class AgentJarIndex {
     private final List<String> prefixes = new ArrayList<>();
     private final ClassNameTrie.Builder prefixTrie = new ClassNameTrie.Builder();
 
+    private final List<String> collectedEntryKeys = new ArrayList<>();
+    private final List<Integer> collectedPrefixIds = new ArrayList<>();
+
     private Path prefixRoot;
     private int prefixId;
-    private Map<Integer, String> prefixMappings = new HashMap<>();
 
     IndexGenerator(Path resourcesDir) {
       this.resourcesDir = resourcesDir;
@@ -111,7 +111,33 @@ public final class AgentJarIndex {
       prefixTrie.put("datadog.*", 0);
     }
 
-    public void writeIndex(Path indexFile) throws IOException {
+    void buildIndex() throws IOException {
+      Files.walkFileTree(resourcesDir, this);
+
+      for (int i = 0; i < collectedEntryKeys.size(); i++) {
+        prefixTrie.put(collectedEntryKeys.get(i), collectedPrefixIds.get(i));
+      }
+
+      // warn if two subsections contain content under the same package prefix
+      // because we're then unable to redirect requests to the right submodule
+      for (int i = 0; i < collectedEntryKeys.size(); i++) {
+        String entryKey = collectedEntryKeys.get(i);
+        int expectedPrefixId = collectedPrefixIds.get(i);
+        int indexedPrefixId = prefixTrie.apply(entryKey);
+        if (indexedPrefixId != expectedPrefixId) {
+          log.warn(
+              "Detected duplicate content '{}' under '{}', already seen in {}. Ensure your content is under a distinct directory.",
+              entryKey,
+              getPrefix(expectedPrefixId),
+              getPrefix(indexedPrefixId));
+        }
+      }
+
+      collectedEntryKeys.clear();
+      collectedPrefixIds.clear();
+    }
+
+    void writeIndex(Path indexFile) throws IOException {
       try (DataOutputStream out =
           new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(indexFile)))) {
         out.writeInt(prefixes.size());
@@ -122,13 +148,20 @@ public final class AgentJarIndex {
       }
     }
 
+    private String getPrefix(int prefixId) {
+      return prefixes.get(prefixId - 1);
+    }
+
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
       if (dir.getParent().equals(resourcesDir)) {
+        String prefix = dir.getFileName() + "/";
         prefixRoot = dir;
-        prefixes.add(dir.getFileName() + "/");
-        prefixId = prefixes.size();
-        prefixMappings.put(prefixId, dir.getFileName().toString());
+        prefixId = 1 + prefixes.indexOf(prefix);
+        if (prefixId < 1) {
+          prefixes.add(prefix);
+          prefixId = prefixes.size();
+        }
       }
       return FileVisitResult.CONTINUE;
     }
@@ -146,19 +179,8 @@ public final class AgentJarIndex {
       if (null != prefixRoot) {
         String entryKey = computeEntryKey(prefixRoot.relativize(file));
         if (null != entryKey) {
-          int existingPrefixId = prefixTrie.apply(entryKey);
-          // warn if two subsections contain content under the same package prefix
-          // because we're then unable to redirect requests to the right submodule
-          // (ignore the two 'datadog.compiler' packages which allow duplication)
-          if (existingPrefixId > 0 && prefixId != existingPrefixId) {
-            log.warn(
-                "Detected duplicate content '{}' under '{}', already seen in {}. Ensure your content is under a distinct directory.",
-                entryKey,
-                resourcesDir.relativize(file).getName(0), // prefix
-                prefixMappings.get(existingPrefixId) // previous prefix
-                );
-          }
-          prefixTrie.put(entryKey, prefixId);
+          collectedEntryKeys.add(entryKey);
+          collectedPrefixIds.add(prefixId);
           if (entryKey.endsWith("*")) {
             // optimization: wildcard will match everything under here so can skip
             return FileVisitResult.SKIP_SIBLINGS;
@@ -168,7 +190,7 @@ public final class AgentJarIndex {
       return FileVisitResult.CONTINUE;
     }
 
-    private static String computeEntryKey(Path path) {
+    static String computeEntryKey(Path path) {
       if (ignoredFileNames.contains(path.getFileName().toString())) {
         return null;
       }
@@ -205,7 +227,7 @@ public final class AgentJarIndex {
         indexDir = Paths.get(args[1]).toAbsolutePath();
       }
       IndexGenerator indexGenerator = new IndexGenerator(resourcesDir);
-      Files.walkFileTree(resourcesDir, indexGenerator);
+      indexGenerator.buildIndex();
       indexGenerator.writeIndex(indexDir.resolve(AGENT_INDEX_FILE_NAME));
     }
   }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
@@ -1,0 +1,243 @@
+package datadog.trace.bootstrap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentJarIndexTest {
+
+  // --- computeEntryKey tests ---
+
+  private static String computeEntryKey(String pathStr) {
+    return AgentJarIndex.IndexGenerator.computeEntryKey(Paths.get(pathStr));
+  }
+
+  @Test
+  void computeEntryKeyReturnsNullForIgnoredFiles() {
+    assertNull(computeEntryKey("MANIFEST.MF"));
+    assertNull(computeEntryKey("NOTICE"));
+    assertNull(computeEntryKey("LICENSE.renamed"));
+  }
+
+  @Test
+  void computeEntryKeyReturnsWildcardForInstrumentationSubtree() {
+    assertEquals(
+        "datadog.trace.instrumentation.*",
+        computeEntryKey("datadog/trace/instrumentation/servlet/ServletAdvice.classdata"));
+    assertEquals(
+        "datadog.trace.instrumentation.*",
+        computeEntryKey("datadog/trace/instrumentation/SomeAdvice.classdata"));
+  }
+
+  @Test
+  void computeEntryKeyReturnsWildcardForDeepPaths() {
+    // 3+ path elements → wildcard on parent directory, regardless of file extension
+    assertEquals("com.example.*", computeEntryKey("com/example/Foo.classdata"));
+    assertEquals("com.example.*", computeEntryKey("com/example/Foo.xml"));
+    assertEquals("com.example.sub.*", computeEntryKey("com/example/sub/Foo.classdata"));
+  }
+
+  @Test
+  void computeEntryKeyReturnsFullPathForSingleElementPaths() {
+    // nameCount == 1 skips the wildcard block entirely
+    assertEquals("Foo.classdata", computeEntryKey("Foo.classdata"));
+    assertEquals("some-lib.jar", computeEntryKey("some-lib.jar"));
+  }
+
+  @Test
+  void computeEntryKeyReturnsWildcardForClassdataAtTwoLevels() {
+    // 2-level .classdata files are deep enough to use a wildcard
+    assertEquals("com.*", computeEntryKey("com/Foo.classdata"));
+  }
+
+  @Test
+  void computeEntryKeyReturnsFullPathForShallowNonClassdataFiles() {
+    // 2-level non-.classdata files keep their full dot-separated name
+    assertEquals("com.Foo.class", computeEntryKey("com/Foo.class"));
+    assertEquals("META-INF.services.Foo", computeEntryKey("META-INF/services/Foo"));
+  }
+
+  @Test
+  void computeEntryKeyDoesNotCountMetaInfAsUniqueElement() {
+    // META-INF/x/y → nameCount effectively 2 → no wildcard
+    assertEquals("META-INF.services.SomeService", computeEntryKey("META-INF/services/SomeService"));
+    // META-INF/x/y/z → nameCount effectively 3 → wildcard
+    assertEquals("META-INF.services.com.*", computeEntryKey("META-INF/services/com/SomeService"));
+  }
+
+  // --- buildIndex / writeIndex / readIndex round-trip ---
+
+  /** Creates a temp JAR containing only the index file written by the generator. */
+  private static AgentJarIndex buildAndReadIndex(Path resourcesDir, Path tempDir) throws Exception {
+    AgentJarIndex.IndexGenerator generator = new AgentJarIndex.IndexGenerator(resourcesDir);
+    generator.buildIndex();
+
+    Path indexFile = tempDir.resolve("dd-java-agent.index");
+    generator.writeIndex(indexFile);
+
+    Path jarFile = tempDir.resolve("test-agent.jar");
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(jarFile))) {
+      zip.putNextEntry(new ZipEntry("dd-java-agent.index"));
+      Files.copy(indexFile, zip);
+      zip.closeEntry();
+    }
+
+    try (JarFile jar = new JarFile(jarFile.toFile())) {
+      return AgentJarIndex.readIndex(jar);
+    }
+  }
+
+  private static void createFile(Path root, String relativePath) throws IOException {
+    Path file = root.resolve(relativePath.replace('/', java.io.File.separatorChar));
+    Files.createDirectories(file.getParent());
+    Files.createFile(file);
+  }
+
+  @Test
+  void classEntryNameResolvesBootstrapClassToTopLevel(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    // Only the inst/ prefix exists; datadog.* falls back to main jar (prefixId == 0)
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    assertEquals(
+        "datadog/trace/bootstrap/Bootstrap.class",
+        index.classEntryName("datadog.trace.bootstrap.Bootstrap"));
+  }
+
+  @Test
+  void classEntryNameResolvesInstrumentationClassToInstPrefix(@TempDir Path tempDir)
+      throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    assertEquals(
+        "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata",
+        index.classEntryName("datadog.trace.instrumentation.servlet.ServletAdvice"));
+  }
+
+  @Test
+  void classEntryNameReturnsNullForUnknownPackage(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    // com.example.* is not indexed → null
+    assertNull(index.classEntryName("com.example.Unknown"));
+  }
+
+  @Test
+  void classEntryNameResolvesDeepNestedClassToCorrectPrefix(@TempDir Path tempDir)
+      throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "metrics/com/datadoghq/stats/StatsClient.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    assertEquals(
+        "metrics/com/datadoghq/stats/StatsClient.classdata",
+        index.classEntryName("com.datadoghq.stats.StatsClient"));
+  }
+
+  @Test
+  void resourceEntryNamePassesThroughTopLevelResources(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    String resourceName = "datadog/trace/bootstrap/Bootstrap.class";
+    assertEquals(resourceName, index.resourceEntryName(resourceName));
+  }
+
+  @Test
+  void resourceEntryNameAppendsDataSuffixForClassResource(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    assertEquals(
+        "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata",
+        index.resourceEntryName("datadog/trace/instrumentation/servlet/ServletAdvice.class"));
+  }
+
+  @Test
+  void multiplePrefixesAreIndexedIndependently(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+    createFile(resources, "metrics/com/datadoghq/stats/StatsClient.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    assertEquals(
+        "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata",
+        index.classEntryName("datadog.trace.instrumentation.servlet.ServletAdvice"));
+    assertEquals(
+        "metrics/com/datadoghq/stats/StatsClient.classdata",
+        index.classEntryName("com.datadoghq.stats.StatsClient"));
+  }
+
+  @Test
+  void buildIndexWithEmptyResourcesDirProducesWorkingIndex(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    Files.createDirectories(resources);
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    // All lookups fall through to main jar (prefixId == 0) or null
+    String name = "datadog/trace/bootstrap/Bootstrap.class";
+    assertEquals(name, index.resourceEntryName(name));
+  }
+
+  @Test
+  void resourceEntryNameReturnsNullForResourceOutsideAnyIndexedPrefix(@TempDir Path tempDir)
+      throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    // com.* is not indexed → null (symmetric with classEntryNameReturnsNullForUnknownPackage)
+    assertNull(index.resourceEntryName("com/example/Foo.class"));
+  }
+
+  @Test
+  void resourceEntryNameDoesNotAppendDataSuffixForNonClassResources(@TempDir Path tempDir)
+      throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    AgentJarIndex index = buildAndReadIndex(resources, tempDir);
+
+    assertNotNull(index);
+    // A non-.class resource under an indexed prefix is returned with the prefix prepended
+    // but without the "data" suffix (only .class resources get "data" appended)
+    assertEquals(
+        "inst/datadog/trace/instrumentation/servlet/services",
+        index.resourceEntryName("datadog/trace/instrumentation/servlet/services"));
+  }
+}


### PR DESCRIPTION
# Motivation

This avoids potential false-positive warnings if a short wildcard is added before a longer wildcard. Previously the longer wildcard would match the shorter one, resulting in the warning - but the index was OK because the trie is greedy and always matches against the longest possible wildcard, so content under each wildcard would still match the correct prefix.

We now collect all entries, add them to the trie, then check for entries with inconsistent prefixes.

Note that we collect entries using a pair of lists - this is deliberate to allow duplication at collection time, which we can then report as warnings at index time.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
