### PR TITLE
Improve http codec extractor tests

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractHttpExtractorTest.java
@@ -1,0 +1,60 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
+import static java.util.Collections.singletonMap;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.junit.utils.config.WithConfig;
+import datadog.trace.test.util.DDJavaSpecification;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/** This class is a base test class for the {@link HttpCodec.Extractor} tests. */
+@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
+abstract class AbstractHttpExtractorTest extends DDJavaSpecification {
+  protected static final String SOME_HEADER = "SOME_HEADER";
+  protected static final String SOME_TAG = "some-tag";
+  protected static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
+  protected static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
+  protected static final String SOME_BAGGAGE = "some-baggage";
+  protected static final String SOME_CASE_SENSITIVE_BAGGAGE = "some-CaseSensitive-baggage";
+  protected static final String SOME_ARBITRARY_HEADER = "SOME_ARBITRARY_HEADER";
+
+  protected HttpCodec.Extractor extractor;
+
+  /** Creates the extractor for the propagation style under test. */
+  protected abstract HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier);
+
+  @BeforeEach
+  void setupExtractor() {
+    this.extractor = buildExtractor(this::newExtractor);
+  }
+
+  @AfterEach
+  void cleanupExtractor() {
+    if (this.extractor != null) {
+      this.extractor.cleanup();
+    }
+  }
+
+  /** Builds an extractor with a test trace config (a basic baggage mapping and header tags). */
+  static HttpCodec.Extractor buildExtractor(
+      BiFunction<Config, Supplier<TraceConfig>, HttpCodec.Extractor> factory) {
+    Map<String, String> baggageMapping = new HashMap<>();
+    baggageMapping.put(SOME_CUSTOM_BAGGAGE_HEADER, SOME_BAGGAGE);
+    baggageMapping.put(SOME_CUSTOM_BAGGAGE_HEADER_2, SOME_CASE_SENSITIVE_BAGGAGE);
+    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
+        DynamicConfig.create()
+            .setHeaderTags(singletonMap(SOME_HEADER, SOME_TAG))
+            .setBaggageMapping(baggageMapping)
+            .apply();
+    return factory.apply(Config.get(), dynamicConfig::captureTraceConfig);
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/AppSecClientInterpreterClientIpTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/AppSecClientInterpreterClientIpTest.java
@@ -1,0 +1,270 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
+import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
+import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
+import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
+import static datadog.trace.core.propagation.AbstractHttpExtractorTest.buildExtractor;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.junit.utils.config.WithConfig;
+import datadog.trace.test.util.DDJavaSpecification;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies client-IP AppSec HTTP header collection. This behavior is implemented in the {@link
+ * ContextInterpreter} and should work with every propagation style.
+ */
+@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
+class AppSecClientInterpreterClientIpTest extends DDJavaSpecification {
+  private boolean origAppSecActive;
+  private HttpCodec.Extractor extractor;
+
+  @BeforeEach
+  void enableAppSec() {
+    this.origAppSecActive = APPSEC_ACTIVE;
+    APPSEC_ACTIVE = true;
+  }
+
+  @AfterEach
+  void restoreAppSec() {
+    if (this.extractor != null) {
+      this.extractor.cleanup();
+    }
+    APPSEC_ACTIVE = this.origAppSecActive;
+  }
+
+  static Stream<Arguments> styles() {
+    return Stream.of(
+        arguments(
+            new Style(
+                "Datadog",
+                DatadogHttpCodec::newExtractor,
+                headers(DatadogHttpCodec.TRACE_ID_KEY, "1", DatadogHttpCodec.SPAN_ID_KEY, "2"),
+                true)),
+        arguments(
+            new Style(
+                "B3",
+                B3HttpCodec::newExtractor,
+                headers(B3HttpCodec.TRACE_ID_KEY, "1", B3HttpCodec.SPAN_ID_KEY, "2"),
+                true)),
+        arguments(
+            new Style(
+                "W3C",
+                W3CHttpCodec::newExtractor,
+                headers(
+                    W3CHttpCodec.TRACE_PARENT_KEY,
+                    "00-00000000000000000000000000000001-0000000000000002-01"),
+                true)),
+        arguments(
+            new Style(
+                "Haystack",
+                HaystackHttpCodec::newExtractor,
+                headers(HaystackHttpCodec.TRACE_ID_KEY, "1", HaystackHttpCodec.SPAN_ID_KEY, "2"),
+                true)),
+        arguments(
+            new Style(
+                "XRay",
+                XRayHttpCodec::newExtractor,
+                headers(
+                    XRayHttpCodec.X_AMZN_TRACE_ID,
+                    "Root=1-00000000-000000000000000000000001;Parent=0000000000000002"),
+                true)),
+        arguments(
+            new Style(
+                "None",
+                NoneCodec::newExtractor,
+                headers(DatadogHttpCodec.TRACE_ID_KEY, "1", DatadogHttpCodec.SPAN_ID_KEY, "2"),
+                false)));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  void extractCommonHttpHeaders(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    // spotless:off
+    Map<String, String> headers = headers(
+        HttpCodec.USER_AGENT_KEY, "some-user-agent",
+        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
+        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
+        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
+        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
+        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
+        HttpCodec.FORWARDED_KEY, "6.6.6.6",
+        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
+        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
+        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9");
+    // spotless:on
+
+    TagContext context = this.extractor.extract(headers, stringValuesMap());
+
+    assertEquals("some-user-agent", context.getUserAgent());
+    assertEquals("1.1.1.1", context.getXClusterClientIp());
+    assertEquals("2.2.2.2", context.getXRealIp());
+    assertEquals("3.3.3.3", context.getXClientIp());
+    assertEquals("4.4.4.4", context.getTrueClientIp());
+    assertEquals("5.5.5.5", context.getForwardedFor());
+    assertEquals("6.6.6.6", context.getForwarded());
+    assertEquals("7.7.7.7", context.getFastlyClientIp());
+    assertEquals("8.8.8.8", context.getCfConnectingIp());
+    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  void extractEmptyHeadersReturnsNull(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    assertNull(
+        this.extractor.extract(headers("ignored-header", "ignored-value"), stringValuesMap()));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  void extractHeadersWithForwarding(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    String forwarded = "for=1.2.3.4:1234";
+
+    TagContext tagOnly = this.extractor.extract(headers("Forwarded", forwarded), stringValuesMap());
+
+    assertNotNull(tagOnly);
+    assertFalse(tagOnly instanceof ExtractedContext);
+    assertEquals(forwarded, tagOnly.getForwarded());
+
+    Map<String, String> fullHeaders = new HashMap<>(style.minimalTraceHeaders);
+    fullHeaders.putAll(headers("Forwarded", forwarded));
+
+    TagContext full = this.extractor.extract(fullHeaders, stringValuesMap());
+
+    assertExpectedTraceContext(full, style);
+    assertEquals(forwarded, full.getForwarded());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  void extractHeadersWithXForwarding(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    String forwardedIp = "1.2.3.4";
+    String forwardedPort = "1234";
+
+    TagContext tagOnly =
+        this.extractor.extract(
+            headers("X-Forwarded-For", forwardedIp, "X-Forwarded-Port", forwardedPort),
+            stringValuesMap());
+
+    assertNotNull(tagOnly);
+    assertFalse(tagOnly instanceof ExtractedContext);
+    assertEquals(forwardedIp, tagOnly.getXForwardedFor());
+    assertEquals(forwardedPort, tagOnly.getXForwardedPort());
+
+    Map<String, String> fullHeaders = new HashMap<>(style.minimalTraceHeaders);
+    fullHeaders.putAll(headers("X-Forwarded-For", forwardedIp, "X-Forwarded-Port", forwardedPort));
+
+    TagContext full = this.extractor.extract(fullHeaders, stringValuesMap());
+
+    assertExpectedTraceContext(full, style);
+    assertEquals(forwardedIp, full.getXForwardedFor());
+    assertEquals(forwardedPort, full.getXForwardedPort());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  @WithConfig(key = TRACE_CLIENT_IP_RESOLVER_ENABLED, value = "false")
+  void extractHeadersWithIpResolutionDisabled(Style style) {
+    // The extractor must be built after @WithConfig is applied: ContextInterpreter reads the
+    // client-IP resolution flag in its constructor.
+    this.extractor = buildExtractor(style.factory);
+    Map<String, String> headers = headers("X-Forwarded-For", "::1", "User-agent", "foo/bar");
+
+    TagContext context = this.extractor.extract(headers, stringValuesMap());
+
+    assertNotNull(context);
+    assertNull(context.getXForwardedFor());
+    assertEquals("foo/bar", context.getUserAgent());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  void extractHeadersWithIpResolutionDisabledAppsecDisabled(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    // collectIpHeaders is recomputed per extract in ContextInterpreter.reset(), so toggling
+    // APPSEC_ACTIVE after building the extractor still takes effect.
+    APPSEC_ACTIVE = false;
+    Map<String, String> headers = headers("X-Forwarded-For", "::1", "User-agent", "foo/bar");
+
+    TagContext context = this.extractor.extract(headers, stringValuesMap());
+
+    assertNotNull(context);
+    assertNull(context.getXForwardedFor());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("styles")
+  @WithConfig(key = TRACE_CLIENT_IP_HEADER, value = "my-header")
+  void customIpHeaderCollectionDoesNotDisableStandardIpHeaderCollection(Style style) {
+    this.extractor = buildExtractor(style.factory);
+    Map<String, String> headers = headers("X-Forwarded-For", "::1", "My-Header", "8.8.8.8");
+
+    TagContext context = this.extractor.extract(headers, stringValuesMap());
+
+    assertNotNull(context);
+    assertEquals("::1", context.getXForwardedFor());
+    assertEquals("8.8.8.8", context.getCustomIpHeader());
+  }
+
+  private static void assertExpectedTraceContext(TagContext context, Style style) {
+    if (style.buildsExtractedContext) {
+      ExtractedContext extracted = assertInstanceOf(ExtractedContext.class, context);
+      assertEquals(1L, extracted.getTraceId().toLong());
+      assertEquals(2L, extracted.getSpanId());
+    } else {
+      assertFalse(context instanceof ExtractedContext);
+      assertEquals(DDTraceId.ZERO, context.getTraceId());
+      assertEquals(DDSpanId.ZERO, context.getSpanId());
+    }
+  }
+
+  /** A propagation style under test: its extractor factory and minimal valid trace headers. */
+  static final class Style {
+    final String name;
+    final BiFunction<Config, Supplier<TraceConfig>, HttpCodec.Extractor> factory;
+    final Map<String, String> minimalTraceHeaders;
+    final boolean buildsExtractedContext;
+
+    Style(
+        String name,
+        BiFunction<Config, Supplier<TraceConfig>, HttpCodec.Extractor> factory,
+        Map<String, String> minimalTraceHeaders,
+        boolean buildsExtractedContext) {
+      this.name = name;
+      this.factory = factory;
+      this.minimalTraceHeaders = minimalTraceHeaders;
+      this.buildsExtractedContext = buildsExtractedContext;
+    }
+
+    @Override
+    public String toString() {
+      return this.name;
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/B3HttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/B3HttpExtractorTest.java
@@ -1,7 +1,5 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_SPAN_ID;
@@ -16,50 +14,27 @@ import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
-import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
-import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.PrioritySamplingConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class B3HttpExtractorTest extends DDJavaSpecification {
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_TAG = "some-tag";
+class B3HttpExtractorTest extends AbstractHttpExtractorTest {
   private static final String SOME_VALUE = "my-interesting-info";
-  private static final String FORWARDED_IP = "1.2.3.4";
-  private static final String FORWARDED_PORT = "1234";
 
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, SOME_TAG))
-            .setBaggageMapping(emptyMap())
-            .apply();
-    this.extractor = B3HttpCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    APPSEC_ACTIVE = this.origAppSecActive;
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return B3HttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -84,7 +59,8 @@ class B3HttpExtractorTest extends DDJavaSpecification {
         SAMPLING_PRIORITY_KEY, samplingPriority != null ? samplingPriority.toString() : null);
     // spotless:on
 
-    ExtractedContext context = (ExtractedContext) extractor.extract(headers, stringValuesMap());
+    ExtractedContext context =
+        (ExtractedContext) this.extractor.extract(headers, stringValuesMap());
 
     assertEquals(B3TraceId.fromHex(traceIdHex), context.getTraceId());
     assertEquals(DDSpanId.fromHex(spanIdHex), context.getSpanId());
@@ -232,67 +208,6 @@ class B3HttpExtractorTest extends DDJavaSpecification {
   }
 
   @Test
-  void extractHeadersWithForwarding() {
-    String forwarded = "for=" + FORWARDED_IP + ":" + FORWARDED_PORT;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", FORWARDED_IP,
-        "X-Forwarded-Port", FORWARDED_PORT
-    );
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "x-forwarded-for", FORWARDED_IP,
-        "x-forwarded-port", FORWARDED_PORT
-    );
-    // spotless:on
-
-    TagContext context = extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertEquals(FORWARDED_IP, context.getXForwardedFor());
-    assertEquals(FORWARDED_PORT, context.getXForwardedPort());
-
-    context = extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(FORWARDED_IP, context.getXForwardedFor());
-    assertEquals(FORWARDED_PORT, context.getXForwardedPort());
-  }
-
-  @Test
-  void extractEmptyHeadersReturnsNull() {
-    assertNull(extractor.extract(headers("ignored-header", "ignored-value"), stringValuesMap()));
-  }
-
-  @Test
   void extractHttpHeadersWithInvalidNonNumericId() {
     // spotless:off
     Map<String, String> headers = headers(
@@ -362,36 +277,5 @@ class B3HttpExtractorTest extends DDJavaSpecification {
       return "0";
     }
     return hex.substring(firstNonZero, length);
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9"
-    );
-    // spotless:on
-
-    TagContext context = extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
@@ -1,11 +1,7 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS_COMMA_ALLOWED;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.DatadogHttpCodec.DATADOG_TAGS_KEY;
 import static datadog.trace.core.propagation.DatadogHttpCodec.ORIGIN_KEY;
@@ -28,55 +24,26 @@ import datadog.trace.api.DD64bTraceId;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.PrioritySamplingConverter;
 import datadog.trace.junit.utils.converter.TraceIdConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class DatadogHttpExtractorTest extends DDJavaSpecification {
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
-  private static final String SOME_ARBITRARY_HEADER = "SOME_ARBITRARY_HEADER";
-  private static final String SOME_TAG = "some-tag";
-  private static final String SOME_BAGGAGE = "some-baggage";
-  private static final String SOME_CASE_SENSITIVE_BAGGAGE = "some-CaseSensitive-baggage";
-
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    Map<String, String> baggageMap = new HashMap<>();
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER, SOME_BAGGAGE);
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER_2, SOME_CASE_SENSITIVE_BAGGAGE);
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, SOME_TAG))
-            .setBaggageMapping(baggageMap)
-            .apply();
-    this.extractor = DatadogHttpCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    this.extractor.cleanup();
-    APPSEC_ACTIVE = this.origAppSecActive;
+class DatadogHttpExtractorTest extends AbstractHttpExtractorTest {
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return DatadogHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -163,113 +130,6 @@ class DatadogHttpExtractorTest extends DDJavaSpecification {
     if (withOrigin) {
       assertEquals("my-origin", asString(context.getOrigin()));
     }
-  }
-
-  @Test
-  void extractHeadersWithForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    String forwarded = "for=" + forwardedIp + ":" + forwardedPort;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", forwardedIp,
-        "X-Forwarded-Port", forwardedPort
-    );
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "x-forwarded-for", forwardedIp,
-        "x-forwarded-port", forwardedPort
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-  }
-
-  @Test
-  void extractEmptyHeadersReturnsNull() {
-    Map<String, String> headers = headers("ignored-header", "ignored-value");
-    assertNull(this.extractor.extract(headers, stringValuesMap()));
-  }
-
-  @Test
-  @WithConfig(key = TRACE_CLIENT_IP_RESOLVER_ENABLED, value = "false")
-  void extractHeadersWithIpResolutionDisabled() {
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("User-agent", "foo/bar");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertNull(context.getXForwardedFor());
-    assertEquals("foo/bar", context.getUserAgent());
-  }
-
-  @Test
-  void extractHeadersWithIpResolutionDisabledAppsecDisabled() {
-    APPSEC_ACTIVE = false;
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("User-agent", "foo/bar");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertNull(context.getXForwardedFor());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_CLIENT_IP_HEADER, value = "my-header")
-  void customIpHeaderCollectionDoesNotDisableStandardIpHeaderCollection() {
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("My-Header", "8.8.8.8");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertEquals("::1", context.getXForwardedFor());
-    assertEquals("8.8.8.8", context.getCustomIpHeader());
   }
 
   @TableTest({
@@ -463,37 +323,6 @@ class DatadogHttpExtractorTest extends DDJavaSpecification {
     } else {
       assertNull(context);
     }
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9"
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 
   private static String asString(CharSequence cs) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
@@ -1,8 +1,6 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.HaystackHttpCodec.HAYSTACK_SPAN_ID_BAGGAGE_KEY;
 import static datadog.trace.core.propagation.HaystackHttpCodec.HAYSTACK_TRACE_ID_BAGGAGE_KEY;
@@ -14,61 +12,27 @@ import static datadog.trace.junit.utils.converter.TraceIdConverter.TRACE_ID_MAX_
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
-import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.TraceIdConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class HaystackHttpExtractorTest extends DDJavaSpecification {
-
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
-  private static final String SOME_ARBITRARY_HEADER = "SOME_ARBITRARY_HEADER";
-  private static final String SOME_TAG = "some-tag";
-  private static final String SOME_BAGGAGE = "some-baggage";
-  private static final String SOME_CASE_SENSITIVE_BAGGAGE = "some-CaseSensitive-baggage";
-
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    Map<String, String> baggageMap = new HashMap<>();
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER, SOME_BAGGAGE);
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER_2, SOME_CASE_SENSITIVE_BAGGAGE);
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, SOME_TAG))
-            .setBaggageMapping(baggageMap)
-            .apply();
-    this.extractor =
-        HaystackHttpCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    this.extractor.cleanup();
-    APPSEC_ACTIVE = origAppSecActive;
+class HaystackHttpExtractorTest extends AbstractHttpExtractorTest {
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return HaystackHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -124,72 +88,6 @@ class HaystackHttpExtractorTest extends DDJavaSpecification {
 
     assertFalse(context instanceof ExtractedContext);
     assertEquals(singletonMap(SOME_TAG, "my-interesting-info"), context.getTags());
-  }
-
-  @Test
-  void extractHeadersWithForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "123";
-    String forwarded = "for=" + forwardedIp + ":" + forwardedPort;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "123";
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", forwardedIp,
-        "X-Forwarded-Port", forwardedPort
-    );
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "x-forwarded-for", forwardedIp,
-        "x-forwarded-port", forwardedPort
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-  }
-
-  @Test
-  void extractEmptyHeadersReturnsNull() {
-    Map<String, String> headers = singletonMap("ignored-header", "ignored-value");
-    assertNull(this.extractor.extract(headers, stringValuesMap()));
   }
 
   @Test
@@ -318,36 +216,5 @@ class HaystackHttpExtractorTest extends DDJavaSpecification {
     } else {
       assertNull(context);
     }
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9"
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/NoneHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/NoneHttpExtractorTest.java
@@ -1,9 +1,7 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS_COMMA_ALLOWED;
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.DatadogHttpCodec.DATADOG_TAGS_KEY;
 import static datadog.trace.core.propagation.DatadogHttpCodec.ORIGIN_KEY;
@@ -15,7 +13,6 @@ import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,54 +21,25 @@ import datadog.trace.api.DD128bTraceId;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.DynamicConfig;
-import datadog.trace.api.config.TracerConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.TraceIdConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class NoneHttpExtractorTest extends DDJavaSpecification {
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
-  private static final String SOME_TAG = "some-tag";
-  private static final String SOME_BAGGAGE = "some-baggage";
-  private static final String SOME_CASE_SENSITIVE_BAGGAGE = "some-CaseSensitive-baggage";
-
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    Map<String, String> baggageMap = new HashMap<>();
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER, SOME_BAGGAGE);
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER_2, SOME_CASE_SENSITIVE_BAGGAGE);
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, SOME_TAG))
-            .setBaggageMapping(baggageMap)
-            .apply();
-    this.extractor = NoneCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    APPSEC_ACTIVE = origAppSecActive;
-    this.extractor.cleanup();
+class NoneHttpExtractorTest extends AbstractHttpExtractorTest {
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return NoneCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -165,114 +133,6 @@ class NoneHttpExtractorTest extends DDJavaSpecification {
     assertNull(context.getOrigin());
   }
 
-  @Test
-  void extractHeadersWithForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    String forwarded = "for=" + forwardedIp + ":" + forwardedPort;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(DDTraceId.ZERO, context.getTraceId());
-    assertEquals(DDSpanId.ZERO, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", forwardedIp,
-        "X-Forwarded-Port", forwardedPort
-    );
-    Map<String, String> fullCtx = headers(
-        TRACE_ID_KEY, "1",
-        SPAN_ID_KEY, "2",
-        "x-forwarded-for", forwardedIp,
-        "x-forwarded-port", forwardedPort
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(DDTraceId.ZERO, context.getTraceId());
-    assertEquals(0L, context.getSpanId());
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-  }
-
-  @Test
-  void extractEmptyHeadersReturnsNull() {
-    assertNull(
-        this.extractor.extract(headers("ignored-header", "ignored-value"), stringValuesMap()));
-  }
-
-  @Test
-  @WithConfig(key = TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED, value = "false")
-  void extractHeadersWithIpResolutionDisabled() {
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("User-agent", "foo/bar");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertNull(context.getXForwardedFor());
-    assertEquals("foo/bar", context.getUserAgent());
-  }
-
-  @Test
-  void extractHeadersWithIpResolutionDisabledAppsecDisabled() {
-    APPSEC_ACTIVE = false;
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("User-agent", "foo/bar");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertNull(context.getXForwardedFor());
-  }
-
-  @Test
-  @WithConfig(key = TracerConfig.TRACE_CLIENT_IP_HEADER, value = "my-header")
-  void customIpHeaderCollectionDoesNotDisableStandardIpHeaderCollection() {
-    Map<String, String> tagOnlyCtx = new HashMap<>();
-    tagOnlyCtx.put("X-Forwarded-For", "::1");
-    tagOnlyCtx.put("My-Header", "8.8.8.8");
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertEquals("::1", context.getXForwardedFor());
-    assertEquals("8.8.8.8", context.getCustomIpHeader());
-  }
-
   @TableTest({
     "scenario            | hexId                             ",
     "64-bit short        | '1'                               ",
@@ -321,35 +181,5 @@ class NoneHttpExtractorTest extends DDJavaSpecification {
 
     assertInstanceOf(TagContext.class, context);
     assertEquals(singletonMap(SOME_TAG, "my-interesting-info"), context.getTags());
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9");
-    // spotless:on
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
@@ -1,9 +1,5 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
 import static datadog.trace.core.propagation.W3CHttpCodec.OT_BAGGAGE_PREFIX;
@@ -21,17 +17,14 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DD64bTraceId;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
-import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.PrioritySamplingConverter;
 import datadog.trace.junit.utils.converter.SamplingMechanismConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,9 +34,7 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class W3CHttpExtractorTest extends DDJavaSpecification {
-
+class W3CHttpExtractorTest extends AbstractHttpExtractorTest {
   private static final long TEST_SPAN_ID = 1311768467463790320L;
   private static final DDTraceId TRACE_ID_ONE =
       DDTraceId.fromHex("00000000000000000000000000000001");
@@ -51,33 +42,11 @@ class W3CHttpExtractorTest extends DDJavaSpecification {
       DDTraceId.fromHex("0000000000000000ffffffffffffffff");
   private static final DDTraceId TRACE_ID_LOW_MAX =
       DDTraceId.fromHex("123456789abcdef0ffffffffffffffff");
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
-  private static final String SOME_ARBITRARY_HEADER = "SOME_ARBITRARY_HEADER";
 
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    Map<String, String> baggageMap = new HashMap<>();
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER, "some-baggage");
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER_2, "some-CaseSensitive-baggage");
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, "some-tag"))
-            .setBaggageMapping(baggageMap)
-            .apply();
-    this.extractor = W3CHttpCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    this.extractor.cleanup();
-    APPSEC_ACTIVE = origAppSecActive;
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return W3CHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -199,121 +168,6 @@ class W3CHttpExtractorTest extends DDJavaSpecification {
     assertEquals(singletonMap("some-tag", "my-interesting-info"), context.getTags());
   }
 
-  @Test
-  void extractHeadersWithForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    String forwarded = "for=" + forwardedIp + ":" + forwardedPort;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        TRACE_PARENT_KEY, "00-00000000000000000000000000000001-0000000000000002-01",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", forwardedIp,
-        "X-Forwarded-Port", forwardedPort
-    );
-    Map<String, String> fullCtx = headers(
-        TRACE_PARENT_KEY, "00-00000000000000000000000000000001-0000000000000002-01",
-        "x-forwarded-for", forwardedIp,
-        "x-forwarded-port", forwardedPort
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-  }
-
-  @Test
-  void extractEmptyHeadersReturnsNull() {
-    assertNull(
-        this.extractor.extract(headers("ignored-header", "ignored-value"), stringValuesMap()));
-  }
-
-  @Test
-  @WithConfig(key = TRACE_CLIENT_IP_RESOLVER_ENABLED, value = "false")
-  void extractHeadersWithIpResolutionDisabled() {
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", "::1",
-        "User-agent", "foo/bar"
-    );
-    // spotless:on
-
-    TagContext ctx = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(ctx);
-    assertNull(ctx.getXForwardedFor());
-    assertEquals("foo/bar", ctx.getUserAgent());
-  }
-
-  @Test
-  void extractHeadersWithIpResolutionDisabledAppsecDisabled() {
-    APPSEC_ACTIVE = false;
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", "::1",
-        "User-agent", "foo/bar"
-    );
-    // spotless:on
-
-    TagContext ctx = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(ctx);
-    assertNull(ctx.getXForwardedFor());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_CLIENT_IP_HEADER, value = "my-header")
-  void customIpHeaderCollectionDoesNotDisableStandardIpHeaderCollection() {
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", "::1",
-        "My-Header", "8.8.8.8"
-    );
-    // spotless:on
-
-    TagContext ctx = extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(ctx);
-    assertEquals("::1", ctx.getXForwardedFor());
-    assertEquals("8.8.8.8", ctx.getCustomIpHeader());
-  }
-
   @TableTest({
     "scenario            | endToEndStartTime",
     "zero start time     | 0                ",
@@ -376,37 +230,6 @@ class W3CHttpExtractorTest extends DDJavaSpecification {
     expectedBaggage.put("k1", "v1");
     expectedBaggage.put("k2", "v2");
     assertEquals(expectedBaggage, context.getBaggage());
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9"
-    );
-    // spotless:on
-
-    TagContext context = extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 
   @TableTest({

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
@@ -1,62 +1,31 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
 import static datadog.trace.core.propagation.XRayHttpCodec.X_AMZN_TRACE_ID;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.DynamicConfig;
-import datadog.trace.api.config.TracerConfig;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
-import datadog.trace.junit.utils.config.WithConfig;
 import datadog.trace.junit.utils.converter.PrioritySamplingConverter;
-import datadog.trace.test.util.DDJavaSpecification;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.tabletest.junit.TableTest;
 
-@WithConfig(key = TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, value = "true")
-class XRayHttpExtractorTest extends DDJavaSpecification {
-
-  private static final String SOME_HEADER = "SOME_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER = "SOME_CUSTOM_BAGGAGE_HEADER";
-  private static final String SOME_CUSTOM_BAGGAGE_HEADER_2 = "SOME_CUSTOM_BAGGAGE_HEADER_2";
-
-  private HttpCodec.Extractor extractor;
-  private boolean origAppSecActive;
-
-  @BeforeEach
-  void setup() {
-    Map<String, String> baggageMap = new HashMap<>();
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER, "some-baggage");
-    baggageMap.put(SOME_CUSTOM_BAGGAGE_HEADER_2, "some-CaseSensitive-baggage");
-    DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
-        DynamicConfig.create()
-            .setHeaderTags(singletonMap(SOME_HEADER, "some-tag"))
-            .setBaggageMapping(baggageMap)
-            .apply();
-    this.extractor = XRayHttpCodec.newExtractor(Config.get(), dynamicConfig::captureTraceConfig);
-
-    this.origAppSecActive = APPSEC_ACTIVE;
-    APPSEC_ACTIVE = true;
-  }
-
-  @AfterEach
-  void teardown() {
-    APPSEC_ACTIVE = this.origAppSecActive;
+class XRayHttpExtractorTest extends AbstractHttpExtractorTest {
+  @Override
+  protected HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return XRayHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
   @TableTest({
@@ -109,71 +78,6 @@ class XRayHttpExtractorTest extends DDJavaSpecification {
 
     assertFalse(context instanceof ExtractedContext);
     assertEquals(singletonMap("some-tag", "my-interesting-info"), context.getTags());
-  }
-
-  @Test
-  void extractHeadersWithForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    String forwarded = "for=" + forwardedIp + ":" + forwardedPort;
-    Map<String, String> tagOnlyCtx = headers("Forwarded", forwarded);
-    // spotless:off
-    Map<String, String> fullCtx = headers(
-        X_AMZN_TRACE_ID, "Root=1-00000000-000000000000000000000001;Parent=0000000000000002",
-        "Forwarded", forwarded
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwarded, context.getForwarded());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwarded, context.getForwarded());
-  }
-
-  @Test
-  void extractHeadersWithXForwarding() {
-    String forwardedIp = "1.2.3.4";
-    String forwardedPort = "1234";
-    // spotless:off
-    Map<String, String> tagOnlyCtx = headers(
-        "X-Forwarded-For", forwardedIp,
-        "X-Forwarded-Port", forwardedPort
-    );
-    Map<String, String> fullCtx = headers(
-        "x-amzn-trace-id", "Root=1-00000000-000000000000000000000001;Parent=0000000000000002",
-        "x-forwarded-for", forwardedIp,
-        "x-forwarded-port", forwardedPort
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(tagOnlyCtx, stringValuesMap());
-
-    assertNotNull(context);
-    assertFalse(context instanceof ExtractedContext);
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-
-    context = this.extractor.extract(fullCtx, stringValuesMap());
-
-    assertInstanceOf(ExtractedContext.class, context);
-    assertEquals(1L, context.getTraceId().toLong());
-    assertEquals(2L, context.getSpanId());
-    assertEquals(forwardedIp, context.getXForwardedFor());
-    assertEquals(forwardedPort, context.getXForwardedPort());
-  }
-
-  @Test
-  void noContextWithEmptyHeaders() {
-    assertNull(
-        this.extractor.extract(headers("ignored-header", "ignored-value"), stringValuesMap()));
   }
 
   @Test
@@ -267,36 +171,5 @@ class XRayHttpExtractorTest extends DDJavaSpecification {
     expectedBaggage.put("k2", "v2");
     assertEquals(expectedBaggage, context.getBaggage());
     assertEquals(endToEndStartTime * 1_000_000L, context.getEndToEndStartTime());
-  }
-
-  @Test
-  void extractCommonHttpHeaders() {
-    // spotless:off
-    Map<String, String> headers = headers(
-        HttpCodec.USER_AGENT_KEY, "some-user-agent",
-        HttpCodec.X_CLUSTER_CLIENT_IP_KEY, "1.1.1.1",
-        HttpCodec.X_REAL_IP_KEY, "2.2.2.2",
-        HttpCodec.X_CLIENT_IP_KEY, "3.3.3.3",
-        HttpCodec.TRUE_CLIENT_IP_KEY, "4.4.4.4",
-        HttpCodec.FORWARDED_FOR_KEY, "5.5.5.5",
-        HttpCodec.FORWARDED_KEY, "6.6.6.6",
-        HttpCodec.FASTLY_CLIENT_IP_KEY, "7.7.7.7",
-        HttpCodec.CF_CONNECTING_IP_KEY, "8.8.8.8",
-        HttpCodec.CF_CONNECTING_IP_V6_KEY, "9.9.9.9"
-    );
-    // spotless:on
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals("some-user-agent", context.getUserAgent());
-    assertEquals("1.1.1.1", context.getXClusterClientIp());
-    assertEquals("2.2.2.2", context.getXRealIp());
-    assertEquals("3.3.3.3", context.getXClientIp());
-    assertEquals("4.4.4.4", context.getTrueClientIp());
-    assertEquals("5.5.5.5", context.getForwardedFor());
-    assertEquals("6.6.6.6", context.getForwarded());
-    assertEquals("7.7.7.7", context.getFastlyClientIp());
-    assertEquals("8.8.8.8", context.getCfConnectingIp());
-    assertEquals("9.9.9.9", context.getCfConnectingIpv6());
   }
 }


### PR DESCRIPTION
Extract the ContextInterpreter tests related to AppSec to remove duplication. Handle extractor initialization in a new parent test class Deduplicate constants and values into the new parent test class

# What Does This Do

This PR improves the HttpCodec extractor tests that were recently moved to JUnit and cleaned up ( #11576, #11581, #11606).
It goes a step further by:

- Extracting the ContextInterpreter tests related to AppSec to remove duplication,
- Handling extractor initialization in a new parent test class
- Deduplicating constants and values into the new parent test class

# Motivation

# Additional Notes

This should only be a refactor, no behavior change.
The only change is that AppSec is now tests with all the propagation styles where B3 and X-Ray were previously missing. 

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
