### PR TITLE
Use workflow artifacts to resolve latest Maven version in instrumentation tests

### DIFF
--- a/.github/workflows/update-smoke-test-latest-versions.yaml
+++ b/.github/workflows/update-smoke-test-latest-versions.yaml
@@ -110,6 +110,12 @@ jobs:
             "maven-surefire.latest=${SUREFIRE_VERSION}" \
             > dd-smoke-tests/maven/src/test/resources/latest-tool-versions.properties
 
+          printf '%s\n' \
+            "# Pinned latest eligible stable version (>=${MIN_DEPENDENCY_AGE_HOURS}h old) for the Maven instrumentation latestDepTest." \
+            "# Updated automatically by the update-smoke-test-latest-versions workflow." \
+            "maven-surefire.latest=${SUREFIRE_VERSION}" \
+            > dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/resources/latest-tool-versions.properties
+
       - name: Check for changes
         id: check-changes
         run: |
@@ -135,7 +141,8 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |
           git add dd-smoke-tests/gradle/src/test/resources/latest-tool-versions.properties \
-                  dd-smoke-tests/maven/src/test/resources/latest-tool-versions.properties
+                  dd-smoke-tests/maven/src/test/resources/latest-tool-versions.properties \
+                  dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/resources/latest-tool-versions.properties
           git commit -m "chore: Update smoke test latest tool versions"
 
       - name: Push changes
@@ -161,7 +168,8 @@ jobs:
             --body "$(cat <<'EOF'
           # What Does This Do
 
-          This PR updates the pinned latest eligible stable tool versions used by CI Visibility smoke tests.
+          This PR updates the pinned latest eligible stable tool versions used by CI Visibility smoke tests
+          and by the Maven instrumentation latestDepTest.
           Only releases at least ${{ env.MIN_DEPENDENCY_AGE_HOURS }} hours old are eligible.
 
           - Gradle: ${{ steps.update.outputs.gradle_line }}

--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
@@ -476,9 +476,8 @@ public class MavenUtilsTest extends AbstractMavenTest {
   }
 
   private static String getLatestMavenSurefireVersion() {
-    // Pinned outside of runtime (resolved against Maven Central) so a newly published Surefire
-    // release cannot break this test on unrelated PRs. The pinned value is bumped on a schedule by
-    // the update-smoke-test-latest-versions workflow. See latest-tool-versions.properties.
+    // The pinned value is bumped on a schedule by the update-smoke-test-latest-versions workflow.
+    // See latest-tool-versions.properties.
     String version = loadLatestToolVersions().getProperty("maven-surefire.latest");
     LOGGER.info("Will run the 'latest' tests with Maven Surefire version {}", version);
     return version;

--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/java/datadog/trace/instrumentation/maven3/MavenUtilsTest.java
@@ -15,18 +15,15 @@ import freemarker.template.TemplateExceptionHandler;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Stream;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
@@ -38,8 +35,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
 
 public class MavenUtilsTest extends AbstractMavenTest {
 
@@ -481,38 +476,28 @@ public class MavenUtilsTest extends AbstractMavenTest {
   }
 
   private static String getLatestMavenSurefireVersion() {
-    OkHttpClient client = new OkHttpClient();
-    Request request =
-        new Request.Builder()
-            .url(
-                "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/maven-metadata.xml")
-            .build();
-    try (Response response = client.newCall(request).execute()) {
-      if (response.isSuccessful()) {
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-        Document doc = dBuilder.parse(response.body().byteStream());
-        doc.getDocumentElement().normalize();
+    // Pinned outside of runtime (resolved against Maven Central) so a newly published Surefire
+    // release cannot break this test on unrelated PRs. The pinned value is bumped on a schedule by
+    // the update-smoke-test-latest-versions workflow. See latest-tool-versions.properties.
+    String version = loadLatestToolVersions().getProperty("maven-surefire.latest");
+    LOGGER.info("Will run the 'latest' tests with Maven Surefire version {}", version);
+    return version;
+  }
 
-        NodeList versionList = doc.getElementsByTagName("latest");
-        if (versionList.getLength() > 0) {
-          String version = versionList.item(0).getTextContent();
-          if (!version.contains("alpha") && !version.contains("beta")) {
-            LOGGER.info("Will run the 'latest' tests with version {}", version);
-            return version;
-          }
-        }
-      } else {
-        LOGGER.warn(
-            "Could not get latest Maven Surefire version, response from repo.maven.apache.org is {}:{}",
-            response.code(),
-            response.body().string());
+  private static Properties loadLatestToolVersions() {
+    Properties properties = new Properties();
+    try (InputStream stream =
+        MavenUtilsTest.class
+            .getClassLoader()
+            .getResourceAsStream("latest-tool-versions.properties")) {
+      if (stream == null) {
+        throw new IllegalStateException(
+            "Could not find latest-tool-versions.properties on classpath");
       }
-    } catch (Exception e) {
-      LOGGER.warn("Could not get latest Maven Surefire version", e);
+      properties.load(stream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
-    String hardcodedLatestVersion = "3.5.0"; // latest version that is known to work
-    LOGGER.info("Will run the 'latest' tests with hard-coded version {}", hardcodedLatestVersion);
-    return hardcodedLatestVersion;
+    return properties;
   }
 }

--- a/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/resources/latest-tool-versions.properties
+++ b/dd-java-agent/instrumentation/maven/maven-3.2.1/src/test/resources/latest-tool-versions.properties
@@ -1,0 +1,3 @@
+# Pinned latest eligible stable version (>=48h old) for the Maven instrumentation latestDepTest.
+# Updated automatically by the update-smoke-test-latest-versions workflow.
+maven-surefire.latest=3.5.5


### PR DESCRIPTION
# What Does This Do

- Extends the maven version resolution artifacts, originally used on the smoke tests, to the maven instrumentation tests.

# Motivation

Avoid new Maven releases braking the default branch due to dynamically resolving the latest version at runtime. By depending the workflow artifacts, the version bumps can be tested before they are actually merged to the default branch.

# Additional Notes

test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
