### PR TITLE
Normalize generated version file for classpath inputs

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFilePlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFilePlugin.kt
@@ -10,7 +10,16 @@ class WriteVersionFilePlugin : Plugin<Project> {
   override fun apply(target: Project) {
     target.pluginManager.apply("java")
 
+    val versionFileName = "${target.name}.version"
     val writeVersionFile = target.tasks.register<WriteVersionFile>("writeVersionNumberFile")
+
+    // Keep volatile generated version metadata from invalidating @Classpath consumers such as CodeNarc.
+    // https://docs.gradle.org/current/userguide/build_cache_concepts.html#runtime_classpath_normalization
+    target.normalization {
+      runtimeClasspath {
+        ignore(versionFileName)
+      }
+    }
 
     target.the<JavaPluginExtension>().sourceSets.named("main") {
       resources.srcDir(writeVersionFile)

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
@@ -125,6 +125,65 @@ class WriteVersionFilePluginTest : VersionPluginsFixture() {
     assertThat(versionFile).doesNotExist()
   }
 
+  @Test
+  fun `generated version file is ignored in runtime classpath normalization`() {
+    writeSettings(
+      """
+      rootProject.name = "my-lib"
+      """
+    )
+    writeRootProject(
+      """
+      import org.gradle.api.DefaultTask
+      import org.gradle.api.file.ConfigurableFileCollection
+      import org.gradle.api.file.RegularFileProperty
+      import org.gradle.api.tasks.Classpath
+      import org.gradle.api.tasks.InputFiles
+      import org.gradle.api.tasks.OutputFile
+      import org.gradle.api.tasks.TaskAction
+
+      plugins {
+        id("dd-trace-java.version-file")
+      }
+
+      version = "1.2.3"
+
+      tasks.named<datadog.gradle.plugin.version.WriteVersionFile>("writeVersionNumberFile") {
+        gitHash.set(providers.gradleProperty("gitHash").orElse("abc12345"))
+      }
+
+      abstract class ClasspathProbe : DefaultTask() {
+        @get:InputFiles
+        @get:Classpath
+        val classpath: ConfigurableFileCollection = project.objects.fileCollection()
+
+        @get:OutputFile
+        val outputFile: RegularFileProperty = project.objects.fileProperty()
+
+        @TaskAction
+        fun probe() {
+          outputFile.get().asFile.writeText("probed")
+        }
+      }
+
+      tasks.register<ClasspathProbe>("classpathProbe") {
+        dependsOn("processResources")
+        classpath.from(sourceSets.main.get().runtimeClasspath)
+        outputFile.set(layout.buildDirectory.file("classpath-probe/output.txt"))
+      }
+      """
+    )
+
+    assertThat(run("classpathProbe", "-PgitHash=abc12345").task(":classpathProbe")?.outcome)
+      .isEqualTo(TaskOutcome.SUCCESS)
+
+    val result = run("classpathProbe", "-PgitHash=def67890")
+
+    assertThat(generatedVersionFile).hasContent("1.2.3~def67890")
+    assertThat(result.task(":writeVersionNumberFile")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":classpathProbe")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+  }
+
   private fun assertVersionFile(
     expectedContentRegex: String,
     task: String = ":writeVersionNumberFile",


### PR DESCRIPTION
# What Does This Do

Configures the version-file convention plugin to ignore its generated `<project>.version` resource during runtime classpath input normalization.

This keeps the changing versioon file from invalidating `@Classpath` inputs. CodeNarc for example makes use of it, and as such is affected when the file changes.

https://docs.gradle.org/current/userguide/build_cache_concepts.html#runtime_classpath_normalization

On second run now, codenarc should be up to date, for example `./gradlew :dd-trace-core:codenarcTest --info` should show the following

```
:dd-trace-core:writeVersionNumberFile   executed
:dd-trace-core:processResources         executed
:dd-trace-core:jar                      UP-TO-DATE
:dd-trace-core:codenarcTest             UP-TO-DATE
```

# Motivation

The generated version resource includes commit short hash. When it appears on classpath inputs, tasks that do not depend on that metadata can rerun unnecessarily after a commit changes.

The issue was likely introduced by #11345 and as such constitute a follow-up to that work.

# Additional Notes

Another strategy is possible: on CI keep today's behavior, but on local machine, use a stable marker.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work/issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]
