### PR TITLE
Do not capture continuation on netty GlobalEventExecutor static init

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -108,7 +108,6 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
         .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
-        .or(NETTY_GLOBAL_EVENT_EXECUTOR)
         .or(JAVA_HTTP_CLIENT);
   }
 

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -47,6 +47,11 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       namedOneOf("reactor.core.scheduler.SchedulerTask", "reactor.core.scheduler.WorkerTask");
   private static final ElementMatcher<TypeDescription> RXJAVA2_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
+  private static final ElementMatcher<TypeDescription> NETTY_GLOBAL_EVENT_EXECUTOR =
+      namedOneOf(
+          "io.netty.util.concurrent.GlobalEventExecutor",
+          // shaded version
+          "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor");
   private static final ElementMatcher<TypeDescription> JAVA_HTTP_CLIENT =
       extendsClass(named("java.net.http.HttpClient"));
   private static final String LETTUCE_HANDSHAKE_HANDLER =
@@ -86,7 +91,9 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "com.mongodb.internal.connection.DefaultConnectionPool$AsyncWorkManager",
       "io.reactivex.internal.schedulers.AbstractDirectTask",
       "jdk.internal.net.http.HttpClientImpl",
-      LETTUCE_HANDSHAKE_HANDLER
+      LETTUCE_HANDSHAKE_HANDLER,
+      "io.netty.util.concurrent.GlobalEventExecutor",
+      "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor"
     };
   }
 
@@ -101,6 +108,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
         .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
+        .or(NETTY_GLOBAL_EVENT_EXECUTOR)
         .or(JAVA_HTTP_CLIENT);
   }
 
@@ -187,6 +195,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
+    transformer.applyAdvice(
+        isTypeInitializer().and(isDeclaredBy(NETTY_GLOBAL_EVENT_EXECUTOR)), advice);
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
     transformer.applyAdvice(
         named("channelRegistered").and(isDeclaredBy(named(LETTUCE_HANDSHAKE_HANDLER))), advice);

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
@@ -15,12 +15,6 @@ import java.util.concurrent.TimeUnit
 
 class ReactorNettyTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
   @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
-  @Override
   boolean testCircularRedirects() {
     false
   }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -53,10 +53,6 @@ class SpringWebfluxTest extends InstrumentationSpecification {
 
   WebClient client = WebClient.builder().clientConnector(new ReactorClientHttpConnector()).build()
 
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
 
   def "Basic GET test #testName"() {
     setup:

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -21,12 +21,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
   abstract WebClient createClient(CharSequence component)
 
   abstract void check()

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -859,11 +859,6 @@ class SpringWebfluxHttp11Test extends InstrumentationSpecification {
     }
     return ret
   }
-
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
 }
 
 class SpringWebfluxHttp2UpgradeTest extends SpringWebfluxHttp11Test {

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-6.0/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
@@ -22,12 +22,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
   abstract WebClient createClient(CharSequence component)
 
   abstract void check()


### PR DESCRIPTION
# What Does This Do

Disable the async propagation when netty's GlobalEventExecutor class initialises. It's a lazily built singleton whose constructor schedules a long-lived housekeeping task. Capturing a continuation on that task pins whatever trace is active at first-touch open forever. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
