### PR TITLE
Ignore capturing connection continuation for armeria

### DIFF
--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
@@ -42,11 +42,6 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
   }
 
   @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
-  @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.trace.grpc.ignored.inbound.methods", "example.Greeter/IgnoreInbound")

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcTest.groovy
@@ -87,11 +87,6 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
     injectSysConfig(GRPC_SERVER_ERROR_STATUSES, "2-14", true)
   }
 
-  @Override
-  boolean useStrictTraceWrites() {
-    false
-  }
-
   def setupSpec() {
     ig = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC)
   }

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -93,7 +93,9 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "jdk.internal.net.http.HttpClientImpl",
       LETTUCE_HANDSHAKE_HANDLER,
       "io.netty.util.concurrent.GlobalEventExecutor",
-      "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor"
+      "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor",
+      "com.linecorp.armeria.client.HttpClientFactory",
+      "com.linecorp.armeria.client.HttpChannelPool"
     };
   }
 
@@ -199,6 +201,14 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
     transformer.applyAdvice(
         named("channelRegistered").and(isDeclaredBy(named(LETTUCE_HANDSHAKE_HANDLER))), advice);
+    // armeria runs its own codec/pipeline, so the active request span captured during connection
+    // pool creation and channel connect will have no consumers.
+    transformer.applyAdvice(
+        named("pool").and(isDeclaredBy(named("com.linecorp.armeria.client.HttpClientFactory"))),
+        advice);
+    transformer.applyAdvice(
+        named("connect").and(isDeclaredBy(named("com.linecorp.armeria.client.HttpChannelPool"))),
+        advice);
   }
 
   public static class DisableAsyncAdvice {


### PR DESCRIPTION
# What Does This Do

Armeria lazily builds its HttpChannelPool on the first request (so the request span is active), and the pool's CompletableFuture close-handler captured that span. It only completes at pool shutdown and the trace stayed pinned for the whole pool lifetime.

Also, netty's ConnectAdvice captures the active span on connect, expecting our http client handler to consume it. Armeria runs its own codec/pipeline, so nothing ever consumed it.

This PR disable capturing continuations for the two cases and rolls back the previous attempt to overhaul largely speaking the netty captures since it had side effects on ratpack.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
