### PR TITLE
Add `StringIndex`: a generic open-addressed string set

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ jmh = "1.37"
 # Profiling
 jmc = "8.1.0"
 jafar = "0.16.0"
+jol = "0.17"
 
 # Web & Network
 jnr-unixsocket = "0.38.25"
@@ -125,6 +126,7 @@ instrument-java = { module = "com.datadoghq:dd-instrument-java", version.ref = "
 jmc-common = { module = "org.openjdk.jmc:common", version.ref = "jmc" }
 jmc-flightrecorder = { module = "org.openjdk.jmc:flightrecorder", version.ref = "jmc" }
 jafar-tools = { module = "io.btrace:jafar-tools", version.ref = "jafar" }
+jol-core = { module = "org.openjdk.jol:jol-core", version.ref = "jol" }
 
 # Web & Network
 okio = { module = "com.datadoghq.okio:okio", version.ref = "okio" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ jmh = "1.37"
 # Profiling
 jmc = "8.1.0"
 jafar = "0.16.0"
+jol = "0.17"
 
 # Web & Network
 jnr-unixsocket = "0.38.25"
@@ -133,6 +134,7 @@ instrument-java = { module = "com.datadoghq:dd-instrument-java", version.ref = "
 jmc-common = { module = "org.openjdk.jmc:common", version.ref = "jmc" }
 jmc-flightrecorder = { module = "org.openjdk.jmc:flightrecorder", version.ref = "jmc" }
 jafar-tools = { module = "io.btrace:jafar-tools", version.ref = "jafar" }
+jol-core = { module = "org.openjdk.jol:jol-core", version.ref = "jol" }
 
 # Web & Network
 okio = { module = "com.datadoghq.okio:okio", version.ref = "okio" }

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -282,6 +282,7 @@ dependencies {
   testImplementation("org.junit.vintage:junit-vintage-engine:${libs.versions.junit5.get()}")
   testImplementation(libs.commons.math)
   testImplementation(libs.bundles.mockito)
+  testImplementation(libs.jol.core)
 }
 
 jmh {

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -124,12 +124,12 @@ public class ImmutableMapBenchmark {
   static final int[] SI_VALUES;
 
   static {
-    StringIndex.Data data = StringIndex.Support.create(INSERTION_KEYS);
+    StringIndex.Data data = StringIndex.EmbeddingSupport.create(INSERTION_KEYS);
     SI_HASHES = data.hashes;
     SI_NAMES = data.names;
     SI_VALUES = new int[SI_HASHES.length];
     for (int i = 0; i < INSERTION_KEYS.length; ++i) {
-      SI_VALUES[StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, INSERTION_KEYS[i])] = i;
+      SI_VALUES[StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, INSERTION_KEYS[i])] = i;
     }
   }
 
@@ -276,12 +276,12 @@ public class ImmutableMapBenchmark {
 
   @Benchmark
   public int support_get(Cursor cursor) {
-    return SI_VALUES[StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey())];
+    return SI_VALUES[StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey())];
   }
 
   @Benchmark
   public int support_get_sameKey(Cursor cursor) {
     return SI_VALUES[
-        StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey(INSERTION_KEYS))];
+        StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey(INSERTION_KEYS))];
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -33,11 +33,55 @@ import org.openjdk.jmh.infra.Blackhole;
  * 10+, falls back to the input map pre-10). {@code Map.copyOf}/{@code MapN} is the honest
  * immutable-map baseline, not {@code HashMap}.
  *
+ * <p>Also compared: {@link StringIndex} used as a string-&gt;int map — an open-addressed index plus
+ * a slot-aligned {@code int[]} of values ({@code SI_VALUES[indexOf(key)]}). {@code
+ * stringIndex_get*} goes through the instance wrapper; {@code support_get*} reads via {@code static
+ * final} arrays (the JIT folds the refs). No {@code iterate} arm — StringIndex is a lookup index,
+ * not an iteration structure; its map use case is the {@code indexOf}-&gt;parallel-array read.
+ *
  * <p>Lookups use {@code EQUAL_KEYS} (distinct String instances) to exercise {@code equals()};
  * {@code *_sameKey} variants reuse the original interned key instances to show the identity fast
  * path — which is the common tracer case, since map keys are typically interned tag-name constants.
- * (Results pending a fresh multi-JVM run — {@code Map.copyOf} only materializes the compact form on
- * Java 10+.)
+ *
+ * <p>JDK 17 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}; M ops/s).
+ * {@code get} uses distinct keys (exercises {@code equals()}); {@code sameKey} reuses the interned
+ * key (the {@code ==} fast path — the common tracer case):
+ *
+ * <pre>{@code
+ * Structure              get    sameKey
+ * support (static)      1498     2081    (fastest)
+ * stringIndex (inst)    1363     1900
+ * hashMap               1216     1850
+ * linkedHashMap         1214       -
+ * tagMap                1167     1386
+ * tracerImmutableMap    1049     1364    (MapN)
+ * treeMap                656       -
+ * }</pre>
+ *
+ * <p>{@code iterate} (full traversal):
+ *
+ * <pre>{@code
+ * tagMap.forEach        148    (fastest)
+ * linkedHashMap         136
+ * tracerImmutableMap    135    (MapN)
+ * treeMap               134
+ * hashMap               104
+ * tagMap (iterator)      96
+ * }</pre>
+ *
+ * <p>Key findings:
+ *
+ * <ul>
+ *   <li>StringIndex-as-map ({@code Support}) is the fastest {@code get} — beating {@code HashMap}
+ *       and {@code Map.copyOf}/{@code MapN}, most on the interned path; the instance wrapper trails
+ *       it by ~10%. (vs {@code MapN} the edge is speed + the slot/parallel-array capability, not
+ *       footprint — see {@link ImmutableSetBenchmark}.)
+ *   <li>{@code TagMap.forEach} (148) beats its own {@code iterator} (96) by ~1.5x: TagMap's
+ *       structure makes a faithful external {@code Iterator} expensive (externalized cursor +
+ *       skip-empty + per-call re-entry + the iterator allocation) — all of which internal {@code
+ *       forEach} avoids. Traverse TagMap via {@code forEach}, never its iterator; that gap only
+ *       widens as TagMap's entry model grows.
+ * </ul>
  */
 // @Fork(5): get_tracerImmutableMap* (MapN reached via interface dispatch) is JIT-bimodal at fewer
 // forks — 5
@@ -71,12 +115,31 @@ public class ImmutableMapBenchmark {
     }
   }
 
+  // StringIndex as a string->int map: an open-addressed index plus a slot-aligned int[] of values
+  // (VALUES[indexOf(key)]). support_* reads via static final arrays (JIT folds the refs to
+  // constants); stringIndex_* goes through the instance wrapper. Both share one placement --
+  // StringIndex.of and Support.create place identically -- so SI_VALUES aligns with either.
+  static final int[] SI_HASHES;
+  static final String[] SI_NAMES;
+  static final int[] SI_VALUES;
+
+  static {
+    StringIndex.Data data = StringIndex.Support.create(INSERTION_KEYS);
+    SI_HASHES = data.hashes;
+    SI_NAMES = data.names;
+    SI_VALUES = new int[SI_HASHES.length];
+    for (int i = 0; i < INSERTION_KEYS.length; ++i) {
+      SI_VALUES[StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, INSERTION_KEYS[i])] = i;
+    }
+  }
+
   // Built once, never mutated -- safe to share across the reader threads.
   HashMap<String, Integer> hashMap;
   LinkedHashMap<String, Integer> linkedHashMap;
   TreeMap<String, Integer> treeMap;
   TagMap tagMap;
   Map<String, Integer> tracerImmutableMap;
+  StringIndex stringIndex;
 
   @Setup(Level.Trial)
   public void setUp() {
@@ -92,6 +155,7 @@ public class ImmutableMapBenchmark {
     }
     // JDK compact immutable map (MapN on Java 10+); the agent's actual fixed-map representation.
     tracerImmutableMap = CollectionUtils.tryMakeImmutableMap(hashMap);
+    stringIndex = StringIndex.of(INSERTION_KEYS);
   }
 
   /** Per-thread lookup cursor so each reader thread cycles keys independently. */
@@ -198,5 +262,26 @@ public class ImmutableMapBenchmark {
       blackhole.consume(entry.getKey());
       blackhole.consume(entry.getValue());
     }
+  }
+
+  @Benchmark
+  public int stringIndex_get(Cursor cursor) {
+    return SI_VALUES[stringIndex.indexOf(cursor.nextKey())];
+  }
+
+  @Benchmark
+  public int stringIndex_get_sameKey(Cursor cursor) {
+    return SI_VALUES[stringIndex.indexOf(cursor.nextKey(INSERTION_KEYS))];
+  }
+
+  @Benchmark
+  public int support_get(Cursor cursor) {
+    return SI_VALUES[StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey())];
+  }
+
+  @Benchmark
+  public int support_get_sameKey(Cursor cursor) {
+    return SI_VALUES[
+        StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey(INSERTION_KEYS))];
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -35,9 +35,10 @@ import org.openjdk.jmh.infra.Blackhole;
  *
  * <p>Also compared: {@link StringIndex} used as a string-&gt;int map — an open-addressed index plus
  * a slot-aligned {@code int[]} of values ({@code SI_VALUES[indexOf(key)]}). {@code
- * stringIndex_get*} goes through the instance wrapper; {@code support_get*} reads via {@code static
- * final} arrays (the JIT folds the refs). No {@code iterate} arm — StringIndex is a lookup index,
- * not an iteration structure; its map use case is the {@code indexOf}-&gt;parallel-array read.
+ * stringIndex_get*} goes through the instance wrapper; {@code stringIndex_embedded_get*} reads via
+ * {@code static final} arrays (the JIT folds the refs). No {@code iterate} arm — StringIndex is a
+ * lookup index, not an iteration structure; its map use case is the {@code
+ * indexOf}-&gt;parallel-array read.
  *
  * <p>Lookups use {@code EQUAL_KEYS} (distinct String instances) to exercise {@code equals()};
  * {@code *_sameKey} variants reuse the original interned key instances to show the identity fast
@@ -48,14 +49,14 @@ import org.openjdk.jmh.infra.Blackhole;
  * key (the {@code ==} fast path — the common tracer case):
  *
  * <pre>{@code
- * Structure              get    sameKey
- * support (static)      1498     2081    (fastest)
- * stringIndex (inst)    1363     1900
- * hashMap               1216     1850
- * linkedHashMap         1214       -
- * tagMap                1167     1386
- * tracerImmutableMap    1049     1364    (MapN)
- * treeMap                656       -
+ * Structure                    get    sameKey
+ * stringIndex_embedded (static) 1498     2081    (fastest)
+ * stringIndex (inst)           1363     1900
+ * hashMap                      1216     1850
+ * linkedHashMap                1214       -
+ * tagMap                       1167     1386
+ * tracerImmutableMap           1049     1364    (MapN)
+ * treeMap                       656       -
  * }</pre>
  *
  * <p>{@code iterate} (full traversal):
@@ -72,10 +73,10 @@ import org.openjdk.jmh.infra.Blackhole;
  * <p>Key findings:
  *
  * <ul>
- *   <li>StringIndex-as-map ({@code Support}) is the fastest {@code get} — beating {@code HashMap}
- *       and {@code Map.copyOf}/{@code MapN}, most on the interned path; the instance wrapper trails
- *       it by ~10%. (vs {@code MapN} the edge is speed + the slot/parallel-array capability, not
- *       footprint — see {@link ImmutableSetBenchmark}.)
+ *   <li>StringIndex-as-map ({@code EmbeddingSupport}) is the fastest {@code get} — beating {@code
+ *       HashMap} and {@code Map.copyOf}/{@code MapN}, most on the interned path; the instance
+ *       wrapper trails it by ~10%. (vs {@code MapN} the edge is speed + the slot/parallel-array
+ *       capability, not footprint — see {@link ImmutableSetBenchmark}.)
  *   <li>{@code TagMap.forEach} (148) beats its own {@code iterator} (96) by ~1.5x: TagMap's
  *       structure makes a faithful external {@code Iterator} expensive (externalized cursor +
  *       skip-empty + per-call re-entry + the iterator allocation) — all of which internal {@code
@@ -116,9 +117,10 @@ public class ImmutableMapBenchmark {
   }
 
   // StringIndex as a string->int map: an open-addressed index plus a slot-aligned int[] of values
-  // (VALUES[indexOf(key)]). support_* reads via static final arrays (JIT folds the refs to
-  // constants); stringIndex_* goes through the instance wrapper. Both share one placement --
-  // StringIndex.of and Support.create place identically -- so SI_VALUES aligns with either.
+  // (VALUES[indexOf(key)]). stringIndex_embedded_* reads via static final arrays (JIT folds the
+  // refs to constants); stringIndex_* goes through the instance wrapper. Both share one placement
+  // -- StringIndex.of and EmbeddingSupport.create place identically -- so SI_VALUES aligns with
+  // either.
   static final int[] SI_HASHES;
   static final String[] SI_NAMES;
   static final int[] SI_VALUES;
@@ -275,12 +277,12 @@ public class ImmutableMapBenchmark {
   }
 
   @Benchmark
-  public int support_get(Cursor cursor) {
+  public int stringIndex_embedded_get(Cursor cursor) {
     return SI_VALUES[StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey())];
   }
 
   @Benchmark
-  public int support_get_sameKey(Cursor cursor) {
+  public int stringIndex_embedded_get_sameKey(Cursor cursor) {
     return SI_VALUES[
         StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextKey(INSERTION_KEYS))];
   }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -49,14 +49,14 @@ import org.openjdk.jmh.infra.Blackhole;
  * key (the {@code ==} fast path — the common tracer case):
  *
  * <pre>{@code
- * Structure                    get    sameKey
- * stringIndex_embedded (static) 1498     2081    (fastest)
- * stringIndex (inst)           1363     1900
- * hashMap                      1216     1850
- * linkedHashMap                1214       -
- * tagMap                       1167     1386
- * tracerImmutableMap           1049     1364    (MapN)
- * treeMap                       656       -
+ * Structure                           get sameKey
+ * stringIndex_embedded (static)      1498    2081    (fastest)
+ * stringIndex (inst)                 1363    1900
+ * hashMap                            1216    1850
+ * linkedHashMap                      1214       -
+ * tagMap                             1167    1386
+ * tracerImmutableMap                 1049    1364    (MapN)
+ * treeMap                             656       -
  * }</pre>
  *
  * <p>{@code iterate} (full traversal):

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -35,34 +35,57 @@ import org.openjdk.jmh.annotations.Warmup;
  *       ({@code ImmutableCollections.SetN}), which is what the agent actually uses for fixed config
  *       sets. Java 10+; falls back to {@code HashSet} pre-10. The realistic baseline for any
  *       flat/immutable set comparison.
+ *   <li>{@code stringIndex} — {@link StringIndex#contains} on the instance wrapper (one field load
+ *       to reach the placed arrays, then an open-addressed probe).
+ *   <li>{@code support} — the same probe via {@link StringIndex.Support#indexOf} over {@code static
+ *       final} arrays, so the JIT folds the refs to constants and there is nothing to dereference
+ *       (the hot path StringIndex recommends). The {@code stringIndex}/{@code support} pair shows
+ *       the indirection cost of the wrapper.
  * </ul>
  *
  * <p>Lookups are interned (the {@code ==} fast path where a structure has one); misses are short
  * and never present.
  *
- * <p>Java 17 results (Apple M1, {@code @Fork(2)}, {@code @Threads(8)}; M ops/s = millions):
+ * <p>JDK 17 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}; M ops/s =
+ * millions):
  *
  * <pre>{@code
  * Structure              hit     miss
- * hashSet               2159     1751    (fastest)
- * tracerImmutableSet    1946     1633    (Set.copyOf / SetN)
- * array                  926      584
- * sortedArray            664      588
- * treeSet                642      593
+ * support (static)      2320     2159    (fastest)
+ * hashSet               2198     2134
+ * stringIndex (inst)    2098     1548 *  (* miss bimodal -- see caveat)
+ * tracerImmutableSet    1914     1663    (Set.copyOf / SetN)
+ * array                  941      589
+ * sortedArray            685      610
+ * treeSet                657      610
  * }</pre>
  *
  * <p>Key findings:
  *
  * <ul>
- *   <li>{@code HashSet} is fastest; {@link java.util.Set#copyOf} ({@code SetN}) trails by only ~10%
- *       on hit and ~7% on miss — and it's the compact, array-backed form the agent already uses for
- *       fixed config sets, so it's a strong default when the set is immutable.
- *   <li>{@code array} / {@code sortedArray} / {@code treeSet} cluster at ~0.6–0.9B — they scan,
- *       binary-search, or tree-walk per lookup, so they trail the hashed structures, most visibly
- *       on the miss path.
+ *   <li>The static {@code Support} path is the fastest — it beats {@code HashSet} on hit and miss
+ *       and crushes the scan/search/tree forms.
+ *   <li>{@code stringIndex} (the instance wrapper) trails {@code Support} by the field-load
+ *       indirection (~10% on hit), landing near {@code HashSet} — fine off the hot path, prefer
+ *       {@code Support} on it.
+ *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) is ~1.2x
+ *       behind {@code Support} on hit but the most <i>compact</i> (~27% smaller — no cached hashes,
+ *       no 2x table). So StringIndex's edge over {@code SetN} is speed + the {@code
+ *       indexOf}-&gt;parallel-array capability, not footprint; over {@code HashSet} it wins both.
+ *   <li>{@code array} / {@code sortedArray} / {@code treeSet} trail the hashed structures, most on
+ *       miss.
  * </ul>
+ *
+ * <p><b>Caveat — the instance {@code stringIndex} miss is bimodal across forks</b> (confirmed at
+ * {@code @Fork(10)}: 6 forks fast, 4 slow, nothing between). ~60% of forks compile to a fast mode
+ * (~2000, ≈ {@code support_miss} — the wrapper indirection is then free) and ~40% to a slow mode
+ * (~1070, ~half); each fork locks one at warmup. So the {@code 1548 ±27%} above is a mode-mix, not
+ * noise. Cause: C2 hoists the instance field-loads ({@code this.hashes}/{@code names}) out of the
+ * miss-path probe loop only in the fast mode; the static {@code Support} path const-folds those
+ * refs and is never bimodal ({@code support_miss} ±0.3%). Prefer {@code Support} where miss latency
+ * matters.
  */
-@Fork(2)
+@Fork(5) // 5 forks settle the bimodal stringIndex_miss / interface-dispatch arms (see header)
 @Warmup(iterations = 2)
 @Measurement(iterations = 3)
 @Threads(8)
@@ -84,12 +107,26 @@ public class ImmutableSetBenchmark {
     return misses;
   }
 
+  // StringIndex static-Support mode: the placed arrays pulled into static final fields, so the JIT
+  // folds the refs to constants and Support.indexOf has nothing to dereference (the hot path the
+  // StringIndex class Javadoc recommends). Contrast support_* (these) with stringIndex_* (the
+  // instance wrapper, one field load) to see the indirection cost.
+  static final int[] SI_HASHES;
+  static final String[] SI_NAMES;
+
+  static {
+    StringIndex.Data data = StringIndex.Support.create(STRINGS);
+    SI_HASHES = data.hashes;
+    SI_NAMES = data.names;
+  }
+
   // Built once, never mutated -- safe to share across the reader threads.
   String[] array;
   String[] sortedArray;
   HashSet<String> hashSet;
   TreeSet<String> treeSet;
   Set<String> tracerImmutableSet;
+  StringIndex stringIndex;
 
   @Setup(Level.Trial)
   public void setUp() {
@@ -99,6 +136,7 @@ public class ImmutableSetBenchmark {
     hashSet = new HashSet<>(Arrays.asList(STRINGS));
     treeSet = new TreeSet<>(Arrays.asList(STRINGS));
     tracerImmutableSet = CollectionUtils.tryMakeImmutableSet(Arrays.asList(STRINGS));
+    stringIndex = StringIndex.of(STRINGS);
   }
 
   /** Per-thread lookup cursor so each reader thread cycles keys independently. */
@@ -183,5 +221,25 @@ public class ImmutableSetBenchmark {
   @Benchmark
   public boolean tracerImmutableSet_miss(Cursor cursor) {
     return tracerImmutableSet.contains(cursor.nextMiss());
+  }
+
+  @Benchmark
+  public boolean stringIndex_hit(Cursor cursor) {
+    return stringIndex.contains(cursor.nextHit());
+  }
+
+  @Benchmark
+  public boolean stringIndex_miss(Cursor cursor) {
+    return stringIndex.contains(cursor.nextMiss());
+  }
+
+  @Benchmark
+  public boolean support_hit(Cursor cursor) {
+    return StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextHit()) >= 0;
+  }
+
+  @Benchmark
+  public boolean support_miss(Cursor cursor) {
+    return StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextMiss()) >= 0;
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -37,10 +37,10 @@ import org.openjdk.jmh.annotations.Warmup;
  *       flat/immutable set comparison.
  *   <li>{@code stringIndex} — {@link StringIndex#contains} on the instance wrapper (one field load
  *       to reach the placed arrays, then an open-addressed probe).
- *   <li>{@code support} — the same probe via {@link StringIndex.Support#indexOf} over {@code static
- *       final} arrays, so the JIT folds the refs to constants and there is nothing to dereference
- *       (the hot path StringIndex recommends). The {@code stringIndex}/{@code support} pair shows
- *       the indirection cost of the wrapper.
+ *   <li>{@code support} — the same probe via {@link StringIndex.EmbeddingSupport#indexOf} over
+ *       {@code static final} arrays, so the JIT folds the refs to constants and there is nothing to
+ *       dereference (the hot path StringIndex recommends). The {@code stringIndex}/{@code support}
+ *       pair shows the indirection cost of the wrapper.
  * </ul>
  *
  * <p>Lookups are interned (the {@code ==} fast path where a structure has one); misses are short
@@ -115,7 +115,7 @@ public class ImmutableSetBenchmark {
   static final String[] SI_NAMES;
 
   static {
-    StringIndex.Data data = StringIndex.Support.create(STRINGS);
+    StringIndex.Data data = StringIndex.EmbeddingSupport.create(STRINGS);
     SI_HASHES = data.hashes;
     SI_NAMES = data.names;
   }
@@ -235,11 +235,11 @@ public class ImmutableSetBenchmark {
 
   @Benchmark
   public boolean support_hit(Cursor cursor) {
-    return StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextHit()) >= 0;
+    return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextHit()) >= 0;
   }
 
   @Benchmark
   public boolean support_miss(Cursor cursor) {
-    return StringIndex.Support.indexOf(SI_HASHES, SI_NAMES, cursor.nextMiss()) >= 0;
+    return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextMiss()) >= 0;
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -37,10 +37,11 @@ import org.openjdk.jmh.annotations.Warmup;
  *       flat/immutable set comparison.
  *   <li>{@code stringIndex} — {@link StringIndex#contains} on the instance wrapper (one field load
  *       to reach the placed arrays, then an open-addressed probe).
- *   <li>{@code support} — the same probe via {@link StringIndex.EmbeddingSupport#indexOf} over
- *       {@code static final} arrays, so the JIT folds the refs to constants and there is nothing to
- *       dereference (the hot path StringIndex recommends). The {@code stringIndex}/{@code support}
- *       pair shows the indirection cost of the wrapper.
+ *   <li>{@code stringIndex_embedded} — the same probe via {@link
+ *       StringIndex.EmbeddingSupport#indexOf} over {@code static final} arrays, so the JIT folds
+ *       the refs to constants and there is nothing to dereference (the hot path StringIndex
+ *       recommends). The {@code stringIndex}/{@code stringIndex_embedded} pair shows the
+ *       indirection cost of the wrapper.
  * </ul>
  *
  * <p>Lookups are interned (the {@code ==} fast path where a structure has one); misses are short
@@ -50,27 +51,27 @@ import org.openjdk.jmh.annotations.Warmup;
  * millions):
  *
  * <pre>{@code
- * Structure              hit     miss
- * support (static)      2320     2159    (fastest)
- * hashSet               2198     2134
- * stringIndex (inst)    2098     1548 *  (* miss bimodal -- see caveat)
- * tracerImmutableSet    1914     1663    (Set.copyOf / SetN)
- * array                  941      589
- * sortedArray            685      610
- * treeSet                657      610
+ * Structure                    hit     miss
+ * stringIndex_embedded (static) 2320     2159    (fastest)
+ * hashSet                      2198     2134
+ * stringIndex (inst)           2098     1548 *  (* miss bimodal -- see caveat)
+ * tracerImmutableSet           1914     1663    (Set.copyOf / SetN)
+ * array                         941      589
+ * sortedArray                   685      610
+ * treeSet                       657      610
  * }</pre>
  *
  * <p>Key findings:
  *
  * <ul>
- *   <li>The static {@code Support} path is the fastest — it beats {@code HashSet} on hit and miss
- *       and crushes the scan/search/tree forms.
- *   <li>{@code stringIndex} (the instance wrapper) trails {@code Support} by the field-load
- *       indirection (~10% on hit), landing near {@code HashSet} — fine off the hot path, prefer
- *       {@code Support} on it.
+ *   <li>The static {@code EmbeddingSupport} path is the fastest — it beats {@code HashSet} on hit
+ *       and miss and crushes the scan/search/tree forms.
+ *   <li>{@code stringIndex} (the instance wrapper) trails {@code EmbeddingSupport} by the
+ *       field-load indirection (~10% on hit), landing near {@code HashSet} — fine off the hot path,
+ *       prefer {@code EmbeddingSupport} on it.
  *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) is ~1.2x
- *       behind {@code Support} on hit but the most <i>compact</i> (~27% smaller — no cached hashes,
- *       no 2x table). So StringIndex's edge over {@code SetN} is speed + the {@code
+ *       behind {@code EmbeddingSupport} on hit but the most <i>compact</i> (~27% smaller — no
+ *       cached hashes, no 2x table). So StringIndex's edge over {@code SetN} is speed + the {@code
  *       indexOf}-&gt;parallel-array capability, not footprint; over {@code HashSet} it wins both.
  *   <li>{@code array} / {@code sortedArray} / {@code treeSet} trail the hashed structures, most on
  *       miss.
@@ -78,12 +79,12 @@ import org.openjdk.jmh.annotations.Warmup;
  *
  * <p><b>Caveat — the instance {@code stringIndex} miss is bimodal across forks</b> (confirmed at
  * {@code @Fork(10)}: 6 forks fast, 4 slow, nothing between). ~60% of forks compile to a fast mode
- * (~2000, ≈ {@code support_miss} — the wrapper indirection is then free) and ~40% to a slow mode
- * (~1070, ~half); each fork locks one at warmup. So the {@code 1548 ±27%} above is a mode-mix, not
- * noise. Cause: C2 hoists the instance field-loads ({@code this.hashes}/{@code names}) out of the
- * miss-path probe loop only in the fast mode; the static {@code Support} path const-folds those
- * refs and is never bimodal ({@code support_miss} ±0.3%). Prefer {@code Support} where miss latency
- * matters.
+ * (~2000, ≈ {@code stringIndex_embedded_miss} — the wrapper indirection is then free) and ~40% to a
+ * slow mode (~1070, ~half); each fork locks one at warmup. So the {@code 1548 ±27%} above is a
+ * mode-mix, not noise. Cause: C2 hoists the instance field-loads ({@code this.hashes}/{@code
+ * names}) out of the miss-path probe loop only in the fast mode; the static {@code
+ * EmbeddingSupport} path const-folds those refs and is never bimodal ({@code
+ * stringIndex_embedded_miss} ±0.3%). Prefer {@code EmbeddingSupport} where miss latency matters.
  */
 @Fork(5) // 5 forks settle the bimodal stringIndex_miss / interface-dispatch arms (see header)
 @Warmup(iterations = 2)
@@ -107,10 +108,10 @@ public class ImmutableSetBenchmark {
     return misses;
   }
 
-  // StringIndex static-Support mode: the placed arrays pulled into static final fields, so the JIT
-  // folds the refs to constants and Support.indexOf has nothing to dereference (the hot path the
-  // StringIndex class Javadoc recommends). Contrast support_* (these) with stringIndex_* (the
-  // instance wrapper, one field load) to see the indirection cost.
+  // StringIndex static-EmbeddingSupport mode: the placed arrays pulled into static final fields, so
+  // the JIT folds the refs to constants and EmbeddingSupport.indexOf has nothing to dereference
+  // (the hot path the StringIndex class Javadoc recommends). Contrast stringIndex_embedded_*
+  // (these) with stringIndex_* (the instance wrapper, one field load) to see the indirection cost.
   static final int[] SI_HASHES;
   static final String[] SI_NAMES;
 
@@ -234,12 +235,12 @@ public class ImmutableSetBenchmark {
   }
 
   @Benchmark
-  public boolean support_hit(Cursor cursor) {
+  public boolean stringIndex_embedded_hit(Cursor cursor) {
     return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextHit()) >= 0;
   }
 
   @Benchmark
-  public boolean support_miss(Cursor cursor) {
+  public boolean stringIndex_embedded_miss(Cursor cursor) {
     return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextMiss()) >= 0;
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -51,14 +51,14 @@ import org.openjdk.jmh.annotations.Warmup;
  * millions):
  *
  * <pre>{@code
- * Structure                    hit     miss
- * stringIndex_embedded (static) 2320     2159    (fastest)
- * hashSet                      2198     2134
- * stringIndex (inst)           2098     1548 *  (* miss bimodal -- see caveat)
- * tracerImmutableSet           1914     1663    (Set.copyOf / SetN)
- * array                         941      589
- * sortedArray                   685      610
- * treeSet                       657      610
+ * Structure                           hit    miss
+ * stringIndex_embedded (static)      2320    2159    (fastest)
+ * hashSet                            2198    2134
+ * stringIndex (inst)                 2098  1548 *    (* miss bimodal -- see caveat)
+ * tracerImmutableSet                 1914    1663    (Set.copyOf / SetN)
+ * array                               941     589
+ * sortedArray                         685     610
+ * treeSet                             657     610
  * }</pre>
  *
  * <p>Key findings:

--- a/internal-api/src/jmh/java/datadog/trace/util/StringIndexSwitchBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/StringIndexSwitchBenchmark.java
@@ -1,0 +1,299 @@
+package datadog.trace.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * The third {@link StringIndex} use case: replacing a {@code switch} over interned {@code String}
+ * literals that maps a key to a small {@code int} id (exactly what {@code TagInterceptor} does to
+ * decide whether/how to intercept a tag). Both forms resolve a key to an id, 0 == "not found".
+ *
+ * <p>Compared:
+ *
+ * <ul>
+ *   <li>{@code switch} — a hand-written {@code switch(key)} over the literals ({@code hashCode}
+ *       switch + {@code equals}), {@code default} returns 0.
+ *   <li>{@code stringIndex} — {@code IDS[Support.indexOf(HASHES, NAMES, key)]} over {@code static
+ *       final} arrays (a miss returns 0), the folded-constant hot path.
+ * </ul>
+ *
+ * <p><b>What this measures: two axes.</b> A prior investigation found the {@code TagInterceptor}
+ * switch wasn't being inlined / specialized into its hot caller. So each form is measured across
+ * (a) inlining — {@code _inlined} vs {@code _noinline} (a real call, {@code TagInterceptor}'s
+ * actual regime) via {@link CompilerControl} — and (b) key shape — a constant key vs a runtime,
+ * varied key. The results (below) land the teaching point: the dominant axis is
+ * <i>key-constancy</i>, not inlining. At steady state the inline-vs-not gap is small for both
+ * forms; what sinks the switch is a runtime, varied key (it can't specialize), while the
+ * StringIndex {@code Support} path stays flat across both axes — so the win is largest exactly
+ * where {@code TagInterceptor} lives.
+ *
+ * <p>The {@code _inlined} and {@code _noinline} helpers carry duplicate bodies on purpose: that's
+ * the only way to pin each form's inlining decision independently.
+ *
+ * <p>{@code @Threads(8)}; read-only, so no store dilutes the signal. Hit keys are the interned
+ * literals (the {@code ==} fast path StringIndex and the switch both get); misses are distinct and
+ * never present. Run via {@code -Pjmh.includes=StringIndexSwitchBenchmark} (add {@code -prof gc} —
+ * should be ~0 B/op both ways; this proves throughput, not allocation).
+ *
+ * <p>JDK 17 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}; M ops/s,
+ * ±1–5%):
+ *
+ * <pre>{@code
+ * key             switch (inl / noinl)   stringIndex (inl / noinl)
+ * const            2778 / 2769            2047 / 2035
+ * hit  (runtime)   1161 / 1166            2147 / 2152
+ * miss             2083 / 2050            2546 / 2539
+ * }</pre>
+ *
+ * <p>Two takeaways:
+ *
+ * <ul>
+ *   <li>The string switch only <i>matches</i> StringIndex in the <b>constant-key</b> corner
+ *       (~2.7B): there the JIT specializes the switch to the single known key — and the {@code
+ *       const} arms show it does so even across a {@code DONT_INLINE} boundary (profile-driven, not
+ *       const-prop-through-inline). Production tags are runtime-varied, so that corner never
+ *       occurs.
+ *   <li>In the realistic regime — a <b>runtime, varied hit key</b>, exactly {@code TagInterceptor}
+ *       — the switch falls to ~1.16B while StringIndex holds ~2.15B (<b>~1.85x</b>). StringIndex is
+ *       flat (~2.0–2.5B) across inline/not-inline <i>and</i> key shape: its throughput doesn't
+ *       depend on the JIT's inlining decisions, which is the whole point. (Misses short-circuit for
+ *       both; StringIndex still ~1.2x.)
+ * </ul>
+ *
+ * <p>So the {@code const} arm is the control: it exposes the switch's "fast" as a single-key
+ * specialization artifact — drop the constant and the switch is ~half StringIndex's throughput.
+ */
+@Fork(5) // matches the documented @Fork(5) numbers; the switch's const-key arm is profile-bimodal
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@Threads(8)
+@State(Scope.Benchmark)
+public class StringIndexSwitchBenchmark {
+  static final String[] KEYS = {
+    "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+    "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa"
+  };
+
+  // A compile-time-constant hit key. javac inlines it, so the JIT can constant-propagate it into an
+  // inlined switch and fold the whole switch away -- the switch's theoretical ceiling. The const_*
+  // arms pair this with INLINE vs DONT_INLINE to show that ceiling only materializes when the call
+  // ALSO inlines: across a DONT_INLINE boundary the constant can't propagate in, so the switch runs
+  // in full. TagInterceptor's real regime is a runtime tag through a non-inlined call -- neither
+  // holds -- which is why StringIndex wins where it counts.
+  static final String CONST_KEY = "mike";
+
+  /** Distinct String instances that are never present, for the miss path. */
+  static final String[] MISSES = newMisses();
+
+  static String[] newMisses() {
+    String[] misses = new String[KEYS.length * 2];
+    for (int i = 0; i < misses.length; ++i) {
+      misses[i] = "dne-" + i;
+    }
+    return misses;
+  }
+
+  // StringIndex placed arrays + slot-aligned ids, pulled into static final fields so the JIT folds
+  // the refs to constants (the hot path StringIndex recommends). IDS[slot] is the 1-based id;
+  // empty slots stay 0, which doubles as the "not found" sentinel.
+  static final int[] HASHES;
+  static final String[] NAMES;
+  static final int[] IDS;
+
+  static {
+    StringIndex.Data data = StringIndex.Support.create(KEYS);
+    HASHES = data.hashes;
+    NAMES = data.names;
+    IDS = new int[HASHES.length];
+    for (int i = 0; i < KEYS.length; ++i) {
+      IDS[StringIndex.Support.indexOf(HASHES, NAMES, KEYS[i])] = i + 1; // 1-based; 0 = not found
+    }
+  }
+
+  /** Per-thread cursors so threads don't contend on a shared index under {@code @Threads(8)}. */
+  @State(Scope.Thread)
+  public static class Cursor {
+    int hit = 0;
+    int miss = 0;
+
+    String nextHit() {
+      int i = hit + 1;
+      if (i >= KEYS.length) {
+        i = 0;
+      }
+      hit = i;
+      return KEYS[i];
+    }
+
+    String nextMiss() {
+      int i = miss + 1;
+      if (i >= MISSES.length) {
+        i = 0;
+      }
+      miss = i;
+      return MISSES[i];
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.INLINE)
+  static int switchInline(String key) {
+    switch (key) {
+      case "alpha":
+        return 1;
+      case "bravo":
+        return 2;
+      case "charlie":
+        return 3;
+      case "delta":
+        return 4;
+      case "echo":
+        return 5;
+      case "foxtrot":
+        return 6;
+      case "golf":
+        return 7;
+      case "hotel":
+        return 8;
+      case "india":
+        return 9;
+      case "juliet":
+        return 10;
+      case "kilo":
+        return 11;
+      case "lima":
+        return 12;
+      case "mike":
+        return 13;
+      case "november":
+        return 14;
+      case "oscar":
+        return 15;
+      case "papa":
+        return 16;
+      default:
+        return 0;
+    }
+  }
+
+  // Duplicate body, pinned non-inlinable -- TagInterceptor's actual call regime.
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int switchNoInline(String key) {
+    switch (key) {
+      case "alpha":
+        return 1;
+      case "bravo":
+        return 2;
+      case "charlie":
+        return 3;
+      case "delta":
+        return 4;
+      case "echo":
+        return 5;
+      case "foxtrot":
+        return 6;
+      case "golf":
+        return 7;
+      case "hotel":
+        return 8;
+      case "india":
+        return 9;
+      case "juliet":
+        return 10;
+      case "kilo":
+        return 11;
+      case "lima":
+        return 12;
+      case "mike":
+        return 13;
+      case "november":
+        return 14;
+      case "oscar":
+        return 15;
+      case "papa":
+        return 16;
+      default:
+        return 0;
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.INLINE)
+  static int indexInline(String key) {
+    int slot = StringIndex.Support.indexOf(HASHES, NAMES, key);
+    return slot >= 0 ? IDS[slot] : 0;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int indexNoInline(String key) {
+    int slot = StringIndex.Support.indexOf(HASHES, NAMES, key);
+    return slot >= 0 ? IDS[slot] : 0;
+  }
+
+  @Benchmark
+  public int switch_hit_inlined(Cursor cursor) {
+    return switchInline(cursor.nextHit());
+  }
+
+  @Benchmark
+  public int switch_miss_inlined(Cursor cursor) {
+    return switchInline(cursor.nextMiss());
+  }
+
+  @Benchmark
+  public int switch_hit_noinline(Cursor cursor) {
+    return switchNoInline(cursor.nextHit());
+  }
+
+  @Benchmark
+  public int switch_miss_noinline(Cursor cursor) {
+    return switchNoInline(cursor.nextMiss());
+  }
+
+  @Benchmark
+  public int stringIndex_hit_inlined(Cursor cursor) {
+    return indexInline(cursor.nextHit());
+  }
+
+  @Benchmark
+  public int stringIndex_miss_inlined(Cursor cursor) {
+    return indexInline(cursor.nextMiss());
+  }
+
+  @Benchmark
+  public int stringIndex_hit_noinline(Cursor cursor) {
+    return indexNoInline(cursor.nextHit());
+  }
+
+  @Benchmark
+  public int stringIndex_miss_noinline(Cursor cursor) {
+    return indexNoInline(cursor.nextMiss());
+  }
+
+  // --- constant key: the switch's best case (const-propagated). Inlined -> folds away; not-inlined
+  // -> the constant can't cross the boundary, so the switch runs in full. ---
+
+  @Benchmark
+  public int switch_const_inlined() {
+    return switchInline(CONST_KEY);
+  }
+
+  @Benchmark
+  public int switch_const_noinline() {
+    return switchNoInline(CONST_KEY);
+  }
+
+  @Benchmark
+  public int stringIndex_const_inlined() {
+    return indexInline(CONST_KEY);
+  }
+
+  @Benchmark
+  public int stringIndex_const_noinline() {
+    return indexNoInline(CONST_KEY);
+  }
+}

--- a/internal-api/src/jmh/java/datadog/trace/util/StringIndexSwitchBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/StringIndexSwitchBenchmark.java
@@ -19,8 +19,8 @@ import org.openjdk.jmh.annotations.Warmup;
  * <ul>
  *   <li>{@code switch} — a hand-written {@code switch(key)} over the literals ({@code hashCode}
  *       switch + {@code equals}), {@code default} returns 0.
- *   <li>{@code stringIndex} — {@code IDS[Support.indexOf(HASHES, NAMES, key)]} over {@code static
- *       final} arrays (a miss returns 0), the folded-constant hot path.
+ *   <li>{@code stringIndex} — {@code IDS[EmbeddingSupport.indexOf(HASHES, NAMES, key)]} over {@code
+ *       static final} arrays (a miss returns 0), the folded-constant hot path.
  * </ul>
  *
  * <p><b>What this measures: two axes.</b> A prior investigation found the {@code TagInterceptor}
@@ -30,8 +30,8 @@ import org.openjdk.jmh.annotations.Warmup;
  * varied key. The results (below) land the teaching point: the dominant axis is
  * <i>key-constancy</i>, not inlining. At steady state the inline-vs-not gap is small for both
  * forms; what sinks the switch is a runtime, varied key (it can't specialize), while the
- * StringIndex {@code Support} path stays flat across both axes — so the win is largest exactly
- * where {@code TagInterceptor} lives.
+ * StringIndex {@code EmbeddingSupport} path stays flat across both axes — so the win is largest
+ * exactly where {@code TagInterceptor} lives.
  *
  * <p>The {@code _inlined} and {@code _noinline} helpers carry duplicate bodies on purpose: that's
  * the only way to pin each form's inlining decision independently.
@@ -107,12 +107,13 @@ public class StringIndexSwitchBenchmark {
   static final int[] IDS;
 
   static {
-    StringIndex.Data data = StringIndex.Support.create(KEYS);
+    StringIndex.Data data = StringIndex.EmbeddingSupport.create(KEYS);
     HASHES = data.hashes;
     NAMES = data.names;
     IDS = new int[HASHES.length];
     for (int i = 0; i < KEYS.length; ++i) {
-      IDS[StringIndex.Support.indexOf(HASHES, NAMES, KEYS[i])] = i + 1; // 1-based; 0 = not found
+      IDS[StringIndex.EmbeddingSupport.indexOf(HASHES, NAMES, KEYS[i])] =
+          i + 1; // 1-based; 0 = not found
     }
   }
 
@@ -224,13 +225,13 @@ public class StringIndexSwitchBenchmark {
 
   @CompilerControl(CompilerControl.Mode.INLINE)
   static int indexInline(String key) {
-    int slot = StringIndex.Support.indexOf(HASHES, NAMES, key);
+    int slot = StringIndex.EmbeddingSupport.indexOf(HASHES, NAMES, key);
     return slot >= 0 ? IDS[slot] : 0;
   }
 
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   static int indexNoInline(String key) {
-    int slot = StringIndex.Support.indexOf(HASHES, NAMES, key);
+    int slot = StringIndex.EmbeddingSupport.indexOf(HASHES, NAMES, key);
     return slot >= 0 ? IDS[slot] : 0;
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -11,11 +11,13 @@ import java.util.function.ToLongFunction;
  * <p>Two ways to use it, trading convenience for indirection:
  *
  * <ul>
- *   <li>{@link Support} — static algorithm over <b>raw arrays</b>. Keep the arrays in your own
- *       (ideally {@code static final}) fields and the JIT folds the refs to constants. The fastest
- *       path; nothing to dereference.
+ *   <li>{@link EmbeddingSupport} — static algorithm over <b>raw arrays</b> you <b>embed</b> in your
+ *       own (ideally {@code static final}) fields; the JIT folds the refs to constants. The fastest
+ *       path, nothing to dereference. (Named for the same role as {@code
+ *       LightMap.EmbeddingSupport}: the static ops you reach for when you own the backing arrays
+ *       directly.)
  *   <li>The {@code StringIndex} <b>instance</b> ({@link #of}) — a convenience wrapper holding the
- *       arrays; {@link #indexOf}/{@link #contains} delegate to {@link Support}. Costs an
+ *       arrays; {@link #indexOf}/{@link #contains} delegate to {@link EmbeddingSupport}. Costs an
  *       instance-field load per call (the indirection the static path removes) — fine off the hot
  *       path.
  * </ul>
@@ -25,18 +27,19 @@ import java.util.function.ToLongFunction;
  * mapIntValues}/{@code mapLongValues} build such an array at construction; {@code lookup}/{@code
  * lookupOrDefault} read one back in a single call (slot resolve + array read).
  *
- * <p>Slot 0-value is the empty sentinel: {@link Support#hash} never returns 0, so {@code hashes[i]
- * == 0} unambiguously means an empty slot.
+ * <p>Slot 0-value is the empty sentinel: {@link EmbeddingSupport#hash} never returns 0, so {@code
+ * hashes[i] == 0} unambiguously means an empty slot.
  *
- * <p>Trades memory for simplicity (and, incidentally, speed). The table is 2x-oversized (load
- * factor &le; 0.5) so build-time placement always finds a free slot and never has to rehash or
- * resize — short probe chains are a welcome side effect, not the design goal. The cached {@code
- * int[]} hashes gate {@code equals()}. Both cost memory, so a tightly-packed set is more compact:
- * prefer {@link java.util.Set#copyOf} (the JDK's {@code SetN}) when you only need membership, and
- * reach for {@code StringIndex} for the {@code indexOf}-&gt;parallel-array (name&rarr;id)
- * capability or the hot, allocation-free static {@link Support} path. (If footprint ever matters
- * more than build simplicity, a higher load factor with construction-time rehashing would close the
- * gap.)
+ * <p>Trades memory for simplicity (and, incidentally, speed). The table is 2x-oversized ({@link
+ * EmbeddingSupport#DEFAULT_LOAD_FACTOR} &le; 0.5) so build-time placement always finds a free slot
+ * and never has to rehash or resize — short probe chains are a welcome side effect, not the design
+ * goal. The cached {@code int[]} hashes gate {@code equals()}. Both cost memory, so a
+ * tightly-packed set is more compact: prefer {@link java.util.Set#copyOf} (the JDK's {@code SetN})
+ * when you only need membership, and reach for {@code StringIndex} for the {@code
+ * indexOf}-&gt;parallel-array (name&rarr;id) capability or the hot, allocation-free static {@link
+ * EmbeddingSupport} path. (If footprint matters more than build simplicity, build via {@link
+ * EmbeddingSupport#capacityFor(int, float)} at a higher load factor — placement still finds a slot
+ * at any factor &lt; 1, so no rehash is needed.)
  */
 public final class StringIndex {
   private final int[] hashes;
@@ -48,16 +51,19 @@ public final class StringIndex {
   }
 
   /**
-   * Convenience instance — wraps the placed arrays. For the hot path prefer raw {@link Support}.
+   * Convenience instance — wraps the placed arrays. For the hot path prefer raw {@link
+   * EmbeddingSupport}.
    */
   public static StringIndex of(String... names) {
-    Data data = Support.create(names);
+    Data data = EmbeddingSupport.create(names);
     return new StringIndex(data.hashes, data.names);
   }
 
-  /** Slot of {@code name}, or -1. Delegates to {@link Support} on the instance's arrays. */
+  /**
+   * Slot of {@code name}, or -1. Delegates to {@link EmbeddingSupport} on the instance's arrays.
+   */
   public int indexOf(String name) {
-    return Support.indexOf(this.hashes, this.names, name);
+    return EmbeddingSupport.indexOf(this.hashes, this.names, name);
   }
 
   public boolean contains(String name) {
@@ -77,49 +83,49 @@ public final class StringIndex {
    * can't allocate a generic array without it). Pair with {@link #lookup(Object[], String)}.
    */
   public <T> T[] mapValues(Class<T> type, Function<String, T> fn) {
-    return Support.mapValues(this.names, type, fn);
+    return EmbeddingSupport.mapValues(this.names, type, fn);
   }
 
   /** Slot-aligned {@code int[]} of values; absent slots stay 0. See {@link #mapValues}. */
   public int[] mapIntValues(ToIntFunction<String> fn) {
-    return Support.mapIntValues(this.names, fn);
+    return EmbeddingSupport.mapIntValues(this.names, fn);
   }
 
   /** Slot-aligned {@code long[]} of values; absent slots stay 0. See {@link #mapValues}. */
   public long[] mapLongValues(ToLongFunction<String> fn) {
-    return Support.mapLongValues(this.names, fn);
+    return EmbeddingSupport.mapLongValues(this.names, fn);
   }
 
   // --- lookup: resolve a key and read its parallel value in one call ---
 
   /** {@code data[indexOf(key)]}, or {@code null} when {@code key} is absent. */
   public <T> T lookup(T[] data, String key) {
-    return Support.lookup(this.hashes, this.names, data, key);
+    return EmbeddingSupport.lookup(this.hashes, this.names, data, key);
   }
 
   /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
   public <T> T lookupOrDefault(T[] data, String key, T defaultValue) {
-    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+    return EmbeddingSupport.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
   }
 
   /** {@code data[indexOf(key)]}, or 0 when {@code key} is absent. */
   public int lookup(int[] data, String key) {
-    return Support.lookup(this.hashes, this.names, data, key);
+    return EmbeddingSupport.lookup(this.hashes, this.names, data, key);
   }
 
   /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
   public int lookupOrDefault(int[] data, String key, int defaultValue) {
-    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+    return EmbeddingSupport.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
   }
 
   /** {@code data[indexOf(key)]}, or 0 when {@code key} is absent. */
   public long lookup(long[] data, String key) {
-    return Support.lookup(this.hashes, this.names, data, key);
+    return EmbeddingSupport.lookup(this.hashes, this.names, data, key);
   }
 
   /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
   public long lookupOrDefault(long[] data, String key, long defaultValue) {
-    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+    return EmbeddingSupport.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
   }
 
   /** Build-time carrier. Pull the fields into your own (static final) fields; don't keep this. */
@@ -136,8 +142,8 @@ public final class StringIndex {
   /**
    * Static algorithm over raw arrays. Query helpers take raw arrays, never a Data or a StringIndex.
    */
-  public static final class Support {
-    private Support() {}
+  public static final class EmbeddingSupport {
+    private EmbeddingSupport() {}
 
     /** Spread of String.hashCode; 0 reserved as the empty sentinel. */
     public static int hash(String name) {
@@ -145,18 +151,43 @@ public final class StringIndex {
       return h == 0 ? 0xDD06 : h ^ (h >>> 16);
     }
 
-    /** Power-of-two size, 2x-oversized so load factor stays &lt;= 0.5. */
-    public static int tableSizeFor(int n) {
-      int size = 1;
-      while (size <= n) {
-        size <<= 1;
+    /**
+     * Balanced default load factor — target fill {@code <= 0.5} ({@code >= 2x} capacity). (Mirrors
+     * {@code FlatHashtable.DEFAULT_LOAD_FACTOR}; duplicated while the two are separate PRs, to be
+     * unified when the flat-collection family converges.)
+     */
+    public static final float DEFAULT_LOAD_FACTOR = 0.5f;
+
+    /** Sparse load factor — target fill {@code <= 0.25} ({@code >= 4x} capacity). */
+    public static final float LOW_LOAD_FACTOR = 0.25f;
+
+    /** Power-of-two capacity for {@code n} names at the {@link #DEFAULT_LOAD_FACTOR}. */
+    public static int capacityFor(int n) {
+      return capacityFor(n, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Power-of-two capacity for {@code n} names at {@code loadFactor}: the smallest power of two
+     * {@code >= ceil(n / loadFactor)} (so the achieved fill is {@code <= loadFactor}). {@code n ==
+     * 0} yields a minimal 2-slot table (StringIndex allows the empty set, unlike FlatHashtable).
+     */
+    public static int capacityFor(int n, float loadFactor) {
+      if (n < 0) {
+        throw new IllegalArgumentException("n must be non-negative: " + n);
       }
-      return size << 1;
+      if (!(loadFactor > 0f && loadFactor < 1f)) {
+        throw new IllegalArgumentException("loadFactor must be in (0, 1): " + loadFactor);
+      }
+      if (n == 0) {
+        return 2; // empty set -> minimal table (one always-empty slot suffices, 2 keeps it pow2)
+      }
+      int min = (int) Math.ceil(n / (double) loadFactor);
+      return Integer.highestOneBit(min - 1) << 1;
     }
 
     /** Build the placed table. Returns a Data carrier; pull its arrays into your own fields. */
     public static Data create(String... names) {
-      int size = tableSizeFor(names.length);
+      int size = capacityFor(names.length);
       int[] hashes = new int[size];
       String[] placed = new String[size];
       for (String name : names) {

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -1,0 +1,293 @@
+package datadog.trace.util;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+
+/**
+ * Flat open-addressed name set. Generic — it knows only names.
+ *
+ * <p>Two ways to use it, trading convenience for indirection:
+ *
+ * <ul>
+ *   <li>{@link Support} — static algorithm over <b>raw arrays</b>. Keep the arrays in your own
+ *       (ideally {@code static final}) fields and the JIT folds the refs to constants. The fastest
+ *       path; nothing to dereference.
+ *   <li>The {@code StringIndex} <b>instance</b> ({@link #of}) — a convenience wrapper holding the
+ *       arrays; {@link #indexOf}/{@link #contains} delegate to {@link Support}. Costs an
+ *       instance-field load per call (the indirection the static path removes) — fine off the hot
+ *       path.
+ * </ul>
+ *
+ * <p>Consumers attach their own parallel payload arrays (ids, values, ...) sized to {@link
+ * #numSlots()} and indexed by the slot {@code indexOf} returns. {@code mapValues}/{@code
+ * mapIntValues}/{@code mapLongValues} build such an array at construction; {@code lookup}/{@code
+ * lookupOrDefault} read one back in a single call (slot resolve + array read).
+ *
+ * <p>Slot 0-value is the empty sentinel: {@link Support#hash} never returns 0, so {@code hashes[i]
+ * == 0} unambiguously means an empty slot.
+ *
+ * <p>Trades memory for simplicity (and, incidentally, speed). The table is 2x-oversized (load
+ * factor &le; 0.5) so build-time placement always finds a free slot and never has to rehash or
+ * resize — short probe chains are a welcome side effect, not the design goal. The cached {@code
+ * int[]} hashes gate {@code equals()}. Both cost memory, so a tightly-packed set is more compact:
+ * prefer {@link java.util.Set#copyOf} (the JDK's {@code SetN}) when you only need membership, and
+ * reach for {@code StringIndex} for the {@code indexOf}-&gt;parallel-array (name&rarr;id)
+ * capability or the hot, allocation-free static {@link Support} path. (If footprint ever matters
+ * more than build simplicity, a higher load factor with construction-time rehashing would close the
+ * gap.)
+ */
+public final class StringIndex {
+  private final int[] hashes;
+  private final String[] names;
+
+  private StringIndex(int[] hashes, String[] names) {
+    this.hashes = hashes;
+    this.names = names;
+  }
+
+  /**
+   * Convenience instance — wraps the placed arrays. For the hot path prefer raw {@link Support}.
+   */
+  public static StringIndex of(String... names) {
+    Data data = Support.create(names);
+    return new StringIndex(data.hashes, data.names);
+  }
+
+  /** Slot of {@code name}, or -1. Delegates to {@link Support} on the instance's arrays. */
+  public int indexOf(String name) {
+    return Support.indexOf(this.hashes, this.names, name);
+  }
+
+  public boolean contains(String name) {
+    return indexOf(name) >= 0;
+  }
+
+  /** Table size — allocate parallel payload arrays of this length. */
+  public int numSlots() {
+    return hashes.length;
+  }
+
+  // --- value mapping: build a slot-aligned parallel array (off the hot path) ---
+
+  /**
+   * Builds a slot-aligned {@code T[]} of values: {@code out[indexOf(name)] == fn.apply(name)} for
+   * every indexed name; other slots stay {@code null}. {@code type} is the array element type (Java
+   * can't allocate a generic array without it). Pair with {@link #lookup(Object[], String)}.
+   */
+  public <T> T[] mapValues(Class<T> type, Function<String, T> fn) {
+    return Support.mapValues(this.names, type, fn);
+  }
+
+  /** Slot-aligned {@code int[]} of values; absent slots stay 0. See {@link #mapValues}. */
+  public int[] mapIntValues(ToIntFunction<String> fn) {
+    return Support.mapIntValues(this.names, fn);
+  }
+
+  /** Slot-aligned {@code long[]} of values; absent slots stay 0. See {@link #mapValues}. */
+  public long[] mapLongValues(ToLongFunction<String> fn) {
+    return Support.mapLongValues(this.names, fn);
+  }
+
+  // --- lookup: resolve a key and read its parallel value in one call ---
+
+  /** {@code data[indexOf(key)]}, or {@code null} when {@code key} is absent. */
+  public <T> T lookup(T[] data, String key) {
+    return Support.lookup(this.hashes, this.names, data, key);
+  }
+
+  /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
+  public <T> T lookupOrDefault(T[] data, String key, T defaultValue) {
+    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+  }
+
+  /** {@code data[indexOf(key)]}, or 0 when {@code key} is absent. */
+  public int lookup(int[] data, String key) {
+    return Support.lookup(this.hashes, this.names, data, key);
+  }
+
+  /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
+  public int lookupOrDefault(int[] data, String key, int defaultValue) {
+    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+  }
+
+  /** {@code data[indexOf(key)]}, or 0 when {@code key} is absent. */
+  public long lookup(long[] data, String key) {
+    return Support.lookup(this.hashes, this.names, data, key);
+  }
+
+  /** {@code data[indexOf(key)]}, or {@code defaultValue} when {@code key} is absent. */
+  public long lookupOrDefault(long[] data, String key, long defaultValue) {
+    return Support.lookupOrDefault(this.hashes, this.names, data, key, defaultValue);
+  }
+
+  /** Build-time carrier. Pull the fields into your own (static final) fields; don't keep this. */
+  public static final class Data {
+    public final int[] hashes;
+    public final String[] names;
+
+    Data(int[] hashes, String[] names) {
+      this.hashes = hashes;
+      this.names = names;
+    }
+  }
+
+  /**
+   * Static algorithm over raw arrays. Query helpers take raw arrays, never a Data or a StringIndex.
+   */
+  public static final class Support {
+    private Support() {}
+
+    /** Spread of String.hashCode; 0 reserved as the empty sentinel. */
+    public static int hash(String name) {
+      int h = name.hashCode(); // cached on String -> field load
+      return h == 0 ? 0xDD06 : h ^ (h >>> 16);
+    }
+
+    /** Power-of-two size, 2x-oversized so load factor stays &lt;= 0.5. */
+    public static int tableSizeFor(int n) {
+      int size = 1;
+      while (size <= n) {
+        size <<= 1;
+      }
+      return size << 1;
+    }
+
+    /** Build the placed table. Returns a Data carrier; pull its arrays into your own fields. */
+    public static Data create(String... names) {
+      int size = tableSizeFor(names.length);
+      int[] hashes = new int[size];
+      String[] placed = new String[size];
+      for (String name : names) {
+        put(hashes, placed, name, hash(name));
+      }
+      return new Data(hashes, placed);
+    }
+
+    /**
+     * Slot-aligned {@code T[]} over placed {@code names}: {@code out[slot] = fn(name)} per name,
+     * {@code null} elsewhere. {@code type} is the array element type (generic-array allocation).
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] mapValues(String[] names, Class<T> type, Function<String, T> fn) {
+      T[] out = (T[]) Array.newInstance(type, names.length);
+      for (int slot = 0; slot < names.length; slot++) {
+        String name = names[slot];
+        if (name != null) {
+          out[slot] = fn.apply(name);
+        }
+      }
+      return out;
+    }
+
+    /**
+     * Slot-aligned {@code int[]} over placed {@code names}; {@code out[slot] = fn(name)}, 0 else.
+     */
+    public static int[] mapIntValues(String[] names, ToIntFunction<String> fn) {
+      int[] out = new int[names.length];
+      for (int slot = 0; slot < names.length; slot++) {
+        String name = names[slot];
+        if (name != null) {
+          out[slot] = fn.applyAsInt(name);
+        }
+      }
+      return out;
+    }
+
+    /**
+     * Slot-aligned {@code long[]} over placed {@code names}; {@code out[slot] = fn(name)}, 0 else.
+     */
+    public static long[] mapLongValues(String[] names, ToLongFunction<String> fn) {
+      long[] out = new long[names.length];
+      for (int slot = 0; slot < names.length; slot++) {
+        String name = names[slot];
+        if (name != null) {
+          out[slot] = fn.applyAsLong(name);
+        }
+      }
+      return out;
+    }
+
+    /** Build-time placement. Returns the slot. */
+    public static int put(int[] hashes, String[] names, String name, int h) {
+      final int mask = hashes.length - 1;
+      int i = h & mask;
+      for (int probes = 0; probes <= mask; probes++, i = (i + 1) & mask) {
+        if (hashes[i] == 0) {
+          hashes[i] = h;
+          names[i] = name;
+          return i;
+        }
+        if (hashes[i] == h && names[i].equals(name)) {
+          return i; // already present
+        }
+      }
+      throw new IllegalStateException("table full"); // impossible at LF <= 0.5
+    }
+
+    /** Probe; returns the slot or -1. Raw arrays — no Data, no instance. */
+    public static int indexOf(int[] hashes, String[] names, String name, int h) {
+      final int mask = hashes.length - 1;
+      int i = h & mask;
+      for (int probes = 0; probes <= mask; probes++, i = (i + 1) & mask) {
+        int sh = hashes[i];
+        if (sh == 0) {
+          return -1;
+        }
+        if (sh == h && names[i].equals(name)) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    public static int indexOf(int[] hashes, String[] names, String name) {
+      return indexOf(hashes, names, name, hash(name));
+    }
+
+    /** Number of slots — the length to size parallel payload arrays to. */
+    public static int numSlots(int[] hashes) {
+      return hashes.length;
+    }
+
+    /** {@code data[indexOf(...)]}, or {@code null} when {@code key} is absent. */
+    public static <T> T lookup(int[] hashes, String[] names, T[] data, String key) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : null;
+    }
+
+    /** {@code data[indexOf(...)]}, or {@code defaultValue} when {@code key} is absent. */
+    public static <T> T lookupOrDefault(
+        int[] hashes, String[] names, T[] data, String key, T defaultValue) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : defaultValue;
+    }
+
+    /** {@code data[indexOf(...)]}, or 0 when {@code key} is absent. */
+    public static int lookup(int[] hashes, String[] names, int[] data, String key) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : 0;
+    }
+
+    /** {@code data[indexOf(...)]}, or {@code defaultValue} when {@code key} is absent. */
+    public static int lookupOrDefault(
+        int[] hashes, String[] names, int[] data, String key, int defaultValue) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : defaultValue;
+    }
+
+    /** {@code data[indexOf(...)]}, or 0 when {@code key} is absent. */
+    public static long lookup(int[] hashes, String[] names, long[] data, String key) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : 0L;
+    }
+
+    /** {@code data[indexOf(...)]}, or {@code defaultValue} when {@code key} is absent. */
+    public static long lookupOrDefault(
+        int[] hashes, String[] names, long[] data, String key, long defaultValue) {
+      int slot = indexOf(hashes, names, key);
+      return slot >= 0 ? data[slot] : defaultValue;
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -326,6 +326,10 @@ public final class StringIndex {
       return -1;
     }
 
+    /**
+     * Probe; returns the slot or -1. Computes {@code name}'s hash for you — prefer this overload
+     * unless you already have the hash on hand (e.g. from probing another table with it).
+     */
     public static int indexOf(int[] hashes, String[] names, String name) {
       return indexOf(hashes, names, name, hash(name));
     }

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -302,7 +302,15 @@ public final class StringIndex {
       throw new IllegalStateException("table full"); // impossible at LF <= 0.5
     }
 
-    /** Probe; returns the slot or -1. Raw arrays — no Data, no instance. */
+    /**
+     * Probe; returns the slot or -1. Raw arrays — no Data, no instance.
+     *
+     * @param h {@code name}'s hash, precomputed by the caller (skips a recomputation when the
+     *     caller already has it, e.g. hashing once to probe several tables). Must be {@link
+     *     #hash(String)}'s exact output for {@code name} — a plain {@code name.hashCode()} (no
+     *     spread) or any other value silently degrades probing or masks a real match as a miss.
+     *     Prefer {@link #indexOf(int[], String[], String)} unless you already have the hash.
+     */
     public static int indexOf(int[] hashes, String[] names, String name, int h) {
       final int mask = hashes.length - 1;
       int i = h & mask;

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -148,6 +148,23 @@ public final class StringIndex {
 
   /**
    * Static algorithm over raw arrays. Query helpers take raw arrays, never a Data or a StringIndex.
+   *
+   * <pre>{@code
+   * private static final int[] METHOD_HASHES;
+   * private static final String[] METHOD_NAMES;
+   * private static final int[] METHOD_IDS;
+   *
+   * static {
+   *   Data data = EmbeddingSupport.create("GET", "POST", "PUT");
+   *   METHOD_HASHES = data.hashes;
+   *   METHOD_NAMES = data.names;
+   *   METHOD_IDS = EmbeddingSupport.mapIntValues(data.names, name -> nextMethodId());
+   * }
+   *
+   * ...
+   * int id = EmbeddingSupport.lookupOrDefault(
+   *     METHOD_HASHES, METHOD_NAMES, METHOD_IDS, incomingMethod, UNKNOWN_METHOD_ID);
+   * }</pre>
    */
   public static final class EmbeddingSupport {
     private EmbeddingSupport() {}

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -161,6 +161,9 @@ public final class StringIndex {
     /** Sparse load factor — target fill {@code <= 0.25} ({@code >= 4x} capacity). */
     public static final float LOW_LOAD_FACTOR = 0.25f;
 
+    /** Largest power-of-two capacity {@link #capacityFor} can return without overflowing. */
+    public static final int MAX_CAPACITY = 1 << 30;
+
     /** Power-of-two capacity for {@code n} names at the {@link #DEFAULT_LOAD_FACTOR}. */
     public static int capacityFor(int n) {
       return capacityFor(n, DEFAULT_LOAD_FACTOR);
@@ -170,6 +173,12 @@ public final class StringIndex {
      * Power-of-two capacity for {@code n} names at {@code loadFactor}: the smallest power of two
      * {@code >= ceil(n / loadFactor)} (so the achieved fill is {@code <= loadFactor}). {@code n ==
      * 0} yields a minimal 2-slot table (StringIndex allows the empty set, unlike FlatHashtable).
+     *
+     * @throws IllegalArgumentException if {@code n} is negative, {@code loadFactor} is not in
+     *     {@code (0, 1)}, or the required capacity exceeds {@link #MAX_CAPACITY} — computing {@code
+     *     ceil(n / loadFactor)} as a {@code double} first (rather than narrowing to {@code int}
+     *     before the check) means a huge result saturates the check instead of silently wrapping to
+     *     a negative array size.
      */
     public static int capacityFor(int n, float loadFactor) {
       if (n < 0) {
@@ -181,8 +190,18 @@ public final class StringIndex {
       if (n == 0) {
         return 2; // empty set -> minimal table (one always-empty slot suffices, 2 keeps it pow2)
       }
-      int min = (int) Math.ceil(n / (double) loadFactor);
-      return Integer.highestOneBit(min - 1) << 1;
+      double min = Math.ceil(n / (double) loadFactor);
+      if (min > MAX_CAPACITY) {
+        throw new IllegalArgumentException(
+            "capacity for n="
+                + n
+                + " at loadFactor="
+                + loadFactor
+                + " exceeds maximum capacity ("
+                + MAX_CAPACITY
+                + ")");
+      }
+      return Integer.highestOneBit((int) min - 1) << 1;
     }
 
     /** Build the placed table. Returns a Data carrier; pull its arrays into your own fields. */

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -283,8 +283,10 @@ public final class StringIndex {
       return out;
     }
 
-    /** Build-time placement. Returns the slot. */
-    public static int put(int[] hashes, String[] names, String name, int h) {
+    /**
+     * Build-time placement. Returns the slot. Package-private: only {@link #create} places names.
+     */
+    static int put(int[] hashes, String[] names, String name, int h) {
       final int mask = hashes.length - 1;
       int i = h & mask;
       for (int probes = 0; probes <= mask; probes++, i = (i + 1) & mask) {

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -27,6 +27,13 @@ import java.util.function.ToLongFunction;
  * mapIntValues}/{@code mapLongValues} build such an array at construction; {@code lookup}/{@code
  * lookupOrDefault} read one back in a single call (slot resolve + array read).
  *
+ * <pre>{@code
+ * StringIndex methods = StringIndex.of("GET", "POST", "PUT");
+ * int[] ids = methods.mapIntValues(name -> nextMethodId());
+ * ...
+ * int id = methods.lookupOrDefault(ids, incomingMethod, UNKNOWN_METHOD_ID);
+ * }</pre>
+ *
  * <p>Slot 0-value is the empty sentinel: {@link EmbeddingSupport#hash} never returns 0, so {@code
  * hashes[i] == 0} unambiguously means an empty slot.
  *

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexFootprintTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexFootprintTest.java
@@ -1,0 +1,88 @@
+package datadog.trace.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jol.info.GraphLayout;
+
+/**
+ * Retained-footprint comparison (JOL) for {@link StringIndex} vs the JDK set representations, over
+ * a fixed read-only string set. Footprint is deterministic, so this is safe to run under load
+ * (unlike the throughput benchmarks).
+ *
+ * <p>All structures hold the <i>same</i> String instances, so the shared strings cancel out and the
+ * differences reflect structural overhead. We report total retained bytes and the overhead above a
+ * plain {@code String[]} (which is just the strings + a reference array). {@code Set.copyOf} yields
+ * the JDK's compact {@code SetN} only on Java 10+ (it falls back to {@code HashSet} pre-10), so the
+ * copyOf row is only meaningful on a 10+ test JVM.
+ *
+ * <p>The one robust cross-JVM invariant we assert is that {@code StringIndex} is lighter than
+ * {@code HashSet} (no per-element {@code Node} objects). The {@code StringIndex} vs {@code SetN}
+ * comparison is left as reported data rather than an assertion: {@code StringIndex} caches an
+ * {@code int[]} of hashes that {@code SetN} does not, so which one wins on bytes is genuinely worth
+ * measuring.
+ *
+ * <p>Measured retained bytes (Java 17, JOL estimate mode — relative ordering reliable, exact bytes
+ * approximate):
+ *
+ * <pre>{@code
+ * n      array   hashSet  treeSet   copyOf  stringIndex
+ * 8        496      864      848      552      760
+ * 32      1936     3168     3152     2088     2872
+ * 128     7696    12384    12368     8232    11320
+ * }</pre>
+ *
+ * Finding: {@code StringIndex} is ~9% lighter than {@code HashSet}/{@code TreeSet} (no per-element
+ * {@code Node} objects), but {@code Set.copyOf} ({@code SetN}) is the most compact by a wide margin
+ * (~27% under {@code StringIndex} at n=128) — {@code StringIndex} pays for its cached {@code int[]}
+ * hashes and 2x-oversized {@code String[]}. So {@code StringIndex}'s edge over {@code SetN} is
+ * speed and the {@code indexOf}-&gt;parallel-array capability, not footprint.
+ */
+class StringIndexFootprintTest {
+
+  static String[] elements(int n) {
+    String[] a = new String[n];
+    for (int i = 0; i < n; ++i) {
+      a[i] = "element-key-" + i;
+    }
+    return a;
+  }
+
+  static long bytes(Object root) {
+    return GraphLayout.parseInstance(root).totalSize();
+  }
+
+  @Test
+  void footprintComparison() {
+    System.out.printf(
+        "%-6s %12s %12s %12s %12s %12s%n",
+        "n", "array", "hashSet", "treeSet", "copyOf", "stringIndex");
+    System.out.printf(
+        "%-6s %12s %12s %12s %12s %12s   (overhead above array)%n", "", "", "", "", "", "");
+
+    for (int n : new int[] {8, 32, 128}) {
+      String[] el = elements(n);
+
+      long array = bytes((Object) el); // baseline: strings + reference array
+      long hashSet = bytes(new HashSet<>(Arrays.asList(el)));
+      long treeSet = bytes(new TreeSet<>(Arrays.asList(el)));
+      Set<String> copy = CollectionUtils.tryMakeImmutableSet(Arrays.asList(el));
+      long copyOf = bytes(copy);
+      long stringIndex = bytes(StringIndex.of(el));
+
+      System.out.printf(
+          "%-6d %12d %12d %12d %12d %12d%n", n, array, hashSet, treeSet, copyOf, stringIndex);
+      System.out.printf(
+          "%-6s %12s %12d %12d %12d %12d%n",
+          "", "", hashSet - array, treeSet - array, copyOf - array, stringIndex - array);
+
+      // Robust cross-JVM invariant: no per-element Node objects -> lighter than HashSet.
+      assertTrue(
+          stringIndex < hashSet, "StringIndex should retain fewer bytes than HashSet at n=" + n);
+    }
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexFootprintTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexFootprintTest.java
@@ -1,11 +1,14 @@
 package datadog.trace.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import datadog.environment.JavaVirtualMachine;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jol.info.GraphLayout;
 
@@ -43,6 +46,14 @@ import org.openjdk.jol.info.GraphLayout;
  * speed and the {@code indexOf}-&gt;parallel-array capability, not footprint.
  */
 class StringIndexFootprintTest {
+
+  @BeforeAll
+  static void assumeNotJ9Jvm() {
+    // JOL's GraphLayout relies on HotSpot-specific Unsafe internals and throws
+    // IllegalStateException on J9-based JVMs (IBM/Semeru) — same guard as
+    // ScopeAndContinuationLayoutTest.
+    assumeFalse(JavaVirtualMachine.isJ9());
+  }
 
   static String[] elements(int n) {
     String[] a = new String[n];

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
@@ -1,0 +1,171 @@
+package datadog.trace.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.util.StringIndex.Data;
+import datadog.trace.util.StringIndex.Support;
+import org.junit.jupiter.api.Test;
+
+class StringIndexTest {
+
+  @Test
+  void hash_spread_and_zeroSentinel() {
+    // "".hashCode() == 0 -> remapped to the non-zero sentinel so 0 can mean "empty slot"
+    assertEquals(0xDD06, Support.hash(""));
+
+    int raw = "foo".hashCode();
+    assertEquals(raw ^ (raw >>> 16), Support.hash("foo"));
+    assertNotEquals(0, Support.hash("foo"));
+  }
+
+  @Test
+  void tableSizeFor_isPow2_andOversized() {
+    assertEquals(2, Support.tableSizeFor(0));
+    assertEquals(4, Support.tableSizeFor(1));
+    assertEquals(8, Support.tableSizeFor(3));
+    assertEquals(16, Support.tableSizeFor(4));
+  }
+
+  @Test
+  void instance_contains_internedAndCopy_andMiss() {
+    StringIndex set = StringIndex.of("foo", "bar", "baz");
+
+    assertEquals(8, set.numSlots()); // 3 names -> tableSizeFor(3) == 8
+
+    assertTrue(set.contains("foo")); // interned literal -> == fast path in eq
+    assertTrue(set.contains(new String("bar"))); // non-interned -> .equals path
+    assertFalse(set.contains("nope"));
+
+    assertTrue(set.indexOf("baz") >= 0);
+    assertEquals(-1, set.indexOf("nope"));
+  }
+
+  @Test
+  void support_create_then_indexOf() {
+    Data d = Support.create("x", "y");
+
+    int slot = Support.indexOf(d.hashes, d.names, "x"); // 3-arg overload computes the hash
+    assertTrue(slot >= 0);
+    assertEquals("x", d.names[slot]);
+
+    assertEquals(-1, Support.indexOf(d.hashes, d.names, "q"));
+  }
+
+  /** Controlled hashes force collision, linear-probe wraparound, and the already-present path. */
+  @Test
+  void put_and_indexOf_collisionAndWraparound() {
+    int[] hashes = new int[4]; // mask = 3
+    String[] names = new String[4];
+
+    assertEquals(3, Support.put(hashes, names, "a", 7)); // 7 & 3 == 3
+    assertEquals(0, Support.put(hashes, names, "b", 7)); // collides at 3, probes (3+1)&3 == 0
+    assertEquals(3, Support.put(hashes, names, "a", 7)); // already present -> existing slot
+
+    assertEquals(3, Support.indexOf(hashes, names, "a", 7)); // direct hit
+    assertEquals(0, Support.indexOf(hashes, names, "b", 7)); // hit after collision + wraparound
+    assertEquals(
+        -1, Support.indexOf(hashes, names, "c", 7)); // miss after probing 3 -> 0 -> 1(empty)
+    assertEquals(-1, Support.indexOf(hashes, names, "z", 6)); // 6 & 3 == 2, empty -> immediate miss
+  }
+
+  @Test
+  void put_throwsWhenFull() {
+    int[] hashes = new int[2]; // mask = 1
+    String[] names = new String[2];
+
+    Support.put(hashes, names, "a", 4); // 4 & 1 == 0
+    Support.put(hashes, names, "b", 5); // 5 & 1 == 1
+
+    // both slots occupied, no match -> probe exhausts -> throw
+    assertThrows(IllegalStateException.class, () -> Support.put(hashes, names, "c", 6));
+  }
+
+  /** The documented usage: build a StringIndex, attach a parallel payload indexed by slot. */
+  @Test
+  void parallelPayloadBySlot() {
+    String[] names = {"a", "b", "c"};
+    Data d = Support.create(names);
+
+    long[] ids = new long[d.names.length];
+    for (int j = 0; j < names.length; j++) {
+      ids[Support.indexOf(d.hashes, d.names, names[j])] = j + 1L;
+    }
+
+    assertEquals(1L, ids[Support.indexOf(d.hashes, d.names, "a")]);
+    assertEquals(2L, ids[Support.indexOf(d.hashes, d.names, "b")]);
+    assertEquals(3L, ids[Support.indexOf(d.hashes, d.names, "c")]);
+  }
+
+  @Test
+  void mapIntValues_slotAligned_andLookup() {
+    StringIndex idx = StringIndex.of("a", "b", "c");
+    // 1-based ids; 0 stays the empty-slot / not-found sentinel.
+    int[] ids = idx.mapIntValues(s -> s.charAt(0) - 'a' + 1);
+    assertEquals(idx.numSlots(), ids.length); // sized to the table, not the name count
+
+    assertEquals(1, idx.lookup(ids, "a"));
+    assertEquals(2, idx.lookup(ids, "b"));
+    assertEquals(3, idx.lookup(ids, "c"));
+    assertEquals(0, idx.lookup(ids, "z")); // miss -> 0
+    assertEquals(-1, idx.lookupOrDefault(ids, "z", -1)); // miss -> supplied default
+  }
+
+  @Test
+  void mapLongValues_slotAligned_andLookup() {
+    Data d = Support.create("a", "b", "c");
+    long[] vals = Support.mapLongValues(d.names, s -> s.charAt(0) - 'a' + 1L);
+
+    assertEquals(1L, Support.lookup(d.hashes, d.names, vals, "a"));
+    assertEquals(3L, Support.lookup(d.hashes, d.names, vals, "c"));
+    assertEquals(0L, Support.lookup(d.hashes, d.names, vals, "z")); // miss -> 0
+    assertEquals(-1L, Support.lookupOrDefault(d.hashes, d.names, vals, "z", -1L));
+  }
+
+  @Test
+  void mapValues_objects_typedArray_andLookup() {
+    StringIndex idx = StringIndex.of("a", "bb", "ccc");
+    Integer[] lengths = idx.mapValues(Integer.class, String::length);
+
+    // Class<T> drives a real Integer[], not an Object[].
+    assertEquals(Integer[].class, lengths.getClass());
+
+    assertEquals(Integer.valueOf(1), idx.lookup(lengths, "a"));
+    assertEquals(Integer.valueOf(3), idx.lookup(lengths, "ccc"));
+    assertNull(idx.lookup(lengths, "z")); // miss -> null
+    assertEquals(Integer.valueOf(-1), idx.lookupOrDefault(lengths, "z", -1));
+  }
+
+  @Test
+  void support_mapValues_objects_sizedToSlots_emptyStayNull() {
+    Data d = Support.create("a", "b", "c");
+    String[] tagged = Support.mapValues(d.names, String.class, s -> s + "!");
+
+    assertEquals(d.names.length, tagged.length); // sized to the table
+    int nonNull = 0;
+    for (String s : tagged) {
+      if (s != null) {
+        nonNull++;
+      }
+    }
+    assertEquals(3, nonNull); // only the placed names map; unfilled slots stay null
+
+    assertEquals("a!", Support.lookup(d.hashes, d.names, tagged, "a"));
+    assertEquals("dflt", Support.lookupOrDefault(d.hashes, d.names, tagged, "z", "dflt"));
+  }
+
+  @Test
+  void instance_lookup_delegatesToSupportArrays() {
+    StringIndex idx = StringIndex.of("x", "y");
+    int[] ids = idx.mapIntValues(s -> "x".equals(s) ? 7 : 9);
+
+    assertEquals(7, idx.lookup(ids, "x"));
+    assertEquals(9, idx.lookup(ids, "y"));
+    assertEquals(0, idx.lookup(ids, "missing"));
+    assertEquals(42, idx.lookupOrDefault(ids, "missing", 42));
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
@@ -168,4 +168,23 @@ class StringIndexTest {
     assertEquals(0, idx.lookup(ids, "missing"));
     assertEquals(42, idx.lookupOrDefault(ids, "missing", 42));
   }
+
+  @Test
+  void instance_longValues_mapAndLookup() {
+    StringIndex idx = StringIndex.of("a", "b", "c");
+    long[] vals = idx.mapLongValues(s -> s.charAt(0) - 'a' + 1L);
+    assertEquals(idx.numSlots(), vals.length); // sized to the table, not the name count
+
+    assertEquals(1L, idx.lookup(vals, "a"));
+    assertEquals(3L, idx.lookup(vals, "c"));
+    assertEquals(0L, idx.lookup(vals, "z")); // miss -> 0
+    assertEquals(2L, idx.lookupOrDefault(vals, "b", -1L)); // hit
+    assertEquals(-1L, idx.lookupOrDefault(vals, "z", -1L)); // miss -> supplied default
+  }
+
+  @Test
+  void support_numSlots_matchesTableSize() {
+    Data d = Support.create("a", "b", "c");
+    assertEquals(d.hashes.length, Support.numSlots(d.hashes));
+  }
 }

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.util.StringIndex.Data;
-import datadog.trace.util.StringIndex.Support;
+import datadog.trace.util.StringIndex.EmbeddingSupport;
 import org.junit.jupiter.api.Test;
 
 class StringIndexTest {
@@ -16,26 +16,34 @@ class StringIndexTest {
   @Test
   void hash_spread_and_zeroSentinel() {
     // "".hashCode() == 0 -> remapped to the non-zero sentinel so 0 can mean "empty slot"
-    assertEquals(0xDD06, Support.hash(""));
+    assertEquals(0xDD06, EmbeddingSupport.hash(""));
 
     int raw = "foo".hashCode();
-    assertEquals(raw ^ (raw >>> 16), Support.hash("foo"));
-    assertNotEquals(0, Support.hash("foo"));
+    assertEquals(raw ^ (raw >>> 16), EmbeddingSupport.hash("foo"));
+    assertNotEquals(0, EmbeddingSupport.hash("foo"));
   }
 
   @Test
-  void tableSizeFor_isPow2_andOversized() {
-    assertEquals(2, Support.tableSizeFor(0));
-    assertEquals(4, Support.tableSizeFor(1));
-    assertEquals(8, Support.tableSizeFor(3));
-    assertEquals(16, Support.tableSizeFor(4));
+  void capacityFor_isPow2_andAtLeastDoubled() {
+    assertEquals(2, EmbeddingSupport.capacityFor(0)); // empty set -> minimal table
+    assertEquals(2, EmbeddingSupport.capacityFor(1)); // >= 2x, smallest power of two
+    assertEquals(8, EmbeddingSupport.capacityFor(3)); // ceil(3/0.5)=6 -> 8
+    assertEquals(8, EmbeddingSupport.capacityFor(4)); // ceil(4/0.5)=8 -> 8 (was 16: tightened)
+    assertEquals(64, EmbeddingSupport.capacityFor(16, EmbeddingSupport.LOW_LOAD_FACTOR)); // 4x
+  }
+
+  @Test
+  void capacityFor_rejectsBadArgs() {
+    assertThrows(IllegalArgumentException.class, () -> EmbeddingSupport.capacityFor(-1));
+    assertThrows(IllegalArgumentException.class, () -> EmbeddingSupport.capacityFor(4, 0f));
+    assertThrows(IllegalArgumentException.class, () -> EmbeddingSupport.capacityFor(4, 1f));
   }
 
   @Test
   void instance_contains_internedAndCopy_andMiss() {
     StringIndex set = StringIndex.of("foo", "bar", "baz");
 
-    assertEquals(8, set.numSlots()); // 3 names -> tableSizeFor(3) == 8
+    assertEquals(8, set.numSlots()); // 3 names -> capacityFor(3) == 8
 
     assertTrue(set.contains("foo")); // interned literal -> == fast path in eq
     assertTrue(set.contains(new String("bar"))); // non-interned -> .equals path
@@ -47,13 +55,13 @@ class StringIndexTest {
 
   @Test
   void support_create_then_indexOf() {
-    Data d = Support.create("x", "y");
+    Data d = EmbeddingSupport.create("x", "y");
 
-    int slot = Support.indexOf(d.hashes, d.names, "x"); // 3-arg overload computes the hash
+    int slot = EmbeddingSupport.indexOf(d.hashes, d.names, "x"); // 3-arg overload computes the hash
     assertTrue(slot >= 0);
     assertEquals("x", d.names[slot]);
 
-    assertEquals(-1, Support.indexOf(d.hashes, d.names, "q"));
+    assertEquals(-1, EmbeddingSupport.indexOf(d.hashes, d.names, "q"));
   }
 
   /** Controlled hashes force collision, linear-probe wraparound, and the already-present path. */
@@ -62,15 +70,20 @@ class StringIndexTest {
     int[] hashes = new int[4]; // mask = 3
     String[] names = new String[4];
 
-    assertEquals(3, Support.put(hashes, names, "a", 7)); // 7 & 3 == 3
-    assertEquals(0, Support.put(hashes, names, "b", 7)); // collides at 3, probes (3+1)&3 == 0
-    assertEquals(3, Support.put(hashes, names, "a", 7)); // already present -> existing slot
-
-    assertEquals(3, Support.indexOf(hashes, names, "a", 7)); // direct hit
-    assertEquals(0, Support.indexOf(hashes, names, "b", 7)); // hit after collision + wraparound
+    assertEquals(3, EmbeddingSupport.put(hashes, names, "a", 7)); // 7 & 3 == 3
     assertEquals(
-        -1, Support.indexOf(hashes, names, "c", 7)); // miss after probing 3 -> 0 -> 1(empty)
-    assertEquals(-1, Support.indexOf(hashes, names, "z", 6)); // 6 & 3 == 2, empty -> immediate miss
+        0, EmbeddingSupport.put(hashes, names, "b", 7)); // collides at 3, probes (3+1)&3 == 0
+    assertEquals(
+        3, EmbeddingSupport.put(hashes, names, "a", 7)); // already present -> existing slot
+
+    assertEquals(3, EmbeddingSupport.indexOf(hashes, names, "a", 7)); // direct hit
+    assertEquals(
+        0, EmbeddingSupport.indexOf(hashes, names, "b", 7)); // hit after collision + wraparound
+    assertEquals(
+        -1,
+        EmbeddingSupport.indexOf(hashes, names, "c", 7)); // miss after probing 3 -> 0 -> 1(empty)
+    assertEquals(
+        -1, EmbeddingSupport.indexOf(hashes, names, "z", 6)); // 6 & 3 == 2, empty -> immediate miss
   }
 
   @Test
@@ -78,27 +91,27 @@ class StringIndexTest {
     int[] hashes = new int[2]; // mask = 1
     String[] names = new String[2];
 
-    Support.put(hashes, names, "a", 4); // 4 & 1 == 0
-    Support.put(hashes, names, "b", 5); // 5 & 1 == 1
+    EmbeddingSupport.put(hashes, names, "a", 4); // 4 & 1 == 0
+    EmbeddingSupport.put(hashes, names, "b", 5); // 5 & 1 == 1
 
     // both slots occupied, no match -> probe exhausts -> throw
-    assertThrows(IllegalStateException.class, () -> Support.put(hashes, names, "c", 6));
+    assertThrows(IllegalStateException.class, () -> EmbeddingSupport.put(hashes, names, "c", 6));
   }
 
   /** The documented usage: build a StringIndex, attach a parallel payload indexed by slot. */
   @Test
   void parallelPayloadBySlot() {
     String[] names = {"a", "b", "c"};
-    Data d = Support.create(names);
+    Data d = EmbeddingSupport.create(names);
 
     long[] ids = new long[d.names.length];
     for (int j = 0; j < names.length; j++) {
-      ids[Support.indexOf(d.hashes, d.names, names[j])] = j + 1L;
+      ids[EmbeddingSupport.indexOf(d.hashes, d.names, names[j])] = j + 1L;
     }
 
-    assertEquals(1L, ids[Support.indexOf(d.hashes, d.names, "a")]);
-    assertEquals(2L, ids[Support.indexOf(d.hashes, d.names, "b")]);
-    assertEquals(3L, ids[Support.indexOf(d.hashes, d.names, "c")]);
+    assertEquals(1L, ids[EmbeddingSupport.indexOf(d.hashes, d.names, "a")]);
+    assertEquals(2L, ids[EmbeddingSupport.indexOf(d.hashes, d.names, "b")]);
+    assertEquals(3L, ids[EmbeddingSupport.indexOf(d.hashes, d.names, "c")]);
   }
 
   @Test
@@ -117,13 +130,13 @@ class StringIndexTest {
 
   @Test
   void mapLongValues_slotAligned_andLookup() {
-    Data d = Support.create("a", "b", "c");
-    long[] vals = Support.mapLongValues(d.names, s -> s.charAt(0) - 'a' + 1L);
+    Data d = EmbeddingSupport.create("a", "b", "c");
+    long[] vals = EmbeddingSupport.mapLongValues(d.names, s -> s.charAt(0) - 'a' + 1L);
 
-    assertEquals(1L, Support.lookup(d.hashes, d.names, vals, "a"));
-    assertEquals(3L, Support.lookup(d.hashes, d.names, vals, "c"));
-    assertEquals(0L, Support.lookup(d.hashes, d.names, vals, "z")); // miss -> 0
-    assertEquals(-1L, Support.lookupOrDefault(d.hashes, d.names, vals, "z", -1L));
+    assertEquals(1L, EmbeddingSupport.lookup(d.hashes, d.names, vals, "a"));
+    assertEquals(3L, EmbeddingSupport.lookup(d.hashes, d.names, vals, "c"));
+    assertEquals(0L, EmbeddingSupport.lookup(d.hashes, d.names, vals, "z")); // miss -> 0
+    assertEquals(-1L, EmbeddingSupport.lookupOrDefault(d.hashes, d.names, vals, "z", -1L));
   }
 
   @Test
@@ -142,8 +155,8 @@ class StringIndexTest {
 
   @Test
   void support_mapValues_objects_sizedToSlots_emptyStayNull() {
-    Data d = Support.create("a", "b", "c");
-    String[] tagged = Support.mapValues(d.names, String.class, s -> s + "!");
+    Data d = EmbeddingSupport.create("a", "b", "c");
+    String[] tagged = EmbeddingSupport.mapValues(d.names, String.class, s -> s + "!");
 
     assertEquals(d.names.length, tagged.length); // sized to the table
     int nonNull = 0;
@@ -154,8 +167,8 @@ class StringIndexTest {
     }
     assertEquals(3, nonNull); // only the placed names map; unfilled slots stay null
 
-    assertEquals("a!", Support.lookup(d.hashes, d.names, tagged, "a"));
-    assertEquals("dflt", Support.lookupOrDefault(d.hashes, d.names, tagged, "z", "dflt"));
+    assertEquals("a!", EmbeddingSupport.lookup(d.hashes, d.names, tagged, "a"));
+    assertEquals("dflt", EmbeddingSupport.lookupOrDefault(d.hashes, d.names, tagged, "z", "dflt"));
   }
 
   @Test
@@ -184,7 +197,7 @@ class StringIndexTest {
 
   @Test
   void support_numSlots_matchesTableSize() {
-    Data d = Support.create("a", "b", "c");
-    assertEquals(d.hashes.length, Support.numSlots(d.hashes));
+    Data d = EmbeddingSupport.create("a", "b", "c");
+    assertEquals(d.hashes.length, EmbeddingSupport.numSlots(d.hashes));
   }
 }

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
@@ -40,6 +40,23 @@ class StringIndexTest {
   }
 
   @Test
+  void capacityFor_boundsAtMaxCapacity() {
+    // ceil(n / loadFactor) landing exactly on MAX_CAPACITY still succeeds.
+    int n = EmbeddingSupport.MAX_CAPACITY / 2; // ceil(n / 0.5) == MAX_CAPACITY
+    assertEquals(EmbeddingSupport.MAX_CAPACITY, EmbeddingSupport.capacityFor(n));
+  }
+
+  @Test
+  void capacityFor_rejectsCapacityAboveMax() {
+    // Required capacity exceeds MAX_CAPACITY: previously the double->int narrowing conversion
+    // saturated at Integer.MAX_VALUE and the subsequent << 1 wrapped to a negative array size.
+    assertThrows(IllegalArgumentException.class, () -> EmbeddingSupport.capacityFor(1, 1e-10f));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> EmbeddingSupport.capacityFor(EmbeddingSupport.MAX_CAPACITY + 1));
+  }
+
+  @Test
   void instance_contains_internedAndCopy_andMiss() {
     StringIndex set = StringIndex.of("foo", "bar", "baz");
 


### PR DESCRIPTION
## What Does This Do

Adds `StringIndex` an open-indexed immutable hash set -- that can also work in conjunction with a separate data array as an immutable map.

In terms of ops/sec, `StringIndex` performs on par or better than `HashSet` and `HashMap` while consuming less memory.
In terms of ops/sec `StringIndex` out performs `Set.of` but consumes more memory.

`StringIndex` excels in situations where map values are primitive types or multiple map values are needed for the same keys.

## Motivation

Data structure that can be reused throughout dd-trace-java that helps reduce tracer overhead - throughput impact and memory footprint

## Additional Notes

`StringIndex` (`datadog.trace.util`, alongside the custom `Hashtable`) — a flat, allocation-free, **open-addressed string set / index**:
- **`EmbeddingSupport`** — the static algorithm over raw `int[] hashes` / `String[] names`. Held in `static final` fields the refs fold to constants (the hot path).
- **`Data`** — a build-time carrier `{int[] hashes, String[] names}` (pull into your own fields).
- an instance wrapper for convenience (`of`/`contains`/`indexOf`).

2×-oversized (load factor ≤ 0.5), linear probe + wraparound, hash gates `equals`, interned `==` fast path, `0` = empty sentinel. **Generic** — no payload baked in; it just knows names. The headline capability is `indexOf`, which assigns each known string a stable dense slot; consumers attach a parallel array (e.g. `long[] ids`) indexed by that slot. Membership (`contains`) falls out as `indexOf >= 0`.

(Renamed from `TagSet` — the structure is more general than tags; a fixed name→id / membership index is just one of its uses.)

The static tier is named `EmbeddingSupport` and the sizing helper `capacityFor`, matching the rest of the flat-collections family (`LightMap`, `Hashtable`) so the "static functions over a caller-owned array/spine" tier is named identically across all of them.

## Benchmarks

The motivating use is a fast, *declared* name→id table — a "pit of success" alternative to hand-rolled string `switch`es and per-name caches — but the structure is general. Benchmarks (Apple M1, JDK 17, `@Fork(5)`, `@Threads(8)`; M ops/s):
- **`ImmutableSetBenchmark`** (membership, hit): static `EmbeddingSupport` **2320** ≳ `HashSet` 2198 > instance `StringIndex` 2098 > `Set.copyOf`/`SetN` 1914, and ~2.5–3.5× the `array`/`sortedArray`/`treeSet` forms. The folded `EmbeddingSupport` path is the fastest membership structure (~6% over `HashSet`); the instance wrapper costs ~10% (a field load), landing near `HashSet`.
- **`ImmutableMapBenchmark`** (name→value `get`): static `EmbeddingSupport` **1498** (interned key **2081**) > instance 1363 > `HashMap` 1216 > `Map.copyOf`/`MapN` 1049 — StringIndex-as-map is the fastest `get`, and a parallel `long[]`/`int[]` avoids the boxing a `HashMap<String, Long>` pays.
- **`StringIndexSwitchBenchmark`** (name→id vs a hand-written string `switch`): on a runtime, varied key — the realistic regime — StringIndex is **~1.85×** the switch (2147 vs 1161) and flat across inline/key-shape; the switch only matches it when the key is a compile-time constant (the JIT const-folds the switch away), which production keys never are.

Footprint (`StringIndexFootprintTest`, JOL): ~9% lighter than `HashSet` (no per-element `Node`s) but ~27% heavier than `Set.copyOf`/`SetN` (it carries the cached `int[]` hashes + a 2×-oversized table) — so vs the JDK compact immutables the edge is speed + the `indexOf`→parallel-array capability, not footprint.

`StringIndexTest` covers hashing/zero-sentinel, probe + wraparound, table-full, and the parallel-payload usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

