### PR TITLE
Avoid unnecessary Context allocations when (re)adding same values

### DIFF
--- a/components/context/src/main/java/datadog/context/IndexedContext.java
+++ b/components/context/src/main/java/datadog/context/IndexedContext.java
@@ -28,6 +28,9 @@ final class IndexedContext implements SelfScopedContext {
   public <T> Context with(ContextKey<T> key, @Nullable T value) {
     requireNonNull(key, "Context key cannot be null");
     int index = key.index;
+    if (index < this.store.length && this.store[index] == value) {
+      return this;
+    }
     Object[] newStore = copyOfRange(this.store, 0, max(this.store.length, index + 1));
     newStore[index] = value;
     return new IndexedContext(newStore);

--- a/components/context/src/main/java/datadog/context/SingletonContext.java
+++ b/components/context/src/main/java/datadog/context/SingletonContext.java
@@ -29,9 +29,13 @@ final class SingletonContext implements SelfScopedContext {
     requireNonNull(secondKey, "Context key cannot be null");
     int secondIndex = secondKey.index;
     if (this.index == secondIndex) {
-      return secondValue == null
-          ? EmptyContext.INSTANCE
-          : new SingletonContext(this.index, secondValue);
+      if (secondValue == null) {
+        return EmptyContext.INSTANCE;
+      } else if (secondValue != this.value) {
+        return new SingletonContext(this.index, secondValue);
+      } else {
+        return this;
+      }
     } else {
       Object[] store = new Object[max(this.index, secondIndex) + 1];
       store[this.index] = this.value;

--- a/components/context/src/test/java/datadog/context/ContextTest.java
+++ b/components/context/src/test/java/datadog/context/ContextTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -165,6 +166,17 @@ class ContextTest {
     assertTrue(
         debugString.contains(context.getClass().getSimpleName()),
         "Context string representation should contain implementation name");
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextImplementations")
+  void testWithSameValueReturnsThis(Context context) {
+    String value = "value";
+    Context context1 = context.with(STRING_KEY, value);
+    // storing the same value again should return the same instance
+    assertSame(context1, context1.with(STRING_KEY, value));
+    // storing a different value should return a new instance
+    assertNotEquals(context1, context1.with(STRING_KEY, "other"));
   }
 
   @SuppressWarnings({"SimplifiableAssertion"})


### PR DESCRIPTION
# Motivation

Avoid unnecessary allocations when adding the same key-value to an existing IndexedContext/SingletonContext

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
