### PR TITLE
Fix new instrumentation lock files leaking into core dependency update PR.

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -74,8 +74,13 @@ jobs:
         run: |
           mkdir -p /tmp/instrumentation-lockfiles
           find dd-smoke-tests dd-java-agent/instrumentation -name 'gradle.lockfile' -exec cp --parents {} /tmp/instrumentation-lockfiles/ \;
-          # Restore instrumentation dirs to original state (keep only core changes)
+          # Restore instrumentation dirs to original state (keep only core changes).
+          # git restore only reverts tracked files; brand-new lock files are untracked
+          # and would otherwise leak into the core PR, so delete the untracked ones too.
           git restore -- 'dd-smoke-tests/' 'dd-java-agent/instrumentation/'
+          git ls-files --others --exclude-standard -- \
+            'dd-smoke-tests/*gradle.lockfile' 'dd-java-agent/instrumentation/*gradle.lockfile' \
+            | xargs -r rm -f
 
       # ==================== Core modules PR ====================
       - name: Check if core changes exist


### PR DESCRIPTION

# What Does This Do
Fixes the `update-gradle-dependencies` workflow so a newly generated instrumentation `gradle.lockfile` no longer leaks into the **core** PR.

# Motivation
Correct PRs.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
