### PR TITLE
Improve crash report message when signal is absent

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/HotspotCrashLogParser.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/HotspotCrashLogParser.java
@@ -550,9 +550,12 @@ public final class HotspotCrashLogParser {
     if (oomMessage != null) {
       kind = "OutOfMemory";
       message = oomMessage;
-    } else {
-      kind = sigInfo != null && sigInfo.name != null ? sigInfo.name : "UNKNOWN";
+    } else if (sigInfo != null && sigInfo.name != null) {
+      kind = sigInfo.name;
       message = "Process terminated by signal " + kind;
+    } else {
+      kind = "InternalError";
+      message = "Process terminated by Internal error";
     }
 
     final List<StackFrame> enrichedFrames = new ArrayList<>(frames.size());

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/J9JavacoreParser.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/parsers/J9JavacoreParser.java
@@ -257,8 +257,8 @@ public final class J9JavacoreParser {
               : eventType.toUpperCase(Locale.ROOT);
       message = "Process terminated by signal " + kind;
     } else {
-      kind = "UNKNOWN";
-      message = "Unknown crash event";
+      kind = "InternalError";
+      message = "Process terminated by Internal error";
     }
 
     // Enrich frames with build IDs (best effort)

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/parsers/HotspotCrashLogParserTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/parsers/HotspotCrashLogParserTest.java
@@ -49,6 +49,8 @@ public class HotspotCrashLogParserTest {
     assertNotNull(crashLog.error.stack);
     assertNotNull(crashLog.error.stack.frames);
     assertEquals(0, crashLog.error.stack.frames.length);
+    assertEquals("InternalError", crashLog.error.kind);
+    assertEquals("Process terminated by Internal error", crashLog.error.message);
   }
 
   /** macOS aarch64 uses lowercase register names: x0-x28, fp, lr, sp, pc, cpsr */
@@ -333,6 +335,25 @@ public class HotspotCrashLogParserTest {
     assertEquals(
         "null".equals(expected) ? null : expected,
         HotspotCrashLogParser.parseCurrentThreadName(line));
+  }
+
+  @Test
+  public void testNoSignalProducesInternalError() throws Exception {
+    // A crash log that reaches the PROCESS section but has no siginfo line
+    String crashLog =
+        "# A fatal error has been detected by the Java Runtime Environment:\n"
+            + "#\n"
+            + "# Core dump will be written.\n"
+            + "---------------  T H R E A D  ---------------\n"
+            + "Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)\n"
+            + "---------------  P R O C E S S  ---------------\n";
+
+    CrashLog result = new HotspotCrashLogParser().parse(UUID.randomUUID().toString(), crashLog);
+
+    assertNotNull(result);
+    assertFalse(result.incomplete);
+    assertEquals("InternalError", result.error.kind);
+    assertEquals("Process terminated by Internal error", result.error.message);
   }
 
   private String readFileAsString(String resource) throws IOException {

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/parsers/J9JavacoreParserTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/parsers/J9JavacoreParserTest.java
@@ -212,6 +212,24 @@ public class J9JavacoreParserTest {
         "Expected ISO-8601 format, got: " + crashLog.timestamp);
   }
 
+  @Test
+  public void testNoSignalProducesInternalError() throws Exception {
+    // A javacore with a THREADS section but no 1TISIGINFO line
+    String javacoreContent =
+        "0SECTION       TITLE subcomponent dump routine\n"
+            + "NULL           ===============================\n"
+            + "1TICHARSET     UTF-8\n"
+            + "NULL           ------------------------------------------------------------------------\n"
+            + "0SECTION       THREADS subcomponent dump routine\n"
+            + "NULL           =================================\n";
+
+    CrashLog result = new J9JavacoreParser().parse(UUID.randomUUID().toString(), javacoreContent);
+
+    assertNotNull(result);
+    assertEquals("InternalError", result.error.kind);
+    assertEquals("Process terminated by Internal error", result.error.message);
+  }
+
   private String readFileAsString(String resource) throws IOException {
     try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resource)) {
       return new BufferedReader(


### PR DESCRIPTION
# What Does This Do

This PR improves the message provided by crashtracking when the termination signal is not known.

Instead of printing:
* Hotspot: `Process terminated by signal UNKNOWN`
* J9: `Unknown crash event"

Is not harmonising this case by surfacing: `Process terminated by Internal error` (given Internal Error what usually appearing in the hotspot hs_err)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
