### PR TITLE
Revert "Ignore capturing connection continuation for armeria (#11657)"

### DIFF
--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcStreamingTest.groovy
@@ -42,6 +42,11 @@ abstract class ArmeriaGrpcStreamingTest extends VersionedNamingTestBase {
   }
 
   @Override
+  boolean useStrictTraceWrites() {
+    false
+  }
+
+  @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.trace.grpc.ignored.inbound.methods", "example.Greeter/IgnoreInbound")

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/test/groovy/ArmeriaGrpcTest.groovy
@@ -87,6 +87,11 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
     injectSysConfig(GRPC_SERVER_ERROR_STATUSES, "2-14", true)
   }
 
+  @Override
+  boolean useStrictTraceWrites() {
+    false
+  }
+
   def setupSpec() {
     ig = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC)
   }

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -93,9 +93,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "jdk.internal.net.http.HttpClientImpl",
       LETTUCE_HANDSHAKE_HANDLER,
       "io.netty.util.concurrent.GlobalEventExecutor",
-      "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor",
-      "com.linecorp.armeria.client.HttpClientFactory",
-      "com.linecorp.armeria.client.HttpChannelPool"
+      "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor"
     };
   }
 
@@ -201,14 +199,6 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
     transformer.applyAdvice(
         named("channelRegistered").and(isDeclaredBy(named(LETTUCE_HANDSHAKE_HANDLER))), advice);
-    // armeria runs its own codec/pipeline, so the active request span captured during connection
-    // pool creation and channel connect will have no consumers.
-    transformer.applyAdvice(
-        named("pool").and(isDeclaredBy(named("com.linecorp.armeria.client.HttpClientFactory"))),
-        advice);
-    transformer.applyAdvice(
-        named("connect").and(isDeclaredBy(named("com.linecorp.armeria.client.HttpChannelPool"))),
-        advice);
   }
 
   public static class DisableAsyncAdvice {


### PR DESCRIPTION
# What Does This Do

Reverts #11657 (`0e13e90dac`).

# Motivation

`0e13e90dac` was bisected as the first commit that introduces a SIGSEGV / JVM-shutdown hang in test suites running with the profiler enabled (DataDog/profiling-backend CI). The failure is reproduced at ~17% per run.

**Reproducer** (linux/glibc, JDK 26-zulu, `CI_JOB_NAME` set):
```
DD_TRACE_JAVA_PATH=<agent.jar> ./gradlew --parallel --rerun-tasks \
    :prof-analyzer:test :prof-tester:test :prof-viz-java:test
```

**Bisect trail** (each commit built from source, tested 8 iterations except where noted):

| Commit | Date | Result |
|---|---|---|
| `v1.63.0` | Jun 1 | ✅ |
| `ee9a8df466` | Jun 5 | ✅ 8/8 |
| `dd22dbf41c` | Jun 12 | ✅ 8/8 |
| `82ced127ea` | Jun 16 | ✅ 8/8 |
| `553bc3edc2` | Jun 17 | ✅ 8/8 |
| `477a0ce839` | Jun 19 09:03 | ✅ **24/24** (8 + 16 retest) |
| `3ac2bc4a97` | Jun 19 | ✅ 8/8 (codenarc-only, skip) |
| **`0e13e90dac`** | **Jun 19 09:31** | **❌ 1/8 crash** |
| `139a1ba3c7` (HEAD) | Jun 19 | ❌ 1/6 crash |

**Note on mechanism**: the profiling-backend test suite does not use Armeria, so the new class matchers (`HttpClientFactory`, `HttpChannelPool`) and method-level advice will never match at runtime. The crash is therefore not caused by the Armeria instrumentation logic itself. The likely explanation is that registering two additional `transformer.applyAdvice()` calls changes agent initialisation timing or thread startup order enough to trigger an existing shutdown race in `libjavaProfiler.so`'s thread-exit cleanup path (the native profiler has had a series of shutdown-time race fixes in recent weeks). The revert removes the trigger; a proper fix for the underlying native race is being tracked separately.

# Additional Notes

DataDog/profiling-backend CI is temporarily protected by pinning `dd-java-agent` to Maven release `1.61.1` (DataDog/profiling-backend#8634) while this is resolved.

Jira ticket: [PROF-XXXX]
