### PR TITLE
Cleanup of Spotbugs annotations. Removed Spotbugs from test scope.

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   implementation(libs.asm.tree)
   implementation(libs.javaparser.symbol.solver)
 
+  testCompileOnly(libs.jsr305)
   testImplementation(libs.bytebuddy)
   testImplementation(libs.bundles.junit5)
   testRuntimeOnly(libs.junit.platform.launcher)

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -25,7 +25,7 @@ apply {
 }
 
 dependencies {
-  compileOnly("com.google.code.findbugs", "jsr305", "3.0.2")
+  compileOnly(libs.jsr305)
 
   implementation("org.freemarker", "freemarker", "2.3.30")
   implementation(libs.asm)
@@ -37,7 +37,6 @@ dependencies {
   testRuntimeOnly(libs.junit.platform.launcher)
   testImplementation(libs.bundles.mockito)
   testImplementation("javax.servlet", "javax.servlet-api", "3.0.1")
-  testImplementation(libs.spotbugs.annotations)
 }
 
 sourceSets {

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/AsmSpecificationBuilderTest.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/AsmSpecificationBuilderTest.java
@@ -15,7 +15,6 @@ import datadog.trace.plugin.csi.impl.CallSiteSpecification.AllArgsSpecification;
 import datadog.trace.plugin.csi.impl.CallSiteSpecification.AroundSpecification;
 import datadog.trace.plugin.csi.impl.CallSiteSpecification.BeforeSpecification;
 import datadog.trace.plugin.csi.util.Types;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -558,7 +557,6 @@ class AsmSpecificationBuilderTest extends BaseCsiPluginTest {
     @CallSite.Around("java.lang.StringBuilder java.lang.StringBuilder.append(java.lang.Object)")
     @CallSite.Around("java.lang.StringBuffer java.lang.StringBuffer.append(java.lang.Object)")
     @Nonnull
-    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     static Appendable aroundAppend(
         @CallSite.This @Nullable Appendable self, @CallSite.Argument(0) @Nullable Object param)
         throws Throwable {

--- a/communication/src/main/java/datadog/communication/util/IOUtils.java
+++ b/communication/src/main/java/datadog/communication/util/IOUtils.java
@@ -1,6 +1,5 @@
 package datadog.communication.util;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,6 +15,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public abstract class IOUtils {
 
@@ -23,11 +23,11 @@ public abstract class IOUtils {
 
   private IOUtils() {}
 
-  public static @NonNull String readFully(InputStream input) throws IOException {
+  public static @Nonnull String readFully(InputStream input) throws IOException {
     return readFully(input, Charset.defaultCharset());
   }
 
-  public static @NonNull String readFully(InputStream input, Charset charset) throws IOException {
+  public static @Nonnull String readFully(InputStream input, Charset charset) throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     readFully(input, output);
     return new String(output.toByteArray(), charset);
@@ -41,17 +41,17 @@ public abstract class IOUtils {
     }
   }
 
-  public static @NonNull List<String> readLines(final InputStream input) throws IOException {
+  public static @Nonnull List<String> readLines(final InputStream input) throws IOException {
     return readLines(input, Charset.defaultCharset());
   }
 
-  public static @NonNull List<String> readLines(final InputStream input, final Charset charset)
+  public static @Nonnull List<String> readLines(final InputStream input, final Charset charset)
       throws IOException {
     final InputStreamReader reader = new InputStreamReader(input, charset);
     return readLines(reader);
   }
 
-  public static @NonNull List<String> readLines(final Reader input) throws IOException {
+  public static @Nonnull List<String> readLines(final Reader input) throws IOException {
     final BufferedReader reader = new BufferedReader(input, DEFAULT_BUFFER_SIZE);
     final List<String> list = new ArrayList<>();
     String line = reader.readLine();

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/SampleJavaClass.java
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/SampleJavaClass.java
@@ -1,13 +1,10 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * Used by {@link BaseDecoratorTest}. Groovy with Java 10+ doesn't seem to treat it properly as an
  * anonymous class, so use a Java class instead.
  */
 public class SampleJavaClass {
-  @SuppressFBWarnings("DM_NEW_FOR_GETCLASS")
   public static Class anonymousClass =
       new Runnable() {
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDiffParser.java
@@ -1,7 +1,6 @@
 package datadog.trace.civisibility.git.tree;
 
 import datadog.trace.civisibility.diff.LineDiff;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 
 public class GitDiffParser {
 
@@ -20,7 +20,7 @@ public class GitDiffParser {
   private static final Pattern CHANGED_LINES_PATTERN =
       Pattern.compile("^@@ -\\d+(,\\d+)? \\+(?<startline>\\d+)(,(?<count>\\d+))? @@");
 
-  public static @NonNull LineDiff parse(InputStream input) throws IOException {
+  public static @Nonnull LineDiff parse(InputStream input) throws IOException {
     Map<String, BitSet> linesByRelativePath = new HashMap<>();
 
     BufferedReader bufferedReader =

--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
@@ -29,8 +29,8 @@ import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.AgentThreadFactory;
 import datadog.trace.util.PidHelper;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.*;
+import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -130,7 +130,7 @@ public final class CrashUploader {
   }
 
   CrashUploader(
-      @NonNull final Config config, @Nonnull final ConfigManager.StoredConfig storedConfig) {
+      @Nonnull final Config config, @Nonnull final ConfigManager.StoredConfig storedConfig) {
     this.config = config;
     this.storedConfig = storedConfig;
     this.uploaderSettings = storedConfig.toCrashUploaderSettings();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
@@ -9,8 +9,8 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import datadog.trace.bootstrap.debugger.el.DebuggerScript;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /** Implements expression language for probe condition */
 public final class ProbeCondition implements DebuggerScript<Boolean> {
@@ -48,7 +48,7 @@ public final class ProbeCondition implements DebuggerScript<Boolean> {
     }
 
     @Override
-    public void toJson(@NonNull JsonWriter jsonWriter, ProbeCondition value) throws IOException {
+    public void toJson(@Nonnull JsonWriter jsonWriter, ProbeCondition value) throws IOException {
       if (value == null) {
         jsonWriter.nullValue();
         return;

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpanEvent.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpanEvent.java
@@ -2,7 +2,6 @@ package datadog.opentelemetry.shim.trace;
 
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -12,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 public class OtelSpanEvent {
   public static final String EXCEPTION_SPAN_EVENT_NAME = "exception";
@@ -43,7 +43,7 @@ public class OtelSpanEvent {
     this.timestamp = unit.toNanos(timestamp);
   }
 
-  @NonNull
+  @Nonnull
   public static String toTag(List<OtelSpanEvent> events) {
     StringBuilder builder = new StringBuilder("[");
     for (OtelSpanEvent event : events) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/TaintableEnumeration.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/TaintableEnumeration.java
@@ -3,8 +3,8 @@ package datadog.trace.agent.tooling.iast;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.util.stacktrace.StackUtils;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Enumeration;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class TaintableEnumeration implements Enumeration<String> {
@@ -25,8 +25,8 @@ public class TaintableEnumeration implements Enumeration<String> {
 
   private TaintableEnumeration(
       final IastContext ctx,
-      @NonNull final Enumeration<String> delegate,
-      @NonNull final PropagationModule module,
+      @Nonnull final Enumeration<String> delegate,
+      @Nonnull final PropagationModule module,
       final byte origin,
       @Nullable final CharSequence name,
       final boolean useValueAsName) {
@@ -78,8 +78,8 @@ public class TaintableEnumeration implements Enumeration<String> {
 
   public static Enumeration<String> wrap(
       final IastContext ctx,
-      @NonNull final Enumeration<String> delegate,
-      @NonNull final PropagationModule module,
+      @Nonnull final Enumeration<String> delegate,
+      @Nonnull final PropagationModule module,
       final byte origin,
       @Nullable final CharSequence name) {
     return new TaintableEnumeration(ctx, delegate, module, origin, name, false);
@@ -87,8 +87,8 @@ public class TaintableEnumeration implements Enumeration<String> {
 
   public static Enumeration<String> wrap(
       final IastContext ctx,
-      @NonNull final Enumeration<String> delegate,
-      @NonNull final PropagationModule module,
+      @Nonnull final Enumeration<String> delegate,
+      @Nonnull final PropagationModule module,
       final byte origin,
       boolean useValueAsName) {
     return new TaintableEnumeration(ctx, delegate, module, origin, null, useValueAsName);

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/TracingSession.java
@@ -21,12 +21,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.util.AgentThreadFactory;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class TracingSession extends SessionWrapper implements CqlSession {
   private static final ExecutorService EXECUTOR_SERVICE =

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/build.gradle
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/build.gradle
@@ -17,8 +17,6 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: otelVersion
-
-  compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
   compileOnly group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.6.6'
 
   testImplementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: otelVersion

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
@@ -40,8 +40,8 @@ import com.datadog.debugger.probe.Where;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.bootstrap.debugger.el.DebuggerScript;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public class MoshiConfigTestHelper {
 
   private static class ProbeConditionJsonAdapter extends ProbeCondition.ProbeConditionJsonAdapter {
     @Override
-    public void toJson(@NonNull JsonWriter jsonWriter, ProbeCondition value) throws IOException {
+    public void toJson(@Nonnull JsonWriter jsonWriter, ProbeCondition value) throws IOException {
       if (value == null) {
         jsonWriter.nullValue();
         return;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
@@ -10,11 +10,11 @@ import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.intake.TrackType;
 import datadog.trace.common.writer.Payload;
 import datadog.trace.common.writer.RemoteApi;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -36,7 +36,7 @@ public class DDEvpProxyApi extends RemoteApi {
 
   public static class DDEvpProxyApiBuilder {
     private String apiVersion = DEFAULT_INTAKE_VERSION;
-    @NonNull private TrackType trackType = TrackType.NOOP;
+    @Nonnull private TrackType trackType = TrackType.NOOP;
     private long timeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_INTAKE_TIMEOUT);
 
     HttpUrl agentUrl = null;
@@ -44,7 +44,7 @@ public class DDEvpProxyApi extends RemoteApi {
     String evpProxyEndpoint;
     boolean compressionEnabled;
 
-    public DDEvpProxyApiBuilder trackType(@NonNull final TrackType trackType) {
+    public DDEvpProxyApiBuilder trackType(@Nonnull final TrackType trackType) {
       this.trackType = trackType;
       return this;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -32,7 +32,6 @@ import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.SpanWrapper;
 import datadog.trace.core.util.StackTraces;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
@@ -876,7 +875,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
   }
 
   @Override
-  public void attachWrapper(@NonNull SpanWrapper wrapper) {
+  public void attachWrapper(@Nonnull SpanWrapper wrapper) {
     WRAPPER_FIELD_UPDATER.compareAndSet(this, null, wrapper);
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 develocity = "4.4.1"
 forbiddenapis = "3.10"
 gradle-tooling-api = "8.14.5"
+jsr305 = "3.0.2"
 spotbugs_annotations = "4.9.8"
 
 # DataDog libs and forks
@@ -80,6 +81,7 @@ testcontainers = "1.21.4"
 develocity = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity" }
 forbiddenapis = { module = "de.thetaphi:forbiddenapis", version.ref = "forbiddenapis" }
 gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "gradle-tooling-api" }
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs_annotations" }
 
 # DataDog libs and forks

--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -60,15 +60,5 @@ tasks.matching { it.name.startsWith('spotbugs') }.configureEach {
 
 dependencies {
   compileOnly(libs.spotbugs.annotations)
-
-  testImplementation(libs.spotbugs.annotations) {
-    // Exclude conflicting JUnit5.
-    exclude group: 'org.junit'
-    exclude group: 'org.junit.jupiter'
-    exclude group: 'org.junit.platform'
-    // Exclude conflicting logback.
-    exclude group: 'ch.qos.logback'
-    // Exclude conflicting log4j.
-    exclude group: 'org.apache.logging.log4j'
-  }
+  testImplementation(libs.jsr305)
 }

--- a/telemetry/src/main/java/datadog/telemetry/metric/CiVisibilityMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/CiVisibilityMetricPeriodicAction.java
@@ -2,10 +2,10 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class CiVisibilityMetricPeriodicAction extends MetricPeriodicAction {
-  @NonNull
+  @Nonnull
   @Override
   public MetricCollector collector() {
     return InstrumentationBridge.getMetricCollector();

--- a/telemetry/src/main/java/datadog/telemetry/metric/ConfigInversionMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/ConfigInversionMetricPeriodicAction.java
@@ -2,11 +2,11 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.ConfigInversionMetricCollectorImpl;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class ConfigInversionMetricPeriodicAction extends MetricPeriodicAction {
   @Override
-  @NonNull
+  @Nonnull
   public MetricCollector collector() {
     return ConfigInversionMetricCollectorImpl.getInstance();
   }

--- a/telemetry/src/main/java/datadog/telemetry/metric/CoreMetricsPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/CoreMetricsPeriodicAction.java
@@ -2,10 +2,10 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.CoreMetricCollector;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class CoreMetricsPeriodicAction extends MetricPeriodicAction {
-  @NonNull
+  @Nonnull
   @Override
   public MetricCollector collector() {
     return CoreMetricCollector.getInstance();

--- a/telemetry/src/main/java/datadog/telemetry/metric/IastMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/IastMetricPeriodicAction.java
@@ -2,12 +2,12 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.iast.telemetry.IastMetricCollector;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class IastMetricPeriodicAction extends MetricPeriodicAction {
 
   @Override
-  @NonNull
+  @Nonnull
   public MetricCollector collector() {
     return IastMetricCollector.get();
   }

--- a/telemetry/src/main/java/datadog/telemetry/metric/LLMObsMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/LLMObsMetricPeriodicAction.java
@@ -2,10 +2,10 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.LLMObsMetricCollector;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class LLMObsMetricPeriodicAction extends MetricPeriodicAction {
-  @NonNull
+  @Nonnull
   @Override
   public MetricCollector collector() {
     return LLMObsMetricCollector.get();

--- a/telemetry/src/main/java/datadog/telemetry/metric/MetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/MetricPeriodicAction.java
@@ -5,11 +5,11 @@ import datadog.telemetry.TelemetryService;
 import datadog.telemetry.api.DistributionSeries;
 import datadog.telemetry.api.Metric;
 import datadog.trace.api.telemetry.MetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public abstract class MetricPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAction {
   @Override
@@ -23,7 +23,7 @@ public abstract class MetricPeriodicAction implements TelemetryRunnable.Telemetr
     toDistributionSeries(rawDistributionSeriesPoints).forEach(service::addDistributionSeries);
   }
 
-  @NonNull
+  @Nonnull
   public abstract MetricCollector<MetricCollector.Metric> collector();
 
   private Collection<Metric> toTelemetryMetrics(final Collection<MetricCollector.Metric> metrics) {

--- a/telemetry/src/main/java/datadog/telemetry/metric/OtelEnvMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/OtelEnvMetricPeriodicAction.java
@@ -2,11 +2,11 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.MetricCollector;
 import datadog.trace.api.telemetry.OtelEnvMetricCollectorImpl;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class OtelEnvMetricPeriodicAction extends MetricPeriodicAction {
   @Override
-  @NonNull
+  @Nonnull
   public MetricCollector collector() {
     return OtelEnvMetricCollectorImpl.getInstance();
   }

--- a/telemetry/src/main/java/datadog/telemetry/metric/OtelSpiMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/OtelSpiMetricPeriodicAction.java
@@ -2,11 +2,11 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.MetricCollector;
 import datadog.trace.api.telemetry.OtelSpiCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class OtelSpiMetricPeriodicAction extends MetricPeriodicAction {
   @Override
-  @NonNull
+  @Nonnull
   public MetricCollector collector() {
     return OtelSpiCollector.getInstance();
   }

--- a/telemetry/src/main/java/datadog/telemetry/metric/WafMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/WafMetricPeriodicAction.java
@@ -2,12 +2,12 @@ package datadog.telemetry.metric;
 
 import datadog.trace.api.telemetry.MetricCollector;
 import datadog.trace.api.telemetry.WafMetricCollector;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 public class WafMetricPeriodicAction extends MetricPeriodicAction {
 
   @Override
-  @NonNull
+  @Nonnull
   public MetricCollector collector() {
     return WafMetricCollector.get();
   }

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
@@ -5,9 +5,9 @@ import datadog.telemetry.TelemetryService
 import datadog.telemetry.api.DistributionSeries
 import datadog.telemetry.api.Metric
 import datadog.trace.api.telemetry.MetricCollector
-import edu.umd.cs.findbugs.annotations.NonNull
 import groovy.transform.NamedDelegate
 import groovy.transform.NamedVariant
+import javax.annotation.Nonnull
 import spock.lang.Specification
 
 class MetricPeriodicActionTest extends Specification {
@@ -159,12 +159,12 @@ class MetricPeriodicActionTest extends Specification {
 
     private final MetricCollector<MetricCollector.Metric> collector
 
-    DefaultMetricPeriodicAction(@NonNull final MetricCollector<MetricCollector.Metric> collector) {
+    DefaultMetricPeriodicAction(@Nonnull final MetricCollector<MetricCollector.Metric> collector) {
       this.collector = collector
     }
 
     @Override
-    @NonNull
+    @Nonnull
     MetricCollector<MetricCollector.Metric> collector() {
       return collector
     }

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfigExtension.java
@@ -2,7 +2,6 @@ package datadog.trace.junit.utils.config;
 
 import datadog.environment.EnvironmentVariables;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -11,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -267,7 +267,7 @@ public class WithConfigExtension
     }
 
     @Override
-    public String get(@NonNull String name) {
+    public String get(@Nonnull String name) {
       return env.get(name);
     }
 


### PR DESCRIPTION
# What Does This Do
1. Replaces usages of `edu.umd.cs.findbugs.annotations.*` annotations with the appropriate `javax.annotation.*` equivalents.
2. Removes SpotBugs dependencies from the test scope, where they are unnecessary and were primarily present because of the annotations mentioned above.

# Motivation
* `javax.annotation.*` annotations are more standard and widely adopted.
* Running SpotBugs in the test scope provides little to no value while introducing an unnecessary dependency.
* This change simplifies dependency management and reduces reliance on SpotBugs-specific annotations.

# Additional Notes
This is a cleanup/refactoring change only. No functional behavior is affected.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
