### PR TITLE
Add missing repositories to Update Gradle dependencies workflow

### DIFF
--- a/.github/scripts/dependency_age.py
+++ b/.github/scripts/dependency_age.py
@@ -551,6 +551,8 @@ def build_validation_summary(
         blocks.append(
             "### :warning: Cannot verify age, reverted\n\n"
             "The age of these dependencies could not be verified, so the lockfiles were reverted. "
+            "This likely means that the following dependencies are published to a repo not yet configured in the workflow. "
+            "If this is the case, add the missing repository as a `--repo-url` in the `Validate changed lock files` step of `.github/workflows/update-gradle-dependencies.yaml`. "
             "**This needs to be resolved manually.**\n\n"
             + "\n".join(sorted(unverified))
         )

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -68,6 +68,9 @@ jobs:
             --min-age-hours "${MIN_DEPENDENCY_AGE_HOURS}" \
             --repo-url "https://repo1.maven.org/maven2" \
             --repo-url "https://repo.akka.io/${AKKA_REPO_TOKEN}/secure" \
+            --repo-url "https://packages.confluent.io/maven" \
+            --repo-url "https://repository.mulesoft.org/releases" \
+            --repo-url "https://repository.mulesoft.org/nexus/content/repositories/public" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Save instrumentation lock files


### PR DESCRIPTION
# What Does This Do

Add missing repositories to check when verifying age of dependencies we need to upgrade. Also add a note for future reference if other dependencies are reported as unverifiable.

# Motivation

Previously, these dependency ages were reported as "unverifiable" and thus reverted, such as in: https://github.com/DataDog/dd-trace-java/pull/11687.

# Additional Notes

I tested the new URLs locally, but the overall workflow can be tested on `master` due to the trust policy ([example failure](https://github.com/DataDog/dd-trace-java/actions/runs/27971832841/job/82779707668)).

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
