### PR TITLE
Add SCA benchmark gitlab config

### DIFF
--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -50,6 +50,10 @@ linux-java-spring-petclinic-load-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_benchmark_rules
 
+linux-java-spring-petclinic-sca-load-parallel:
+  needs: ["publish-artifacts-to-s3"]
+  rules: *parallel_benchmark_rules
+
 linux-java-insecure-bank-startup-parallel:
   needs: ["publish-artifacts-to-s3"]
   rules: *parallel_startup_benchmark_rules


### PR DESCRIPTION
# What Does This Do

Add the same benchmark configurations to SCA benchmarks as we have for the other load benchmarks

# Motivation

SCA benchmarks would fail occasionally if run before the `publish-artifacts-to-s3` job completed. The load benchmark Gitlab configuration ensures that these benchmarks run after the `publish-artifacts-to-s3` job completed.

# Additional Notes

We can see that the Gitlab job dependencies are configured correctly now in the pipeline: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/120292368 (click "Show dependencies" to see the job dependency graph).

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
