### PR TITLE
Add server.request.body.files_content AppSec address support for Jetty

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1785,8 +1785,8 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     TEST_WRITER.get(0).any {
       span ->
       def tag = span.getTag('request.body.files_content') as String
-      tag?.contains("content_of_file_$maxFilesToInspect") &&
-      !tag.contains("content_of_file_${maxFilesToInspect + 1}")
+      // Exactly maxFilesToInspect files inspected; which file is excluded depends on iteration order
+      tag != null && tag.count('content_of_file_') == maxFilesToInspect
     }
 
     cleanup:

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/MultipartHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty11;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
@@ -49,7 +50,7 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
-        log.debug("extractFilenames: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
@@ -77,7 +78,7 @@ public class MultipartHelper {
         }
         contents.add(readFileContent(part));
       } catch (Exception ignored) {
-        log.debug("extractContents: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractContents: skipping malformed part", ignored);
       }
     }
     return contents;
@@ -87,7 +88,7 @@ public class MultipartHelper {
     try (InputStream is = part.getInputStream()) {
       return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
     } catch (Exception e) {
-      log.debug("readFileContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readFileContent: stream read failed", e);
       return "";
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/MultipartHelper.java
@@ -3,26 +3,36 @@ package datadog.trace.instrumentation.jetty11;
 import static datadog.trace.api.gateway.Events.EVENTS;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import jakarta.servlet.http.Part;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MultipartHelper {
+
+  public static final int MAX_CONTENT_BYTES = Config.get().getAppSecMaxFileContentBytes();
+  public static final int MAX_FILES_TO_INSPECT = Config.get().getAppSecMaxFileContentCount();
+
+  private static final Logger log = LoggerFactory.getLogger(MultipartHelper.class);
 
   private MultipartHelper() {}
 
   /**
    * Extracts non-null, non-empty filenames from a collection of multipart {@link Part}s using
-   * {@link Part#getSubmittedFileName()} (Servlet 5.0+, Jetty 11.x).
+   * {@link Part#getSubmittedFileName()} (Servlet 3.1+, Jetty 11.0.x).
    *
    * @return list of filenames; never {@code null}, may be empty
    */
@@ -39,9 +49,78 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
+        log.debug("extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
+  }
+
+  /**
+   * Extracts file content from a collection of multipart {@link Part}s. Form fields (those with a
+   * {@code null} submitted filename) are skipped. Reads up to {@link #MAX_CONTENT_BYTES} bytes per
+   * part, up to {@link #MAX_FILES_TO_INSPECT} parts total.
+   *
+   * @return list of decoded content strings; never {@code null}, may be empty
+   */
+  public static List<String> extractContents(Collection<Part> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> contents = new ArrayList<>(Math.min(parts.size(), MAX_FILES_TO_INSPECT));
+    for (Part part : parts) {
+      if (contents.size() >= MAX_FILES_TO_INSPECT) {
+        break;
+      }
+      try {
+        if (part.getSubmittedFileName() == null) {
+          continue; // form field — skip
+        }
+        contents.add(readFileContent(part));
+      } catch (Exception ignored) {
+        log.debug("extractContents: skipping malformed part", ignored);
+      }
+    }
+    return contents;
+  }
+
+  private static String readFileContent(Part part) {
+    try (InputStream is = part.getInputStream()) {
+      return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
+    } catch (Exception e) {
+      log.debug("readFileContent: stream read failed", e);
+      return "";
+    }
+  }
+
+  /**
+   * Fires the {@code requestFilesContent} IG event and returns a {@link BlockingException} if the
+   * WAF requests blocking, or {@code null} otherwise.
+   */
+  public static BlockingException fireFilesContentEvent(
+      Collection<Part> parts, RequestContext reqCtx) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (callback == null) {
+      return null;
+    }
+    List<String> contents = extractContents(parts);
+    if (contents.isEmpty()) {
+      return null;
+    }
+    Flow<Void> flow = callback.apply(reqCtx, contents);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
+          reqCtx.getTraceSegment().effectivelyBlocked();
+          return new BlockingException("Blocked request (multipart file content)");
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/main/java/datadog/trace/instrumentation/jetty11/RequestExtractContentParametersInstrumentation.java
@@ -162,6 +162,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 
@@ -188,6 +191,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/test/java/datadog/trace/instrumentation/jetty11/MultipartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-11.0/src/test/java/datadog/trace/instrumentation/jetty11/MultipartHelperTest.java
@@ -8,6 +8,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.Part;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -63,5 +68,80 @@ class MultipartHelperTest {
     Part p = mock(Part.class);
     when(p.getSubmittedFileName()).thenReturn(submittedFileName);
     return p;
+  }
+
+  // ── extractContents ─────────────────────────────────────────────────────────
+
+  @Test
+  void extractContentsReturnsEmptyListForNull() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(null));
+  }
+
+  @Test
+  void extractContentsReturnsEmptyListForEmpty() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(emptyList()));
+  }
+
+  @Test
+  void extractContentsSkipsFormFieldParts() {
+    List<Part> parts = asList(part(null), part(null));
+    assertEquals(emptyList(), MultipartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsIncludesFileWithEmptyFilename() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("data"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsReadsFileContent() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("photo.jpg");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("file-content".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("file-content"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsTruncatesAtMaxContentBytes() throws IOException {
+    byte[] large = new byte[MultipartHelper.MAX_CONTENT_BYTES + 1];
+    Arrays.fill(large, (byte) 'A');
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("big.bin");
+    when(p.getInputStream()).thenReturn(new ByteArrayInputStream(large));
+    when(p.getContentType()).thenReturn(null);
+    List<String> contents = MultipartHelper.extractContents(singletonList(p));
+    assertEquals(1, contents.size());
+    assertEquals(MultipartHelper.MAX_CONTENT_BYTES, contents.get(0).length());
+  }
+
+  @Test
+  void extractContentsReturnsEmptyStringOnIOException() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("file.txt");
+    when(p.getInputStream()).thenThrow(new IOException("simulated"));
+    assertEquals(singletonList(""), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsCappsAtMaxFilesToInspect() throws IOException {
+    int count = MultipartHelper.MAX_FILES_TO_INSPECT + 1;
+    List<Part> parts = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      Part p = mock(Part.class);
+      when(p.getSubmittedFileName()).thenReturn("file" + i + ".txt");
+      when(p.getInputStream())
+          .thenReturn(new ByteArrayInputStream("c".getBytes(StandardCharsets.UTF_8)));
+      when(p.getContentType()).thenReturn(null);
+      parts.add(p);
+    }
+    List<String> contents = MultipartHelper.extractContents(parts);
+    assertEquals(MultipartHelper.MAX_FILES_TO_INSPECT, contents.size());
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty8;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
@@ -104,7 +105,7 @@ public class PartHelper {
           filenames.add(filename);
         }
       } catch (Exception e) {
-        log.debug("extractFilenames: skipping malformed part", e);
+        log.debug(EXCLUDE_TELEMETRY, "extractFilenames: skipping malformed part", e);
       }
     }
     return filenames;
@@ -122,11 +123,10 @@ public class PartHelper {
     if (parts == null || parts.isEmpty()) {
       return Collections.emptyMap();
     }
-    int maxFields = Config.get().getAppSecMaxFileContentCount();
     Map<String, List<String>> result = new LinkedHashMap<>();
     int count = 0;
     for (Object obj : parts) {
-      if (count >= maxFields) {
+      if (count >= MAX_FILES_TO_INSPECT) {
         break;
       }
       try {
@@ -145,7 +145,7 @@ public class PartHelper {
         result.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
         count++;
       } catch (Exception e) {
-        log.debug("extractFormFields: skipping malformed part", e);
+        log.debug(EXCLUDE_TELEMETRY, "extractFormFields: skipping malformed part", e);
       }
     }
     return result;
@@ -295,7 +295,7 @@ public class PartHelper {
         }
         contents.add(readFileContent(part));
       } catch (Exception e) {
-        log.debug("extractContents: skipping malformed part", e);
+        log.debug(EXCLUDE_TELEMETRY, "extractContents: skipping malformed part", e);
       }
     }
     return contents;
@@ -305,7 +305,7 @@ public class PartHelper {
     try (InputStream is = part.getInputStream()) {
       return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
     } catch (Exception e) {
-      log.debug("readFileContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readFileContent: stream read failed", e);
       return "";
     }
   }
@@ -344,23 +344,22 @@ public class PartHelper {
   private static String readPartContent(Part part) {
     Charset charset = charsetFromContentType(part.getContentType());
     // Bound the buffered form-field text by the file-content byte cap. There is no dedicated
-    // "max form-field bytes" config, so we intentionally reuse getAppSecMaxFileContentBytes():
+    // "max form-field bytes" config, so we intentionally reuse MAX_CONTENT_BYTES:
     // this is the only framework that must manually buffer form-field text (Servlet 3.0 has no
     // container-side bound), and without a cap a single huge text field could exhaust the heap.
-    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
     try (InputStream is = part.getInputStream()) {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       byte[] buf = new byte[4096];
       int total = 0;
       int read;
-      while (total < maxBytes
-          && (read = is.read(buf, 0, Math.min(buf.length, maxBytes - total))) != -1) {
+      while (total < MAX_CONTENT_BYTES
+          && (read = is.read(buf, 0, Math.min(buf.length, MAX_CONTENT_BYTES - total))) != -1) {
         baos.write(buf, 0, read);
         total += read;
       }
       return new String(baos.toByteArray(), charset);
     } catch (IOException e) {
-      log.debug("readPartContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readPartContent: stream read failed", e);
       return null;
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
@@ -114,10 +114,9 @@ public class PartHelper {
   /**
    * Returns a name→values map of form-field parts (those without a {@code filename=} parameter).
    * File-upload parts are skipped to avoid reading potentially large content. Reads up to {@link
-   * Config#getAppSecMaxFileContentBytes()} bytes per field, up to {@link
-   * Config#getAppSecMaxFileContentCount()} fields total — same knobs and cap pattern as {@code
-   * MultipartHelper#extractContents()} uses for file content (PR #11706), reused here since there
-   * is no dedicated "max form fields" config.
+   * #MAX_CONTENT_BYTES} bytes per field, up to {@link #MAX_FILES_TO_INSPECT} fields total — same
+   * knobs and cap pattern as {@link #extractContents} uses for file content, reused here since
+   * there is no dedicated "max form fields" config.
    */
   public static Map<String, List<String>> extractFormFields(Collection<?> parts) {
     if (parts == null || parts.isEmpty()) {

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
@@ -9,6 +9,7 @@ import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,6 +39,9 @@ import org.slf4j.LoggerFactory;
 public class PartHelper {
 
   private static final Logger log = LoggerFactory.getLogger(PartHelper.class);
+
+  public static final int MAX_CONTENT_BYTES = Config.get().getAppSecMaxFileContentBytes();
+  public static final int MAX_FILES_TO_INSPECT = Config.get().getAppSecMaxFileContentCount();
 
   private PartHelper() {}
 
@@ -262,6 +266,75 @@ public class PartHelper {
         if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
           reqCtx.getTraceSegment().effectivelyBlocked();
           return new BlockingException("Blocked request (multipart file upload)");
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extracts file content from a collection of multipart {@link Part}s. Form fields (those without
+   * a {@code filename} parameter in the {@code Content-Disposition} header) are skipped. Reads up
+   * to {@link #MAX_CONTENT_BYTES} bytes per part, up to {@link #MAX_FILES_TO_INSPECT} parts total.
+   *
+   * @return list of decoded content strings; never {@code null}, may be empty
+   */
+  public static List<String> extractContents(Collection<?> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> contents = new ArrayList<>(Math.min(parts.size(), MAX_FILES_TO_INSPECT));
+    for (Object obj : parts) {
+      if (contents.size() >= MAX_FILES_TO_INSPECT) {
+        break;
+      }
+      try {
+        Part part = (Part) obj;
+        if (filenameFromPart(part) == null) {
+          continue; // form field — skip
+        }
+        contents.add(readFileContent(part));
+      } catch (Exception e) {
+        log.debug("extractContents: skipping malformed part", e);
+      }
+    }
+    return contents;
+  }
+
+  private static String readFileContent(Part part) {
+    try (InputStream is = part.getInputStream()) {
+      return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
+    } catch (Exception e) {
+      log.debug("readFileContent: stream read failed", e);
+      return "";
+    }
+  }
+
+  /**
+   * Fires the {@code requestFilesContent} IG event for file-upload parts in {@code parts} and
+   * returns a {@link BlockingException} if the WAF requests blocking, or {@code null} otherwise.
+   */
+  public static BlockingException fireFilesContentEvent(
+      Collection<?> parts, RequestContext reqCtx) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (callback == null) {
+      return null;
+    }
+    List<String> contents = extractContents(parts);
+    if (contents.isEmpty()) {
+      return null;
+    }
+    Flow<Void> flow = callback.apply(reqCtx, contents);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
+          reqCtx.getTraceSegment().effectivelyBlocked();
+          return new BlockingException("Blocked request (multipart file content)");
         }
       }
     }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
@@ -150,7 +150,9 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
       BlockingException bodyBlock = PartHelper.fireBodyProcessedEvent(parts, reqCtx);
       BlockingException filenamesBlock = PartHelper.fireFilenamesEvent(parts, reqCtx);
       BlockingException contentBlock =
-          filenamesBlock == null ? PartHelper.fireFilesContentEvent(parts, reqCtx) : null;
+          bodyBlock == null && filenamesBlock == null
+              ? PartHelper.fireFilesContentEvent(parts, reqCtx)
+              : null;
       t = bodyBlock != null ? bodyBlock : (filenamesBlock != null ? filenamesBlock : contentBlock);
     }
   }
@@ -195,7 +197,9 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
       BlockingException bodyBlock = PartHelper.fireBodyProcessedEvent(parts, reqCtx);
       BlockingException filenamesBlock = PartHelper.fireFilenamesEvent(parts, reqCtx);
       BlockingException contentBlock =
-          filenamesBlock == null ? PartHelper.fireFilesContentEvent(parts, reqCtx) : null;
+          bodyBlock == null && filenamesBlock == null
+              ? PartHelper.fireFilesContentEvent(parts, reqCtx)
+              : null;
       t = bodyBlock != null ? bodyBlock : (filenamesBlock != null ? filenamesBlock : contentBlock);
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
@@ -149,7 +149,9 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
       }
       BlockingException bodyBlock = PartHelper.fireBodyProcessedEvent(parts, reqCtx);
       BlockingException filenamesBlock = PartHelper.fireFilenamesEvent(parts, reqCtx);
-      t = bodyBlock != null ? bodyBlock : filenamesBlock;
+      BlockingException contentBlock =
+          filenamesBlock == null ? PartHelper.fireFilesContentEvent(parts, reqCtx) : null;
+      t = bodyBlock != null ? bodyBlock : (filenamesBlock != null ? filenamesBlock : contentBlock);
     }
   }
 
@@ -192,7 +194,9 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
       }
       BlockingException bodyBlock = PartHelper.fireBodyProcessedEvent(parts, reqCtx);
       BlockingException filenamesBlock = PartHelper.fireFilenamesEvent(parts, reqCtx);
-      t = bodyBlock != null ? bodyBlock : filenamesBlock;
+      BlockingException contentBlock =
+          filenamesBlock == null ? PartHelper.fireFilesContentEvent(parts, reqCtx) : null;
+      t = bodyBlock != null ? bodyBlock : (filenamesBlock != null ? filenamesBlock : contentBlock);
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
@@ -14,6 +14,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -262,6 +264,77 @@ class PartHelperTest {
     }
     Map<String, List<String>> result = PartHelper.extractFormFields(asList(parts));
     assertEquals(maxFields, result.size());
+  }
+
+  // ── extractContents ─────────────────────────────────────────────────────────
+
+  @Test
+  void extractContentsReturnsEmptyListForNull() {
+    assertEquals(emptyList(), PartHelper.extractContents(null));
+  }
+
+  @Test
+  void extractContentsReturnsEmptyListForEmpty() {
+    assertEquals(emptyList(), PartHelper.extractContents(emptyList()));
+  }
+
+  @Test
+  void extractContentsSkipsFormFieldParts() {
+    List<Part> parts = asList(formField("a"), formField("b"));
+    assertEquals(emptyList(), PartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsIncludesFileWithEmptyFilename() throws IOException {
+    List<Part> parts = singletonList(emptyFilenamePart("upload"));
+    Part p = parts.get(0);
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("data"), PartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsReadsFileContent() throws IOException {
+    Part p = filePart("photo.jpg");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("file-content".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("file-content"), PartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsTruncatesAtMaxContentBytes() throws IOException {
+    byte[] large = new byte[PartHelper.MAX_CONTENT_BYTES + 1];
+    Arrays.fill(large, (byte) 'A');
+    Part p = filePart("big.bin");
+    when(p.getInputStream()).thenReturn(new ByteArrayInputStream(large));
+    when(p.getContentType()).thenReturn(null);
+    List<String> contents = PartHelper.extractContents(singletonList(p));
+    assertEquals(1, contents.size());
+    assertEquals(PartHelper.MAX_CONTENT_BYTES, contents.get(0).length());
+  }
+
+  @Test
+  void extractContentsReturnsEmptyStringOnIOException() throws IOException {
+    Part p = filePart("file.txt");
+    when(p.getInputStream()).thenThrow(new IOException("simulated"));
+    assertEquals(singletonList(""), PartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsCappsAtMaxFilesToInspect() throws IOException {
+    int count = PartHelper.MAX_FILES_TO_INSPECT + 1;
+    List<Part> parts = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      Part p = filePart("file" + i + ".txt");
+      when(p.getInputStream())
+          .thenReturn(new ByteArrayInputStream("c".getBytes(StandardCharsets.UTF_8)));
+      when(p.getContentType()).thenReturn(null);
+      parts.add(p);
+    }
+    List<String> contents = PartHelper.extractContents(parts);
+    assertEquals(PartHelper.MAX_FILES_TO_INSPECT, contents.size());
   }
 
   // ── getAllParts ─────────────────────────────────────────────────────────────

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
@@ -3,26 +3,36 @@ package datadog.trace.instrumentation.jetty92;
 import static datadog.trace.api.gateway.Events.EVENTS;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import javax.servlet.http.Part;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MultipartHelper {
+
+  public static final int MAX_CONTENT_BYTES = Config.get().getAppSecMaxFileContentBytes();
+  public static final int MAX_FILES_TO_INSPECT = Config.get().getAppSecMaxFileContentCount();
+
+  private static final Logger log = LoggerFactory.getLogger(MultipartHelper.class);
 
   private MultipartHelper() {}
 
   /**
    * Extracts non-null, non-empty filenames from a collection of multipart {@link Part}s using
-   * {@link Part#getSubmittedFileName()} (Servlet 3.1+, Jetty 9.2.x).
+   * {@link Part#getSubmittedFileName()} (Servlet 3.1+, Jetty 9.3.x).
    *
    * @return list of filenames; never {@code null}, may be empty
    */
@@ -39,9 +49,78 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
+        log.debug("extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
+  }
+
+  /**
+   * Extracts file content from a collection of multipart {@link Part}s. Form fields (those with a
+   * {@code null} submitted filename) are skipped. Reads up to {@link #MAX_CONTENT_BYTES} bytes per
+   * part, up to {@link #MAX_FILES_TO_INSPECT} parts total.
+   *
+   * @return list of decoded content strings; never {@code null}, may be empty
+   */
+  public static List<String> extractContents(Collection<Part> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> contents = new ArrayList<>(Math.min(parts.size(), MAX_FILES_TO_INSPECT));
+    for (Part part : parts) {
+      if (contents.size() >= MAX_FILES_TO_INSPECT) {
+        break;
+      }
+      try {
+        if (part.getSubmittedFileName() == null) {
+          continue; // form field — skip
+        }
+        contents.add(readFileContent(part));
+      } catch (Exception ignored) {
+        log.debug("extractContents: skipping malformed part", ignored);
+      }
+    }
+    return contents;
+  }
+
+  private static String readFileContent(Part part) {
+    try (InputStream is = part.getInputStream()) {
+      return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
+    } catch (Exception e) {
+      log.debug("readFileContent: stream read failed", e);
+      return "";
+    }
+  }
+
+  /**
+   * Fires the {@code requestFilesContent} IG event and returns a {@link BlockingException} if the
+   * WAF requests blocking, or {@code null} otherwise.
+   */
+  public static BlockingException fireFilesContentEvent(
+      Collection<Part> parts, RequestContext reqCtx) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (callback == null) {
+      return null;
+    }
+    List<String> contents = extractContents(parts);
+    if (contents.isEmpty()) {
+      return null;
+    }
+    Flow<Void> flow = callback.apply(reqCtx, contents);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
+          reqCtx.getTraceSegment().effectivelyBlocked();
+          return new BlockingException("Blocked request (multipart file content)");
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
@@ -32,7 +32,7 @@ public class MultipartHelper {
 
   /**
    * Extracts non-null, non-empty filenames from a collection of multipart {@link Part}s using
-   * {@link Part#getSubmittedFileName()} (Servlet 3.1+, Jetty 9.3.x).
+   * {@link Part#getSubmittedFileName()} (Servlet 3.1+, Jetty 9.2.x).
    *
    * @return list of filenames; never {@code null}, may be empty
    */

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/MultipartHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty92;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
@@ -49,7 +50,7 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
-        log.debug("extractFilenames: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
@@ -77,7 +78,7 @@ public class MultipartHelper {
         }
         contents.add(readFileContent(part));
       } catch (Exception ignored) {
-        log.debug("extractContents: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractContents: skipping malformed part", ignored);
       }
     }
     return contents;
@@ -87,7 +88,7 @@ public class MultipartHelper {
     try (InputStream is = part.getInputStream()) {
       return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
     } catch (Exception e) {
-      log.debug("readFileContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readFileContent: stream read failed", e);
       return "";
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
@@ -181,6 +181,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 
@@ -209,6 +212,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/test/java/datadog/trace/instrumentation/jetty92/MultipartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.2/src/test/java/datadog/trace/instrumentation/jetty92/MultipartHelperTest.java
@@ -7,6 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
@@ -63,5 +68,80 @@ class MultipartHelperTest {
     Part p = mock(Part.class);
     when(p.getSubmittedFileName()).thenReturn(submittedFileName);
     return p;
+  }
+
+  // ── extractContents ─────────────────────────────────────────────────────────
+
+  @Test
+  void extractContentsReturnsEmptyListForNull() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(null));
+  }
+
+  @Test
+  void extractContentsReturnsEmptyListForEmpty() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(emptyList()));
+  }
+
+  @Test
+  void extractContentsSkipsFormFieldParts() {
+    List<Part> parts = asList(part(null), part(null));
+    assertEquals(emptyList(), MultipartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsIncludesFileWithEmptyFilename() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("data"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsReadsFileContent() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("photo.jpg");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("file-content".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("file-content"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsTruncatesAtMaxContentBytes() throws IOException {
+    byte[] large = new byte[MultipartHelper.MAX_CONTENT_BYTES + 1];
+    Arrays.fill(large, (byte) 'A');
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("big.bin");
+    when(p.getInputStream()).thenReturn(new ByteArrayInputStream(large));
+    when(p.getContentType()).thenReturn(null);
+    List<String> contents = MultipartHelper.extractContents(singletonList(p));
+    assertEquals(1, contents.size());
+    assertEquals(MultipartHelper.MAX_CONTENT_BYTES, contents.get(0).length());
+  }
+
+  @Test
+  void extractContentsReturnsEmptyStringOnIOException() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("file.txt");
+    when(p.getInputStream()).thenThrow(new IOException("simulated"));
+    assertEquals(singletonList(""), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsCappsAtMaxFilesToInspect() throws IOException {
+    int count = MultipartHelper.MAX_FILES_TO_INSPECT + 1;
+    List<Part> parts = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      Part p = mock(Part.class);
+      when(p.getSubmittedFileName()).thenReturn("file" + i + ".txt");
+      when(p.getInputStream())
+          .thenReturn(new ByteArrayInputStream("c".getBytes(StandardCharsets.UTF_8)));
+      when(p.getContentType()).thenReturn(null);
+      parts.add(p);
+    }
+    List<String> contents = MultipartHelper.extractContents(parts);
+    assertEquals(MultipartHelper.MAX_FILES_TO_INSPECT, contents.size());
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/MultipartHelper.java
@@ -3,20 +3,30 @@ package datadog.trace.instrumentation.jetty93;
 import static datadog.trace.api.gateway.Events.EVENTS;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import javax.servlet.http.Part;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MultipartHelper {
+
+  public static final int MAX_CONTENT_BYTES = Config.get().getAppSecMaxFileContentBytes();
+  public static final int MAX_FILES_TO_INSPECT = Config.get().getAppSecMaxFileContentCount();
+
+  private static final Logger log = LoggerFactory.getLogger(MultipartHelper.class);
 
   private MultipartHelper() {}
 
@@ -39,9 +49,78 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
+        log.debug("extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
+  }
+
+  /**
+   * Extracts file content from a collection of multipart {@link Part}s. Form fields (those with a
+   * {@code null} submitted filename) are skipped. Reads up to {@link #MAX_CONTENT_BYTES} bytes per
+   * part, up to {@link #MAX_FILES_TO_INSPECT} parts total.
+   *
+   * @return list of decoded content strings; never {@code null}, may be empty
+   */
+  public static List<String> extractContents(Collection<Part> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> contents = new ArrayList<>(Math.min(parts.size(), MAX_FILES_TO_INSPECT));
+    for (Part part : parts) {
+      if (contents.size() >= MAX_FILES_TO_INSPECT) {
+        break;
+      }
+      try {
+        if (part.getSubmittedFileName() == null) {
+          continue; // form field — skip
+        }
+        contents.add(readFileContent(part));
+      } catch (Exception ignored) {
+        log.debug("extractContents: skipping malformed part", ignored);
+      }
+    }
+    return contents;
+  }
+
+  private static String readFileContent(Part part) {
+    try (InputStream is = part.getInputStream()) {
+      return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
+    } catch (Exception e) {
+      log.debug("readFileContent: stream read failed", e);
+      return "";
+    }
+  }
+
+  /**
+   * Fires the {@code requestFilesContent} IG event and returns a {@link BlockingException} if the
+   * WAF requests blocking, or {@code null} otherwise.
+   */
+  public static BlockingException fireFilesContentEvent(
+      Collection<Part> parts, RequestContext reqCtx) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (callback == null) {
+      return null;
+    }
+    List<String> contents = extractContents(parts);
+    if (contents.isEmpty()) {
+      return null;
+    }
+    Flow<Void> flow = callback.apply(reqCtx, contents);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
+          reqCtx.getTraceSegment().effectivelyBlocked();
+          return new BlockingException("Blocked request (multipart file content)");
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/MultipartHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty93;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
@@ -49,7 +50,7 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
-        log.debug("extractFilenames: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
@@ -77,7 +78,7 @@ public class MultipartHelper {
         }
         contents.add(readFileContent(part));
       } catch (Exception ignored) {
-        log.debug("extractContents: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractContents: skipping malformed part", ignored);
       }
     }
     return contents;
@@ -87,7 +88,7 @@ public class MultipartHelper {
     try (InputStream is = part.getInputStream()) {
       return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
     } catch (Exception e) {
-      log.debug("readFileContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readFileContent: stream read failed", e);
       return "";
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
@@ -156,6 +156,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 
@@ -185,6 +188,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/test/java/datadog/trace/instrumentation/jetty93/MultipartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.3/src/test/java/datadog/trace/instrumentation/jetty93/MultipartHelperTest.java
@@ -7,6 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
@@ -63,5 +68,80 @@ class MultipartHelperTest {
     Part p = mock(Part.class);
     when(p.getSubmittedFileName()).thenReturn(submittedFileName);
     return p;
+  }
+
+  // ── extractContents ─────────────────────────────────────────────────────────
+
+  @Test
+  void extractContentsReturnsEmptyListForNull() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(null));
+  }
+
+  @Test
+  void extractContentsReturnsEmptyListForEmpty() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(emptyList()));
+  }
+
+  @Test
+  void extractContentsSkipsFormFieldParts() {
+    List<Part> parts = asList(part(null), part(null));
+    assertEquals(emptyList(), MultipartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsIncludesFileWithEmptyFilename() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("data"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsReadsFileContent() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("photo.jpg");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("file-content".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("file-content"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsTruncatesAtMaxContentBytes() throws IOException {
+    byte[] large = new byte[MultipartHelper.MAX_CONTENT_BYTES + 1];
+    Arrays.fill(large, (byte) 'A');
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("big.bin");
+    when(p.getInputStream()).thenReturn(new ByteArrayInputStream(large));
+    when(p.getContentType()).thenReturn(null);
+    List<String> contents = MultipartHelper.extractContents(singletonList(p));
+    assertEquals(1, contents.size());
+    assertEquals(MultipartHelper.MAX_CONTENT_BYTES, contents.get(0).length());
+  }
+
+  @Test
+  void extractContentsReturnsEmptyStringOnIOException() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("file.txt");
+    when(p.getInputStream()).thenThrow(new IOException("simulated"));
+    assertEquals(singletonList(""), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsCappsAtMaxFilesToInspect() throws IOException {
+    int count = MultipartHelper.MAX_FILES_TO_INSPECT + 1;
+    List<Part> parts = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      Part p = mock(Part.class);
+      when(p.getSubmittedFileName()).thenReturn("file" + i + ".txt");
+      when(p.getInputStream())
+          .thenReturn(new ByteArrayInputStream("c".getBytes(StandardCharsets.UTF_8)));
+      when(p.getContentType()).thenReturn(null);
+      parts.add(p);
+    }
+    List<String> contents = MultipartHelper.extractContents(parts);
+    assertEquals(MultipartHelper.MAX_FILES_TO_INSPECT, contents.size());
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/MultipartHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty94;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
@@ -49,7 +50,7 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
-        log.debug("extractFilenames: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
@@ -77,7 +78,7 @@ public class MultipartHelper {
         }
         contents.add(readFileContent(part));
       } catch (Exception ignored) {
-        log.debug("extractContents: skipping malformed part", ignored);
+        log.debug(EXCLUDE_TELEMETRY, "extractContents: skipping malformed part", ignored);
       }
     }
     return contents;
@@ -87,7 +88,7 @@ public class MultipartHelper {
     try (InputStream is = part.getInputStream()) {
       return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
     } catch (Exception e) {
-      log.debug("readFileContent: stream read failed", e);
+      log.debug(EXCLUDE_TELEMETRY, "readFileContent: stream read failed", e);
       return "";
     }
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/MultipartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/MultipartHelper.java
@@ -3,20 +3,30 @@ package datadog.trace.instrumentation.jetty94;
 import static datadog.trace.api.gateway.Events.EVENTS;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import javax.servlet.http.Part;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MultipartHelper {
+
+  public static final int MAX_CONTENT_BYTES = Config.get().getAppSecMaxFileContentBytes();
+  public static final int MAX_FILES_TO_INSPECT = Config.get().getAppSecMaxFileContentCount();
+
+  private static final Logger log = LoggerFactory.getLogger(MultipartHelper.class);
 
   private MultipartHelper() {}
 
@@ -39,9 +49,78 @@ public class MultipartHelper {
         }
       } catch (Exception ignored) {
         // malformed or inaccessible part — skip and continue with remaining parts
+        log.debug("extractFilenames: skipping malformed part", ignored);
       }
     }
     return filenames;
+  }
+
+  /**
+   * Extracts file content from a collection of multipart {@link Part}s. Form fields (those with a
+   * {@code null} submitted filename) are skipped. Reads up to {@link #MAX_CONTENT_BYTES} bytes per
+   * part, up to {@link #MAX_FILES_TO_INSPECT} parts total.
+   *
+   * @return list of decoded content strings; never {@code null}, may be empty
+   */
+  public static List<String> extractContents(Collection<Part> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> contents = new ArrayList<>(Math.min(parts.size(), MAX_FILES_TO_INSPECT));
+    for (Part part : parts) {
+      if (contents.size() >= MAX_FILES_TO_INSPECT) {
+        break;
+      }
+      try {
+        if (part.getSubmittedFileName() == null) {
+          continue; // form field — skip
+        }
+        contents.add(readFileContent(part));
+      } catch (Exception ignored) {
+        log.debug("extractContents: skipping malformed part", ignored);
+      }
+    }
+    return contents;
+  }
+
+  private static String readFileContent(Part part) {
+    try (InputStream is = part.getInputStream()) {
+      return MultipartContentDecoder.readInputStream(is, MAX_CONTENT_BYTES, part.getContentType());
+    } catch (Exception e) {
+      log.debug("readFileContent: stream read failed", e);
+      return "";
+    }
+  }
+
+  /**
+   * Fires the {@code requestFilesContent} IG event and returns a {@link BlockingException} if the
+   * WAF requests blocking, or {@code null} otherwise.
+   */
+  public static BlockingException fireFilesContentEvent(
+      Collection<Part> parts, RequestContext reqCtx) {
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (callback == null) {
+      return null;
+    }
+    List<String> contents = extractContents(parts);
+    if (contents.isEmpty()) {
+      return null;
+    }
+    Flow<Void> flow = callback.apply(reqCtx, contents);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        if (brf.tryCommitBlockingResponse(reqCtx.getTraceSegment(), rba)) {
+          reqCtx.getTraceSegment().effectivelyBlocked();
+          return new BlockingException("Blocked request (multipart file content)");
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/main/java/datadog/trace/instrumentation/jetty94/RequestExtractContentParametersInstrumentation.java
@@ -168,6 +168,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 
@@ -194,6 +197,9 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
       t = MultipartHelper.fireFilenamesEvent(parts, reqCtx);
+      if (t == null) {
+        t = MultipartHelper.fireFilesContentEvent(parts, reqCtx);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/test/java/datadog/trace/instrumentation/jetty94/MultipartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-9.4/src/test/java/datadog/trace/instrumentation/jetty94/MultipartHelperTest.java
@@ -7,6 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
@@ -63,5 +68,80 @@ class MultipartHelperTest {
     Part p = mock(Part.class);
     when(p.getSubmittedFileName()).thenReturn(submittedFileName);
     return p;
+  }
+
+  // ── extractContents ─────────────────────────────────────────────────────────
+
+  @Test
+  void extractContentsReturnsEmptyListForNull() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(null));
+  }
+
+  @Test
+  void extractContentsReturnsEmptyListForEmpty() {
+    assertEquals(emptyList(), MultipartHelper.extractContents(emptyList()));
+  }
+
+  @Test
+  void extractContentsSkipsFormFieldParts() {
+    List<Part> parts = asList(part(null), part(null));
+    assertEquals(emptyList(), MultipartHelper.extractContents(parts));
+  }
+
+  @Test
+  void extractContentsIncludesFileWithEmptyFilename() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("data"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsReadsFileContent() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("photo.jpg");
+    when(p.getInputStream())
+        .thenReturn(new ByteArrayInputStream("file-content".getBytes(StandardCharsets.UTF_8)));
+    when(p.getContentType()).thenReturn("text/plain; charset=UTF-8");
+    assertEquals(singletonList("file-content"), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsTruncatesAtMaxContentBytes() throws IOException {
+    byte[] large = new byte[MultipartHelper.MAX_CONTENT_BYTES + 1];
+    Arrays.fill(large, (byte) 'A');
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("big.bin");
+    when(p.getInputStream()).thenReturn(new ByteArrayInputStream(large));
+    when(p.getContentType()).thenReturn(null);
+    List<String> contents = MultipartHelper.extractContents(singletonList(p));
+    assertEquals(1, contents.size());
+    assertEquals(MultipartHelper.MAX_CONTENT_BYTES, contents.get(0).length());
+  }
+
+  @Test
+  void extractContentsReturnsEmptyStringOnIOException() throws IOException {
+    Part p = mock(Part.class);
+    when(p.getSubmittedFileName()).thenReturn("file.txt");
+    when(p.getInputStream()).thenThrow(new IOException("simulated"));
+    assertEquals(singletonList(""), MultipartHelper.extractContents(singletonList(p)));
+  }
+
+  @Test
+  void extractContentsCappsAtMaxFilesToInspect() throws IOException {
+    int count = MultipartHelper.MAX_FILES_TO_INSPECT + 1;
+    List<Part> parts = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      Part p = mock(Part.class);
+      when(p.getSubmittedFileName()).thenReturn("file" + i + ".txt");
+      when(p.getInputStream())
+          .thenReturn(new ByteArrayInputStream("c".getBytes(StandardCharsets.UTF_8)));
+      when(p.getContentType()).thenReturn(null);
+      parts.add(p);
+    }
+    List<String> contents = MultipartHelper.extractContents(parts);
+    assertEquals(MultipartHelper.MAX_FILES_TO_INSPECT, contents.size());
   }
 }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-10.0/src/test/groovy/datadog/trace/instrumentation/jetty10/Jetty10Test.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-10.0/src/test/groovy/datadog/trace/instrumentation/jetty10/Jetty10Test.groovy
@@ -101,6 +101,11 @@ abstract class Jetty10Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testSessionId() {
     true
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-11.0/src/test/groovy/Jetty11Test.groovy
@@ -83,6 +83,11 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testBlocking() {
     true
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/src/test/groovy/Jetty8LatestDepForkedTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-7.6/src/test/groovy/Jetty8LatestDepForkedTest.java
@@ -52,6 +52,11 @@ abstract class Jetty8LatestDepForkedTest extends Jetty76Test {
     return false;
   }
 
+  @Override
+  public boolean testBodyFilesContent() {
+    return true;
+  }
+
   static class Jetty8TestHandler extends AbstractHandler {
     private static final MultipartConfigElement MULTIPART_CONFIG =
         new MultipartConfigElement(System.getProperty("java.io.tmpdir"));

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0.4/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty92LatestDepForkedTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.0.4/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty92LatestDepForkedTest.java
@@ -34,6 +34,11 @@ abstract class Jetty92LatestDepForkedTest extends Jetty9Test {
   public boolean testBodyFilenamesCalledOnceCombined() {
     return true;
   }
+
+  @Override
+  public boolean testBodyFilesContent() {
+    return true;
+  }
 }
 
 @EnabledIfSystemProperty(named = "test.dd.jetty92", matches = ".+")

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.3/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.3/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
@@ -100,6 +100,11 @@ abstract class Jetty9Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testSessionId() {
     true
   }

--- a/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.4.21/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty/jetty-server/jetty-server-9.4.21/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
@@ -101,6 +101,11 @@ abstract class Jetty9Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testSessionId() {
     true
   }


### PR DESCRIPTION
# What Does This Do

- Adds `extractContents()` to `MultipartHelper` (jetty-appsec-9.2/9.3/9.4/11.0) and `PartHelper` (jetty-appsec-8.1.3) to extract file content from multipart `Part`s, reading up to `dd.appsec.max-file-content-bytes` (default 4096) bytes per part, capped at `dd.appsec.max-file-content-count` (default 25) parts per request
- Adds `fireFilesContentEvent()` to each helper, firing the `server.request.body.files_content` IG event via `EVENTS.requestFilesContent()`
- Updates both advice classes in all five AppSec modules to fire the content event sequentially after the filenames event: `t = fireFilenamesEvent(...); if (t == null) t = fireFilesContentEvent(...)`
- Form fields (parts with `null` submitted filename) are excluded; files with empty filename (`""`) are included for content inspection but excluded from filenames — matches the filter established in #11198
- Content is decoded via `MultipartContentDecoder.readInputStream()` with charset detection from the part's `Content-Type` header
- For Jetty 8.1.3, `filenameFromPart()` (Content-Disposition header parsing) is used in place of `getSubmittedFileName()`, which was only added in Servlet 3.1
- Adds unit tests for `extractContents()` in all five modules (null/empty, form-field skip, empty-filename include, content read, byte truncation, IOException fallback, count cap)
- Enables `testBodyFilesContent()` in integration test classes for Jetty 8.x, 9.2, 9.3, 9.4, 10.0, and 11.0

# Motivation

Extends the `server.request.body.files_content` WAF address to Jetty, following the Tomcat/Netty implementation in #11198 and building on the Jetty filenames support from #10988.

# Additional Notes

The content event fires sequentially after the filenames event — only when filenames did not block. This matches the intent from #11137 (commons-fileupload). The `MAX_CONTENT_BYTES` and `MAX_FILES_TO_INSPECT` constants are `static final` fields on the helper classes (not on advice inner classes with `@RequiresRequestContext`) to avoid muzzle validation failures at CI.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: N/A

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).