### PR TITLE
feat(feign-10.8): toolkit-generated feign HTTP client instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -159,7 +159,10 @@ TaskProvider<JavaExec> registerIndexTask(String indexTaskName, String indexer, S
 }
 
 instrumentationNaming {
-  exclusions = ["org-json-20230227"] // org-json does not use semver
+  exclusions = [
+    "org-json-20230227", // org-json does not use semver
+    "feign-10.8-generated", // research convention: toolkit-generated side-by-side eval module
+  ]
   suffixes = ["-common", "-stubs", "-iast"]
 }
 

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -160,7 +160,8 @@ TaskProvider<JavaExec> registerIndexTask(String indexTaskName, String indexer, S
 
 instrumentationNaming {
   exclusions = [
-    "org-json-20230227", // org-json does not use semver
+    "org-json-20230227",
+    // org-json does not use semver
     "feign-10.8-generated", // research convention: toolkit-generated side-by-side eval module
   ]
   suffixes = ["-common", "-stubs", "-iast"]

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/build.gradle
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/build.gradle
@@ -3,7 +3,6 @@ muzzle {
     group = "io.github.openfeign"
     module = "feign-core"
     versions = "[10.8,)"
-    assertInverse = true
   }
 }
 

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/build.gradle
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/build.gradle
@@ -1,0 +1,20 @@
+muzzle {
+  pass {
+    group = "io.github.openfeign"
+    module = "feign-core"
+    versions = "[10.8,)"
+    assertInverse = true
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly(group: 'io.github.openfeign', name: 'feign-core', version: '10.8')
+
+  testImplementation(group: 'io.github.openfeign', name: 'feign-core', version: '10.8')
+
+  latestDepTestImplementation group: 'io.github.openfeign', name: 'feign-core', version: '10+'
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignAsyncClientInstrumentation.java
@@ -1,0 +1,124 @@
+package datadog.trace.instrumentation.feign;
+
+import static datadog.context.Context.current;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.FEIGN;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.HTTP_REQUEST;
+import static datadog.trace.instrumentation.feign.RequestHeaderInjectAdapter.SETTER;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import feign.AsyncClient;
+import feign.Request;
+import feign.Response;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public class FeignAsyncClientInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public FeignAsyncClientInstrumentation() {
+    super("feign", "feign-10.8");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "feign.AsyncClient";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".FeignClientDecorator",
+      packageName + ".RequestHeaderInjectAdapter",
+      packageName + ".SpanFinishingCallback",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("execute"))
+            .and(isPublic())
+            .and(takesArguments(3))
+            .and(takesArgument(0, named("feign.Request")))
+            .and(takesArgument(1, named("feign.Request$Options"))),
+        FeignAsyncClientInstrumentation.class.getName() + "$AsyncExecuteAdvice");
+  }
+
+  public static class AsyncExecuteAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope methodEnter(
+        @Advice.Argument(value = 0, readOnly = false) Request request) {
+      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(AsyncClient.class);
+      if (callDepth > 0) {
+        return null;
+      }
+
+      final AgentSpan span = startSpan(FEIGN.toString(), HTTP_REQUEST);
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, request);
+
+      final AgentScope scope = activateSpan(span);
+
+      // Inject trace context into request headers
+      Map<String, Collection<String>> injectedHeaders = new LinkedHashMap<>();
+      DECORATE.injectContext(current(), injectedHeaders, SETTER);
+      request = RequestHeaderInjectAdapter.inject(request, injectedHeaders);
+
+      return scope;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void methodExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Return(readOnly = false) CompletableFuture<Response> future,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      final AgentSpan span = scope.span();
+      scope.close();
+      CallDepthThreadLocalMap.reset(AsyncClient.class);
+
+      if (throwable != null) {
+        DECORATE.onError(span, throwable);
+        DECORATE.beforeFinish(span);
+        span.finish();
+        return;
+      }
+
+      if (future != null) {
+        future = future.whenComplete(new SpanFinishingCallback(span));
+      } else {
+        DECORATE.beforeFinish(span);
+        span.finish();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignClientDecorator.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignClientDecorator.java
@@ -1,0 +1,63 @@
+package datadog.trace.instrumentation.feign;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
+import feign.Request;
+import feign.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class FeignClientDecorator extends HttpClientDecorator<Request, Response> {
+
+  public static final CharSequence FEIGN = UTF8BytesString.create("feign");
+  public static final FeignClientDecorator DECORATE = new FeignClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"feign", "feign-10.8"};
+  }
+
+  @Override
+  protected CharSequence component() {
+    return FEIGN;
+  }
+
+  @Override
+  protected String method(final Request request) {
+    return request.httpMethod().name();
+  }
+
+  @Override
+  protected URI url(final Request request) {
+    try {
+      return new URI(request.url());
+    } catch (URISyntaxException e) {
+      return null;
+    }
+  }
+
+  @Override
+  protected int status(final Response response) {
+    return response.status();
+  }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    java.util.Collection<String> values = request.headers().get(headerName);
+    if (values != null && !values.isEmpty()) {
+      return values.iterator().next();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    java.util.Collection<String> values = response.headers().get(headerName);
+    if (values != null && !values.isEmpty()) {
+      return values.iterator().next();
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/FeignClientInstrumentation.java
@@ -1,0 +1,116 @@
+package datadog.trace.instrumentation.feign;
+
+import static datadog.context.Context.current;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.FEIGN;
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.HTTP_REQUEST;
+import static datadog.trace.instrumentation.feign.RequestHeaderInjectAdapter.SETTER;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public class FeignClientInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public FeignClientInstrumentation() {
+    super("feign", "feign-10.8");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "feign.Client";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".FeignClientDecorator", packageName + ".RequestHeaderInjectAdapter",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("execute"))
+            .and(isPublic())
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("feign.Request")))
+            .and(takesArgument(1, named("feign.Request$Options"))),
+        FeignClientInstrumentation.class.getName() + "$ExecuteAdvice");
+  }
+
+  public static class ExecuteAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope methodEnter(
+        @Advice.Argument(value = 0, readOnly = false) Request request) {
+      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Client.class);
+      if (callDepth > 0) {
+        return null;
+      }
+
+      final AgentSpan span = startSpan(FEIGN.toString(), HTTP_REQUEST);
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, request);
+
+      final AgentScope scope = activateSpan(span);
+
+      // Inject trace context into request headers
+      Map<String, Collection<String>> injectedHeaders = new LinkedHashMap<>();
+      DECORATE.injectContext(current(), injectedHeaders, SETTER);
+      request = RequestHeaderInjectAdapter.inject(request, injectedHeaders);
+
+      return scope;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void methodExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Return final Response response,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      final AgentSpan span = scope.span();
+      try {
+        if (response != null) {
+          DECORATE.onResponse(span, response);
+        }
+        DECORATE.onError(span, throwable);
+        DECORATE.beforeFinish(span);
+      } finally {
+        scope.close();
+        span.finish();
+        CallDepthThreadLocalMap.reset(Client.class);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/RequestHeaderInjectAdapter.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/RequestHeaderInjectAdapter.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.feign;
+
+import datadog.context.propagation.CarrierSetter;
+import feign.Request;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class RequestHeaderInjectAdapter implements CarrierSetter<Map<String, Collection<String>>> {
+
+  public static final RequestHeaderInjectAdapter SETTER = new RequestHeaderInjectAdapter();
+
+  @Override
+  public void set(
+      final Map<String, Collection<String>> carrier, final String key, final String value) {
+    Collection<String> values = new ArrayList<>(1);
+    values.add(value);
+    carrier.put(key, values);
+  }
+
+  /**
+   * Feign Request objects are immutable — headers cannot be modified after creation. This method
+   * creates a new Request with the trace context headers injected.
+   */
+  public static Request inject(
+      final Request original, final Map<String, Collection<String>> injectedHeaders) {
+    Map<String, Collection<String>> merged = new LinkedHashMap<>(original.headers());
+    merged.putAll(injectedHeaders);
+    return Request.create(
+        original.httpMethod(), original.url(), merged, original.body(), StandardCharsets.UTF_8);
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/SpanFinishingCallback.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/main/java/datadog/trace/instrumentation/feign/SpanFinishingCallback.java
@@ -1,0 +1,32 @@
+package datadog.trace.instrumentation.feign;
+
+import static datadog.trace.instrumentation.feign.FeignClientDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import feign.Response;
+import java.util.function.BiConsumer;
+
+/** Callback to finish a span when a {@link java.util.concurrent.CompletableFuture} completes. */
+public class SpanFinishingCallback implements BiConsumer<Response, Throwable> {
+
+  private final AgentSpan span;
+
+  public SpanFinishingCallback(final AgentSpan span) {
+    this.span = span;
+  }
+
+  @Override
+  public void accept(final Response response, final Throwable error) {
+    try {
+      if (response != null) {
+        DECORATE.onResponse(span, response);
+      }
+      if (error != null) {
+        DECORATE.onError(span, error);
+      }
+      DECORATE.beforeFinish(span);
+    } finally {
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/test/java/datadog/trace/instrumentation/feign/FeignAsyncClientTest.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/test/java/datadog/trace/instrumentation/feign/FeignAsyncClientTest.java
@@ -1,0 +1,526 @@
+package datadog.trace.instrumentation.feign;
+
+import static datadog.trace.agent.test.assertions.Matchers.is;
+import static datadog.trace.agent.test.assertions.Matchers.isNonNull;
+import static datadog.trace.agent.test.assertions.Matchers.matches;
+import static datadog.trace.agent.test.assertions.Matchers.validates;
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpan;
+import datadog.trace.junit.utils.config.WithConfig;
+import feign.AsyncClient;
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithConfig(key = "trace.enabled", value = "true")
+public class FeignAsyncClientTest extends AbstractInstrumentationTest {
+
+  private HttpServer httpServer;
+  private int port;
+
+  @BeforeAll
+  void setupServer() throws IOException {
+    httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+
+    httpServer.createContext(
+        "/api/users",
+        exchange -> {
+          byte[] body = "{\"id\":1,\"name\":\"Alice\"}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+
+    httpServer.createContext(
+        "/api/error",
+        exchange -> {
+          byte[] body = "{\"error\":\"Internal Server Error\"}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(500, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+
+    httpServer.setExecutor(null);
+    httpServer.start();
+    port = httpServer.getAddress().getPort();
+  }
+
+  @AfterAll
+  void tearDownServer() {
+    if (httpServer != null) {
+      httpServer.stop(0);
+    }
+  }
+
+  @Test
+  void asyncGetCreatesClientSpan()
+      throws ExecutionException, TimeoutException, InterruptedException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/users", null);
+      CompletableFuture<Response> future =
+          asyncClient.execute(request, defaultOptions(), Optional.empty());
+      response = future.get(10, TimeUnit.SECONDS);
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    // AsyncClient.Pseudo delegates to Client.Default, which is also instrumented,
+    // resulting in two client spans: one from the async instrumentation and one from the sync
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .resourceName(r -> r != null && r.toString().startsWith("GET"))
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void asyncPostCreatesClientSpanWithCorrectMethod()
+      throws ExecutionException, TimeoutException, InterruptedException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+      byte[] body = "{\"name\":\"Bob\"}".getBytes(StandardCharsets.UTF_8);
+      Request request = buildRequest(Request.HttpMethod.POST, "/api/users", body);
+      CompletableFuture<Response> future =
+          asyncClient.execute(request, defaultOptions(), Optional.empty());
+      response = future.get(10, TimeUnit.SECONDS);
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    // AsyncClient.Pseudo delegates to Client.Default, which is also instrumented,
+    // resulting in two client spans: one from the async instrumentation and one from the sync
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .resourceName(r -> r != null && r.toString().startsWith("POST"))
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("POST")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("POST")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void asyncErrorResponseSetsStatusCodeAndErrorFlag()
+      throws ExecutionException, TimeoutException, InterruptedException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/error", null);
+      CompletableFuture<Response> future =
+          asyncClient.execute(request, defaultOptions(), Optional.empty());
+      response = future.get(10, TimeUnit.SECONDS);
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(500, response.status());
+    response.close();
+
+    // 500 is a server error, not in dd-trace-java's default HTTP client error statuses (400-499)
+    // AsyncClient.Pseudo delegates to Client.Default, producing two client spans
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/error"))),
+                    tag("http.status_code", is(500)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/error"))),
+                    tag("http.status_code", is(500)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void asyncConnectionExceptionSetsErrorTags() throws TimeoutException, InterruptedException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    try {
+      AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+      // Use a port that is not listening to force a connection error
+      Request request =
+          Request.create(
+              Request.HttpMethod.GET,
+              "http://localhost:1/not-listening",
+              Collections.emptyMap(),
+              null,
+              StandardCharsets.UTF_8);
+      CompletableFuture<Response> future =
+          asyncClient.execute(request, defaultOptions(), Optional.empty());
+      try {
+        future.get(10, TimeUnit.SECONDS);
+      } catch (ExecutionException expected) {
+        // expected - connection refused wrapped in ExecutionException
+      }
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    // AsyncClient.Pseudo delegates to Client.Default, producing two client spans (both with error)
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(true)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/not-listening"))),
+                    tag("error.type", isNonNull()),
+                    tag("error.message", isNonNull()),
+                    tag("error.stack", isNonNull()),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(1))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(true)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/not-listening"))),
+                    tag("error.type", isNonNull()),
+                    tag("error.message", isNonNull()),
+                    tag("error.stack", isNonNull()),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(1)))));
+  }
+
+  @Test
+  void asyncContextPropagationInjectsHeaders()
+      throws ExecutionException, TimeoutException, InterruptedException {
+    // Capture headers received by the server
+    Map<String, List<String>> receivedHeaders = new HashMap<>();
+    httpServer.createContext(
+        "/api/headers",
+        exchange -> {
+          for (Map.Entry<String, List<String>> entry : exchange.getRequestHeaders().entrySet()) {
+            receivedHeaders.put(entry.getKey().toLowerCase(), entry.getValue());
+          }
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/headers", null);
+      CompletableFuture<Response> future =
+          asyncClient.execute(request, defaultOptions(), Optional.empty());
+      response = future.get(10, TimeUnit.SECONDS);
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    // AsyncClient.Pseudo delegates to Client.Default, producing two client spans
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/headers"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/headers"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+
+    // Verify context propagation headers were injected
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-trace-id"),
+        "Server should receive x-datadog-trace-id header. Received headers: "
+            + receivedHeaders.keySet());
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-parent-id"),
+        "Server should receive x-datadog-parent-id header");
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-sampling-priority"),
+        "Server should receive x-datadog-sampling-priority header");
+
+    String traceId = receivedHeaders.get("x-datadog-trace-id").get(0);
+    String parentId = receivedHeaders.get("x-datadog-parent-id").get(0);
+    assertNotNull(traceId, "x-datadog-trace-id should not be null");
+    assertNotNull(parentId, "x-datadog-parent-id should not be null");
+    assertFalse(traceId.isEmpty(), "x-datadog-trace-id should not be empty");
+    assertFalse(parentId.isEmpty(), "x-datadog-parent-id should not be empty");
+
+    // Verify the trace ID matches the active trace
+    List<DDSpan> allSpans = flattenTraces();
+    DDSpan clientSpan = findSpanByKind(allSpans, "client");
+    assertNotNull(clientSpan, "Expected an HTTP client span from feign async");
+    assertEquals(
+        String.valueOf(clientSpan.getTraceId().toLong()),
+        traceId,
+        "Injected trace ID should match the client span's trace ID");
+  }
+
+  @Test
+  void asyncSpanFinishesAfterFutureCompletes()
+      throws ExecutionException, TimeoutException, InterruptedException {
+    // Verify the span lifecycle: span should start at execute() and finish when the future
+    // completes, capturing the response status code from the completed future
+    AsyncClient<Object> asyncClient = new AsyncClient.Pseudo<>(new Client.Default(null, null));
+    Request request = buildRequest(Request.HttpMethod.GET, "/api/users", null);
+    CompletableFuture<Response> future =
+        asyncClient.execute(request, defaultOptions(), Optional.empty());
+    Response response = future.get(10, TimeUnit.SECONDS);
+    response.close();
+
+    // AsyncClient.Pseudo delegates to Client.Default, producing two client spans
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .root()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port))),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  // ---- Helper methods ----
+
+  private Request buildRequest(Request.HttpMethod method, String path, byte[] requestBody) {
+    String url = "http://localhost:" + port + path;
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("Accept", Collections.singletonList("application/json"));
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    return Request.create(method, url, headers, requestBody, StandardCharsets.UTF_8);
+  }
+
+  private Request.Options defaultOptions() {
+    return new Request.Options(5, TimeUnit.SECONDS, 5, TimeUnit.SECONDS, true);
+  }
+
+  private List<DDSpan> flattenTraces() {
+    List<DDSpan> result = new ArrayList<>();
+    for (List<DDSpan> trace : writer) {
+      result.addAll(trace);
+    }
+    return result;
+  }
+
+  private DDSpan findSpanByKind(List<DDSpan> spans, String spanKind) {
+    for (DDSpan span : spans) {
+      if (spanKind.equals(String.valueOf(span.getTag("span.kind")))) {
+        return span;
+      }
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/test/java/datadog/trace/instrumentation/feign/FeignClientTest.java
+++ b/dd-java-agent/instrumentation/feign/feign-10.8-generated/src/test/java/datadog/trace/instrumentation/feign/FeignClientTest.java
@@ -1,0 +1,403 @@
+package datadog.trace.instrumentation.feign;
+
+import static datadog.trace.agent.test.assertions.Matchers.is;
+import static datadog.trace.agent.test.assertions.Matchers.isNonNull;
+import static datadog.trace.agent.test.assertions.Matchers.matches;
+import static datadog.trace.agent.test.assertions.Matchers.validates;
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpan;
+import datadog.trace.junit.utils.config.WithConfig;
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithConfig(key = "trace.enabled", value = "true")
+public class FeignClientTest extends AbstractInstrumentationTest {
+
+  private HttpServer httpServer;
+  private int port;
+
+  @BeforeAll
+  void setupServer() throws IOException {
+    httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+
+    httpServer.createContext(
+        "/api/users",
+        exchange -> {
+          byte[] body = "{\"id\":1,\"name\":\"Alice\"}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+
+    httpServer.createContext(
+        "/api/error",
+        exchange -> {
+          byte[] body = "{\"error\":\"Internal Server Error\"}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(500, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+
+    httpServer.setExecutor(null);
+    httpServer.start();
+    port = httpServer.getAddress().getPort();
+  }
+
+  @AfterAll
+  void tearDownServer() {
+    if (httpServer != null) {
+      httpServer.stop(0);
+    }
+  }
+
+  @Test
+  void syncGetCreatesClientSpan() throws IOException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      Client client = new Client.Default(null, null);
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/users", null);
+      response = client.execute(request, defaultOptions());
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .resourceName(r -> r != null && r.toString().startsWith("GET"))
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void syncPostCreatesClientSpanWithCorrectMethod() throws IOException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      Client client = new Client.Default(null, null);
+      byte[] body = "{\"name\":\"Bob\"}".getBytes(StandardCharsets.UTF_8);
+      Request request = buildRequest(Request.HttpMethod.POST, "/api/users", body);
+      response = client.execute(request, defaultOptions());
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .resourceName(r -> r != null && r.toString().startsWith("POST"))
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("POST")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void syncErrorResponseSetsStatusCodeAndErrorFlag() throws IOException {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      Client client = new Client.Default(null, null);
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/error", null);
+      response = client.execute(request, defaultOptions());
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(500, response.status());
+    response.close();
+
+    // 500 is a server error, not in dd-trace-java's default HTTP client error statuses (400-499)
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/error"))),
+                    tag("http.status_code", is(500)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  @Test
+  void syncConnectionExceptionSetsErrorTags() {
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    try {
+      Client client = new Client.Default(null, null);
+      // Use a port that is not listening to force a connection error
+      Request request =
+          Request.create(
+              Request.HttpMethod.GET,
+              "http://localhost:1/not-listening",
+              Collections.emptyMap(),
+              null,
+              StandardCharsets.UTF_8);
+      try {
+        client.execute(request, defaultOptions());
+      } catch (IOException expected) {
+        // expected - connection refused
+      }
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(true)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/not-listening"))),
+                    tag("error.type", isNonNull()),
+                    tag("error.message", isNonNull()),
+                    tag("error.stack", isNonNull()),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(1)))));
+  }
+
+  @Test
+  void syncContextPropagationInjectsHeaders() throws IOException {
+    // Capture headers received by the server
+    Map<String, List<String>> receivedHeaders = new HashMap<>();
+    httpServer.createContext(
+        "/api/headers",
+        exchange -> {
+          for (Map.Entry<String, List<String>> entry : exchange.getRequestHeaders().entrySet()) {
+            receivedHeaders.put(entry.getKey().toLowerCase(), entry.getValue());
+          }
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+
+    AgentSpan parentSpan = startSpan("test", "parent");
+    AgentScope parentScope = activateSpan(parentSpan);
+    Response response;
+    try {
+      Client client = new Client.Default(null, null);
+      Request request = buildRequest(Request.HttpMethod.GET, "/api/headers", null);
+      response = client.execute(request, defaultOptions());
+    } finally {
+      parentScope.close();
+      parentSpan.finish();
+    }
+
+    assertEquals(200, response.status());
+    response.close();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName(Pattern.compile("parent")),
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .childOfPrevious()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/headers"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+
+    // Verify context propagation headers were injected
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-trace-id"),
+        "Server should receive x-datadog-trace-id header. Received headers: "
+            + receivedHeaders.keySet());
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-parent-id"),
+        "Server should receive x-datadog-parent-id header");
+    assertTrue(
+        receivedHeaders.containsKey("x-datadog-sampling-priority"),
+        "Server should receive x-datadog-sampling-priority header");
+
+    String traceId = receivedHeaders.get("x-datadog-trace-id").get(0);
+    String parentId = receivedHeaders.get("x-datadog-parent-id").get(0);
+    assertNotNull(traceId, "x-datadog-trace-id should not be null");
+    assertNotNull(parentId, "x-datadog-parent-id should not be null");
+    assertFalse(traceId.isEmpty(), "x-datadog-trace-id should not be empty");
+    assertFalse(parentId.isEmpty(), "x-datadog-parent-id should not be empty");
+
+    // Verify the trace ID matches the active trace
+    List<DDSpan> allSpans = flattenTraces();
+    DDSpan clientSpan = findSpanByKind(allSpans, "client");
+    assertNotNull(clientSpan, "Expected an HTTP client span from feign");
+    assertEquals(
+        String.valueOf(clientSpan.getTraceId().toLong()),
+        traceId,
+        "Injected trace ID should match the client span's trace ID");
+    // Verify the parent ID in the header matches the client span's span ID
+    // This ensures the downstream service will correctly link its span as a child of this client
+    // span
+    assertEquals(
+        String.valueOf(clientSpan.getSpanId()),
+        parentId,
+        "Injected parent ID should match the client span's span ID");
+  }
+
+  @Test
+  void syncClientSpanWithoutParentIsRootSpan() throws IOException {
+    // Execute without an active parent span to verify span is still created
+    Client client = new Client.Default(null, null);
+    Request request = buildRequest(Request.HttpMethod.GET, "/api/users", null);
+    Response response = client.execute(request, defaultOptions());
+    response.close();
+
+    assertTraces(
+        trace(
+            span()
+                .operationName(Pattern.compile("http\\.request"))
+                .type("http")
+                .error(false)
+                .root()
+                .tags(
+                    defaultTags(),
+                    tag("span.kind", matches("client")),
+                    tag("component", matches("feign")),
+                    tag("http.method", matches("GET")),
+                    tag(
+                        "http.url",
+                        validates(v -> v != null && v.toString().contains("/api/users"))),
+                    tag("http.status_code", is(200)),
+                    tag("peer.hostname", matches("localhost")),
+                    tag("peer.port", is(port)))));
+  }
+
+  // ---- Helper methods ----
+
+  private Request buildRequest(Request.HttpMethod method, String path, byte[] requestBody) {
+    String url = "http://localhost:" + port + path;
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("Accept", Collections.singletonList("application/json"));
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    return Request.create(method, url, headers, requestBody, StandardCharsets.UTF_8);
+  }
+
+  private Request.Options defaultOptions() {
+    return new Request.Options(5, TimeUnit.SECONDS, 5, TimeUnit.SECONDS, true);
+  }
+
+  private List<DDSpan> flattenTraces() {
+    List<DDSpan> result = new ArrayList<>();
+    for (List<DDSpan> trace : writer) {
+      result.addAll(trace);
+    }
+    return result;
+  }
+
+  private DDSpan findSpanByKind(List<DDSpan> spans, String spanKind) {
+    for (DDSpan span : spans) {
+      if (spanKind.equals(String.valueOf(span.getTag("span.kind")))) {
+        return span;
+      }
+    }
+    return null;
+  }
+}

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5657,6 +5657,38 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_FEIGN_10_8_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_TRACE_INTEGRATION_FEIGN_10_8_ENABLED", "DD_INTEGRATION_FEIGN_10_8_ENABLED"]
+      }
+    ],
+    "DD_TRACE_FEIGN_ANALYTICS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_FEIGN_ANALYTICS_ENABLED"]
+      }
+    ],
+    "DD_TRACE_FEIGN_ANALYTICS_SAMPLE_RATE": [
+      {
+        "version": "A",
+        "type": "decimal",
+        "default": "1.0",
+        "aliases": ["DD_FEIGN_ANALYTICS_SAMPLE_RATE"]
+      }
+    ],
+    "DD_TRACE_FEIGN_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_TRACE_INTEGRATION_FEIGN_ENABLED", "DD_INTEGRATION_FEIGN_ENABLED"]
+      }
+    ],
     "DD_TRACE_FILEITEMITERATOR_ENABLED": [
       {
         "version": "A",

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5657,6 +5657,22 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_FEIGN_10_8_ANALYTICS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_FEIGN_10_8_ANALYTICS_ENABLED"]
+      }
+    ],
+    "DD_TRACE_FEIGN_10_8_ANALYTICS_SAMPLE_RATE": [
+      {
+        "version": "A",
+        "type": "decimal",
+        "default": "1.0",
+        "aliases": ["DD_FEIGN_10_8_ANALYTICS_SAMPLE_RATE"]
+      }
+    ],
     "DD_TRACE_FEIGN_10_8_ENABLED": [
       {
         "version": "A",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -356,6 +356,7 @@ include(
   ":dd-java-agent:instrumentation:elasticsearch:elasticsearch-transport:elasticsearch-transport-7.3",
   ":dd-java-agent:instrumentation:elasticsearch:elasticsearch-transport:elasticsearch-transport-common",
   ":dd-java-agent:instrumentation:elasticsearch:elasticsearch-common",
+  ":dd-java-agent:instrumentation:feign:feign-10.8-generated",
   ":dd-java-agent:instrumentation:finatra-2.9",
   ":dd-java-agent:instrumentation:freemarker:freemarker-2.3.24",
   ":dd-java-agent:instrumentation:freemarker:freemarker-2.3.9",


### PR DESCRIPTION
##  Summary                                                                                                                                                    
                                                                                                                                                             
  Toolkit-generated greenfield instrumentation for Feign HTTP client (io.github.openfeign:feign-core 10.8+). Part of the dd-trace-java APM toolkit eval program. ⚠️  DO NOT MERGE. Open for review; 
  reviewer feedback feeds back into toolkit R-rules.
                                                                                                                                                                                                   
## Wins from prior reviewer feedback                                                                                                                          
                                                                                                                                                             
  @mcculls reviewed the prior toolkit feign attempt on #10579 (CLOSED). This regeneration addresses three of his key concerns:                                                                     
  - ✅ Lambda-in-advice replaced with named helper class (SpanFinishingCallback) — fixes invokedynamic-on-unprepared-class footgun
  - ✅ @Advice.Return(readOnly = false) CompletableFuture<Response> future correctly assigned back via future = future.whenComplete(...)                                                           
  - ✅ Async CallDepthThreadLocalMap.reset(...) happens on the calling thread (not the completion thread)                                                    
                                                                                                                                                                                                   ##  Regressions / concerns vs prior review and master conventions                                                                                                                                    
                                                                                                                                                                                                   
  1. build.gradle:1-7 — assertInverse = true dropped from muzzle. @mcculls explicitly praised this on #10579 ("something people often forget"). Clean regression.                                  
  2. Two @AutoService(InstrumenterModule.class) classes (FeignClientInstrumentation + FeignAsyncClientInstrumentation) instead of one aggregator FeignModule with typeInstrumentations(). @mcculls 
  asked for the ReactorCoreModule pattern explicitly on #10579.                                                                                                                                    
  3. AsyncClient.Pseudo double-span. Sync advice uses Client.class as the CallDepthThreadLocalMap key; async uses AsyncClient.class. AsyncClient.Pseudo delegates to Client.Default — different
  keys → two HTTP spans per request. Tests assert this rather than fix it. Use a shared sentinel.                                                                                                  
  4. RequestHeaderInjectAdapter.inject() hardcodes StandardCharsets.UTF_8 — drops original.charset(). Non-UTF-8 callers silently get bodies rewritten.       
  5. FeignClientDecorator missing sourceUrl(...) and service() overrides — convention drift vs OkHttpClientDecorator / ApacheHttpClientDecorator.                                                  
  6. Span lifecycle order inverted at FeignClientInstrumentation.java:109-112 — scope.close() before span.finish(). Skill convention (R8) is the inverse.                                          
  7. DD_TRACE_FEIGN_ENABLED defaults to false — most HTTP-client integrations default-enabled.                                                                                                     
  8. Tests bypass shared HttpClientTest base — bespoke com.sun.net.httpserver. Loses cross-tracer behavioral parity.                                                                               
                                                                                                                                                                                                   
## What was structurally correct                                                                                                                                                                    
                                                                                                                                                                                                   
  HttpClientDecorator<Request, Response> shape matches master HTTP-client conventions. Module path dd-java-agent/instrumentation/feign/feign-10.8-generated/ follows version-suffix + parent-dir   
  naming.                                                                                                                                                    
                                                                                                                                                                                                   
## CI                                                                                                                                                         
                                                                                                                                                             
  All substantive jobs pass (build, instrumentationTest, latestDepTest, muzzle 8/8, smokeTest, profiling). Only failing check is dd-gitlab/validate_supported_configurations_v2_local_file —       
  external registry validator requires DD_TRACE_FEIGN_* keys to be pre-registered out-of-band. Not a code issue.
                                                                                                                                                                                                   
## What reviewers should do                                                                                                                                   
                                                                                                                                                             
  1. Decide on the aggregator-module pattern and the Pseudo double-span fix (both rooted in @mcculls's prior feedback).                                                                            
  2. Flag charset-loss and default-enabled concerns for product decision.
  3. Coordinate registry registration before merge.                                                                                                                                                
                                                                                                                                                             
##  Related                                                                                                                                                                                          
                                                                                                                                                             
  Prior toolkit attempts: #10579 (review from @mcculls), #10980, #10855. Sibling eval PRs: #11708 (sparkjava), #11717 (commons-httpclient).     
🤖 Generated with [Claude Code](https://claude.com/claude-code)