### PR TITLE
Add server.request.body.files_content AppSec address for Vert.x 3/4/5

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -387,6 +387,11 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     false
   }
 
+  /** Override to false when the multipart implementation uses a set with non-deterministic ordering (e.g. HashSet). */
+  boolean testBodyFilesContentOrdering() {
+    true
+  }
+
   boolean testBodyJson() {
     false
   }
@@ -1767,7 +1772,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   def 'test instrumentation gateway file upload content max files limit'() {
     setup:
-    assumeTrue(testBodyFilesContent())
+    assumeTrue(testBodyFilesContent() && testBodyFilesContentOrdering())
     def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()
     def bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM)
     (1..maxFilesToInspect + 1).each {

--- a/dd-java-agent/instrumentation/vertx/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
@@ -45,6 +45,11 @@ class VertxRxCircuitBreakerHttpServerForkedTest extends VertxHttpServerForkedTes
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    false
+  }
+
+  @Override
   boolean testBodyJson() {
     false
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/FileUploadHelper.java
@@ -10,9 +10,9 @@ import java.io.FileInputStream;
 import java.util.List;
 import java.util.function.BiFunction;
 
-class FileUploadHelper {
+public class FileUploadHelper {
 
-  static BlockingException commitBlockingResponse(
+  public static BlockingException commitBlockingResponse(
       BiFunction<RequestContext, List<String>, Flow<Void>> cb,
       RequestContext reqCtx,
       List<String> data,
@@ -30,7 +30,7 @@ class FileUploadHelper {
     return null;
   }
 
-  static String readUploadContent(FileUpload upload, int maxBytes) {
+  public static String readUploadContent(FileUpload upload, int maxBytes) {
     try {
       String path = upload.uploadedFileName();
       if (path == null || path.isEmpty()) {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/FileUploadHelper.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.vertx_3_4.server;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.http.MultipartContentDecoder;
+import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.function.BiFunction;
+
+class FileUploadHelper {
+
+  static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        brf.tryCommitBlockingResponse(
+            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
+        return new BlockingException(reason);
+      }
+    }
+    return null;
+  }
+
+  static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
+      }
+    } catch (Exception ignored) {
+      return "";
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
@@ -5,14 +5,17 @@ import static datadog.trace.api.gateway.Events.EVENTS;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -38,35 +41,83 @@ class RoutingContextFilenamesAdvice {
       return;
     }
 
-    List<String> filenames = new ArrayList<>(uploads.size());
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
+        cbp.getCallback(EVENTS.requestFilesFilenames());
+    BiFunction<RequestContext, List<String>, Flow<Void>> contentCb =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (filenamesCb == null && contentCb == null) {
+      return;
+    }
+
+    int maxFiles = Config.get().getAppSecMaxFileContentCount();
+    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
+    List<String> filenames = null;
+    List<String> filesContent = null;
+
     for (FileUpload upload : uploads) {
       String name = upload.fileName();
-      if (name != null && !name.isEmpty()) {
+      if (filenamesCb != null && name != null && !name.isEmpty()) {
+        if (filenames == null) {
+          filenames = new ArrayList<>();
+        }
         filenames.add(name);
       }
+      if (contentCb != null
+          && maxFiles > 0
+          && (filesContent == null || filesContent.size() < maxFiles)) {
+        if (filesContent == null) {
+          filesContent = new ArrayList<>();
+        }
+        filesContent.add(readUploadContent(upload, maxBytes));
+      }
     }
-    if (filenames.isEmpty()) {
+
+    if (filenamesCb != null && filenames != null) {
+      throwable =
+          commitBlockingResponse(
+              filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
+    }
+
+    if (throwable != null) {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-    BiFunction<RequestContext, List<String>, Flow<Void>> cb =
-        cbp.getCallback(EVENTS.requestFilesFilenames());
-    if (cb == null) {
-      return;
+    if (contentCb != null && filesContent != null) {
+      throwable =
+          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
+  }
 
-    Flow<Void> flow = cb.apply(reqCtx, filenames);
+  private static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
     Flow.Action action = flow.getAction();
     if (action instanceof Flow.Action.RequestBlockingAction) {
       BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
       if (brf != null) {
         brf.tryCommitBlockingResponse(
             reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        if (throwable == null) {
-          throwable = new BlockingException("Blocked request (multipart file upload)");
-        }
+        return new BlockingException(reason);
       }
+    }
+    return null;
+  }
+
+  private static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+      }
+    } catch (Exception ignored) {
+      return "";
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
@@ -113,8 +113,13 @@ class RoutingContextFilenamesAdvice {
       if (path == null || path.isEmpty()) {
         return "";
       }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
       try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
       }
     } catch (Exception ignored) {
       return "";

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextFilenamesAdvice.java
@@ -2,20 +2,16 @@ package datadog.trace.instrumentation.vertx_3_4.server;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
 
-import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.Config;
-import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -69,13 +65,13 @@ class RoutingContextFilenamesAdvice {
         if (filesContent == null) {
           filesContent = new ArrayList<>();
         }
-        filesContent.add(readUploadContent(upload, maxBytes));
+        filesContent.add(FileUploadHelper.readUploadContent(upload, maxBytes));
       }
     }
 
     if (filenamesCb != null && filenames != null) {
       throwable =
-          commitBlockingResponse(
+          FileUploadHelper.commitBlockingResponse(
               filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
     }
 
@@ -85,44 +81,8 @@ class RoutingContextFilenamesAdvice {
 
     if (contentCb != null && filesContent != null) {
       throwable =
-          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
-    }
-  }
-
-  private static BlockingException commitBlockingResponse(
-      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
-      RequestContext reqCtx,
-      List<String> data,
-      String reason) {
-    Flow<Void> flow = cb.apply(reqCtx, data);
-    Flow.Action action = flow.getAction();
-    if (action instanceof Flow.Action.RequestBlockingAction) {
-      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
-      if (brf != null) {
-        brf.tryCommitBlockingResponse(
-            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        return new BlockingException(reason);
-      }
-    }
-    return null;
-  }
-
-  private static String readUploadContent(FileUpload upload, int maxBytes) {
-    try {
-      String path = upload.uploadedFileName();
-      if (path == null || path.isEmpty()) {
-        return "";
-      }
-      String charSet = upload.charSet();
-      String contentType =
-          charSet != null && !charSet.isEmpty()
-              ? upload.contentType() + "; charset=" + charSet
-              : upload.contentType();
-      try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
-      }
-    } catch (Exception ignored) {
-      return "";
+          FileUploadHelper.commitBlockingResponse(
+              contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
@@ -18,6 +18,8 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   private static final Reference FILE_UPLOAD_REF =
       new Reference.Builder("io.vertx.ext.web.FileUpload")
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
@@ -20,6 +20,7 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "charSet", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextImplInstrumentation.java
@@ -28,6 +28,11 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".FileUploadHelper"};
+  }
+
+  @Override
   public String instrumentedType() {
     return "io.vertx.ext.web.impl.RoutingContextImpl";
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -98,8 +98,13 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
-  def 'test instrumentation gateway file upload content max files limit'() {
+  @Override
+  boolean testBodyFilesContentOrdering() {
+    false
+  }
+
+  // fileUploads() returns a HashSet in Vert.x: check count instead of which specific file is excluded
+  def 'test instrumentation gateway file upload content max files limit count'() {
     setup:
     assumeTrue(testBodyFilesContent())
     def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -88,6 +88,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -98,7 +98,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
   def 'test instrumentation gateway file upload content max files limit'() {
     setup:
     assumeTrue(testBodyFilesContent())

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,6 +1,8 @@
 package server
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -10,6 +12,10 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
@@ -90,6 +96,32 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override
   boolean testBodyFilesContent() {
     true
+  }
+
+  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  def 'test instrumentation gateway file upload content max files limit'() {
+    setup:
+    assumeTrue(testBodyFilesContent())
+    def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()
+    def bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM)
+    (1..maxFilesToInspect + 1).each { i ->
+      bodyBuilder.addFormDataPart("file${i}", "file${i}.bin",
+        RequestBody.create(MediaType.parse('application/octet-stream'), "content_of_file_${i}"))
+    }
+    def httpRequest = request(BODY_MULTIPART, 'POST', bodyBuilder.build()).build()
+    def response = client.newCall(httpRequest).execute()
+
+    when:
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.get(0).any { span ->
+      def tag = span.getTag('request.body.files_content') as String
+      tag != null && tag.count('content_of_file_') == maxFilesToInspect
+    }
+
+    cleanup:
+    response.close()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
@@ -93,8 +93,13 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
-  def 'test instrumentation gateway file upload content max files limit'() {
+  @Override
+  boolean testBodyFilesContentOrdering() {
+    false
+  }
+
+  // fileUploads() returns a HashSet in Vert.x: check count instead of which specific file is excluded
+  def 'test instrumentation gateway file upload content max files limit count'() {
     setup:
     assumeTrue(testBodyFilesContent())
     def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,6 +1,8 @@
 package server
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -10,6 +12,10 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
@@ -85,6 +91,32 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override
   boolean testBodyFilesContent() {
     true
+  }
+
+  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  def 'test instrumentation gateway file upload content max files limit'() {
+    setup:
+    assumeTrue(testBodyFilesContent())
+    def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()
+    def bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM)
+    (1..maxFilesToInspect + 1).each { i ->
+      bodyBuilder.addFormDataPart("file${i}", "file${i}.bin",
+        RequestBody.create(MediaType.parse('application/octet-stream'), "content_of_file_${i}"))
+    }
+    def httpRequest = request(BODY_MULTIPART, 'POST', bodyBuilder.build()).build()
+    def response = client.newCall(httpRequest).execute()
+
+    when:
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.get(0).any { span ->
+      def tag = span.getTag('request.body.files_content') as String
+      tag != null && tag.count('content_of_file_') == maxFilesToInspect
+    }
+
+    cleanup:
+    response.close()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
@@ -83,6 +83,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/latestDepTest/groovy/server/VertxHttpServerForkedTest.groovy
@@ -93,7 +93,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
   def 'test instrumentation gateway file upload content max files limit'() {
     setup:
     assumeTrue(testBodyFilesContent())

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/FileUploadHelper.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.http.MultipartContentDecoder;
+import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.function.BiFunction;
+
+class FileUploadHelper {
+
+  static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        brf.tryCommitBlockingResponse(
+            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
+        return new BlockingException(reason);
+      }
+    }
+    return null;
+  }
+
+  static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
+      }
+    } catch (Exception ignored) {
+      return "";
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/FileUploadHelper.java
@@ -10,9 +10,9 @@ import java.io.FileInputStream;
 import java.util.List;
 import java.util.function.BiFunction;
 
-class FileUploadHelper {
+public class FileUploadHelper {
 
-  static BlockingException commitBlockingResponse(
+  public static BlockingException commitBlockingResponse(
       BiFunction<RequestContext, List<String>, Flow<Void>> cb,
       RequestContext reqCtx,
       List<String> data,
@@ -30,7 +30,7 @@ class FileUploadHelper {
     return null;
   }
 
-  static String readUploadContent(FileUpload upload, int maxBytes) {
+  public static String readUploadContent(FileUpload upload, int maxBytes) {
     try {
       String path = upload.uploadedFileName();
       if (path == null || path.isEmpty()) {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
@@ -2,20 +2,16 @@ package datadog.trace.instrumentation.vertx_4_0.server;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
 
-import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.Config;
-import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -69,13 +65,13 @@ class RoutingContextFilenamesAdvice {
         if (filesContent == null) {
           filesContent = new ArrayList<>();
         }
-        filesContent.add(readUploadContent(upload, maxBytes));
+        filesContent.add(FileUploadHelper.readUploadContent(upload, maxBytes));
       }
     }
 
     if (filenamesCb != null && filenames != null) {
       throwable =
-          commitBlockingResponse(
+          FileUploadHelper.commitBlockingResponse(
               filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
     }
 
@@ -85,44 +81,8 @@ class RoutingContextFilenamesAdvice {
 
     if (contentCb != null && filesContent != null) {
       throwable =
-          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
-    }
-  }
-
-  private static BlockingException commitBlockingResponse(
-      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
-      RequestContext reqCtx,
-      List<String> data,
-      String reason) {
-    Flow<Void> flow = cb.apply(reqCtx, data);
-    Flow.Action action = flow.getAction();
-    if (action instanceof Flow.Action.RequestBlockingAction) {
-      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
-      if (brf != null) {
-        brf.tryCommitBlockingResponse(
-            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        return new BlockingException(reason);
-      }
-    }
-    return null;
-  }
-
-  private static String readUploadContent(FileUpload upload, int maxBytes) {
-    try {
-      String path = upload.uploadedFileName();
-      if (path == null || path.isEmpty()) {
-        return "";
-      }
-      String charSet = upload.charSet();
-      String contentType =
-          charSet != null && !charSet.isEmpty()
-              ? upload.contentType() + "; charset=" + charSet
-              : upload.contentType();
-      try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
-      }
-    } catch (Exception ignored) {
-      return "";
+          FileUploadHelper.commitBlockingResponse(
+              contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
@@ -5,14 +5,17 @@ import static datadog.trace.api.gateway.Events.EVENTS;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -38,35 +41,83 @@ class RoutingContextFilenamesAdvice {
       return;
     }
 
-    List<String> filenames = new ArrayList<>(uploads.size());
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
+        cbp.getCallback(EVENTS.requestFilesFilenames());
+    BiFunction<RequestContext, List<String>, Flow<Void>> contentCb =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (filenamesCb == null && contentCb == null) {
+      return;
+    }
+
+    int maxFiles = Config.get().getAppSecMaxFileContentCount();
+    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
+    List<String> filenames = null;
+    List<String> filesContent = null;
+
     for (FileUpload upload : uploads) {
       String name = upload.fileName();
-      if (name != null && !name.isEmpty()) {
+      if (filenamesCb != null && name != null && !name.isEmpty()) {
+        if (filenames == null) {
+          filenames = new ArrayList<>();
+        }
         filenames.add(name);
       }
+      if (contentCb != null
+          && maxFiles > 0
+          && (filesContent == null || filesContent.size() < maxFiles)) {
+        if (filesContent == null) {
+          filesContent = new ArrayList<>();
+        }
+        filesContent.add(readUploadContent(upload, maxBytes));
+      }
     }
-    if (filenames.isEmpty()) {
+
+    if (filenamesCb != null && filenames != null) {
+      throwable =
+          commitBlockingResponse(
+              filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
+    }
+
+    if (throwable != null) {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-    BiFunction<RequestContext, List<String>, Flow<Void>> cb =
-        cbp.getCallback(EVENTS.requestFilesFilenames());
-    if (cb == null) {
-      return;
+    if (contentCb != null && filesContent != null) {
+      throwable =
+          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
+  }
 
-    Flow<Void> flow = cb.apply(reqCtx, filenames);
+  private static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
     Flow.Action action = flow.getAction();
     if (action instanceof Flow.Action.RequestBlockingAction) {
       BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
       if (brf != null) {
         brf.tryCommitBlockingResponse(
             reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        if (throwable == null) {
-          throwable = new BlockingException("Blocked request (multipart file upload)");
-        }
+        return new BlockingException(reason);
       }
+    }
+    return null;
+  }
+
+  private static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+      }
+    } catch (Exception ignored) {
+      return "";
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextFilenamesAdvice.java
@@ -113,8 +113,13 @@ class RoutingContextFilenamesAdvice {
       if (path == null || path.isEmpty()) {
         return "";
       }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
       try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
       }
     } catch (Exception ignored) {
       return "";

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -31,6 +31,11 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".FileUploadHelper"};
+  }
+
+  @Override
   public Reference[] additionalMuzzleReferences() {
     return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE, FILE_UPLOAD_REF};
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -23,6 +23,7 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "charSet", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -21,6 +21,8 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   private static final Reference FILE_UPLOAD_REF =
       new Reference.Builder("io.vertx.ext.web.FileUpload")
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,6 +1,8 @@
 package server
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -10,6 +12,10 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
@@ -86,6 +92,32 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override
   boolean testBodyFilesContent() {
     true
+  }
+
+  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  def 'test instrumentation gateway file upload content max files limit'() {
+    setup:
+    assumeTrue(testBodyFilesContent())
+    def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()
+    def bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM)
+    (1..maxFilesToInspect + 1).each { i ->
+      bodyBuilder.addFormDataPart("file${i}", "file${i}.bin",
+        RequestBody.create(MediaType.parse('application/octet-stream'), "content_of_file_${i}"))
+    }
+    def httpRequest = request(BODY_MULTIPART, 'POST', bodyBuilder.build()).build()
+    def response = client.newCall(httpRequest).execute()
+
+    when:
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.get(0).any { span ->
+      def tag = span.getTag('request.body.files_content') as String
+      tag != null && tag.count('content_of_file_') == maxFilesToInspect
+    }
+
+    cleanup:
+    response.close()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -94,8 +94,13 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
-  def 'test instrumentation gateway file upload content max files limit'() {
+  @Override
+  boolean testBodyFilesContentOrdering() {
+    false
+  }
+
+  // fileUploads() returns a HashSet in Vert.x: check count instead of which specific file is excluded
+  def 'test instrumentation gateway file upload content max files limit count'() {
     setup:
     assumeTrue(testBodyFilesContent())
     def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -84,6 +84,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -94,7 +94,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
   def 'test instrumentation gateway file upload content max files limit'() {
     setup:
     assumeTrue(testBodyFilesContent())

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/FileUploadHelper.java
@@ -10,9 +10,9 @@ import java.io.FileInputStream;
 import java.util.List;
 import java.util.function.BiFunction;
 
-class FileUploadHelper {
+public class FileUploadHelper {
 
-  static BlockingException commitBlockingResponse(
+  public static BlockingException commitBlockingResponse(
       BiFunction<RequestContext, List<String>, Flow<Void>> cb,
       RequestContext reqCtx,
       List<String> data,
@@ -30,7 +30,7 @@ class FileUploadHelper {
     return null;
   }
 
-  static String readUploadContent(FileUpload upload, int maxBytes) {
+  public static String readUploadContent(FileUpload upload, int maxBytes) {
     try {
       String path = upload.uploadedFileName();
       if (path == null || path.isEmpty()) {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/FileUploadHelper.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/FileUploadHelper.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.vertx_5_0.server;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.http.MultipartContentDecoder;
+import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.function.BiFunction;
+
+class FileUploadHelper {
+
+  static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
+      if (brf != null) {
+        brf.tryCommitBlockingResponse(
+            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
+        return new BlockingException(reason);
+      }
+    }
+    return null;
+  }
+
+  static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
+      }
+    } catch (Exception ignored) {
+      return "";
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
@@ -112,8 +112,13 @@ class RoutingContextFilenamesAdvice {
       if (path == null || path.isEmpty()) {
         return "";
       }
+      String charSet = upload.charSet();
+      String contentType =
+          charSet != null && !charSet.isEmpty()
+              ? upload.contentType() + "; charset=" + charSet
+              : upload.contentType();
       try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
       }
     } catch (Exception ignored) {
       return "";

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
@@ -5,14 +5,17 @@ import static datadog.trace.api.gateway.Events.EVENTS;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -37,35 +40,83 @@ class RoutingContextFilenamesAdvice {
       return;
     }
 
-    List<String> filenames = new ArrayList<>(uploads.size());
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCb =
+        cbp.getCallback(EVENTS.requestFilesFilenames());
+    BiFunction<RequestContext, List<String>, Flow<Void>> contentCb =
+        cbp.getCallback(EVENTS.requestFilesContent());
+    if (filenamesCb == null && contentCb == null) {
+      return;
+    }
+
+    int maxFiles = Config.get().getAppSecMaxFileContentCount();
+    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
+    List<String> filenames = null;
+    List<String> filesContent = null;
+
     for (FileUpload upload : uploads) {
       String name = upload.fileName();
-      if (name != null && !name.isEmpty()) {
+      if (filenamesCb != null && name != null && !name.isEmpty()) {
+        if (filenames == null) {
+          filenames = new ArrayList<>();
+        }
         filenames.add(name);
       }
+      if (contentCb != null
+          && maxFiles > 0
+          && (filesContent == null || filesContent.size() < maxFiles)) {
+        if (filesContent == null) {
+          filesContent = new ArrayList<>();
+        }
+        filesContent.add(readUploadContent(upload, maxBytes));
+      }
     }
-    if (filenames.isEmpty()) {
+
+    if (filenamesCb != null && filenames != null) {
+      throwable =
+          commitBlockingResponse(
+              filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
+    }
+
+    if (throwable != null) {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-    BiFunction<RequestContext, List<String>, Flow<Void>> cb =
-        cbp.getCallback(EVENTS.requestFilesFilenames());
-    if (cb == null) {
-      return;
+    if (contentCb != null && filesContent != null) {
+      throwable =
+          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
+  }
 
-    Flow<Void> flow = cb.apply(reqCtx, filenames);
+  private static BlockingException commitBlockingResponse(
+      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
+      RequestContext reqCtx,
+      List<String> data,
+      String reason) {
+    Flow<Void> flow = cb.apply(reqCtx, data);
     Flow.Action action = flow.getAction();
     if (action instanceof Flow.Action.RequestBlockingAction) {
       BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
       if (brf != null) {
         brf.tryCommitBlockingResponse(
             reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        if (throwable == null) {
-          throwable = new BlockingException("Blocked request (multipart file upload)");
-        }
+        return new BlockingException(reason);
       }
+    }
+    return null;
+  }
+
+  private static String readUploadContent(FileUpload upload, int maxBytes) {
+    try {
+      String path = upload.uploadedFileName();
+      if (path == null || path.isEmpty()) {
+        return "";
+      }
+      try (FileInputStream fis = new FileInputStream(path)) {
+        return MultipartContentDecoder.readInputStream(fis, maxBytes, upload.contentType());
+      }
+    } catch (Exception ignored) {
+      return "";
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextFilenamesAdvice.java
@@ -2,20 +2,16 @@ package datadog.trace.instrumentation.vertx_5_0.server;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
 
-import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.Config;
-import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.api.http.MultipartContentDecoder;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.ext.web.FileUpload;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -68,13 +64,13 @@ class RoutingContextFilenamesAdvice {
         if (filesContent == null) {
           filesContent = new ArrayList<>();
         }
-        filesContent.add(readUploadContent(upload, maxBytes));
+        filesContent.add(FileUploadHelper.readUploadContent(upload, maxBytes));
       }
     }
 
     if (filenamesCb != null && filenames != null) {
       throwable =
-          commitBlockingResponse(
+          FileUploadHelper.commitBlockingResponse(
               filenamesCb, reqCtx, filenames, "Blocked request (multipart file upload)");
     }
 
@@ -84,44 +80,8 @@ class RoutingContextFilenamesAdvice {
 
     if (contentCb != null && filesContent != null) {
       throwable =
-          commitBlockingResponse(contentCb, reqCtx, filesContent, "Blocked request (file content)");
-    }
-  }
-
-  private static BlockingException commitBlockingResponse(
-      BiFunction<RequestContext, List<String>, Flow<Void>> cb,
-      RequestContext reqCtx,
-      List<String> data,
-      String reason) {
-    Flow<Void> flow = cb.apply(reqCtx, data);
-    Flow.Action action = flow.getAction();
-    if (action instanceof Flow.Action.RequestBlockingAction) {
-      BlockResponseFunction brf = reqCtx.getBlockResponseFunction();
-      if (brf != null) {
-        brf.tryCommitBlockingResponse(
-            reqCtx.getTraceSegment(), (Flow.Action.RequestBlockingAction) action);
-        return new BlockingException(reason);
-      }
-    }
-    return null;
-  }
-
-  private static String readUploadContent(FileUpload upload, int maxBytes) {
-    try {
-      String path = upload.uploadedFileName();
-      if (path == null || path.isEmpty()) {
-        return "";
-      }
-      String charSet = upload.charSet();
-      String contentType =
-          charSet != null && !charSet.isEmpty()
-              ? upload.contentType() + "; charset=" + charSet
-              : upload.contentType();
-      try (FileInputStream fis = new FileInputStream(path)) {
-        return MultipartContentDecoder.readInputStream(fis, maxBytes, contentType);
-      }
-    } catch (Exception ignored) {
-      return "";
+          FileUploadHelper.commitBlockingResponse(
+              contentCb, reqCtx, filesContent, "Blocked request (file content)");
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
@@ -15,6 +15,8 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   private static final Reference FILE_UPLOAD_REF =
       new Reference.Builder("io.vertx.ext.web.FileUpload")
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
@@ -25,6 +25,11 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".FileUploadHelper"};
+  }
+
+  @Override
   public String instrumentedType() {
     return "io.vertx.ext.web.impl.RoutingContextImpl";
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/main/java/datadog/trace/instrumentation/vertx_5_0/server/RoutingContextImplInstrumentation.java
@@ -17,6 +17,7 @@ public class RoutingContextImplInstrumentation extends InstrumenterModule.AppSec
           .withMethod(new String[0], 0, "fileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "uploadedFileName", "Ljava/lang/String;")
           .withMethod(new String[0], 0, "contentType", "Ljava/lang/String;")
+          .withMethod(new String[0], 0, "charSet", "Ljava/lang/String;")
           .build();
 
   public RoutingContextImplInstrumentation() {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -23,8 +23,6 @@ import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Vertx
-import okhttp3.MediaType
-import okhttp3.RequestBody
 
 class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -101,8 +101,13 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
-  def 'test instrumentation gateway file upload content max files limit'() {
+  @Override
+  boolean testBodyFilesContentOrdering() {
+    false
+  }
+
+  // fileUploads() returns a HashSet in Vert.x: check count instead of which specific file is excluded
+  def 'test instrumentation gateway file upload content max files limit count'() {
     setup:
     assumeTrue(testBodyFilesContent())
     def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,7 +1,9 @@
 package server
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -11,6 +13,10 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
@@ -93,6 +99,32 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override
   boolean testBodyFilesContent() {
     true
+  }
+
+  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  def 'test instrumentation gateway file upload content max files limit'() {
+    setup:
+    assumeTrue(testBodyFilesContent())
+    def maxFilesToInspect = Config.get().getAppSecMaxFileContentCount()
+    def bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM)
+    (1..maxFilesToInspect + 1).each { i ->
+      bodyBuilder.addFormDataPart("file${i}", "file${i}.bin",
+        RequestBody.create(MediaType.parse('application/octet-stream'), "content_of_file_${i}"))
+    }
+    def httpRequest = request(BODY_MULTIPART, 'POST', bodyBuilder.build()).build()
+    def response = client.newCall(httpRequest).execute()
+
+    when:
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.get(0).any { span ->
+      def tag = span.getTag('request.body.files_content') as String
+      tag != null && tag.count('content_of_file_') == maxFilesToInspect
+    }
+
+    cleanup:
+    response.close()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -101,7 +101,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     true
   }
 
-  // fileUploads() returns a HashSet in Vert.x — override to verify count instead of which specific file is last
+  // fileUploads() returns a HashSet in Vert.x: override to verify count instead of which specific file is last
   def 'test instrumentation gateway file upload content max files limit'() {
     setup:
     assumeTrue(testBodyFilesContent())

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-5.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -91,6 +91,11 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   }
 
   @Override
+  boolean testBodyFilesContent() {
+    true
+  }
+
+  @Override
   boolean testBodyJson() {
     true
   }


### PR DESCRIPTION
# What Does This Do

Extends `RoutingContextFilenamesAdvice` in `vertx-web-3.4`, `vertx-web-4.0`, and `vertx-web-5.0` to fire the `server.request.body.files_content` WAF address alongside the existing `server.request.body.filenames` address.

## Changes

- `RoutingContextFilenamesAdvice` (3 modules) - adds `requestFilesContent()` IG callback dispatch:
  - Reads file content from disk via `FileInputStream` + `MultipartContentDecoder.readInputStream()` (charset-aware, introduced in #11212)
  - Respects `DD_APPSEC_MAX_FILE_CONTENT_COUNT` and `DD_APPSEC_MAX_FILE_CONTENT_BYTES` limits
  - Sequential guard: content callback fires only if the filenames callback did not trigger a block
  - Extracts a `commitBlockingResponse()` private static helper to deduplicate the blocking dispatch pattern
- `RoutingContextImplInstrumentation` (3 modules) - updates `FILE_UPLOAD_REF` to include `uploadedFileName()` and `contentType()` muzzle references required by the content reader
- `VertxHttpServerForkedTest` (4 test files) - enables `testBodyFilesContent()` override

# Motivation

Part of APPSEC-61875: adds `server.request.body.files_content` across all Java frameworks. Vert.x BodyHandler always persists uploads to disk, making content reading via `uploadedFileName()` straightforward and always valid.

# Additional Notes

The content loop uses a `maxFiles > 0` leading guard to match the behavior of the reference implementations (Jersey, Tomcat, Netty). Without it, `maxFiles=0` would admit one file because the lazy-init null check short-circuits the size comparison.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APPSEC-61875](https://datadoghq.atlassian.net/browse/APPSEC-61875)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

[APPSEC-61875]: https://datadoghq.atlassian.net/browse/APPSEC-61875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ