### PR TITLE
Avoid final field modification in Weaver instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
+++ b/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
@@ -1,12 +1,12 @@
 package datadog.trace.instrumentation.weaver;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.lang.reflect.Field;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import net.bytebuddy.asm.Advice;
@@ -38,34 +38,34 @@ public class WeaverInstrumentation extends InstrumenterModule.CiVisibility
 
   @Override
   public void methodAdvice(MethodTransformer transformer) {
+    // disney's implementation (0.8.4+) uses a ConcurrentLinkedQueue
     transformer.applyAdvice(
-        isConstructor(), WeaverInstrumentation.class.getName() + "$SbtTaskCreationAdvice");
+        isConstructor().and(takesArgument(5, named("java.util.concurrent.ConcurrentLinkedQueue"))),
+        WeaverInstrumentation.class.getName() + "$ConcurrentLinkedQueueAdvice");
+    // typelevel's implementation (0.9+) uses a LinkedBlockingQueue
+    transformer.applyAdvice(
+        isConstructor().and(takesArgument(5, named("java.util.concurrent.LinkedBlockingQueue"))),
+        WeaverInstrumentation.class.getName() + "$LinkedBlockingQueueAdvice");
   }
 
-  public static class SbtTaskCreationAdvice {
-    // TODO: JEP 500 - avoid mutating final fields
-    @SuppressForbidden
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onTaskCreation(
-        @Advice.This Object sbtTask, @Advice.FieldValue("taskDef") TaskDef taskDef) {
-      try {
-        Field queueField = sbtTask.getClass().getDeclaredField("queue");
-        queueField.setAccessible(true);
-        Object queue = queueField.get(sbtTask);
-        if (queue instanceof ConcurrentLinkedQueue) {
-          // disney's implementation (0.8.4+) uses a ConcurrentLinkedQueue for the field
-          queueField.set(
-              sbtTask,
-              new TaskDefAwareConcurrentLinkedQueueProxy<SuiteEvent>(
-                  taskDef, (ConcurrentLinkedQueue<SuiteEvent>) queue));
-        } else if (queue instanceof LinkedBlockingQueue) {
-          // typelevel's implementation (0.9+) uses a LinkedBlockingQueue for the field
-          queueField.set(
-              sbtTask,
-              new TaskDefAwareLinkedBlockingQueueProxy<SuiteEvent>(
-                  taskDef, (LinkedBlockingQueue<SuiteEvent>) queue));
-        }
-      } catch (Exception ignored) {
+  public static class ConcurrentLinkedQueueAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrapQueue(
+        @Advice.Argument(0) TaskDef taskDef,
+        @Advice.Argument(value = 5, readOnly = false) ConcurrentLinkedQueue<SuiteEvent> queue) {
+      if (!(queue instanceof TaskDefAwareConcurrentLinkedQueueProxy)) {
+        queue = new TaskDefAwareConcurrentLinkedQueueProxy<>(taskDef, queue);
+      }
+    }
+  }
+
+  public static class LinkedBlockingQueueAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrapQueue(
+        @Advice.Argument(0) TaskDef taskDef,
+        @Advice.Argument(value = 5, readOnly = false) LinkedBlockingQueue<SuiteEvent> queue) {
+      if (!(queue instanceof TaskDefAwareLinkedBlockingQueueProxy)) {
+        queue = new TaskDefAwareLinkedBlockingQueueProxy<>(taskDef, queue);
       }
     }
   }

--- a/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
+++ b/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
@@ -42,7 +42,7 @@ public class WeaverInstrumentation extends InstrumenterModule.CiVisibility
     transformer.applyAdvice(
         isConstructor().and(takesArgument(5, named("java.util.concurrent.ConcurrentLinkedQueue"))),
         WeaverInstrumentation.class.getName() + "$ConcurrentLinkedQueueAdvice");
-    // typelevel's implementation (0.9+) uses a LinkedBlockingQueue
+    // typelevel/weaver-test (0.9+) uses a LinkedBlockingQueue
     transformer.applyAdvice(
         isConstructor().and(takesArgument(5, named("java.util.concurrent.LinkedBlockingQueue"))),
         WeaverInstrumentation.class.getName() + "$LinkedBlockingQueueAdvice");

--- a/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
+++ b/dd-java-agent/instrumentation/weaver-0.9/src/main/java/datadog/trace/instrumentation/weaver/WeaverInstrumentation.java
@@ -38,7 +38,7 @@ public class WeaverInstrumentation extends InstrumenterModule.CiVisibility
 
   @Override
   public void methodAdvice(MethodTransformer transformer) {
-    // disney's implementation (0.8.4+) uses a ConcurrentLinkedQueue
+    // disneystreaming/weaver-test (0.8.4+) uses a ConcurrentLinkedQueue
     transformer.applyAdvice(
         isConstructor().and(takesArgument(5, named("java.util.concurrent.ConcurrentLinkedQueue"))),
         WeaverInstrumentation.class.getName() + "$ConcurrentLinkedQueueAdvice");


### PR DESCRIPTION
# What Does This Do

- Avoid final field modifications in Weaver instrumentation by intercepting the constructor argument `OnMethodEnter` instead of modifying the field `OnMethodExit`.

# Motivation

Avoid failures in future JDKs due to [JEP 500: Prepare to Make Final Mean Final](https://openjdk.org/jeps/500).

# Additional Notes

Running an example project on JDK26 with `JAVA_TOOL_OPTIONS: --illegal-final-field-mutation=debug` produced the following logs:

```
Final field queue in class weaver.framework.SbtTask has been mutated reflectively by class weaver.framework.SbtTask in unnamed module
```

The build containing the fix doesn't produce the logs.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [SDTEST-3866]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-3866]: https://datadoghq.atlassian.net/browse/SDTEST-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ