### PR TITLE
Upgrade Shadow plugin to 9.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
   id("com.github.spotbugs") version "6.5.5"
   id("de.thetaphi.forbiddenapis") version "3.10"
   id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-  id("com.gradleup.shadow") version "9.4.2" apply false
+  alias(libs.plugins.shadow) apply false
   id("me.champeau.jmh") version "0.7.3" apply false
   id("org.gradle.playframework") version "0.16.0" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
   id("com.github.spotbugs") version "6.5.5"
   id("de.thetaphi.forbiddenapis") version "3.10"
   id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-  id("com.gradleup.shadow") version "8.3.9" apply false
+  id("com.gradleup.shadow") version "9.4.2" apply false
   id("me.champeau.jmh") version "0.7.3" apply false
   id("org.gradle.playframework") version "0.16.0" apply false
 }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -70,13 +70,8 @@ tasks {
 
   shadowJar {
     duplicatesStrategy = DuplicatesStrategy.FAIL
-    mergeServiceFiles()
-    // Service descriptors are intentionally merged by mergeServiceFiles(); let
-    // duplicate service entries reach that transformer instead of failing first.
-    filesMatching("META-INF/services/**") {
-      duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    }
-    filesNotMatching("META-INF/services/**") {
+    // Let's ignore license/notice since Let's ignore
+    filesMatching(listOf("META-INF/LICENSE*", "META-INF/NOTICE*")) {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
     manifest {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -70,7 +70,7 @@ tasks {
 
   shadowJar {
     duplicatesStrategy = DuplicatesStrategy.FAIL
-    // Let's ignore license/notice since Let's ignore
+    // Let's skip license/notice since this jar's only use is during build
     filesMatching(listOf("META-INF/LICENSE*", "META-INF/NOTICE*")) {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   java
   id("com.diffplug.spotless") version "8.4.0"
-  id("com.gradleup.shadow") version "9.4.2"
+  alias(libs.plugins.shadow)
 }
 
 java {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -69,10 +69,13 @@ tasks {
   }
 
   shadowJar {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.FAIL
     mergeServiceFiles()
     // Service descriptors are intentionally merged by mergeServiceFiles(); let
     // duplicate service entries reach that transformer instead of failing first.
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     filesNotMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   java
   id("com.diffplug.spotless") version "8.4.0"
-  id("com.gradleup.shadow") version "8.3.9"
+  id("com.gradleup.shadow") version "9.4.2"
 }
 
 java {
@@ -69,7 +69,13 @@ tasks {
   }
 
   shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
+    // Service descriptors are intentionally merged by mergeServiceFiles(); let
+    // duplicate service entries reach that transformer instead of failing first.
+    filesNotMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
     manifest {
       attributes(mapOf("Main-Class" to "datadog.trace.plugin.csi.PluginApplication"))
     }

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   java
-  id("com.gradleup.shadow") version "9.4.2"
+  alias(libs.plugins.shadow)
 }
 
 java {

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   java
-  id("com.gradleup.shadow") version "8.3.9"
+  id("com.gradleup.shadow") version "9.4.2"
 }
 
 java {

--- a/dd-java-agent/agent-aiguard/build.gradle
+++ b/dd-java-agent/agent-aiguard/build.gradle
@@ -34,4 +34,3 @@ tasks.named("shadowJar", ShadowJar) {
 tasks.named("jar", Jar) {
   archiveClassifier = 'unbundled'
 }
-

--- a/dd-java-agent/benchmark-integration/build.gradle
+++ b/dd-java-agent/benchmark-integration/build.gradle
@@ -1,26 +1,3 @@
-buildscript {
-  repositories {
-    mavenLocal()
-    if (project.rootProject.hasProperty("gradlePluginProxy")) {
-      maven {
-        url project.rootProject.property("gradlePluginProxy")
-        allowInsecureProtocol = true
-      }
-    }
-    if (project.rootProject.hasProperty("mavenRepositoryProxy")) {
-      maven {
-        url project.rootProject.property("mavenRepositoryProxy")
-        allowInsecureProtocol = true
-      }
-    }
-    gradlePluginPortal()
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
-  }
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Integration Level Agent benchmarks.'

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -81,8 +81,24 @@ dependencies {
 def generalShadowJarConfig(ShadowJar shadowJarTask) {
   shadowJarTask.with {
     mergeServiceFiles()
+    addMultiReleaseAttribute = false
 
     duplicatesStrategy = DuplicatesStrategy.FAIL
+    // Service descriptors are intentionally merged by mergeServiceFiles(); let
+    // duplicate service entries reach that transformer instead of failing first.
+    filesMatching('META-INF/services/**') {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    // Vendored dependencies often repeat license/notice metadata. Keep one copy
+    // while still failing on unexpected duplicate runtime resources and classes.
+    filesMatching([
+      'META-INF/LICENSE*',
+      'META-INF/NOTICE*',
+      'META-INF/AL2.0',
+      'META-INF/LGPL2.1',
+    ]) {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 
     // Remove some cruft from the final jar.
     // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
@@ -99,6 +115,7 @@ def generalShadowJarConfig(ShadowJar shadowJarTask) {
     exclude '**/inst/META-INF/versions/**'
     exclude '**/META-INF/versions/*/org/yaml/**'
     exclude '**/package.html'
+    exclude '**/about.html'
 
     // Used to generate Java code during build, no need to include original file
     exclude '**/*.trie'
@@ -257,7 +274,7 @@ includeSubprojShadowJar(project(':products:metrics:metrics-lib'), 'metrics', inc
 includeSubprojShadowJar(project(':products:feature-flagging:feature-flagging-agent'), 'feature-flagging', includedJarFileTree)
 
 def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
-  it.configurations = [project.configurations.sharedShadowInclude]
+  it.configurations.add(project.configurations.named('sharedShadowInclude'))
   // Put the jar in a different directory so we don't overwrite the normal shadow jar and
   // break caching, and also to not interfere with CI scripts that copy everything in the
   // libs directory
@@ -275,16 +292,16 @@ def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
     exclude(project(':utils:time-utils'))
     exclude(project(':products:metrics:metrics-api'))
     exclude(project(':products:metrics:metrics-agent'))
-    exclude(dependency('org.slf4j::'))
+    exclude(dependency('org.slf4j:.*:.*'))
     // use dd-instrument-java's embedded copy of asm
-    exclude(dependency('org.ow2.asm:asm:'))
+    exclude(dependency('org.ow2.asm:asm:.*'))
   }
 }
 includeShadowJar(sharedShadowJar, 'shared', includedJarFileTree)
 
 // place the tracer in its own shadow jar separate to instrumentation
 def traceShadowJar = tasks.register('traceShadowJar', ShadowJar) {
-  it.configurations = [project.configurations.traceShadowInclude]
+  it.configurations.add(project.configurations.named('traceShadowInclude'))
   it.destinationDirectory.set(project.layout.buildDirectory.dir("trace-lib"))
   it.archiveClassifier = 'trace'
   it.dependencies deps.excludeShared
@@ -299,7 +316,10 @@ tasks.named("shadowJar", ShadowJar) {
 
   generalShadowJarConfig(it)
 
-  configurations = [project.configurations.shadowInclude]
+  // The default shadowJar task has a runtimeClasspath convention. Replace it
+  // instead of adding to it, otherwise runtimeClasspath would be bundled too.
+  configurations.empty()
+  configurations.add(project.configurations.named('shadowInclude'))
 
   archiveClassifier = ''
 

--- a/dd-java-agent/ddprof-lib/build.gradle
+++ b/dd-java-agent/ddprof-lib/build.gradle
@@ -16,10 +16,8 @@ dependencies {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  dependencies {
-    deps.excludeShared
-    exclude '**/*.debug'
-  }
+  dependencies deps.excludeShared
+  exclude '**/*.debug'
   archiveClassifier = 'all'
   include {
     def rslt = false

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -149,7 +149,7 @@ tasks.named('shadowJar', ShadowJar) {
     exclude(project(":dd-trace-core"))
     exclude(dependency('com.datadoghq:sketches-java'))
     exclude(dependency('com.google.re2j:re2j'))
-    deps.excludeShared(delegate)
+    deps.excludeShared.execute(it)
   }
 }
 

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -120,13 +120,37 @@ if (project.gradle.startParameter.taskNames.any { it.endsWith("generateMuzzleRep
 
 tasks.named('shadowJar', ShadowJar) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
+  // Shadow 8.x silently wrote duplicate class (130+) entries into the instrumentation jar.
+  // Those duplicate entries did not survive as duplicates in the final agent jar,
+  // because `:dd-java-agent:expandAgentShadowJarInst` expands the instrumentation jar
+  // with a `Sync` task, and the specific `inst` expansion keeps the first duplicate path.
+  // (explicit `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` on the `inst` prefix).
+  //
+  // Shadow 9 refactored deeply it's "copy" pipeline via https://github.com/GradleUp/shadow/pull/1233
+  // by `Project.zipTree` and can now honor `DuplicatesStrategy`, see in particular
+  // * https://github.com/GradleUp/shadow/issues/1223 - Duplicates from jars are not handled per duplicatesStrategy
+  // * https://github.com/GradleUp/shadow/issues/488 - DuplicatesStrategy.FAIL doesn't work with transform
+  //
+  // Keeping `duplicatesStrategy = FAIL` only, Shadow 9 now fails while creating the instrumentation jar.
+  filesMatching([
+    // agent-installer also publishes this Java 11 source-set output at runtime.
+    'datadog/trace/agent/tooling/bytebuddy/DDJava9ClassFileTransformer*.class',
+    // agent-installer also publishes this Java 25 source-set output at runtime.
+    'datadog/trace/agent/tooling/servicediscovery/MemFDUnixWriterFFM*.class',
+    // aggregate instrumentation includes some classes directly and via jars.
+    'datadog/trace/instrumentation/**/*.class',
+    // same aggregate duplication, for Java 11 exception profiling advice.
+    'datadog/exceptions/instrumentation/**/*.class',
+  ]) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  }
   dependencies {
     // the tracer is now in a separate shadow jar
     exclude(project(":dd-trace-core"))
     exclude(dependency('com.datadoghq:sketches-java'))
     exclude(dependency('com.google.re2j:re2j'))
+    deps.excludeShared(delegate)
   }
-  dependencies deps.excludeShared
 }
 
 // temporary config to add slf4j-simple so we get logging from instrumenters while indexing

--- a/dd-java-agent/instrumentation/liberty/liberty-23.0/build.gradle
+++ b/dd-java-agent/instrumentation/liberty/liberty-23.0/build.gradle
@@ -137,7 +137,10 @@ tasks.named('filterLogbackClassic', Sync) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.shadow]
+  // The default shadowJar task has a runtimeClasspath convention. Replace it
+  // instead of adding to it; this jar is intentionally built from the shadow configuration only.
+  configurations.empty()
+  configurations.add(project.configurations.named('shadow'))
   zip64 = true
 
   archiveFileName = 'openliberty-shadow.jar'

--- a/dd-java-agent/instrumentation/servlet/jakarta-servlet-5.0/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/jakarta-servlet-5.0/build.gradle
@@ -37,7 +37,7 @@ tasks.register('relocatedJavaxJar', ShadowJar) {
 
   archiveClassifier.set('relocated-javax')
 
-  configurations = [project.configurations.javaxClassesToRelocate]
+  configurations.add(project.configurations.named('javaxClassesToRelocate'))
 
   include '**/*.jar'
   include '**/Servlet31InputStreamWrapper.class'

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -67,9 +67,9 @@ tasks.named("shadowJar", ShadowJar) {
   // Only bundle jetty dependencies into the jar (relocated)
   // All other dependencies remain as transitive dependencies
   dependencies {
-    include(dependency {
+    include {
       it.moduleGroup == 'org.eclipse.jetty' || it.moduleGroup == 'org.eclipse.jetty.http2'
-    })
+    }
   }
 
   // Relocate jetty classes to avoid conflicts with instrumented versions

--- a/dd-smoke-tests/appsec/springboot-graphql/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-graphql/build.gradle
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 
 plugins {
   id 'com.gradleup.shadow'
@@ -16,8 +17,23 @@ jar {
 }
 
 shadowJar {
-  mergeServiceFiles {
-    include 'META-INF/spring.*'
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  mergeServiceFiles()
+  append 'META-INF/spring.handlers'
+  append 'META-INF/spring.schemas'
+  append 'META-INF/spring.tooling'
+  transform(PropertiesFileTransformer) {
+    paths = ['META-INF/spring.factories']
+    mergeStrategy = "append"
+  }
+  filesNotMatching([
+    'META-INF/services/**',
+    'META-INF/spring.handlers',
+    'META-INF/spring.schemas',
+    'META-INF/spring.tooling',
+    'META-INF/spring.factories',
+  ]) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 }
 

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -14,7 +14,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/field-injection/build.gradle
+++ b/dd-smoke-tests/field-injection/build.gradle
@@ -14,7 +14,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/grpc-1.5/build.gradle
+++ b/dd-smoke-tests/grpc-1.5/build.gradle
@@ -39,8 +39,12 @@ protobuf {
 }
 
 tasks.withType(ShadowJar).configureEach {
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   archiveClassifier.set("fat")
   mergeServiceFiles()
+  filesNotMatching('META-INF/services/**') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -30,7 +30,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/log-injection/build.gradle
+++ b/dd-smoke-tests/log-injection/build.gradle
@@ -178,7 +178,9 @@ def generateTestingJar(String interfaceName, String backend, List<NamedDomainObj
 
     archiveBaseName.set(name)
 
-    configurations = [project.configurations.named('runtimeClasspath').get()] + configurationProviders.collect { it.get() }
+    configurations = providers.provider {
+      [project.configurations.named('runtimeClasspath').get()] + configurationProviders.collect { it.get() }
+    }
   }
 }
 
@@ -391,5 +393,4 @@ tasks.withType(Test).configureEach {
     .orElse(Math.max(1, (Runtime.runtime.availableProcessors() / 2).toInteger()))
     .get()
 }
-
 

--- a/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
@@ -17,7 +17,8 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
   append 'META-INF/spring.handlers'
   append 'META-INF/spring.schemas'
@@ -25,6 +26,15 @@ tasks.named("shadowJar", ShadowJar) {
   transform(PropertiesFileTransformer) {
     paths = ['META-INF/spring.factories']
     mergeStrategy = "append"
+  }
+  filesNotMatching([
+    'META-INF/services/**',
+    'META-INF/spring.handlers',
+    'META-INF/spring.schemas',
+    'META-INF/spring.tooling',
+    'META-INF/spring.factories',
+  ]) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 }
 

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -16,7 +16,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
@@ -16,7 +16,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
@@ -17,7 +17,8 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
   append 'META-INF/spring.handlers'
   append 'META-INF/spring.schemas'
@@ -25,6 +26,15 @@ tasks.named("shadowJar", ShadowJar) {
   transform(PropertiesFileTransformer) {
     paths = ['META-INF/spring.factories']
     mergeStrategy = "append"
+  }
+  filesNotMatching([
+    'META-INF/services/**',
+    'META-INF/spring.handlers',
+    'META-INF/spring.schemas',
+    'META-INF/spring.tooling',
+    'META-INF/spring.factories',
+  ]) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 }
 

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
@@ -18,7 +18,8 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
   append 'META-INF/spring.handlers'
   append 'META-INF/spring.schemas'
@@ -26,6 +27,15 @@ tasks.named("shadowJar", ShadowJar) {
   transform(PropertiesFileTransformer) {
     paths = ['META-INF/spring.factories']
     mergeStrategy = "append"
+  }
+  filesNotMatching([
+    'META-INF/services/**',
+    'META-INF/spring.handlers',
+    'META-INF/spring.schemas',
+    'META-INF/spring.tooling',
+    'META-INF/spring.factories',
+  ]) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 }
 

--- a/dd-smoke-tests/spring-boot-rabbit/build.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/build.gradle
@@ -16,7 +16,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -41,7 +41,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-smoke-tests/springboot-mongo/build.gradle
+++ b/dd-smoke-tests/springboot-mongo/build.gradle
@@ -16,7 +16,7 @@ tasks.named("jar", Jar) {
 }
 
 tasks.named("shadowJar", ShadowJar) {
-  configurations = [project.configurations.runtimeClasspath]
+  configurations.add(project.configurations.named('runtimeClasspath'))
 }
 
 dependencies {

--- a/dd-trace-ot/build.gradle.kts
+++ b/dd-trace-ot/build.gradle.kts
@@ -119,12 +119,12 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
   dependencies {
     // direct dependencies
     exclude(project(":dd-trace-api"))
-    exclude(dependency("io.opentracing:"))
-    exclude(dependency("io.opentracing.contrib:"))
-    exclude(dependency("org.slf4j:"))
-    exclude(dependency("com.github.jnr:"))
+    exclude(dependency("io.opentracing:.*:.*"))
+    exclude(dependency("io.opentracing.contrib:.*:.*"))
+    exclude(dependency("org.slf4j:.*:.*"))
+    exclude(dependency("com.github.jnr:.*:.*"))
     // indirect dependency of JNR, no need to embed
-    exclude(dependency("org.ow2.asm:"))
+    exclude(dependency("org.ow2.asm:.*:.*"))
   }
 
   relocate("com.", "ddtrot.com.") {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,12 @@ final class CachedData {
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
     // which is similar but not exactly the same as the regular gradle dependency{} block
     // Also, transitive dependencies have to be explicitly listed
-    excludeShared        : (Closure) {
+    excludeShared        : (Closure) { Object filter = null ->
+      def spec = filter ?: delegate
+      def project = { notation -> spec.project(notation) }
+      def dependency = { notation -> spec.dependency(notation) }
+      def exclude = { notation -> spec.exclude(notation) }
+
       // projects bundled with shared or on bootstrap
       exclude(project(':dd-java-agent:agent-bootstrap'))
       exclude(project(':dd-java-agent:agent-debugger:debugger-bootstrap'))
@@ -36,8 +41,8 @@ final class CachedData {
       exclude(project(':utils:version-utils'))
       exclude(project(':dd-java-agent:agent-crashtracking'))
       exclude(project(':dd-java-agent:ddprof-lib'))
-      exclude(dependency('org.slf4j::'))
-      exclude(dependency(':dd-instrument-java:'))
+      exclude(dependency('org.slf4j:.*:.*'))
+      exclude(dependency('.*:dd-instrument-java:.*'))
 
       // okhttp and its transitives (both fork and non-fork)
       exclude(dependency('com.datadoghq.okhttp3:okhttp'))
@@ -49,8 +54,8 @@ final class CachedData {
 
       // dogstatsd and its transitives
       exclude(dependency('com.datadoghq:java-dogstatsd-client'))
-      exclude(dependency('com.github.jnr::'))
-      exclude(dependency('org.ow2.asm::'))
+      exclude(dependency('com.github.jnr:.*:.*'))
+      exclude(dependency('org.ow2.asm:.*:.*'))
 
       // sketches-java used by dd-trace-core (DataStreams) and metrics
       exclude(dependency('com.datadoghq:sketches-java'))
@@ -59,13 +64,13 @@ final class CachedData {
       exclude(dependency('com.datadoghq:dd-javac-plugin-client'))
 
       // moshi and its transitives
-      exclude(dependency('com.squareup.moshi::'))
+      exclude(dependency('com.squareup.moshi:.*:.*'))
 
       // jctools and its transitives
-      exclude(dependency('org.jctools::'))
+      exclude(dependency('org.jctools:.*:.*'))
 
       // cafe_crypto and its transitives
-      exclude(dependency('cafe.cryptography::'))
+      exclude(dependency('cafe.cryptography:.*:.*'))
 
       // snakeyaml-engine and its transitives
       exclude(dependency('org.snakeyaml:snakeyaml-engine'))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,76 +7,76 @@ final class CachedData {
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
     // which is similar but not exactly the same as the regular gradle dependency{} block
     // Also, transitive dependencies have to be explicitly listed
-    excludeShared        : (Closure) { Object filter = null ->
-      def spec = filter ?: delegate
-      def project = { notation -> spec.project(notation) }
-      def dependency = { notation -> spec.dependency(notation) }
-      def exclude = { notation -> spec.exclude(notation) }
+    // Can't use shadow's Action<DependencyFilter> because dependencies.gradle is used in
+    // projects that don't have this plugin (e.g. the other unrelated declarations)
+    excludeShared        : new Action<Object>() {
+      @Override
+      void execute(Object filter) {
+        // projects bundled with shared or on bootstrap
+        filter.exclude(filter.project(':dd-java-agent:agent-bootstrap'))
+        filter.exclude(filter.project(':dd-java-agent:agent-debugger:debugger-bootstrap'))
+        filter.exclude(filter.project(':dd-java-agent:agent-logging'))
+        filter.exclude(filter.project(':dd-trace-api'))
+        filter.exclude(filter.project(':internal-api'))
+        filter.exclude(filter.project(':internal-api:internal-api-9'))
+        filter.exclude(filter.project(':communication'))
+        filter.exclude(filter.project(':components:context'))
+        filter.exclude(filter.project(':components:environment'))
+        filter.exclude(filter.project(':components:json'))
+        filter.exclude(filter.project(':products:feature-flagging:feature-flagging-bootstrap'))
+        filter.exclude(filter.project(':products:metrics:metrics-agent'))
+        filter.exclude(filter.project(':products:metrics:metrics-api'))
+        filter.exclude(filter.project(':products:metrics:metrics-lib'))
+        filter.exclude(filter.project(':remote-config:remote-config-api'))
+        filter.exclude(filter.project(':remote-config:remote-config-core'))
+        filter.exclude(filter.project(':telemetry'))
+        filter.exclude(filter.project(':utils:config-utils'))
+        filter.exclude(filter.project(':utils:container-utils'))
+        filter.exclude(filter.project(':utils:filesystem-utils'))
+        filter.exclude(filter.project(':utils:queue-utils'))
+        filter.exclude(filter.project(':utils:socket-utils'))
+        filter.exclude(filter.project(':utils:time-utils'))
+        filter.exclude(filter.project(':utils:logging-utils'))
+        filter.exclude(filter.project(':utils:version-utils'))
+        filter.exclude(filter.project(':dd-java-agent:agent-crashtracking'))
+        filter.exclude(filter.project(':dd-java-agent:ddprof-lib'))
+        filter.exclude(filter.dependency('org.slf4j:.*:.*'))
+        filter.exclude(filter.dependency('.*:dd-instrument-java:.*'))
 
-      // projects bundled with shared or on bootstrap
-      exclude(project(':dd-java-agent:agent-bootstrap'))
-      exclude(project(':dd-java-agent:agent-debugger:debugger-bootstrap'))
-      exclude(project(':dd-java-agent:agent-logging'))
-      exclude(project(':dd-trace-api'))
-      exclude(project(':internal-api'))
-      exclude(project(':internal-api:internal-api-9'))
-      exclude(project(':communication'))
-      exclude(project(':components:context'))
-      exclude(project(':components:environment'))
-      exclude(project(':components:json'))
-      exclude(project(':products:feature-flagging:feature-flagging-bootstrap'))
-      exclude(project(':products:metrics:metrics-agent'))
-      exclude(project(':products:metrics:metrics-api'))
-      exclude(project(':products:metrics:metrics-lib'))
-      exclude(project(':remote-config:remote-config-api'))
-      exclude(project(':remote-config:remote-config-core'))
-      exclude(project(':telemetry'))
-      exclude(project(':utils:config-utils'))
-      exclude(project(':utils:container-utils'))
-      exclude(project(':utils:filesystem-utils'))
-      exclude(project(':utils:queue-utils'))
-      exclude(project(':utils:socket-utils'))
-      exclude(project(':utils:time-utils'))
-      exclude(project(':utils:logging-utils'))
-      exclude(project(':utils:version-utils'))
-      exclude(project(':dd-java-agent:agent-crashtracking'))
-      exclude(project(':dd-java-agent:ddprof-lib'))
-      exclude(dependency('org.slf4j:.*:.*'))
-      exclude(dependency('.*:dd-instrument-java:.*'))
+        // okhttp and its transitives (both fork and non-fork)
+        filter.exclude(filter.dependency('com.datadoghq.okhttp3:okhttp'))
+        filter.exclude(filter.dependency('com.squareup.okhttp3:okhttp'))
+        filter.exclude(filter.dependency('com.datadoghq.okio:okio'))
+        filter.exclude(filter.dependency('com.squareup.okio:okio'))
+        filter.exclude(filter.dependency('at.yawk.lz4:lz4-java'))
+        filter.exclude(filter.dependency('io.airlift:aircompressor'))
 
-      // okhttp and its transitives (both fork and non-fork)
-      exclude(dependency('com.datadoghq.okhttp3:okhttp'))
-      exclude(dependency('com.squareup.okhttp3:okhttp'))
-      exclude(dependency('com.datadoghq.okio:okio'))
-      exclude(dependency('com.squareup.okio:okio'))
-      exclude(dependency('at.yawk.lz4:lz4-java'))
-      exclude(dependency('io.airlift:aircompressor'))
+        // dogstatsd and its transitives
+        filter.exclude(filter.dependency('com.datadoghq:java-dogstatsd-client'))
+        filter.exclude(filter.dependency('com.github.jnr:.*:.*'))
+        filter.exclude(filter.dependency('org.ow2.asm:.*:.*'))
 
-      // dogstatsd and its transitives
-      exclude(dependency('com.datadoghq:java-dogstatsd-client'))
-      exclude(dependency('com.github.jnr:.*:.*'))
-      exclude(dependency('org.ow2.asm:.*:.*'))
+        // sketches-java used by dd-trace-core (DataStreams) and metrics
+        filter.exclude(filter.dependency('com.datadoghq:sketches-java'))
 
-      // sketches-java used by dd-trace-core (DataStreams) and metrics
-      exclude(dependency('com.datadoghq:sketches-java'))
+        // javac plugin client
+        filter.exclude(filter.dependency('com.datadoghq:dd-javac-plugin-client'))
 
-      // javac plugin client
-      exclude(dependency('com.datadoghq:dd-javac-plugin-client'))
+        // moshi and its transitives
+        filter.exclude(filter.dependency('com.squareup.moshi:.*:.*'))
 
-      // moshi and its transitives
-      exclude(dependency('com.squareup.moshi:.*:.*'))
+        // jctools and its transitives
+        filter.exclude(filter.dependency('org.jctools:.*:.*'))
 
-      // jctools and its transitives
-      exclude(dependency('org.jctools:.*:.*'))
+        // cafe_crypto and its transitives
+        filter.exclude(filter.dependency('cafe.cryptography:.*:.*'))
 
-      // cafe_crypto and its transitives
-      exclude(dependency('cafe.cryptography:.*:.*'))
+        // snakeyaml-engine and its transitives
+        filter.exclude(filter.dependency('org.snakeyaml:snakeyaml-engine'))
 
-      // snakeyaml-engine and its transitives
-      exclude(dependency('org.snakeyaml:snakeyaml-engine'))
-
-      // re2j and its transitives
-      exclude(dependency('com.google.re2j:re2j'))
+        // re2j and its transitives
+        filter.exclude(filter.dependency('com.google.re2j:re2j'))
+      }
     }
   ]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ develocity = "4.4.1"
 forbiddenapis = "3.10"
 gradle-tooling-api = "8.14.5"
 jsr305 = "3.0.2"
+shadow = "9.4.2"
 spotbugs_annotations = "4.9.8"
 
 # DataDog libs and forks
@@ -190,3 +191,6 @@ junit-platform = ["junit-platform-launcher"]
 mockito = ["mokito-core", "mokito-junit-jupiter", "bytebuddy", "bytebuddyagent"]
 groovy = ["groovy", "groovy-json"]
 spock = ["spock-core", "objenesis"]
+
+[plugins]
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/products/feature-flagging/feature-flagging-agent/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-agent/build.gradle.kts
@@ -1,4 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.DependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Action
 import org.gradle.kotlin.dsl.project
 
 plugins {
@@ -23,8 +25,7 @@ dependencies {
 tasks.named<ShadowJar>("shadowJar") {
   dependencies {
     val deps = project.extra["deps"] as Map<*, *>
-    val excludeShared = deps["excludeShared"] as groovy.lang.Closure<*>
-    excludeShared.delegate = this
-    excludeShared.call()
+    val excludeShared = deps["excludeShared"] as Action<DependencyFilter>
+    excludeShared.execute(this)
   }
 }

--- a/products/metrics/metrics-lib/build.gradle.kts
+++ b/products/metrics/metrics-lib/build.gradle.kts
@@ -1,4 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.DependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Action
 
 plugins {
   `java-library`
@@ -27,9 +29,8 @@ dependencies {
 tasks.named<ShadowJar>("shadowJar") {
   dependencies {
     val deps = project.extra["deps"] as Map<*, *>
-    val excludeShared = deps["excludeShared"] as groovy.lang.Closure<*>
-    excludeShared.delegate = this
-    excludeShared.call()
+    val excludeShared = deps["excludeShared"] as Action<DependencyFilter>
+    excludeShared.execute(this)
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Upgrades the Gradle Shadow plugin from 8.3.9 to 9.4.2 in the main build.

The build wiring is updated for Shadow 9 APIs and behavior:

- use lazy configuration providers for `ShadowJar` configuration inputs where practical
- make shared dependency filtering explicit through a reusable Action
- use regex dependency filter patterns where Shadow 9 no longer treats empty module/version fields as broad wildcards
- make duplicate handling explicit for service-file transforms, license metadata, and known identical instrumentation classes
- preserve the previous agent manifest shape by disabling automatic Multi-Release manifest inheritance
- apply the same required Shadow 9 adjustments to smoke-test modules that run in the main Gradle build

# Motivation

Shadow 9 brings several build-pipeline fixes that are useful for this project:

- lazy configuration support for ShadowJar inputs, which avoids eagerly resolving configurations where providers are available  
  https://github.com/GradleUp/shadow/pull/1044  
  https://github.com/GradleUp/shadow/pull/1045
- consistent duplicate handling for entries coming from dependency jars and for transformer inputs, so duplicate resources/classes are handled by the configured strategy instead of being silently written or skipped later  
  https://github.com/GradleUp/shadow/pull/1233  
  https://github.com/GradleUp/shadow/pull/1617
- stricter dependency filter matching, which makes broad excludes rely on explicit regex patterns  
  https://github.com/GradleUp/shadow/pull/1328
- broader relocation support for descriptor-shaped string constants  
  https://github.com/GradleUp/shadow/pull/1714  
  https://github.com/GradleUp/shadow/pull/1731

# Additional Notes

[bric3/jardiff](https://github.com/bric3/jardiff/releases) was used between a master 11646d3c2b751803d25d06439d2c4dc97de5c10d agent jar and this this branch's agent jar using ASM textifier output. 

```
$ jardiff \
    -c classdata \
    --class-text-producer=asm-textifier \
    --color=never \
    master/dd-java-agent/build/libs/dd-java-agent-1.64.0-SNAPSHOT.jar \
    shadow-9/dd-java-agent/build/libs/dd-java-agent-1.64.0-SNAPSHOT.jar
--- ci-visibility/org/jacoco/core/runtime/LoggerRuntime.classdata
+++ ci-visibility/org/jacoco/core/runtime/LoggerRuntime.classdata
@@ -107,9 +107,9 @@
     ALOAD 5
     SIPUSH 184
     LDC "datadog/trace/bootstrap/PatchLogger"
     LDC "getLogger"
-    LDC "(Ljava/lang/String;)Ljava/util/logging/Logger;"
+    LDC "(Ljava/lang/String;)Ldatadog/trace/bootstrap/PatchLogger;"
     ICONST_0
     INVOKEVIRTUAL datadog/instrument/asm/MethodVisitor.visitMethodInsn (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
    L4
     LINENUMBER 100 L4
```

The difference is in a string constant inside JaCoCo’s `LoggerRuntime`, not in `PatchLogger.java` itself.

Shadow 9.2+ started relocating descriptor-shaped string constants. So this `LDC` changed:

```diff
 LDC "datadog/trace/bootstrap/PatchLogger"
 LDC "getLogger"
-LDC "(Ljava/lang/String;)Ljava/util/logging/Logger;"
+LDC "(Ljava/lang/String;)Ldatadog/trace/bootstrap/PatchLogger;"
```

That comes from the `org.jacoco.core.runtime.LoggerRuntime` class included via `:dd-java-agent:agent-ci-visibility`.

Before Shadow 9, relocation had already changed the method owner to `datadog/trace/bootstrap/PatchLogger`, but the descriptor string still said the method returned `java.util.logging.Logger`. That describes a method that does not exist: `PatchLogger.getLogger(String):Logger`. Shadow 9 rewrites the descriptor too, so generated bytecode calls the real method: `PatchLogger.getLogger(String):PatchLogger`, which matches `datadog.trace.bootstrapPatchLogger` in `:dd-java-agent:agent-bootstrap`.

https://github.com/DataDog/dd-trace-java/blob/987a0eba81a1121ea037005640cd0f407aaf5389/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/PatchLogger.java#L16-L19

In my opinion this looks like a correctness fix for that generated-accessor path, not a behavioral regression. It is also aligned with the agent relocation rule that intentionally redirects `java.util.logging.Logger` to `PatchLogger` to avoid JUL initialization during premain: 

https://github.com/DataDog/dd-trace-java/blob/987a0eba81a1121ea037005640cd0f407aaf5389/dd-java-agent/build.gradle#L114-L116

Coverage-wise:
* The Maven and Gradle smoke tests cover the real CI Visibility JaCoCo integration path: they enable the JaCoCo plugin version and assert received coverages/reports. 

  https://github.com/DataDog/dd-trace-java/blob/11646d3c2b751803d25d06439d2c4dc97de5c10d/dd-smoke-tests/maven/src/test/java/datadog/smoketest/MavenSmokeTest.java#L84-L102
  
  https://github.com/DataDog/dd-trace-java/blob/11646d3c2b751803d25d06439d2c4dc97de5c10d/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java#L96-L112

* That path uses the external JaCoCo agent runtime, which our instrumentation targets via `org.jacoco.agent.rt.internal...:`

  https://github.com/DataDog/dd-trace-java/blob/11646d3c2b751803d25d06439d2c4dc97de5c10d/dd-java-agent/instrumentation/jacoco-0.8.9/src/main/java/datadog/trace/instrumentation/jacoco/InstrumenterInstrumentation.java#L28-L35

* The shaded `org.jacoco.core` dependency in `agent-ci-visibility` appears used for parsing/analyzing coverage data and reports, not for `LoggerRuntime`: 

  https://github.com/DataDog/dd-trace-java/blob/11646d3c2b751803d25d06439d2c4dc97de5c10d/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/report/JacocoCoverageProcessor.java#L233-L234

  https://github.com/DataDog/dd-trace-java/blob/11646d3c2b751803d25d06439d2c4dc97de5c10d/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java#L27-L29

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-workflow/using-keywords-in-issues-and-pull-requests) when referencing an issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`.

Jira ticket: [PROJ-IDENT]
