### PR TITLE
feat(feature-flagging): FFE APM feature-flag span enrichment (experimental, gated)

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/FeatureFlaggingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/FeatureFlaggingConfig.java
@@ -3,4 +3,13 @@ package datadog.trace.api.config;
 public class FeatureFlaggingConfig {
 
   public static final String FLAGGING_PROVIDER_ENABLED = "experimental.flagging.provider.enabled";
+
+  /**
+   * Opt-in gate for APM span enrichment with feature-flag evaluation metadata. The dot-form maps to
+   * {@code DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED} via the dot-to-underscore +
+   * {@code DD_} prefix normalization rule. This is DISTINCT from {@link #FLAGGING_PROVIDER_ENABLED}
+   * and is OFF by default — enabling the provider does not enable span enrichment.
+   */
+  public static final String SPAN_ENRICHMENT_ENABLED =
+      "experimental.flagging.provider.span.enrichment.enabled";
 }

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -1497,6 +1497,14 @@
         "aliases": []
       }
     ],
+    "DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": [
       {
         "version": "B",

--- a/products/feature-flagging/feature-flagging-api/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-api/build.gradle.kts
@@ -45,11 +45,18 @@ dependencies {
 
   compileOnly(project(":products:feature-flagging:feature-flagging-bootstrap"))
   compileOnly(project(":utils:config-utils"))
+  // Span enrichment (JAVA-01): TraceInterceptor / GlobalTracer / AgentTracer / AgentSpan for the
+  // write tier + active-root-span lookup. compileOnly because the agent runtime
+  // (feature-flagging-agent depends on :internal-api) provides these classes; the published
+  // dd-openfeature jar must not bundle the tracer.
+  compileOnly(project(":internal-api"))
   compileOnly("io.opentelemetry:opentelemetry-api:1.47.0")
   compileOnly("io.opentelemetry:opentelemetry-sdk-metrics:1.47.0")
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp:1.47.0")
 
   testImplementation(project(":products:feature-flagging:feature-flagging-bootstrap"))
+  testImplementation(project(":internal-api"))
+  testImplementation(project(":utils:config-utils"))
   testImplementation("io.opentelemetry:opentelemetry-api:1.47.0")
   testImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.47.0")
   testImplementation("io.opentelemetry:opentelemetry-exporter-otlp:1.47.0")

--- a/products/feature-flagging/feature-flagging-api/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-api/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
   compileOnly(project(":products:feature-flagging:feature-flagging-bootstrap"))
   compileOnly(project(":utils:config-utils"))
-  // Span enrichment (JAVA-01): TraceInterceptor / GlobalTracer / AgentTracer / AgentSpan for the
+  // Span enrichment: TraceInterceptor / GlobalTracer / AgentTracer / AgentSpan for the
   // write tier + active-root-span lookup. compileOnly because the agent runtime
   // (feature-flagging-agent depends on :internal-api) provides these classes; the published
   // dd-openfeature jar must not bundle the tracer.

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -392,9 +392,9 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .addString("flagKey", flag.key)
             .addString("variationType", flag.variationType.name())
             .addString("allocationKey", allocation.key);
-    // Surface the UFC split's serial id and the allocation's doLog flag for APM span enrichment
-    // (JAVA-01). __dd_split_serial_id is omitted when the split carries no serial id; __dd_do_log
-    // is always present so the span-enrichment hook can decide whether to record the subject.
+    // Surface the UFC split's serial id and the allocation's doLog flag for APM span enrichment.
+    // __dd_split_serial_id is omitted when the split carries no serial id; __dd_do_log is always
+    // present so the span-enrichment hook can decide whether to record the subject.
     if (split.serialId != null) {
       metadataBuilder.addString("__dd_split_serial_id", split.serialId.toString());
     }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -392,6 +392,14 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .addString("flagKey", flag.key)
             .addString("variationType", flag.variationType.name())
             .addString("allocationKey", allocation.key);
+    // Surface the UFC split's serial id and the allocation's doLog flag for APM span enrichment
+    // (JAVA-01). __dd_split_serial_id is omitted when the split carries no serial id; __dd_do_log
+    // is always present so the span-enrichment hook can decide whether to record the subject.
+    if (split.serialId != null) {
+      metadataBuilder.addString("__dd_split_serial_id", split.serialId.toString());
+    }
+    metadataBuilder.addString(
+        "__dd_do_log", String.valueOf(allocation.doLog != null && allocation.doLog));
     final ProviderEvaluation<T> result =
         ProviderEvaluation.<T>builder()
             .value(mappedValue)

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -47,9 +47,12 @@ public class Provider extends EventProvider implements Metadata {
       new AtomicReference<>(InitializationState.NOT_STARTED);
   private final FlagEvalMetrics flagEvalMetrics;
   private final FlagEvalHook flagEvalHook;
-  // Span enrichment (JAVA-01): both are null unless the gate is on (DG-005 — no idle overhead).
+  // Span enrichment: null unless the gate is on, so the feature has no idle overhead when off.
   private final SpanEnrichmentHook spanEnrichmentHook;
-  private final SpanEnrichmentInterceptor spanEnrichmentInterceptor;
+  private final SpanEnrichmentStates spanEnrichmentStates;
+  // Precomputed hook list returned by getProviderHooks() on every evaluation. Immutable and built
+  // once so gate-off evaluation allocates nothing on this hot path.
+  private final List<Hook> providerHooks;
 
   public Provider() {
     this(DEFAULT_OPTIONS, null);
@@ -65,10 +68,10 @@ public class Provider extends EventProvider implements Metadata {
 
   /**
    * Registers a {@link SpanEnrichmentInterceptor} with the running tracer, returning {@code true}
-   * when it was added and {@code false} when the tracer rejected it (e.g. a duplicate-priority
-   * interceptor from an earlier provider is already registered). Injectable so tests can drive the
-   * success and rejected-registration (reconfiguration) paths deterministically without mutating
-   * the global tracer (mirrors the {@code spanEnrichmentEnabledOverride} seam).
+   * when it was added and {@code false} when the tracer rejected it (e.g. the interceptor is
+   * already registered, or the global tracer is the no-op placeholder). Injectable so tests can
+   * drive registration deterministically without mutating the global tracer (mirrors the {@code
+   * spanEnrichmentEnabledOverride} seam).
    */
   interface TraceInterceptorRegistrar {
     boolean register(SpanEnrichmentInterceptor interceptor);
@@ -113,49 +116,46 @@ public class Provider extends EventProvider implements Metadata {
     this.flagEvalMetrics = metrics;
     this.flagEvalHook = hook;
 
-    // Gate-gated span enrichment: construct + register ONLY when the gate is on. When off, nothing
-    // is constructed and no interceptor/state exists (DG-005 zero-idle-overhead negative control).
+    // Span enrichment is wired ONLY when the gate is on. When off, no hook/state is constructed and
+    // there is no idle per-evaluation or per-span overhead.
     final boolean spanEnrichmentEnabled =
         spanEnrichmentEnabledOverride != null
             ? spanEnrichmentEnabledOverride
             : isSpanEnrichmentEnabled();
     SpanEnrichmentHook seHook = null;
-    SpanEnrichmentInterceptor seInterceptor = null;
+    SpanEnrichmentStates seStates = null;
     if (spanEnrichmentEnabled) {
       try {
-        // Per-provider state store (NOT a global static): owned by the interceptor, shared with the
-        // hook, so this provider's shutdown can never clear another provider's state (CR-03), and a
-        // never-completing trace cannot leak unboundedly (CR-02, bounded inside the store).
-        final SpanEnrichmentStates seStates = new SpanEnrichmentStates();
-        final SpanEnrichmentInterceptor candidate = new SpanEnrichmentInterceptor(seStates);
-        // HONOR the registration result (CR-03): the tracer rejects an interceptor whose priority
-        // is
-        // already taken (e.g. a SECOND gate-on provider after reconfiguration) and returns false.
-        // If
-        // we ignored it, this provider would still wire a hook into shared state yet never have its
-        // interceptor invoked, and its shutdown() would clear the FIRST provider's live state. So
-        // we
-        // only wire the hook+interceptor when registration actually succeeded.
-        if (registrar.register(candidate)) {
-          seInterceptor = candidate;
-          seHook = new SpanEnrichmentHook(seStates);
-        } else {
-          // Duplicate registration (active interceptor already owns priority 4). Leave hook +
-          // interceptor null so this provider neither accumulates orphan state nor clears the
-          // active provider's state on shutdown. Its own seStates is unreferenced and GC'd.
-          log.warn(
-              "Span enrichment interceptor already registered (duplicate provider); "
-                  + "skipping duplicate registration to avoid corrupting active provider state");
-        }
+        // Per-provider state store, shared with this provider's capture hook. The single,
+        // process-wide interceptor is registered once (reconfiguration-safe) and rebound to this
+        // provider's store. A later gate-on provider rebinds it to its own store; this provider's
+        // shutdown only unbinds if it is still the active provider, so reconfiguration never
+        // permanently disables enrichment and providers never clobber each other's live state.
+        seStates = new SpanEnrichmentStates();
+        SpanEnrichmentInterceptor.ensureRegistered(registrar);
+        SpanEnrichmentInterceptor.INSTANCE.bind(seStates);
+        seHook = new SpanEnrichmentHook(seStates);
       } catch (LinkageError | Exception e) {
         // Tracer classes absent (e.g. API-only classpath): degrade to no span enrichment.
         log.warn("Span enrichment unavailable — tracer classes not on classpath", e);
         seHook = null;
-        seInterceptor = null;
+        seStates = null;
       }
     }
     this.spanEnrichmentHook = seHook;
-    this.spanEnrichmentInterceptor = seInterceptor;
+    this.spanEnrichmentStates = seStates;
+
+    // Precompute the immutable hook list once so getProviderHooks() (called on every evaluation)
+    // allocates nothing, including when the gate is off.
+    final List<Hook> hooks = new ArrayList<>(2);
+    if (flagEvalHook != null) {
+      hooks.add(flagEvalHook);
+    }
+    if (seHook != null) {
+      hooks.add(seHook);
+    }
+    this.providerHooks =
+        hooks.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(hooks);
   }
 
   private static boolean isSpanEnrichmentEnabled() {
@@ -274,14 +274,7 @@ public class Provider extends EventProvider implements Metadata {
 
   @Override
   public List<Hook> getProviderHooks() {
-    final List<Hook> hooks = new ArrayList<>(2);
-    if (flagEvalHook != null) {
-      hooks.add(flagEvalHook);
-    }
-    if (spanEnrichmentHook != null) {
-      hooks.add(spanEnrichmentHook);
-    }
-    return hooks.isEmpty() ? Collections.emptyList() : hooks;
+    return providerHooks;
   }
 
   @Override
@@ -289,14 +282,13 @@ public class Provider extends EventProvider implements Metadata {
     if (flagEvalMetrics != null) {
       flagEvalMetrics.shutdown();
     }
-    // Provider-close cleanup for span enrichment (Pitfall 3): the tracer has no interceptor-removal
-    // API, so disable the interceptor (it then no-ops + drains its OWN residual state). Because the
-    // state store is instance-owned, this clears only this provider's state and can never wipe an
-    // active second provider's in-flight state (CR-03). When this provider's registration was
-    // rejected as a duplicate, spanEnrichmentInterceptor is null here, so shutdown is a no-op and
-    // the active provider's state is untouched.
-    if (spanEnrichmentInterceptor != null) {
-      spanEnrichmentInterceptor.disable();
+    // Provider-close cleanup for span enrichment: the tracer has no interceptor-removal API, so we
+    // unbind this provider's store from the process-wide interceptor (which clears the store and
+    // makes the interceptor inert until a new provider rebinds it). The unbind is a no-op if a
+    // newer provider has already rebound the interceptor, so we never wipe another provider's
+    // in-flight state.
+    if (spanEnrichmentStates != null) {
+      SpanEnrichmentInterceptor.INSTANCE.unbind(spanEnrichmentStates);
     }
     if (evaluator != null) {
       evaluator.shutdown();
@@ -308,8 +300,8 @@ public class Provider extends EventProvider implements Metadata {
     return spanEnrichmentHook;
   }
 
-  SpanEnrichmentInterceptor spanEnrichmentInterceptor() {
-    return spanEnrichmentInterceptor;
+  SpanEnrichmentStates spanEnrichmentStates() {
+    return spanEnrichmentStates;
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -64,6 +64,17 @@ public class Provider extends EventProvider implements Metadata {
   }
 
   /**
+   * Registers a {@link SpanEnrichmentInterceptor} with the running tracer, returning {@code true}
+   * when it was added and {@code false} when the tracer rejected it (e.g. a duplicate-priority
+   * interceptor from an earlier provider is already registered). Injectable so tests can drive the
+   * success and rejected-registration (reconfiguration) paths deterministically without mutating
+   * the global tracer (mirrors the {@code spanEnrichmentEnabledOverride} seam).
+   */
+  interface TraceInterceptorRegistrar {
+    boolean register(SpanEnrichmentInterceptor interceptor);
+  }
+
+  /**
    * @param spanEnrichmentEnabledOverride when non-null, forces the span-enrichment gate (test
    *     seam); when null, the gate is read from {@link #SPAN_ENRICHMENT_ENABLED_ENV}.
    */
@@ -71,6 +82,22 @@ public class Provider extends EventProvider implements Metadata {
       final Options options,
       final Evaluator evaluator,
       final Boolean spanEnrichmentEnabledOverride) {
+    this(
+        options,
+        evaluator,
+        spanEnrichmentEnabledOverride,
+        interceptor -> GlobalTracer.get().addTraceInterceptor(interceptor));
+  }
+
+  /**
+   * @param registrar registers the span-enrichment interceptor with the tracer; injectable for
+   *     tests (see {@link TraceInterceptorRegistrar}).
+   */
+  Provider(
+      final Options options,
+      final Evaluator evaluator,
+      final Boolean spanEnrichmentEnabledOverride,
+      final TraceInterceptorRegistrar registrar) {
     this.options = options;
     this.evaluator = evaluator;
     FlagEvalMetrics metrics = null;
@@ -96,9 +123,30 @@ public class Provider extends EventProvider implements Metadata {
     SpanEnrichmentInterceptor seInterceptor = null;
     if (spanEnrichmentEnabled) {
       try {
-        seHook = new SpanEnrichmentHook();
-        seInterceptor = new SpanEnrichmentInterceptor();
-        GlobalTracer.get().addTraceInterceptor(seInterceptor);
+        // Per-provider state store (NOT a global static): owned by the interceptor, shared with the
+        // hook, so this provider's shutdown can never clear another provider's state (CR-03), and a
+        // never-completing trace cannot leak unboundedly (CR-02, bounded inside the store).
+        final SpanEnrichmentStates seStates = new SpanEnrichmentStates();
+        final SpanEnrichmentInterceptor candidate = new SpanEnrichmentInterceptor(seStates);
+        // HONOR the registration result (CR-03): the tracer rejects an interceptor whose priority
+        // is
+        // already taken (e.g. a SECOND gate-on provider after reconfiguration) and returns false.
+        // If
+        // we ignored it, this provider would still wire a hook into shared state yet never have its
+        // interceptor invoked, and its shutdown() would clear the FIRST provider's live state. So
+        // we
+        // only wire the hook+interceptor when registration actually succeeded.
+        if (registrar.register(candidate)) {
+          seInterceptor = candidate;
+          seHook = new SpanEnrichmentHook(seStates);
+        } else {
+          // Duplicate registration (active interceptor already owns priority 4). Leave hook +
+          // interceptor null so this provider neither accumulates orphan state nor clears the
+          // active provider's state on shutdown. Its own seStates is unreferenced and GC'd.
+          log.warn(
+              "Span enrichment interceptor already registered (duplicate provider); "
+                  + "skipping duplicate registration to avoid corrupting active provider state");
+        }
       } catch (LinkageError | Exception e) {
         // Tracer classes absent (e.g. API-only classpath): degrade to no span enrichment.
         log.warn("Span enrichment unavailable — tracer classes not on classpath", e);
@@ -242,7 +290,11 @@ public class Provider extends EventProvider implements Metadata {
       flagEvalMetrics.shutdown();
     }
     // Provider-close cleanup for span enrichment (Pitfall 3): the tracer has no interceptor-removal
-    // API, so disable the interceptor (it then no-ops + drains residual state) and drop the hook.
+    // API, so disable the interceptor (it then no-ops + drains its OWN residual state). Because the
+    // state store is instance-owned, this clears only this provider's state and can never wipe an
+    // active second provider's in-flight state (CR-03). When this provider's registration was
+    // rejected as a duplicate, spanEnrichmentInterceptor is null here, so shutdown is a no-op and
+    // the active provider's state is untouched.
     if (spanEnrichmentInterceptor != null) {
       spanEnrichmentInterceptor.disable();
     }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -2,6 +2,8 @@ package datadog.trace.api.openfeature;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.config.inversion.ConfigHelper;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
@@ -16,6 +18,7 @@ import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +31,15 @@ public class Provider extends EventProvider implements Metadata {
   private static final Logger log = LoggerFactory.getLogger(Provider.class);
   static final String METADATA = "datadog-openfeature-provider";
   private static final String EVALUATOR_IMPL = "datadog.trace.api.openfeature.DDEvaluator";
+
+  /**
+   * Environment variable form of {@link
+   * datadog.trace.api.config.FeatureFlaggingConfig#SPAN_ENRICHMENT_ENABLED}. Distinct from the
+   * provider-enabled gate; OFF by default (experimental opt-in).
+   */
+  static final String SPAN_ENRICHMENT_ENABLED_ENV =
+      "DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED";
+
   private static final Options DEFAULT_OPTIONS = new Options().initTimeout(30, SECONDS);
   private volatile Evaluator evaluator;
   private final Options options;
@@ -35,6 +47,9 @@ public class Provider extends EventProvider implements Metadata {
       new AtomicReference<>(InitializationState.NOT_STARTED);
   private final FlagEvalMetrics flagEvalMetrics;
   private final FlagEvalHook flagEvalHook;
+  // Span enrichment (JAVA-01): both are null unless the gate is on (DG-005 — no idle overhead).
+  private final SpanEnrichmentHook spanEnrichmentHook;
+  private final SpanEnrichmentInterceptor spanEnrichmentInterceptor;
 
   public Provider() {
     this(DEFAULT_OPTIONS, null);
@@ -45,6 +60,17 @@ public class Provider extends EventProvider implements Metadata {
   }
 
   Provider(final Options options, final Evaluator evaluator) {
+    this(options, evaluator, null);
+  }
+
+  /**
+   * @param spanEnrichmentEnabledOverride when non-null, forces the span-enrichment gate (test
+   *     seam); when null, the gate is read from {@link #SPAN_ENRICHMENT_ENABLED_ENV}.
+   */
+  Provider(
+      final Options options,
+      final Evaluator evaluator,
+      final Boolean spanEnrichmentEnabledOverride) {
     this.options = options;
     this.evaluator = evaluator;
     FlagEvalMetrics metrics = null;
@@ -59,6 +85,38 @@ public class Provider extends EventProvider implements Metadata {
     }
     this.flagEvalMetrics = metrics;
     this.flagEvalHook = hook;
+
+    // Gate-gated span enrichment: construct + register ONLY when the gate is on. When off, nothing
+    // is constructed and no interceptor/state exists (DG-005 zero-idle-overhead negative control).
+    final boolean spanEnrichmentEnabled =
+        spanEnrichmentEnabledOverride != null
+            ? spanEnrichmentEnabledOverride
+            : isSpanEnrichmentEnabled();
+    SpanEnrichmentHook seHook = null;
+    SpanEnrichmentInterceptor seInterceptor = null;
+    if (spanEnrichmentEnabled) {
+      try {
+        seHook = new SpanEnrichmentHook();
+        seInterceptor = new SpanEnrichmentInterceptor();
+        GlobalTracer.get().addTraceInterceptor(seInterceptor);
+      } catch (LinkageError | Exception e) {
+        // Tracer classes absent (e.g. API-only classpath): degrade to no span enrichment.
+        log.warn("Span enrichment unavailable — tracer classes not on classpath", e);
+        seHook = null;
+        seInterceptor = null;
+      }
+    }
+    this.spanEnrichmentHook = seHook;
+    this.spanEnrichmentInterceptor = seInterceptor;
+  }
+
+  private static boolean isSpanEnrichmentEnabled() {
+    try {
+      final String value = ConfigHelper.env(SPAN_ENRICHMENT_ENABLED_ENV);
+      return "true".equalsIgnoreCase(value) || "1".equals(value);
+    } catch (final Throwable t) {
+      return false; // never let config reading break provider construction
+    }
   }
 
   @Override
@@ -168,10 +226,14 @@ public class Provider extends EventProvider implements Metadata {
 
   @Override
   public List<Hook> getProviderHooks() {
-    if (flagEvalHook == null) {
-      return Collections.emptyList();
+    final List<Hook> hooks = new ArrayList<>(2);
+    if (flagEvalHook != null) {
+      hooks.add(flagEvalHook);
     }
-    return Collections.singletonList(flagEvalHook);
+    if (spanEnrichmentHook != null) {
+      hooks.add(spanEnrichmentHook);
+    }
+    return hooks.isEmpty() ? Collections.emptyList() : hooks;
   }
 
   @Override
@@ -179,9 +241,23 @@ public class Provider extends EventProvider implements Metadata {
     if (flagEvalMetrics != null) {
       flagEvalMetrics.shutdown();
     }
+    // Provider-close cleanup for span enrichment (Pitfall 3): the tracer has no interceptor-removal
+    // API, so disable the interceptor (it then no-ops + drains residual state) and drop the hook.
+    if (spanEnrichmentInterceptor != null) {
+      spanEnrichmentInterceptor.disable();
+    }
     if (evaluator != null) {
       evaluator.shutdown();
     }
+  }
+
+  // Visible for tests: expose whether span enrichment is wired (gate-on) without leaking the impls.
+  SpanEnrichmentHook spanEnrichmentHook() {
+    return spanEnrichmentHook;
+  }
+
+  SpanEnrichmentInterceptor spanEnrichmentInterceptor() {
+    return spanEnrichmentInterceptor;
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
@@ -1,25 +1,27 @@
 package datadog.trace.api.openfeature;
 
+import dev.openfeature.sdk.Structure;
+import dev.openfeature.sdk.Value;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * Per-local-root-span accumulator for APM feature-flag span enrichment (JAVA-01).
+ * Per-local-root-span accumulator for APM feature-flag span enrichment.
  *
  * <p>Holds the serial ids, hashed subjects, and runtime defaults captured during flag evaluation
  * for a single local trace fragment. The limits, dedupe semantics, truncation, and output tag
  * shapes are FROZEN against the Node reference ({@code dd-trace-js#8343}) — see {@link
  * ULeb128Encoder}.
  *
- * <p>Instances are created lazily and held in a per-provider {@link SpanEnrichmentStates} store,
- * keyed by the local-root span's trace id. The capture hook ({@link SpanEnrichmentHook}) writes;
- * the write interceptor ({@link SpanEnrichmentInterceptor}) reads and clears. When the
- * span-enrichment gate is off, no store and no accumulator are ever created, so there is no idle
- * per-span overhead (DG-005).
+ * <p>Instances are created lazily and held in a {@link SpanEnrichmentStates} store, keyed by the
+ * local-root span's full trace id. The capture hook ({@link SpanEnrichmentHook}) writes; the write
+ * interceptor ({@link SpanEnrichmentInterceptor}) reads and clears. When the span-enrichment gate
+ * is off, no store and no accumulator are ever created, so there is no idle per-span overhead.
  *
- * <p>Output tag shapes (Pattern F):
+ * <p>Output tag shapes:
  *
  * <ul>
  *   <li>{@code ffe_flags_enc} — a bare base64 string (delta-varint of the serial ids)
@@ -139,22 +141,87 @@ final class SpanEnrichmentAccumulator {
   // ---- helpers (visible for tests) ----
 
   /**
-   * Mirrors the Node {@code (typeof object && !null) ? JSON.stringify(value) : String(value)} rule:
-   * structured values (maps, lists) are JSON-stringified, scalars use their string form, null
-   * becomes the JSON literal {@code null}.
+   * Mirrors the Node {@code (typeof value === 'object' && value !== null) ? JSON.stringify(value) :
+   * String(value)} rule: structured values (objects, arrays) are JSON-stringified; scalars use
+   * their string form; {@code null} becomes the bare {@code null}.
+   *
+   * <p>On the real OpenFeature object-evaluation path the runtime-default arrives wrapped in a
+   * {@link Value}; we unwrap it to its native representation first so a structured default
+   * serializes to JSON (matching Node's {@code JSON.stringify} of the equivalent JS object) instead
+   * of {@code Value.toString()} (which is {@code "Value(innerObject=...)"}). The scalar cases
+   * ({@code String}/{@code Boolean}/number) collapse to the same string form Node produces.
    */
   static String stringifyDefault(final Object value) {
-    if (value == null) {
+    final Object unwrapped = value instanceof Value ? unwrapValue((Value) value) : value;
+    if (unwrapped == null) {
       return "null";
     }
-    if (value instanceof Map || value instanceof Iterable || value.getClass().isArray()) {
-      return toJsonValue(value);
+    if (unwrapped instanceof Map
+        || unwrapped instanceof Iterable
+        || unwrapped.getClass().isArray()) {
+      return toJsonValue(unwrapped);
     }
-    if (value instanceof CharSequence || value instanceof Character) {
-      return value.toString();
+    if (unwrapped instanceof CharSequence || unwrapped instanceof Character) {
+      return unwrapped.toString();
     }
-    // Numbers / booleans — their string form matches JSON for these scalar cases.
-    return String.valueOf(value);
+    // Numbers / booleans / Instant — their string form matches what Node's String(value) emits for
+    // these scalar cases.
+    return String.valueOf(unwrapped);
+  }
+
+  /**
+   * Recursively unwraps an OpenFeature {@link Value} into its native Java representation:
+   * structures become {@code Map<String, Object>}, lists become {@code List<Object>}, and scalars
+   * become their boxed value (or {@code null}). Nested {@link Value}s are unwrapped at every level
+   * so a structure containing further structures/lists serializes correctly.
+   */
+  private static Object unwrapValue(final Value value) {
+    if (value == null || value.isNull()) {
+      return null;
+    }
+    if (value.isStructure()) {
+      final Structure structure = value.asStructure();
+      final Map<String, Object> map = new LinkedHashMap<>();
+      if (structure != null) {
+        for (final String key : structure.keySet()) {
+          map.put(key, unwrapValue(structure.getValue(key)));
+        }
+      }
+      return map;
+    }
+    if (value.isList()) {
+      final java.util.List<Value> list = value.asList();
+      final java.util.List<Object> out = new java.util.ArrayList<>(list == null ? 0 : list.size());
+      if (list != null) {
+        for (final Value element : list) {
+          out.add(unwrapValue(element));
+        }
+      }
+      return out;
+    }
+    if (value.isBoolean()) {
+      return value.asBoolean();
+    }
+    if (value.isString()) {
+      return value.asString();
+    }
+    if (value.isNumber()) {
+      // Preserve integral vs fractional so the rendered JSON number matches Node.
+      final Double d = value.asDouble();
+      if (d != null && d == Math.rint(d) && !Double.isInfinite(d)) {
+        final Integer i = value.asInteger();
+        if (i != null) {
+          return i;
+        }
+      }
+      return d;
+    }
+    final Instant instant = value.asInstant();
+    if (instant != null) {
+      return instant.toString();
+    }
+    // Unknown shape: fall back to the wrapped object's own representation.
+    return value.asObject();
   }
 
   /** UTF-8-safe truncation: never split a surrogate pair at the {@code maxChars} boundary. */
@@ -194,7 +261,10 @@ final class SpanEnrichmentAccumulator {
   }
 
   @SuppressWarnings("unchecked")
-  private static void appendJsonValue(final StringBuilder sb, final Object value) {
+  private static void appendJsonValue(final StringBuilder sb, final Object rawValue) {
+    // Unwrap any OpenFeature Value to its native representation first so nested structures/lists
+    // serialize as JSON rather than via Value.toString().
+    final Object value = rawValue instanceof Value ? unwrapValue((Value) rawValue) : rawValue;
     if (value == null) {
       sb.append("null");
     } else if (value instanceof Map) {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
@@ -1,0 +1,291 @@
+package datadog.trace.api.openfeature;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-local-root-span accumulator for APM feature-flag span enrichment (JAVA-01).
+ *
+ * <p>Holds the serial ids, hashed subjects, and runtime defaults captured during flag evaluation
+ * for a single local trace fragment. The limits, dedupe semantics, truncation, and output tag
+ * shapes are FROZEN against the Node reference ({@code dd-trace-js#8343}) — see {@link
+ * ULeb128Encoder}.
+ *
+ * <p>Instances are created lazily and stored in {@link #STATES}, keyed by the local-root span's
+ * trace id. The capture hook ({@link SpanEnrichmentHook}) writes; the write interceptor ({@link
+ * SpanEnrichmentInterceptor}) reads and clears. When the span-enrichment gate is off, nothing
+ * touches {@link #STATES}, so there is no idle per-span overhead (DG-005).
+ *
+ * <p>Output tag shapes (Pattern F):
+ *
+ * <ul>
+ *   <li>{@code ffe_flags_enc} — a bare base64 string (delta-varint of the serial ids)
+ *   <li>{@code ffe_subjects_enc} — a JSON object string {@code {"<sha256hex>": "<base64>", ...}}
+ *   <li>{@code ffe_runtime_defaults} — a JSON object string {@code {"<flagKey>": "<value>", ...}}
+ * </ul>
+ */
+final class SpanEnrichmentAccumulator {
+
+  static final int MAX_SERIAL_IDS = 200;
+  static final int MAX_SUBJECTS = 10;
+  static final int MAX_EXPERIMENTS_PER_SUBJECT = 20;
+  static final int MAX_DEFAULTS = 5;
+  static final int MAX_DEFAULT_VALUE_LENGTH = 64;
+
+  static final String TAG_FLAGS_ENC = "ffe_flags_enc";
+  static final String TAG_SUBJECTS_ENC = "ffe_subjects_enc";
+  static final String TAG_RUNTIME_DEFAULTS = "ffe_runtime_defaults";
+
+  /**
+   * Shared per-trace state, keyed by the local-root span's trace id ({@code DDTraceId.toLong()}).
+   * Capture (hook) puts; write (interceptor) reads + removes. Only ever populated when the gate is
+   * on (DG-005).
+   */
+  static final ConcurrentHashMap<Long, SpanEnrichmentAccumulator> STATES =
+      new ConcurrentHashMap<>();
+
+  // dedupe is structural (a Set); sorted for deterministic encoding.
+  private final TreeSet<Integer> serialIds = new TreeSet<>();
+  // sha256hex(targetingKey) -> serial ids. LinkedHashMap for stable iteration order.
+  private final Map<String, TreeSet<Integer>> subjects = new LinkedHashMap<>();
+  // flagKey -> value string (first-wins, truncated to MAX_DEFAULT_VALUE_LENGTH).
+  private final Map<String, String> defaults = new LinkedHashMap<>();
+
+  /** Adds a serial id, dropping silently once {@link #MAX_SERIAL_IDS} is reached. */
+  synchronized void addSerialId(final int id) {
+    if (serialIds.size() >= MAX_SERIAL_IDS && !serialIds.contains(id)) {
+      return;
+    }
+    serialIds.add(id);
+  }
+
+  /**
+   * Records that the given targeting key was exposed to the experiment identified by {@code id}.
+   * The targeting key is SHA-256-hashed before storage. Enforces both the subject cap ({@link
+   * #MAX_SUBJECTS}) and the per-subject experiment cap ({@link #MAX_EXPERIMENTS_PER_SUBJECT}).
+   */
+  synchronized void addSubject(final String targetingKey, final int id) {
+    if (targetingKey == null) {
+      return;
+    }
+    final String hashed = ULeb128Encoder.hashTargetingKey(targetingKey);
+    final TreeSet<Integer> existing = subjects.get(hashed);
+    if (existing != null) {
+      if (existing.size() >= MAX_EXPERIMENTS_PER_SUBJECT && !existing.contains(id)) {
+        return;
+      }
+      existing.add(id);
+      return;
+    }
+    if (subjects.size() >= MAX_SUBJECTS) {
+      return;
+    }
+    final TreeSet<Integer> ids = new TreeSet<>();
+    ids.add(id);
+    subjects.put(hashed, ids);
+  }
+
+  /**
+   * Records a runtime-default value for {@code flagKey} (first-wins). Object values are serialized
+   * to JSON (NOT {@code toString()}); the result is truncated to {@link #MAX_DEFAULT_VALUE_LENGTH}.
+   */
+  synchronized void addDefault(final String flagKey, final Object value) {
+    if (flagKey == null) {
+      return;
+    }
+    if (defaults.containsKey(flagKey)) {
+      return; // first-wins
+    }
+    if (defaults.size() >= MAX_DEFAULTS) {
+      return;
+    }
+    String valueStr = stringifyDefault(value);
+    if (valueStr.length() > MAX_DEFAULT_VALUE_LENGTH) {
+      valueStr = utf8SafeTruncate(valueStr, MAX_DEFAULT_VALUE_LENGTH);
+    }
+    defaults.put(flagKey, valueStr);
+  }
+
+  /**
+   * @return true when there is at least one serial id or runtime default to write. Subjects are not
+   *     checked because a subject is never recorded without its serial id.
+   */
+  synchronized boolean hasData() {
+    return !serialIds.isEmpty() || !defaults.isEmpty();
+  }
+
+  /**
+   * Builds the {@code ffe_*} span tags from the accumulated state. Empty groups are omitted.
+   *
+   * @return a map of tag name to tag value (a subset of {@code ffe_flags_enc}, {@code
+   *     ffe_subjects_enc}, {@code ffe_runtime_defaults})
+   */
+  synchronized Map<String, String> toSpanTags() {
+    final Map<String, String> tags = new LinkedHashMap<>();
+    if (!serialIds.isEmpty()) {
+      final String encoded = ULeb128Encoder.encodeDeltaVarint(serialIds);
+      if (!encoded.isEmpty()) {
+        tags.put(TAG_FLAGS_ENC, encoded);
+      }
+    }
+    if (!subjects.isEmpty()) {
+      final Map<String, String> encodedSubjects = new LinkedHashMap<>();
+      for (final Map.Entry<String, TreeSet<Integer>> entry : subjects.entrySet()) {
+        encodedSubjects.put(entry.getKey(), ULeb128Encoder.encodeDeltaVarint(entry.getValue()));
+      }
+      tags.put(TAG_SUBJECTS_ENC, toJsonObject(encodedSubjects));
+    }
+    if (!defaults.isEmpty()) {
+      tags.put(TAG_RUNTIME_DEFAULTS, toJsonObject(defaults));
+    }
+    return tags;
+  }
+
+  // ---- helpers (visible for tests) ----
+
+  /**
+   * Mirrors the Node {@code (typeof object && !null) ? JSON.stringify(value) : String(value)} rule:
+   * structured values (maps, lists) are JSON-stringified, scalars use their string form, null
+   * becomes the JSON literal {@code null}.
+   */
+  static String stringifyDefault(final Object value) {
+    if (value == null) {
+      return "null";
+    }
+    if (value instanceof Map || value instanceof Iterable || value.getClass().isArray()) {
+      return toJsonValue(value);
+    }
+    if (value instanceof CharSequence || value instanceof Character) {
+      return value.toString();
+    }
+    // Numbers / booleans — their string form matches JSON for these scalar cases.
+    return String.valueOf(value);
+  }
+
+  /** UTF-8-safe truncation: never split a surrogate pair at the {@code maxChars} boundary. */
+  static String utf8SafeTruncate(final String value, final int maxChars) {
+    if (value.length() <= maxChars) {
+      return value;
+    }
+    int end = maxChars;
+    if (Character.isHighSurrogate(value.charAt(end - 1))) {
+      end--; // drop the dangling high surrogate rather than emit a broken pair
+    }
+    return value.substring(0, end);
+  }
+
+  /** Serializes a String->String map to a compact JSON object string (keys + values escaped). */
+  static String toJsonObject(final Map<String, String> map) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append('{');
+    boolean first = true;
+    for (final Map.Entry<String, String> entry : map.entrySet()) {
+      if (!first) {
+        sb.append(',');
+      }
+      first = false;
+      appendJsonString(sb, entry.getKey());
+      sb.append(':');
+      appendJsonString(sb, entry.getValue());
+    }
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private static String toJsonValue(final Object value) {
+    final StringBuilder sb = new StringBuilder();
+    appendJsonValue(sb, value);
+    return sb.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void appendJsonValue(final StringBuilder sb, final Object value) {
+    if (value == null) {
+      sb.append("null");
+    } else if (value instanceof Map) {
+      sb.append('{');
+      boolean first = true;
+      for (final Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+        if (!first) {
+          sb.append(',');
+        }
+        first = false;
+        appendJsonString(sb, String.valueOf(entry.getKey()));
+        sb.append(':');
+        appendJsonValue(sb, entry.getValue());
+      }
+      sb.append('}');
+    } else if (value instanceof Iterable) {
+      sb.append('[');
+      boolean first = true;
+      for (final Object element : (Iterable<Object>) value) {
+        if (!first) {
+          sb.append(',');
+        }
+        first = false;
+        appendJsonValue(sb, element);
+      }
+      sb.append(']');
+    } else if (value instanceof CharSequence || value instanceof Character) {
+      appendJsonString(sb, value.toString());
+    } else if (value instanceof Number || value instanceof Boolean) {
+      sb.append(String.valueOf(value));
+    } else {
+      appendJsonString(sb, String.valueOf(value));
+    }
+  }
+
+  private static void appendJsonString(final StringBuilder sb, final String value) {
+    sb.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        case '\b':
+          sb.append("\\b");
+          break;
+        case '\f':
+          sb.append("\\f");
+          break;
+        default:
+          if (c < 0x20) {
+            sb.append(String.format("\\u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
+      }
+    }
+    sb.append('"');
+  }
+
+  // ---- test-only accessors ----
+
+  synchronized Set<Integer> serialIdsView() {
+    return new TreeSet<>(serialIds);
+  }
+
+  synchronized int subjectCount() {
+    return subjects.size();
+  }
+
+  synchronized int defaultCount() {
+    return defaults.size();
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentAccumulator.java
@@ -4,7 +4,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Per-local-root-span accumulator for APM feature-flag span enrichment (JAVA-01).
@@ -14,10 +13,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * shapes are FROZEN against the Node reference ({@code dd-trace-js#8343}) — see {@link
  * ULeb128Encoder}.
  *
- * <p>Instances are created lazily and stored in {@link #STATES}, keyed by the local-root span's
- * trace id. The capture hook ({@link SpanEnrichmentHook}) writes; the write interceptor ({@link
- * SpanEnrichmentInterceptor}) reads and clears. When the span-enrichment gate is off, nothing
- * touches {@link #STATES}, so there is no idle per-span overhead (DG-005).
+ * <p>Instances are created lazily and held in a per-provider {@link SpanEnrichmentStates} store,
+ * keyed by the local-root span's trace id. The capture hook ({@link SpanEnrichmentHook}) writes;
+ * the write interceptor ({@link SpanEnrichmentInterceptor}) reads and clears. When the
+ * span-enrichment gate is off, no store and no accumulator are ever created, so there is no idle
+ * per-span overhead (DG-005).
  *
  * <p>Output tag shapes (Pattern F):
  *
@@ -38,14 +38,6 @@ final class SpanEnrichmentAccumulator {
   static final String TAG_FLAGS_ENC = "ffe_flags_enc";
   static final String TAG_SUBJECTS_ENC = "ffe_subjects_enc";
   static final String TAG_RUNTIME_DEFAULTS = "ffe_runtime_defaults";
-
-  /**
-   * Shared per-trace state, keyed by the local-root span's trace id ({@code DDTraceId.toLong()}).
-   * Capture (hook) puts; write (interceptor) reads + removes. Only ever populated when the gate is
-   * on (DG-005).
-   */
-  static final ConcurrentHashMap<Long, SpanEnrichmentAccumulator> STATES =
-      new ConcurrentHashMap<>();
 
   // dedupe is structural (a Set); sorted for deterministic encoding.
   private final TreeSet<Integer> serialIds = new TreeSet<>();

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
@@ -1,0 +1,134 @@
+package datadog.trace.api.openfeature;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.ImmutableMetadata;
+import java.util.Map;
+
+/**
+ * OpenFeature {@code finally} hook that captures feature-flag evaluation metadata into
+ * per-local-root span state for APM span enrichment (JAVA-01). This is the CAPTURE half of the
+ * capture-vs-write split — the WRITE half is {@link SpanEnrichmentInterceptor}, which flushes the
+ * accumulated tags onto the local root span when the trace completes.
+ *
+ * <p>Mirrors {@link FlagEvalHook}: registered via {@link Provider#getProviderHooks()} (only when
+ * the span-enrichment gate is on) and reading {@code details.getFlagMetadata()}. It resolves the
+ * active local-root span via {@link AgentTracer#activeSpan()} and keys the shared {@link
+ * SpanEnrichmentAccumulator#STATES} map by that root's trace id, so an interceptor running later on
+ * the write thread can recover the same state from the completed span collection.
+ *
+ * <p>Capture branch (frozen Node reference):
+ *
+ * <ul>
+ *   <li>serial id present → addSerialId, plus addSubject when {@code __dd_do_log} AND a targeting
+ *       key
+ *   <li>else variant missing (runtime default) → addDefault(flagKey, value)
+ * </ul>
+ *
+ * <p>All work is wrapped in try/catch — enrichment must NEVER break flag evaluation (Pattern D).
+ */
+class SpanEnrichmentHook implements Hook<Object> {
+
+  static final String METADATA_SERIAL_ID = "__dd_split_serial_id";
+  static final String METADATA_DO_LOG = "__dd_do_log";
+
+  /**
+   * Resolves the local-root span for the active trace. Injectable so tests need no static mocks.
+   */
+  interface RootSpanResolver {
+    AgentSpan activeLocalRoot();
+  }
+
+  private static final RootSpanResolver DEFAULT_RESOLVER =
+      () -> {
+        final AgentSpan active = AgentTracer.activeSpan();
+        if (active == null) {
+          return null;
+        }
+        final AgentSpan localRoot = active.getLocalRootSpan();
+        return localRoot != null ? localRoot : active;
+      };
+
+  private final RootSpanResolver rootSpanResolver;
+
+  SpanEnrichmentHook() {
+    this(DEFAULT_RESOLVER);
+  }
+
+  SpanEnrichmentHook(final RootSpanResolver rootSpanResolver) {
+    this.rootSpanResolver = rootSpanResolver;
+  }
+
+  @Override
+  public void finallyAfter(
+      final HookContext<Object> ctx,
+      final FlagEvaluationDetails<Object> details,
+      final Map<String, Object> hints) {
+    if (details == null) {
+      return;
+    }
+    try {
+      final AgentSpan root = rootSpanResolver.activeLocalRoot();
+      if (root == null || root.getTraceId() == null) {
+        return; // no active span → nothing to enrich
+      }
+      final long traceKey = root.getTraceId().toLong();
+      capture(traceKey, ctx, details);
+    } catch (final Throwable t) {
+      // Never let span enrichment break flag evaluation.
+    }
+  }
+
+  /**
+   * Applies the frozen Node capture branch against the state keyed by {@code traceKey}. Package
+   * private so it can be driven deterministically in tests without stubbing the static tracer.
+   */
+  void capture(
+      final long traceKey,
+      final HookContext<Object> ctx,
+      final FlagEvaluationDetails<Object> details) {
+    final ImmutableMetadata metadata = details.getFlagMetadata();
+    final String serialIdStr = metadata != null ? metadata.getString(METADATA_SERIAL_ID) : null;
+    final String doLogStr = metadata != null ? metadata.getString(METADATA_DO_LOG) : null;
+    final boolean doLog = "true".equalsIgnoreCase(doLogStr);
+    final String targetingKey = targetingKey(ctx);
+
+    if (serialIdStr != null) {
+      final int serialId;
+      try {
+        serialId = Integer.parseInt(serialIdStr);
+      } catch (final NumberFormatException e) {
+        return; // malformed serial id — drop, never break eval
+      }
+      final SpanEnrichmentAccumulator state = getOrCreateState(traceKey);
+      state.addSerialId(serialId);
+      if (doLog && targetingKey != null) {
+        state.addSubject(targetingKey, serialId);
+      }
+    } else if (details.getVariant() == null) {
+      // Runtime-default detection = MISSING VARIANT (never a reason enum).
+      getOrCreateState(traceKey).addDefault(details.getFlagKey(), details.getValue());
+    }
+  }
+
+  private static SpanEnrichmentAccumulator getOrCreateState(final long traceKey) {
+    return SpanEnrichmentAccumulator.STATES.computeIfAbsent(
+        traceKey, k -> new SpanEnrichmentAccumulator());
+  }
+
+  private static String targetingKey(final HookContext<Object> ctx) {
+    if (ctx == null) {
+      return null;
+    }
+    final EvaluationContext evaluationContext = ctx.getCtx();
+    if (evaluationContext == null) {
+      return null;
+    }
+    final String key = evaluationContext.getTargetingKey();
+    return (key == null || key.isEmpty()) ? null : key;
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
@@ -11,17 +11,17 @@ import java.util.Map;
 
 /**
  * OpenFeature {@code finally} hook that captures feature-flag evaluation metadata into
- * per-local-root span state for APM span enrichment (JAVA-01). This is the CAPTURE half of the
+ * per-local-root span state for APM span enrichment. This is the CAPTURE half of the
  * capture-vs-write split — the WRITE half is {@link SpanEnrichmentInterceptor}, which flushes the
  * accumulated tags onto the local root span when the trace completes.
  *
  * <p>Mirrors {@link FlagEvalHook}: registered via {@link Provider#getProviderHooks()} (only when
  * the span-enrichment gate is on) and reading {@code details.getFlagMetadata()}. It resolves the
- * active local-root span via {@link AgentTracer#activeSpan()} and keys the per-provider {@link
- * SpanEnrichmentStates} store (shared with this provider's {@link SpanEnrichmentInterceptor}) by
- * that root's trace id, so the interceptor running later on the write thread can recover the same
- * state from the completed span collection. The store is owned by the interceptor (not a global
- * static), so a second provider can never clear this one's state (CR-03).
+ * active local-root span via {@link AgentTracer#activeSpan()} and keys the {@link
+ * SpanEnrichmentStates} store (shared with the {@link SpanEnrichmentInterceptor}) by that root's
+ * full trace id (hex), so the interceptor running later on the write thread can recover the same
+ * state from the completed span collection. The full hex key avoids merging two distinct 128-bit
+ * traces that happen to share their low-order 64 bits.
  *
  * <p>Capture branch (frozen Node reference):
  *
@@ -31,7 +31,7 @@ import java.util.Map;
  *   <li>else variant missing (runtime default) → addDefault(flagKey, value)
  * </ul>
  *
- * <p>All work is wrapped in try/catch — enrichment must NEVER break flag evaluation (Pattern D).
+ * <p>All work is wrapped in try/catch — enrichment must NEVER break flag evaluation.
  */
 class SpanEnrichmentHook implements Hook<Object> {
 
@@ -56,9 +56,7 @@ class SpanEnrichmentHook implements Hook<Object> {
       };
 
   private final RootSpanResolver rootSpanResolver;
-  // Per-provider state store, shared with this provider's interceptor (NOT a global static). The
-  // hook writes here; the interceptor reads + removes. Owning the store on the interceptor is what
-  // makes one provider's shutdown unable to clear another's in-flight state (CR-03).
+  // State store shared with the interceptor. The hook writes here; the interceptor reads + removes.
   private final SpanEnrichmentStates states;
 
   SpanEnrichmentHook(final SpanEnrichmentStates states) {
@@ -83,7 +81,9 @@ class SpanEnrichmentHook implements Hook<Object> {
       if (root == null || root.getTraceId() == null) {
         return; // no active span → nothing to enrich
       }
-      final long traceKey = root.getTraceId().toLong();
+      // Key by the full trace id (hex), not toLong(): the low-order 64 bits alone would merge two
+      // distinct 128-bit traces that share their low bits.
+      final String traceKey = root.getTraceId().toHexString();
       capture(traceKey, ctx, details);
     } catch (final Throwable t) {
       // Never let span enrichment break flag evaluation.
@@ -95,7 +95,7 @@ class SpanEnrichmentHook implements Hook<Object> {
    * private so it can be driven deterministically in tests without stubbing the static tracer.
    */
   void capture(
-      final long traceKey,
+      final String traceKey,
       final HookContext<Object> ctx,
       final FlagEvaluationDetails<Object> details) {
     final ImmutableMetadata metadata = details.getFlagMetadata();

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentHook.java
@@ -17,9 +17,11 @@ import java.util.Map;
  *
  * <p>Mirrors {@link FlagEvalHook}: registered via {@link Provider#getProviderHooks()} (only when
  * the span-enrichment gate is on) and reading {@code details.getFlagMetadata()}. It resolves the
- * active local-root span via {@link AgentTracer#activeSpan()} and keys the shared {@link
- * SpanEnrichmentAccumulator#STATES} map by that root's trace id, so an interceptor running later on
- * the write thread can recover the same state from the completed span collection.
+ * active local-root span via {@link AgentTracer#activeSpan()} and keys the per-provider {@link
+ * SpanEnrichmentStates} store (shared with this provider's {@link SpanEnrichmentInterceptor}) by
+ * that root's trace id, so the interceptor running later on the write thread can recover the same
+ * state from the completed span collection. The store is owned by the interceptor (not a global
+ * static), so a second provider can never clear this one's state (CR-03).
  *
  * <p>Capture branch (frozen Node reference):
  *
@@ -54,13 +56,18 @@ class SpanEnrichmentHook implements Hook<Object> {
       };
 
   private final RootSpanResolver rootSpanResolver;
+  // Per-provider state store, shared with this provider's interceptor (NOT a global static). The
+  // hook writes here; the interceptor reads + removes. Owning the store on the interceptor is what
+  // makes one provider's shutdown unable to clear another's in-flight state (CR-03).
+  private final SpanEnrichmentStates states;
 
-  SpanEnrichmentHook() {
-    this(DEFAULT_RESOLVER);
+  SpanEnrichmentHook(final SpanEnrichmentStates states) {
+    this(DEFAULT_RESOLVER, states);
   }
 
-  SpanEnrichmentHook(final RootSpanResolver rootSpanResolver) {
+  SpanEnrichmentHook(final RootSpanResolver rootSpanResolver, final SpanEnrichmentStates states) {
     this.rootSpanResolver = rootSpanResolver;
+    this.states = states;
   }
 
   @Override
@@ -104,20 +111,15 @@ class SpanEnrichmentHook implements Hook<Object> {
       } catch (final NumberFormatException e) {
         return; // malformed serial id — drop, never break eval
       }
-      final SpanEnrichmentAccumulator state = getOrCreateState(traceKey);
+      final SpanEnrichmentAccumulator state = states.getOrCreate(traceKey);
       state.addSerialId(serialId);
       if (doLog && targetingKey != null) {
         state.addSubject(targetingKey, serialId);
       }
     } else if (details.getVariant() == null) {
       // Runtime-default detection = MISSING VARIANT (never a reason enum).
-      getOrCreateState(traceKey).addDefault(details.getFlagKey(), details.getValue());
+      states.getOrCreate(traceKey).addDefault(details.getFlagKey(), details.getValue());
     }
-  }
-
-  private static SpanEnrichmentAccumulator getOrCreateState(final long traceKey) {
-    return SpanEnrichmentAccumulator.STATES.computeIfAbsent(
-        traceKey, k -> new SpanEnrichmentAccumulator());
   }
 
   private static String targetingKey(final HookContext<Object> ctx) {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
@@ -6,17 +6,33 @@ import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * {@link TraceInterceptor} that writes the accumulated {@code ffe_*} tags onto the local root span
- * when a trace <em>actually completes</em> (JAVA-01). This is the WRITE half of the
- * capture-vs-write split — the CAPTURE half is {@link SpanEnrichmentHook}, which fills this
- * interceptor's per-provider {@link SpanEnrichmentStates} store during flag evaluation.
+ * Process-wide {@link TraceInterceptor} that writes the accumulated {@code ffe_*} tags onto the
+ * local root span when a trace <em>actually completes</em>. This is the WRITE half of the
+ * capture-vs-write split — the CAPTURE half is {@link SpanEnrichmentHook}, which fills the active
+ * {@link SpanEnrichmentStates} store during flag evaluation.
  *
- * <h2>Partial-flush correctness (CR-01)</h2>
+ * <h2>Reconfiguration safety</h2>
+ *
+ * <p>The tracer holds interceptors in an add-only, priority-keyed set with no public removal API: a
+ * given priority can be occupied by exactly one interceptor for the life of the tracer. If each
+ * provider registered its own interceptor at the same priority, the first registration would win
+ * forever; after that provider closed, every later gate-on provider would be rejected as a
+ * duplicate and enrichment would be permanently disabled.
+ *
+ * <p>To survive provider close/reopen we therefore register a single, long-lived delegating
+ * interceptor ({@link #INSTANCE}) exactly once, and {@linkplain #bind(SpanEnrichmentStates) rebind}
+ * it to whichever provider is currently active. A provider {@linkplain
+ * #unbind(SpanEnrichmentStates) unbinds} on close. When no provider is bound the interceptor is
+ * inert; a fresh provider rebinds it and enrichment resumes — no second registration is ever
+ * attempted.
+ *
+ * <h2>Partial-flush correctness</h2>
  *
  * <p>{@code dd-trace-core} runs {@code onTraceComplete} on <b>every</b> flush, not only on final
- * trace completion: {@code CoreTracer.write(SpanList)} →{@code interceptCompleteTrace(...)} fires
+ * trace completion: {@code CoreTracer.write(SpanList)} → {@code interceptCompleteTrace(...)} fires
  * for both partial flushes ({@code PendingTrace.partialFlush()} → {@code write(true)}) and the
  * final write ({@code write(false)}). A <b>partial</b> flush deliberately <b>excludes the
  * still-open local root</b> — {@code PendingTrace} holds the root back ({@code rootSpanWritten})
@@ -30,14 +46,14 @@ import java.util.Map;
  * the accumulator and write tags onto a not-yet-finished root, silently dropping all pre-flush
  * enrichment — exactly the long-running-trace data-loss bug.
  *
- * <h2>State ownership (CR-02 / CR-03)</h2>
+ * <h2>State ownership</h2>
  *
- * <p>State lives in a per-interceptor (per-provider) {@link SpanEnrichmentStates} store, not a
- * global static. {@link #disable()} clears only this instance's store, so one provider's shutdown
- * can never wipe another's in-flight state (CR-03). The store is hard-bounded, so a trace that
- * never reaches this interceptor cannot leak unboundedly (CR-02).
+ * <p>State lives in the per-provider {@link SpanEnrichmentStates} store that is currently bound.
+ * {@link #unbind(SpanEnrichmentStates)} clears only the store it unbinds, so one provider's close
+ * can never wipe another's in-flight state. The store is hard-bounded, so a trace that never
+ * reaches this interceptor cannot leak unboundedly.
  *
- * <p>All work is wrapped in try/catch — enrichment must NEVER break trace finish (Pattern D).
+ * <p>All work is wrapped in try/catch — enrichment must NEVER break trace finish.
  */
 final class SpanEnrichmentInterceptor implements TraceInterceptor {
 
@@ -48,53 +64,85 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
    */
   static final int PRIORITY = 4;
 
-  // The tracer holds interceptors in an add-only sorted set keyed by priority with no public
-  // removal API. On provider shutdown we cannot un-register, so we disable this instance instead:
-  // a disabled interceptor no-ops and drains its own residual state (Pitfall 3 — provider-close
-  // cleanup). Because state is instance-owned, disabling never touches another provider's state.
-  private volatile boolean enabled = true;
+  /** The single, long-lived interceptor registered with the tracer (reconfiguration safety). */
+  static final SpanEnrichmentInterceptor INSTANCE = new SpanEnrichmentInterceptor();
 
-  // Per-provider state store, shared with this provider's hook. Owned here so cleanup is scoped.
-  private final SpanEnrichmentStates states;
+  // Whether INSTANCE has been accepted by a real tracer. Registration can legitimately fail when
+  // the global tracer is still the no-op (not yet installed); in that case we leave this false so a
+  // later provider retries. Once true we never re-attempt (the interceptor is in for good).
+  private final AtomicBoolean registered = new AtomicBoolean(false);
 
-  SpanEnrichmentInterceptor(final SpanEnrichmentStates states) {
-    this.states = states;
+  // The store of the currently-active provider. null when no gate-on provider is bound, in which
+  // case the interceptor is inert. Volatile: the eval/bind threads write, the trace-write thread
+  // reads.
+  private volatile SpanEnrichmentStates activeStates;
+
+  private SpanEnrichmentInterceptor() {}
+
+  /**
+   * Idempotently registers {@link #INSTANCE} with the tracer via {@code registrar}. Safe to call
+   * from every gate-on provider: the first successful registration wins and subsequent calls are
+   * no-ops. If registration fails because the tracer is not yet installed, a later call retries.
+   */
+  static void ensureRegistered(final Provider.TraceInterceptorRegistrar registrar) {
+    if (INSTANCE.registered.get()) {
+      return;
+    }
+    if (registrar.register(INSTANCE)) {
+      INSTANCE.registered.set(true);
+    }
   }
 
-  /** The state store shared with this interceptor's capture hook. */
-  SpanEnrichmentStates states() {
-    return states;
+  /** Binds the active store to {@code states}, displacing any previously-bound provider. */
+  void bind(final SpanEnrichmentStates states) {
+    this.activeStates = states;
   }
 
-  /** Disables the interceptor and clears its OWN accumulated state (provider-close cleanup). */
-  void disable() {
-    enabled = false;
-    states.clear();
+  /**
+   * Unbinds {@code states} if it is still the active store and clears it (cleanup on provider
+   * close). If a newer provider has already rebound the interceptor, this is a no-op so the new
+   * provider's in-flight state is left untouched.
+   */
+  void unbind(final SpanEnrichmentStates states) {
+    if (this.activeStates == states) {
+      this.activeStates = null;
+    }
+    if (states != null) {
+      states.clear();
+    }
   }
 
-  boolean isEnabled() {
-    return enabled;
+  /** The currently-bound store, or {@code null} when the interceptor is inert. */
+  SpanEnrichmentStates activeStates() {
+    return activeStates;
+  }
+
+  boolean isRegistered() {
+    return registered.get();
   }
 
   @Override
   public Collection<? extends MutableSpan> onTraceComplete(
       final Collection<? extends MutableSpan> trace) {
     try {
-      if (!enabled || trace == null || trace.isEmpty()) {
+      final SpanEnrichmentStates states = this.activeStates;
+      if (states == null || trace == null || trace.isEmpty()) {
         return trace;
       }
       // Resolve the local root for this fragment, then require that the root is actually PRESENT in
-      // this collection. A partial flush excludes the still-open root (CR-01), so its absence means
-      // "not the final write" — keep the accumulator and bail.
+      // this collection. A partial flush excludes the still-open root, so its absence means "not
+      // the
+      // final write" — keep the accumulator and bail.
       final MutableSpan localRoot = findLocalRootInFragment(trace);
       if (!(localRoot instanceof AgentSpan)) {
         return trace; // partial flush, or no resolvable in-fragment root: keep state untouched
       }
       final DDTraceId traceId = ((AgentSpan) localRoot).getTraceId();
       if (traceId == null) {
-        return trace; // no trace id (e.g. Noop span) — cannot key state; keep it (WR-01)
+        return trace; // no trace id (e.g. Noop span) — cannot key state; keep it
       }
-      final long traceKey = traceId.toLong();
+      // Key by the full trace id (hex) to match the capture-side keying.
+      final String traceKey = traceId.toHexString();
       final SpanEnrichmentAccumulator state = states.remove(traceKey);
       if (state == null || !state.hasData()) {
         return trace;
@@ -114,12 +162,11 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
   /**
    * Resolves the local root span for this fragment and returns it ONLY if it is actually present in
    * the fragment by reference identity. Returns {@code null} when the root is not in the collection
-   * (a partial flush excludes the still-open root — CR-01) or when no root can be safely
-   * identified.
+   * (a partial flush excludes the still-open root) or when no root can be safely identified.
    *
-   * <p>We never guess: a non-root span is never returned (WR-02). If the first span reports a
-   * non-null local root, we accept it only after confirming that exact object is in the fragment;
-   * otherwise we look for a span that is provably its own local root and present.
+   * <p>We never guess: a non-root span is never returned. If the first span reports a non-null
+   * local root, we accept it only after confirming that exact object is in the fragment; otherwise
+   * we look for a span that is provably its own local root and present.
    */
   private static MutableSpan findLocalRootInFragment(
       final Collection<? extends MutableSpan> trace) {
@@ -136,7 +183,7 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
       return null; // root excluded from this fragment → partial flush, do not flush/remove
     }
     // Local root unknown for the first span: only accept a span that is provably its own local root
-    // and present here. Never fall back to an arbitrary span (WR-02).
+    // and present here. Never fall back to an arbitrary span.
     for (final MutableSpan span : trace) {
       if (span.getLocalRootSpan() == span) {
         return span;

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.openfeature;
 
+import datadog.trace.api.DDTraceId;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -8,18 +9,35 @@ import java.util.Map;
 
 /**
  * {@link TraceInterceptor} that writes the accumulated {@code ffe_*} tags onto the local root span
- * when a trace completes (JAVA-01). This is the WRITE half of the capture-vs-write split — the
- * CAPTURE half is {@link SpanEnrichmentHook}, which fills {@link SpanEnrichmentAccumulator#STATES}
- * during flag evaluation.
+ * when a trace <em>actually completes</em> (JAVA-01). This is the WRITE half of the
+ * capture-vs-write split — the CAPTURE half is {@link SpanEnrichmentHook}, which fills this
+ * interceptor's per-provider {@link SpanEnrichmentStates} store during flag evaluation.
  *
- * <p>{@code onTraceComplete} finds the local root span in the collection (single pass — the root is
- * reachable via {@link MutableSpan#getLocalRootSpan()}), reads the accumulator keyed by that root's
- * trace id, writes the {@code ffe_*} tags, and removes the state. Span order is not guaranteed, so
- * the root is resolved through {@code getLocalRootSpan()} rather than by position.
+ * <h2>Partial-flush correctness (CR-01)</h2>
  *
- * <p>The state is cleared on flush regardless of whether it had data, so a trace that captured
- * nothing (or whose accumulator was never created) leaves no residue (DG-005). All work is wrapped
- * in try/catch — enrichment must NEVER break trace finish (Pattern D).
+ * <p>{@code dd-trace-core} runs {@code onTraceComplete} on <b>every</b> flush, not only on final
+ * trace completion: {@code CoreTracer.write(SpanList)} →{@code interceptCompleteTrace(...)} fires
+ * for both partial flushes ({@code PendingTrace.partialFlush()} → {@code write(true)}) and the
+ * final write ({@code write(false)}). A <b>partial</b> flush deliberately <b>excludes the
+ * still-open local root</b> — {@code PendingTrace} holds the root back ({@code rootSpanWritten})
+ * and {@code getRootSpan()} returns null on a partial fragment, so {@code CoreTracer.write} does
+ * not invoke {@code onRootSpanFinished} for it.
+ *
+ * <p>Therefore this interceptor flushes+removes state <b>only when the local root span is present
+ * in the flushed collection</b> (i.e. this is the final write for the trace). On a partial flush
+ * the root is absent, so we return early and <b>keep the accumulator intact</b>, preserving every
+ * flag evaluated before the flush boundary. Without this guard, the first partial flush would drain
+ * the accumulator and write tags onto a not-yet-finished root, silently dropping all pre-flush
+ * enrichment — exactly the long-running-trace data-loss bug.
+ *
+ * <h2>State ownership (CR-02 / CR-03)</h2>
+ *
+ * <p>State lives in a per-interceptor (per-provider) {@link SpanEnrichmentStates} store, not a
+ * global static. {@link #disable()} clears only this instance's store, so one provider's shutdown
+ * can never wipe another's in-flight state (CR-03). The store is hard-bounded, so a trace that
+ * never reaches this interceptor cannot leak unboundedly (CR-02).
+ *
+ * <p>All work is wrapped in try/catch — enrichment must NEVER break trace finish (Pattern D).
  */
 final class SpanEnrichmentInterceptor implements TraceInterceptor {
 
@@ -31,15 +49,27 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
   static final int PRIORITY = 4;
 
   // The tracer holds interceptors in an add-only sorted set keyed by priority with no public
-  // removal API. On provider shutdown we cannot un-register, so we disable the singleton instead:
-  // a disabled interceptor no-ops and drains any residual state (Pitfall 3 — provider-close
-  // cleanup; idempotent because re-registration with the same priority is rejected).
+  // removal API. On provider shutdown we cannot un-register, so we disable this instance instead:
+  // a disabled interceptor no-ops and drains its own residual state (Pitfall 3 — provider-close
+  // cleanup). Because state is instance-owned, disabling never touches another provider's state.
   private volatile boolean enabled = true;
 
-  /** Disables the interceptor and clears all accumulated state (provider-close cleanup). */
+  // Per-provider state store, shared with this provider's hook. Owned here so cleanup is scoped.
+  private final SpanEnrichmentStates states;
+
+  SpanEnrichmentInterceptor(final SpanEnrichmentStates states) {
+    this.states = states;
+  }
+
+  /** The state store shared with this interceptor's capture hook. */
+  SpanEnrichmentStates states() {
+    return states;
+  }
+
+  /** Disables the interceptor and clears its OWN accumulated state (provider-close cleanup). */
   void disable() {
     enabled = false;
-    SpanEnrichmentAccumulator.STATES.clear();
+    states.clear();
   }
 
   boolean isEnabled() {
@@ -53,12 +83,19 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
       if (!enabled || trace == null || trace.isEmpty()) {
         return trace;
       }
-      final MutableSpan localRoot = findLocalRoot(trace);
+      // Resolve the local root for this fragment, then require that the root is actually PRESENT in
+      // this collection. A partial flush excludes the still-open root (CR-01), so its absence means
+      // "not the final write" — keep the accumulator and bail.
+      final MutableSpan localRoot = findLocalRootInFragment(trace);
       if (!(localRoot instanceof AgentSpan)) {
-        return trace; // cannot resolve trace id without AgentSpan; nothing to flush
+        return trace; // partial flush, or no resolvable in-fragment root: keep state untouched
       }
-      final long traceKey = ((AgentSpan) localRoot).getTraceId().toLong();
-      final SpanEnrichmentAccumulator state = SpanEnrichmentAccumulator.STATES.remove(traceKey);
+      final DDTraceId traceId = ((AgentSpan) localRoot).getTraceId();
+      if (traceId == null) {
+        return trace; // no trace id (e.g. Noop span) — cannot key state; keep it (WR-01)
+      }
+      final long traceKey = traceId.toLong();
+      final SpanEnrichmentAccumulator state = states.remove(traceKey);
       if (state == null || !state.hasData()) {
         return trace;
       }
@@ -74,19 +111,38 @@ final class SpanEnrichmentInterceptor implements TraceInterceptor {
     return trace;
   }
 
-  private static MutableSpan findLocalRoot(final Collection<? extends MutableSpan> trace) {
+  /**
+   * Resolves the local root span for this fragment and returns it ONLY if it is actually present in
+   * the fragment by reference identity. Returns {@code null} when the root is not in the collection
+   * (a partial flush excludes the still-open root — CR-01) or when no root can be safely
+   * identified.
+   *
+   * <p>We never guess: a non-root span is never returned (WR-02). If the first span reports a
+   * non-null local root, we accept it only after confirming that exact object is in the fragment;
+   * otherwise we look for a span that is provably its own local root and present.
+   */
+  private static MutableSpan findLocalRootInFragment(
+      final Collection<? extends MutableSpan> trace) {
     final MutableSpan first = trace.iterator().next();
-    final MutableSpan localRoot = first.getLocalRootSpan();
-    if (localRoot != null) {
-      return localRoot;
+    final MutableSpan candidate = first.getLocalRootSpan();
+    if (candidate != null) {
+      // Accept the reported local root only if it is genuinely part of THIS fragment. On a partial
+      // flush the root is reachable by reference but NOT in the collection → reject (keep state).
+      for (final MutableSpan span : trace) {
+        if (span == candidate) {
+          return candidate;
+        }
+      }
+      return null; // root excluded from this fragment → partial flush, do not flush/remove
     }
-    // Fallback: scan for a span that is its own local root (no parent in this fragment).
+    // Local root unknown for the first span: only accept a span that is provably its own local root
+    // and present here. Never fall back to an arbitrary span (WR-02).
     for (final MutableSpan span : trace) {
-      if (span.getLocalRootSpan() == span || span.getLocalRootSpan() == null) {
+      if (span.getLocalRootSpan() == span) {
         return span;
       }
     }
-    return first;
+    return null;
   }
 
   @Override

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentInterceptor.java
@@ -1,0 +1,96 @@
+package datadog.trace.api.openfeature;
+
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * {@link TraceInterceptor} that writes the accumulated {@code ffe_*} tags onto the local root span
+ * when a trace completes (JAVA-01). This is the WRITE half of the capture-vs-write split — the
+ * CAPTURE half is {@link SpanEnrichmentHook}, which fills {@link SpanEnrichmentAccumulator#STATES}
+ * during flag evaluation.
+ *
+ * <p>{@code onTraceComplete} finds the local root span in the collection (single pass — the root is
+ * reachable via {@link MutableSpan#getLocalRootSpan()}), reads the accumulator keyed by that root's
+ * trace id, writes the {@code ffe_*} tags, and removes the state. Span order is not guaranteed, so
+ * the root is resolved through {@code getLocalRootSpan()} rather than by position.
+ *
+ * <p>The state is cleared on flush regardless of whether it had data, so a trace that captured
+ * nothing (or whose accumulator was never created) leaves no residue (DG-005). All work is wrapped
+ * in try/catch — enrichment must NEVER break trace finish (Pattern D).
+ */
+final class SpanEnrichmentInterceptor implements TraceInterceptor {
+
+  /**
+   * Unique priority in the "trace data enrichment" band, after {@code GIT_METADATA} (3) and before
+   * the custom-sampling band ({@code Integer.MAX_VALUE - 2}). Distinct from every value in {@code
+   * AbstractTraceInterceptor.Priority} and from the CI Visibility interceptors.
+   */
+  static final int PRIORITY = 4;
+
+  // The tracer holds interceptors in an add-only sorted set keyed by priority with no public
+  // removal API. On provider shutdown we cannot un-register, so we disable the singleton instead:
+  // a disabled interceptor no-ops and drains any residual state (Pitfall 3 — provider-close
+  // cleanup; idempotent because re-registration with the same priority is rejected).
+  private volatile boolean enabled = true;
+
+  /** Disables the interceptor and clears all accumulated state (provider-close cleanup). */
+  void disable() {
+    enabled = false;
+    SpanEnrichmentAccumulator.STATES.clear();
+  }
+
+  boolean isEnabled() {
+    return enabled;
+  }
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      final Collection<? extends MutableSpan> trace) {
+    try {
+      if (!enabled || trace == null || trace.isEmpty()) {
+        return trace;
+      }
+      final MutableSpan localRoot = findLocalRoot(trace);
+      if (!(localRoot instanceof AgentSpan)) {
+        return trace; // cannot resolve trace id without AgentSpan; nothing to flush
+      }
+      final long traceKey = ((AgentSpan) localRoot).getTraceId().toLong();
+      final SpanEnrichmentAccumulator state = SpanEnrichmentAccumulator.STATES.remove(traceKey);
+      if (state == null || !state.hasData()) {
+        return trace;
+      }
+      for (final Map.Entry<String, String> tag : state.toSpanTags().entrySet()) {
+        final String value = tag.getValue();
+        if (value != null && !value.isEmpty()) {
+          localRoot.setTag(tag.getKey(), value);
+        }
+      }
+    } catch (final Throwable t) {
+      // Never let span enrichment break trace finish.
+    }
+    return trace;
+  }
+
+  private static MutableSpan findLocalRoot(final Collection<? extends MutableSpan> trace) {
+    final MutableSpan first = trace.iterator().next();
+    final MutableSpan localRoot = first.getLocalRootSpan();
+    if (localRoot != null) {
+      return localRoot;
+    }
+    // Fallback: scan for a span that is its own local root (no parent in this fragment).
+    for (final MutableSpan span : trace) {
+      if (span.getLocalRootSpan() == span || span.getLocalRootSpan() == null) {
+        return span;
+      }
+    }
+    return first;
+  }
+
+  @Override
+  public int priority() {
+    return PRIORITY;
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentStates.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentStates.java
@@ -8,21 +8,24 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Bounded, instance-owned store of per-trace {@link SpanEnrichmentAccumulator} state, keyed by the
- * local-root span's trace id ({@code DDTraceId.toLong()}).
+ * local-root span's full trace id (the lower-case zero-padded hex string).
  *
- * <p>This replaces the previous global {@code static} map (review IN-03 / CR-02 / CR-03). Each
- * {@link SpanEnrichmentInterceptor} owns exactly one instance and shares it with the {@link
- * SpanEnrichmentHook} for the same provider, so:
+ * <p>The full hex key matters for 128-bit trace ids: keying by {@code DDTraceId.toLong()} (the
+ * low-order 64 bits only) would merge two distinct 128-bit traces that share their low bits into a
+ * single accumulator, cross-contaminating enrichment between unrelated traces. The full hex string
+ * is unique across all 128 bits and is cached on the id, so it is cheap to obtain.
+ *
+ * <p>Each {@link SpanEnrichmentHook}/{@link SpanEnrichmentInterceptor} pair shares one store
+ * instance, so:
  *
  * <ul>
- *   <li><b>CR-02 (unbounded leak):</b> the store is hard-capped at {@link #MAX_TRACES}. A trace
- *       that never reaches the interceptor (dropped, Noop tracer, never-finishing root) can no
- *       longer leak unboundedly — once the cap is reached, the <em>oldest</em> in-flight entry is
- *       evicted (FIFO by insertion order) so the map size is strictly bounded regardless of trace
- *       completion. This is the exact #4844 leak class.
- *   <li><b>CR-03 (reconfiguration corruption):</b> because the store is per-interceptor rather than
- *       a shared static, one provider's {@code shutdown()} clears only its own state and can never
- *       wipe another (still-active) provider's in-flight entries.
+ *   <li><b>Unbounded leak:</b> the store is hard-capped at {@link #MAX_TRACES}. A trace that never
+ *       reaches the interceptor (dropped, Noop tracer, never-finishing root) can no longer leak
+ *       unboundedly — once the cap is reached, the <em>oldest</em> in-flight entry is evicted (FIFO
+ *       by insertion order) so the map size is strictly bounded regardless of trace completion.
+ *   <li><b>Isolation:</b> because the store is instance-owned rather than a shared static, one
+ *       provider's cleanup clears only its own state and can never wipe another (still-active)
+ *       provider's in-flight entries.
  * </ul>
  *
  * <p>Bounded eviction is intentionally lossy under pathological pressure: dropping the oldest
@@ -40,14 +43,14 @@ final class SpanEnrichmentStates {
   /**
    * Hard cap on the number of concurrently-tracked traces. Sized well above any realistic count of
    * simultaneously in-flight traces with active flag evaluations on a single JVM, so the live path
-   * never evicts; the cap exists purely to bound a leak of never-completing traces (CR-02).
+   * never evicts; the cap exists purely to bound a leak of never-completing traces.
    */
   static final int MAX_TRACES = 4096;
 
   // Insertion-ordered so the eldest entry is the natural eviction victim (FIFO). accessOrder=false
   // (the default) — we evict by age of creation, not by recency of use, so a long-running but
   // never-completing trace cannot pin the map by being repeatedly touched.
-  private final LinkedHashMap<Long, SpanEnrichmentAccumulator> states = new LinkedHashMap<>();
+  private final LinkedHashMap<String, SpanEnrichmentAccumulator> states = new LinkedHashMap<>();
 
   // One-shot guard so a sustained leak logs once at WARN rather than on every eviction.
   private boolean evictionWarned = false;
@@ -55,9 +58,9 @@ final class SpanEnrichmentStates {
   /**
    * Returns the accumulator for {@code traceKey}, creating (and inserting) it if absent. When
    * insertion would exceed {@link #MAX_TRACES}, the eldest entry is evicted first so the store
-   * stays bounded (CR-02).
+   * stays bounded.
    */
-  synchronized SpanEnrichmentAccumulator getOrCreate(final long traceKey) {
+  synchronized SpanEnrichmentAccumulator getOrCreate(final String traceKey) {
     SpanEnrichmentAccumulator existing = states.get(traceKey);
     if (existing != null) {
       return existing;
@@ -71,11 +74,11 @@ final class SpanEnrichmentStates {
   }
 
   /** Removes and returns the accumulator for {@code traceKey}, or {@code null} if absent. */
-  synchronized SpanEnrichmentAccumulator remove(final long traceKey) {
+  synchronized SpanEnrichmentAccumulator remove(final String traceKey) {
     return states.remove(traceKey);
   }
 
-  /** Clears all tracked state (provider-close cleanup). Scoped to this instance only (CR-03). */
+  /** Clears all tracked state (cleanup on provider close / unbind). */
   synchronized void clear() {
     states.clear();
   }
@@ -90,12 +93,12 @@ final class SpanEnrichmentStates {
 
   // ---- test-only accessor ----
 
-  synchronized SpanEnrichmentAccumulator peek(final long traceKey) {
+  synchronized SpanEnrichmentAccumulator peek(final String traceKey) {
     return states.get(traceKey);
   }
 
   private void evictEldest() {
-    final Iterator<Map.Entry<Long, SpanEnrichmentAccumulator>> it = states.entrySet().iterator();
+    final Iterator<Map.Entry<String, SpanEnrichmentAccumulator>> it = states.entrySet().iterator();
     if (it.hasNext()) {
       it.next();
       it.remove();

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentStates.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/SpanEnrichmentStates.java
@@ -1,0 +1,112 @@
+package datadog.trace.api.openfeature;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bounded, instance-owned store of per-trace {@link SpanEnrichmentAccumulator} state, keyed by the
+ * local-root span's trace id ({@code DDTraceId.toLong()}).
+ *
+ * <p>This replaces the previous global {@code static} map (review IN-03 / CR-02 / CR-03). Each
+ * {@link SpanEnrichmentInterceptor} owns exactly one instance and shares it with the {@link
+ * SpanEnrichmentHook} for the same provider, so:
+ *
+ * <ul>
+ *   <li><b>CR-02 (unbounded leak):</b> the store is hard-capped at {@link #MAX_TRACES}. A trace
+ *       that never reaches the interceptor (dropped, Noop tracer, never-finishing root) can no
+ *       longer leak unboundedly — once the cap is reached, the <em>oldest</em> in-flight entry is
+ *       evicted (FIFO by insertion order) so the map size is strictly bounded regardless of trace
+ *       completion. This is the exact #4844 leak class.
+ *   <li><b>CR-03 (reconfiguration corruption):</b> because the store is per-interceptor rather than
+ *       a shared static, one provider's {@code shutdown()} clears only its own state and can never
+ *       wipe another (still-active) provider's in-flight entries.
+ * </ul>
+ *
+ * <p>Bounded eviction is intentionally lossy under pathological pressure: dropping the oldest
+ * accumulator degrades enrichment for that one (likely already-abandoned) trace rather than
+ * exhausting the heap. Enrichment correctness is best-effort by contract; heap safety is not.
+ *
+ * <p>Thread-safety: all access is guarded by the intrinsic lock on this instance. The hook writes
+ * (eval thread) and the interceptor reads+removes (trace-write thread) concurrently, so every
+ * mutator and accessor synchronizes. Contention is low — operations are O(1) map touches.
+ */
+final class SpanEnrichmentStates {
+
+  private static final Logger log = LoggerFactory.getLogger(SpanEnrichmentStates.class);
+
+  /**
+   * Hard cap on the number of concurrently-tracked traces. Sized well above any realistic count of
+   * simultaneously in-flight traces with active flag evaluations on a single JVM, so the live path
+   * never evicts; the cap exists purely to bound a leak of never-completing traces (CR-02).
+   */
+  static final int MAX_TRACES = 4096;
+
+  // Insertion-ordered so the eldest entry is the natural eviction victim (FIFO). accessOrder=false
+  // (the default) — we evict by age of creation, not by recency of use, so a long-running but
+  // never-completing trace cannot pin the map by being repeatedly touched.
+  private final LinkedHashMap<Long, SpanEnrichmentAccumulator> states = new LinkedHashMap<>();
+
+  // One-shot guard so a sustained leak logs once at WARN rather than on every eviction.
+  private boolean evictionWarned = false;
+
+  /**
+   * Returns the accumulator for {@code traceKey}, creating (and inserting) it if absent. When
+   * insertion would exceed {@link #MAX_TRACES}, the eldest entry is evicted first so the store
+   * stays bounded (CR-02).
+   */
+  synchronized SpanEnrichmentAccumulator getOrCreate(final long traceKey) {
+    SpanEnrichmentAccumulator existing = states.get(traceKey);
+    if (existing != null) {
+      return existing;
+    }
+    if (states.size() >= MAX_TRACES) {
+      evictEldest();
+    }
+    final SpanEnrichmentAccumulator created = new SpanEnrichmentAccumulator();
+    states.put(traceKey, created);
+    return created;
+  }
+
+  /** Removes and returns the accumulator for {@code traceKey}, or {@code null} if absent. */
+  synchronized SpanEnrichmentAccumulator remove(final long traceKey) {
+    return states.remove(traceKey);
+  }
+
+  /** Clears all tracked state (provider-close cleanup). Scoped to this instance only (CR-03). */
+  synchronized void clear() {
+    states.clear();
+  }
+
+  synchronized int size() {
+    return states.size();
+  }
+
+  synchronized boolean isEmpty() {
+    return states.isEmpty();
+  }
+
+  // ---- test-only accessor ----
+
+  synchronized SpanEnrichmentAccumulator peek(final long traceKey) {
+    return states.get(traceKey);
+  }
+
+  private void evictEldest() {
+    final Iterator<Map.Entry<Long, SpanEnrichmentAccumulator>> it = states.entrySet().iterator();
+    if (it.hasNext()) {
+      it.next();
+      it.remove();
+    }
+    if (!evictionWarned) {
+      evictionWarned = true;
+      log.warn(
+          "Span-enrichment state cap ({}) reached; evicting oldest in-flight trace state. "
+              + "This indicates traces with flag evaluations that never complete; enrichment for "
+              + "evicted traces is dropped to bound memory.",
+          MAX_TRACES);
+    }
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/ULeb128Encoder.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/ULeb128Encoder.java
@@ -1,0 +1,119 @@
+package datadog.trace.api.openfeature;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * ULEB128 delta-varint + base64 codec for APM feature-flag span enrichment (JAVA-01).
+ *
+ * <p>Ported VERBATIM from the frozen Node reference ({@code dd-trace-js#8343}). The tag names,
+ * encoding, and golden vectors are FROZEN against that contract — backend/Trino decode and the
+ * parametric system-tests assertions depend on exact parity, so this MUST NOT be re-derived.
+ *
+ * <p>Algorithm: dedupe (via {@link Set}) → sort ascending → emit the delta from the previous id as
+ * an unsigned LEB128 varint (7 bits/byte, MSB = continuation) → base64-encode the byte buffer. The
+ * empty set encodes to the empty string (the caller then omits the tag).
+ *
+ * <p>Golden vector: {@code {100, 108, 128, 130}} → deltas {@code [100, 8, 20, 2]} → bytes {@code
+ * [0x64, 0x08, 0x14, 0x02]} → base64 {@code "ZAgUAg=="}.
+ */
+final class ULeb128Encoder {
+
+  private ULeb128Encoder() {}
+
+  /**
+   * ULEB128 delta-varint encodes the given serial ids into a bare base64 string.
+   *
+   * @param serialIds the serial ids to encode (deduped + sorted ascending internally)
+   * @return the base64-encoded delta-varint bytes, or the empty string when {@code serialIds} is
+   *     empty or null
+   */
+  static String encodeDeltaVarint(final Set<Integer> serialIds) {
+    if (serialIds == null || serialIds.isEmpty()) {
+      // Empty set encodes to the empty string; the caller omits the tag.
+      return "";
+    }
+    final SortedSet<Integer> sorted =
+        serialIds instanceof SortedSet ? (SortedSet<Integer>) serialIds : new TreeSet<>(serialIds);
+    // Worst case: 5 bytes per 32-bit varint.
+    final byte[] buffer = new byte[sorted.size() * 5];
+    int length = 0;
+    int previous = 0;
+    for (final Integer id : sorted) {
+      long delta =
+          ((long) id) - previous; // long to stay safe; deltas are non-negative (sorted asc)
+      previous = id;
+      while (delta > 0x7FL) {
+        buffer[length++] = (byte) ((delta & 0x7FL) | 0x80L);
+        delta >>>= 7;
+      }
+      buffer[length++] = (byte) (delta & 0x7FL);
+    }
+    final byte[] out = new byte[length];
+    System.arraycopy(buffer, 0, out, 0, length);
+    return Base64.getEncoder().encodeToString(out);
+  }
+
+  /**
+   * Decodes a delta-varint base64 string back into the original ascending serial ids. Used by the
+   * codec round-trip oracle (the decode side mirrors the L2 system-tests decoder).
+   *
+   * @param encoded a base64 string produced by {@link #encodeDeltaVarint(Set)}
+   * @return the decoded serial ids in ascending order (empty for the empty string)
+   */
+  static SortedSet<Integer> decodeDeltaVarint(final String encoded) {
+    final SortedSet<Integer> result = new TreeSet<>();
+    if (encoded == null || encoded.isEmpty()) {
+      return result;
+    }
+    final byte[] bytes = Base64.getDecoder().decode(encoded);
+    int previous = 0;
+    int index = 0;
+    while (index < bytes.length) {
+      long value = 0;
+      int shift = 0;
+      while (true) {
+        final byte b = bytes[index++];
+        value |= ((long) (b & 0x7F)) << shift;
+        if ((b & 0x80) == 0) {
+          break;
+        }
+        shift += 7;
+      }
+      previous += (int) value; // delta from previous
+      result.add(previous);
+    }
+    return result;
+  }
+
+  /**
+   * Lower-case hex SHA-256 of the given string. Used to hash subject targeting keys before they are
+   * emitted (privacy: subject keys are never emitted in clear text).
+   *
+   * @param value the value to hash
+   * @return the lower-case hex SHA-256 digest
+   */
+  static String hashTargetingKey(final String value) {
+    try {
+      final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      final byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      final StringBuilder hex = new StringBuilder(hash.length * 2);
+      for (final byte b : hash) {
+        final int v = b & 0xFF;
+        if (v < 0x10) {
+          hex.append('0');
+        }
+        hex.append(Integer.toHexString(v));
+      }
+      return hex.toString();
+    } catch (final NoSuchAlgorithmException e) {
+      // SHA-256 is mandated by the JLS to be present on every JVM; this is unreachable in practice.
+      throw new IllegalStateException("SHA-256 algorithm not available", e);
+    }
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/ULeb128Encoder.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/ULeb128Encoder.java
@@ -9,7 +9,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
- * ULEB128 delta-varint + base64 codec for APM feature-flag span enrichment (JAVA-01).
+ * ULEB128 delta-varint + base64 codec for APM feature-flag span enrichment.
  *
  * <p>Ported VERBATIM from the frozen Node reference ({@code dd-trace-js#8343}). The tag names,
  * encoding, and golden vectors are FROZEN against that contract — backend/Trino decode and the

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -641,7 +641,7 @@ public class DDEvaluatorTest {
   private Flag createSimpleFlag(String key, ValueType type, Object value, String variantKey) {
     final Map<String, Variant> variants = new HashMap<>();
     variants.put(variantKey, new Variant(variantKey, value));
-    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null));
+    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null, null));
     final List<Allocation> allocations =
         singletonList(new Allocation("alloc1", null, null, null, splits, false));
     return new Flag(key, true, type, variants, allocations);
@@ -657,12 +657,12 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.MATCHES, "email", "@company\\.com$"));
     final List<Rule> premiumRules = singletonList(new Rule(premiumConditions));
-    final List<Split> premiumSplits = singletonList(new Split(emptyList(), "premium", null));
+    final List<Split> premiumSplits = singletonList(new Split(emptyList(), "premium", null, null));
     final Allocation premiumAllocation =
         new Allocation("premium-alloc", premiumRules, null, null, premiumSplits, false);
 
     // Fallback allocation for basic
-    final List<Split> basicSplits = singletonList(new Split(emptyList(), "basic", null));
+    final List<Split> basicSplits = singletonList(new Split(emptyList(), "basic", null, null));
     final Allocation basicAllocation =
         new Allocation("basic-alloc", null, null, null, basicSplits, false);
 
@@ -680,12 +680,12 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> vipConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.GTE, "score", 800));
     final List<Rule> vipRules = singletonList(new Rule(vipConditions));
-    final List<Split> vipSplits = singletonList(new Split(emptyList(), "vip", null));
+    final List<Split> vipSplits = singletonList(new Split(emptyList(), "vip", null, null));
     final Allocation vipAllocation =
         new Allocation("vip-alloc", vipRules, null, null, vipSplits, false);
 
     // Fallback
-    final List<Split> regularSplits = singletonList(new Split(emptyList(), "regular", null));
+    final List<Split> regularSplits = singletonList(new Split(emptyList(), "regular", null, null));
     final Allocation regularAllocation =
         new Allocation("regular-alloc", null, null, null, regularSplits, false);
 
@@ -706,12 +706,12 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> noBetaConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.IS_NULL, "beta_feature", true));
     final List<Rule> noBetaRules = singletonList(new Rule(noBetaConditions));
-    final List<Split> noBetaSplits = singletonList(new Split(emptyList(), "no-beta", null));
+    final List<Split> noBetaSplits = singletonList(new Split(emptyList(), "no-beta", null, null));
     final Allocation noBetaAllocation =
         new Allocation("no-beta-alloc", noBetaRules, null, null, noBetaSplits, false);
 
     // Fallback
-    final List<Split> hasBetaSplits = singletonList(new Split(emptyList(), "has-beta", null));
+    final List<Split> hasBetaSplits = singletonList(new Split(emptyList(), "has-beta", null, null));
     final Allocation hasBetaAllocation =
         new Allocation("has-beta-alloc", null, null, null, hasBetaSplits, false);
 
@@ -734,12 +734,13 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.ONE_OF, "region", allowedRegions));
     final List<Rule> regionalRules = singletonList(new Rule(regionalConditions));
-    final List<Split> regionalSplits = singletonList(new Split(emptyList(), "regional", null));
+    final List<Split> regionalSplits =
+        singletonList(new Split(emptyList(), "regional", null, null));
     final Allocation regionalAllocation =
         new Allocation("regional-alloc", regionalRules, null, null, regionalSplits, false);
 
     // Fallback
-    final List<Split> globalSplits = singletonList(new Split(emptyList(), "global", null));
+    final List<Split> globalSplits = singletonList(new Split(emptyList(), "global", null, null));
     final Allocation globalAllocation =
         new Allocation("global-alloc", null, null, null, globalSplits, false);
 
@@ -755,7 +756,7 @@ public class DDEvaluatorTest {
     final Map<String, Variant> variants = new HashMap<>();
     variants.put("time-limited", new Variant("time-limited", "time-limited"));
 
-    final List<Split> splits = singletonList(new Split(emptyList(), "time-limited", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "time-limited", null, null));
 
     // Allocation that ended in 2022 (should be inactive)
     final List<Allocation> allocations =
@@ -779,7 +780,7 @@ public class DDEvaluatorTest {
     final List<ShardRange> ranges = singletonList(new ShardRange(0, 50)); // 0-49 out of 100
     final List<Shard> shards = singletonList(new Shard("test-salt", ranges, 100));
 
-    final List<Split> splits = singletonList(new Split(shards, "shard-variant", null));
+    final List<Split> splits = singletonList(new Split(shards, "shard-variant", null, null));
 
     final List<Allocation> allocations =
         singletonList(new Allocation("shard-alloc", null, null, null, splits, false));
@@ -792,7 +793,7 @@ public class DDEvaluatorTest {
     final Map<String, Variant> variants = new HashMap<>();
     variants.put("existing", new Variant("existing", "value"));
 
-    final List<Split> splits = singletonList(new Split(emptyList(), "missing-variant", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "missing-variant", null, null));
 
     final List<Allocation> allocations =
         singletonList(new Allocation("alloc1", null, null, null, splits, false));
@@ -814,7 +815,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> conditions =
         singletonList(new ConditionConfiguration(operator, attribute, threshold));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null));
+    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null, null));
     final Allocation allocation = new Allocation(allocKey, rules, null, null, splits, false);
 
     return new Flag(flagKey, true, ValueType.STRING, variants, singletonList(allocation));
@@ -849,7 +850,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> conditions =
         singletonList(new ConditionConfiguration(operator, attribute, value));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null));
+    final List<Split> splits = singletonList(new Split(emptyList(), variantKey, null, null));
     final Allocation allocation = new Allocation(allocKey, rules, null, null, splits, false);
 
     return new Flag(flagKey, true, ValueType.STRING, variants, singletonList(allocation));
@@ -886,7 +887,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> piConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.MATCHES, "rate", "3.14159"));
     final List<Rule> piRules = singletonList(new Rule(piConditions));
-    final List<Split> piSplits = singletonList(new Split(emptyList(), "pi", null));
+    final List<Split> piSplits = singletonList(new Split(emptyList(), "pi", null, null));
     final Allocation piAllocation =
         new Allocation("pi-alloc", piRules, null, null, piSplits, false);
 
@@ -903,7 +904,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.MATCHES, "user.profile.level", "premium"));
     final List<Rule> premiumRules = singletonList(new Rule(premiumConditions));
-    final List<Split> premiumSplits = singletonList(new Split(emptyList(), "premium", null));
+    final List<Split> premiumSplits = singletonList(new Split(emptyList(), "premium", null, null));
     final Allocation premiumAllocation =
         new Allocation("premium-nested-alloc", premiumRules, null, null, premiumSplits, false);
 
@@ -915,7 +916,7 @@ public class DDEvaluatorTest {
     final Map<String, Variant> variants = new HashMap<>();
     variants.put("tracked", new Variant("tracked", "tracked-value"));
 
-    final List<Split> splits = singletonList(new Split(emptyList(), "tracked", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "tracked", null, null));
     // Create allocation with doLog=true to trigger exposure logging
     final List<Allocation> allocations =
         singletonList(new Allocation("exposure-alloc", null, null, null, splits, true));
@@ -931,7 +932,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> exactConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.LTE, "score", 3.14159));
     final List<Rule> exactRules = singletonList(new Rule(exactConditions));
-    final List<Split> exactSplits = singletonList(new Split(emptyList(), "exact", null));
+    final List<Split> exactSplits = singletonList(new Split(emptyList(), "exact", null, null));
     final Allocation exactAllocation =
         new Allocation("exact-alloc", exactRules, null, null, exactSplits, false);
 
@@ -947,7 +948,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> loggedConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.MATCHES, "feature", "premium"));
     final List<Rule> loggedRules = singletonList(new Rule(loggedConditions));
-    final List<Split> loggedSplits = singletonList(new Split(emptyList(), "logged", null));
+    final List<Split> loggedSplits = singletonList(new Split(emptyList(), "logged", null, null));
     // Create allocation with doLog=true to trigger exposure logging and allocationKey method
     final Allocation loggedAllocation =
         new Allocation("logged-alloc", loggedRules, null, null, loggedSplits, true);
@@ -966,7 +967,8 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> numericConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.ONE_OF, "score", numericValues));
     final List<Rule> numericRules = singletonList(new Rule(numericConditions));
-    final List<Split> numericSplits = singletonList(new Split(emptyList(), "numeric-match", null));
+    final List<Split> numericSplits =
+        singletonList(new Split(emptyList(), "numeric-match", null, null));
     final Allocation numericAllocation =
         new Allocation("numeric-alloc", numericRules, null, null, numericSplits, false);
 
@@ -985,7 +987,8 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_ONE_OF, "score", excludedValues));
     final List<Rule> excludedRules = singletonList(new Rule(excludedConditions));
-    final List<Split> excludedSplits = singletonList(new Split(emptyList(), "excluded", null));
+    final List<Split> excludedSplits =
+        singletonList(new Split(emptyList(), "excluded", null, null));
     final Allocation excludedAllocation =
         new Allocation("excluded-alloc", excludedRules, null, null, excludedSplits, false);
 
@@ -1005,7 +1008,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> notNullConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.IS_NULL, "attr", false));
     final List<Rule> notNullRules = singletonList(new Rule(notNullConditions));
-    final List<Split> notNullSplits = singletonList(new Split(emptyList(), "not-null", null));
+    final List<Split> notNullSplits = singletonList(new Split(emptyList(), "not-null", null, null));
     final Allocation notNullAllocation =
         new Allocation("not-null-alloc", notNullRules, null, null, notNullSplits, false);
 
@@ -1022,7 +1025,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.IS_NULL, "missing_attr", "string"));
     final List<Rule> nullRules = singletonList(new Rule(nullConditions));
-    final List<Split> nullSplits = singletonList(new Split(emptyList(), "null-match", null));
+    final List<Split> nullSplits = singletonList(new Split(emptyList(), "null-match", null, null));
     final Allocation nullAllocation =
         new Allocation("null-alloc", nullRules, null, null, nullSplits, false);
 
@@ -1042,7 +1045,8 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> nullAttrConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.MATCHES, null, "test"));
     final List<Rule> nullAttrRules = singletonList(new Rule(nullAttrConditions));
-    final List<Split> nullAttrSplits = singletonList(new Split(emptyList(), "fallback", null));
+    final List<Split> nullAttrSplits =
+        singletonList(new Split(emptyList(), "fallback", null, null));
     final Allocation nullAttrAllocation =
         new Allocation("null-attr-alloc", nullAttrRules, null, null, nullAttrSplits, false);
 
@@ -1059,7 +1063,8 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_MATCHES, "email", "@company\\.com"));
     final List<Rule> externalRules = singletonList(new Rule(externalConditions));
-    final List<Split> externalSplits = singletonList(new Split(emptyList(), "external", null));
+    final List<Split> externalSplits =
+        singletonList(new Split(emptyList(), "external", null, null));
     final Allocation externalAllocation =
         new Allocation("external-alloc", externalRules, null, null, externalSplits, false);
 
@@ -1081,7 +1086,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_ONE_OF, "region", excludedRegions));
     final List<Rule> otherRules = singletonList(new Rule(otherConditions));
-    final List<Split> otherSplits = singletonList(new Split(emptyList(), "other", null));
+    final List<Split> otherSplits = singletonList(new Split(emptyList(), "other", null, null));
     final Allocation otherAllocation =
         new Allocation("other-alloc", otherRules, null, null, otherSplits, false);
 
@@ -1101,7 +1106,8 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> highScoreConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.GTE, "score", 800));
     final List<Rule> highScoreRules = singletonList(new Rule(highScoreConditions));
-    final List<Split> highScoreSplits = singletonList(new Split(emptyList(), "high-score", null));
+    final List<Split> highScoreSplits =
+        singletonList(new Split(emptyList(), "high-score", null, null));
     final Allocation highScoreAllocation =
         new Allocation("high-score-alloc", highScoreRules, null, null, highScoreSplits, false);
 
@@ -1131,7 +1137,7 @@ public class DDEvaluatorTest {
 
     // Rule with empty conditions list - this will be skipped, causing allocation to not match
     final Rule emptyConditionsRule = new Rule(emptyList());
-    final List<Split> splits = singletonList(new Split(emptyList(), "default", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "default", null, null));
     final Allocation allocation =
         new Allocation(
             "empty-conditions-alloc",
@@ -1153,7 +1159,7 @@ public class DDEvaluatorTest {
     final List<ShardRange> ranges =
         singletonList(new ShardRange(0, 100)); // Full range to ensure match
     final List<Shard> shards = singletonList(new Shard("test-salt", ranges, 100));
-    final List<Split> splits = singletonList(new Split(shards, "matched", null));
+    final List<Split> splits = singletonList(new Split(shards, "matched", null, null));
     final Allocation allocation =
         new Allocation("shard-matching-alloc", null, null, null, splits, false);
 
@@ -1165,7 +1171,7 @@ public class DDEvaluatorTest {
     final Map<String, Variant> variants = new HashMap<>();
     variants.put("future", new Variant("future", "future-value"));
 
-    final List<Split> splits = singletonList(new Split(emptyList(), "future", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "future", null, null));
 
     // Allocation that starts in the future (2050)
     final Allocation allocation =
@@ -1185,7 +1191,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.MATCHES, "id", "user-special-id"));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "id-match", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "id-match", null, null));
     final Allocation allocation = new Allocation("id-attr-alloc", rules, null, null, splits, false);
 
     return new Flag(
@@ -1200,7 +1206,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> conditions =
         singletonList(new ConditionConfiguration(ConditionOperator.ONE_OF, "attr", "single-value"));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "no-match", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "no-match", null, null));
     final Allocation allocation =
         new Allocation("non-iterable-alloc", rules, null, null, splits, false);
 
@@ -1250,7 +1256,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_MATCHES, "email", "@company\\.com"));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "internal", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "internal", null, null));
     final Allocation allocation =
         new Allocation("not-matches-false-alloc", rules, null, null, splits, false);
 
@@ -1269,7 +1275,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_ONE_OF, "region", excludedRegions));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "excluded", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "excluded", null, null));
     final Allocation allocation =
         new Allocation("not-one-of-false-alloc", rules, null, null, splits, false);
 
@@ -1285,7 +1291,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> conditions =
         singletonList(new ConditionConfiguration(ConditionOperator.IS_NULL, "nullAttr", true));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "null-variant", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "null-variant", null, null));
     final Allocation allocation =
         new Allocation("null-context-alloc", rules, null, null, splits, false);
 
@@ -1303,12 +1309,12 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> usConditions =
         singletonList(new ConditionConfiguration(ConditionOperator.ONE_OF, "country", usCountries));
     final List<Rule> usRules = singletonList(new Rule(usConditions));
-    final List<Split> usSplits = singletonList(new Split(emptyList(), "us", null));
+    final List<Split> usSplits = singletonList(new Split(emptyList(), "us", null, null));
     final Allocation usAllocation =
         new Allocation("us-alloc", usRules, null, null, usSplits, false);
 
     // Fallback allocation (no rules, no shards)
-    final List<Split> globalSplits = singletonList(new Split(emptyList(), "global", null));
+    final List<Split> globalSplits = singletonList(new Split(emptyList(), "global", null, null));
     final Allocation globalAllocation =
         new Allocation("global-alloc", null, null, null, globalSplits, false);
 
@@ -1328,7 +1334,7 @@ public class DDEvaluatorTest {
     final List<ConditionConfiguration> conditions =
         singletonList(new ConditionConfiguration(ConditionOperator.MATCHES, "email", "[invalid"));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "matched", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "matched", null, null));
     final Allocation allocation =
         new Allocation("invalid-regex-alloc", rules, null, null, splits, false);
 
@@ -1345,7 +1351,7 @@ public class DDEvaluatorTest {
         singletonList(
             new ConditionConfiguration(ConditionOperator.NOT_MATCHES, "email", "[invalid"));
     final List<Rule> rules = singletonList(new Rule(conditions));
-    final List<Split> splits = singletonList(new Split(emptyList(), "excluded", null));
+    final List<Split> splits = singletonList(new Split(emptyList(), "excluded", null, null));
     final Allocation allocation =
         new Allocation("invalid-regex-not-matches-alloc", rules, null, null, splits, false);
 

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -198,6 +198,49 @@ public class DDEvaluatorTest {
   }
 
   @Test
+  public void testSerialIdSurfacedInFlagMetadata() {
+    final Map<String, Variant> variants = new HashMap<>();
+    variants.put("on", new Variant("on", "test-value"));
+    final List<Split> splits = singletonList(new Split(emptyList(), "on", null, 42));
+    final List<Allocation> allocations =
+        singletonList(new Allocation("alloc1", null, null, null, splits, false));
+    final Map<String, Flag> flags = new HashMap<>();
+    flags.put(
+        "serial-id-flag",
+        new Flag("serial-id-flag", true, ValueType.STRING, variants, allocations));
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    evaluator.accept(new ServerConfiguration(null, null, null, flags));
+
+    final ProviderEvaluation<?> details =
+        evaluator.evaluate(
+            String.class, "serial-id-flag", "default", new MutableContext("user-123"));
+
+    assertThat(details.getFlagMetadata().getString("__dd_split_serial_id"), equalTo("42"));
+    assertThat(details.getFlagMetadata().getString("__dd_do_log"), equalTo("false"));
+  }
+
+  @Test
+  public void testNullSerialIdAbsentFromFlagMetadata() {
+    final Map<String, Variant> variants = new HashMap<>();
+    variants.put("on", new Variant("on", "test-value"));
+    final List<Split> splits = singletonList(new Split(emptyList(), "on", null, null));
+    final List<Allocation> allocations =
+        singletonList(new Allocation("alloc1", null, null, null, splits, false));
+    final Map<String, Flag> flags = new HashMap<>();
+    flags.put(
+        "no-serial-id-flag",
+        new Flag("no-serial-id-flag", true, ValueType.STRING, variants, allocations));
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    evaluator.accept(new ServerConfiguration(null, null, null, flags));
+
+    final ProviderEvaluation<?> details =
+        evaluator.evaluate(
+            String.class, "no-serial-id-flag", "default", new MutableContext("user-123"));
+
+    assertThat(details.getFlagMetadata().getString("__dd_split_serial_id"), nullValue());
+  }
+
+  @Test
   public void testNoAllocations() {
     final Map<String, Flag> flags = new HashMap<>();
     flags.put("null-allocation", new Flag("target", true, null, null, null));

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
@@ -38,10 +38,18 @@ import org.junit.jupiter.api.Test;
  */
 class SpanEnrichmentHookTest {
 
+  // Per-test instance-owned state store (replaces the former global static). The hook and the
+  // interceptor under test share this one, mirroring how a single Provider wires them (CR-03).
+  private SpanEnrichmentStates states;
+
   @BeforeEach
+  void freshState() {
+    states = new SpanEnrichmentStates();
+  }
+
   @AfterEach
   void clearState() {
-    SpanEnrichmentAccumulator.STATES.clear();
+    states.clear();
   }
 
   // ---- helpers ----
@@ -94,9 +102,14 @@ class SpanEnrichmentHookTest {
         details(flagKey, variant, value, metadata(serialId, doLog)));
   }
 
-  private static MutableSpan rootSpanCollection(final long traceId, final MutableSpan rootSpan) {
+  /**
+   * Configures a mock root span to report itself as its own local root with the given trace id. The
+   * returned span, passed in a singleton collection, models a FINAL flush (the root is present in
+   * the fragment), so the interceptor flushes + removes state (CR-01 final-write path).
+   */
+  private static AgentSpan rootSpanCollection(final long traceId, final AgentSpan rootSpan) {
     when(rootSpan.getLocalRootSpan()).thenReturn(rootSpan);
-    when(((AgentSpan) rootSpan).getTraceId()).thenReturn(DDTraceId.from(traceId));
+    when(rootSpan.getTraceId()).thenReturn(DDTraceId.from(traceId));
     return rootSpan;
   }
 
@@ -126,14 +139,13 @@ class SpanEnrichmentHookTest {
   @Test
   void noActiveSpanDoesNotCrashOrAccumulate() {
     // Injected resolver returns null => no active local root (the no-span case).
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> null);
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> null, states);
     // Should be a no-op, never throw.
     hook.finallyAfter(
         ctx("flag", "user-1"),
         details("flag", "on", "v", metadata(100, true)),
         Collections.emptyMap());
-    assertTrue(
-        SpanEnrichmentAccumulator.STATES.isEmpty(), "no active span => no accumulator state");
+    assertTrue(states.isEmpty(), "no active span => no accumulator state");
   }
 
   @Test
@@ -141,12 +153,12 @@ class SpanEnrichmentHookTest {
     // Drives finallyAfter end-to-end with an injected root resolver (no static mocks).
     final AgentSpan root = mock(AgentSpan.class);
     when(root.getTraceId()).thenReturn(DDTraceId.from(0x77L));
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> root);
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> root, states);
     hook.finallyAfter(
         ctx("flag", "user-1"),
         details("flag", "on", "v", metadata(42, true)),
         Collections.emptyMap());
-    final SpanEnrichmentAccumulator state = SpanEnrichmentAccumulator.STATES.get(0x77L);
+    final SpanEnrichmentAccumulator state = states.peek(0x77L);
     assertTrue(state != null && state.serialIdsView().contains(42));
     assertEquals(1, state.subjectCount(), "doLog=true + targeting key => subject recorded");
   }
@@ -155,7 +167,7 @@ class SpanEnrichmentHookTest {
 
   @Test
   void finishedRootFlushesFlagsEncTag() {
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
     final long traceId = 0xABCDL;
     // accumulate {100,108,128,130} with a duplicate 100 to prove dedupe
     capture(hook, traceId, "f1", "user-1", "on", "v", 100, false);
@@ -166,20 +178,20 @@ class SpanEnrichmentHookTest {
 
     final AgentSpan root = mock(AgentSpan.class);
     rootSpanCollection(traceId, root);
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor();
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
 
     interceptor.onTraceComplete(Collections.singletonList(root));
 
     verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZAgUAg==");
     // state cleared after flush
-    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "state must be cleared on flush");
+    assertTrue(states.isEmpty(), "state must be cleared on flush");
   }
 
   // ---- 4. error/default variant (missing variant -> ffe_runtime_defaults JSON object) ----
 
   @Test
   void runtimeDefaultMissingVariantWritesJsonObject() {
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
     final long traceId = 0x1234L;
     // no serial id + null variant => runtime default; object value must be JSON-stringified
     final Map<String, Object> objectValue = Collections.singletonMap("k", "val");
@@ -195,7 +207,7 @@ class SpanEnrichmentHookTest {
 
     final AgentSpan root = mock(AgentSpan.class);
     rootSpanCollection(traceId, root);
-    new SpanEnrichmentInterceptor().onTraceComplete(Collections.singletonList(root));
+    new SpanEnrichmentInterceptor(states).onTraceComplete(Collections.singletonList(root));
 
     // ffe_runtime_defaults is a JSON object string, NOT [object Object]/toString.
     verify(root)
@@ -213,15 +225,12 @@ class SpanEnrichmentHookTest {
     final SpanEnrichmentAccumulator acc = new SpanEnrichmentAccumulator();
 
     // doLog gating: addSubject only happens when doLog true (driven via the hook branch below).
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
     final long traceId = 0x5L;
     capture(hook, traceId, "f", "user-A", "on", "v", 1, false); // doLog=false => no subject
-    assertEquals(
-        0,
-        SpanEnrichmentAccumulator.STATES.get(traceId).subjectCount(),
-        "doLog=false must not record a subject");
+    assertEquals(0, states.peek(traceId).subjectCount(), "doLog=false must not record a subject");
     capture(hook, traceId, "f", "user-A", "on", "v", 2, true); // doLog=true => subject recorded
-    assertEquals(1, SpanEnrichmentAccumulator.STATES.get(traceId).subjectCount());
+    assertEquals(1, states.peek(traceId).subjectCount());
 
     // per-subject experiment cap: 20 max
     for (int i = 0; i < 25; i++) {
@@ -305,16 +314,23 @@ class SpanEnrichmentHookTest {
       assertFalse(
           hook instanceof SpanEnrichmentHook, "gate off => SpanEnrichmentHook never registered");
     }
-    // No accumulator state created.
-    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "gate off => no accumulator state");
+    // No state store is created at all when the gate is off: the per-provider store lives only
+    // inside the gate-on branch, so a null interceptor means no store and no idle overhead
+    // (DG-005).
+    assertNull(
+        provider.spanEnrichmentInterceptor(),
+        "gate off => no interceptor, hence no state store and no accumulator state");
   }
 
   // ---- gate-on construction + provider-close cleanup ----
 
   @Test
   void gateOnConstructsHookAndInterceptorThenShutdownDisables() {
-    // Gate ON via the injectable override.
-    final Provider provider = new Provider(new Provider.Options(), null, Boolean.TRUE);
+    // Gate ON via the injectable override; registration succeeds (injected registrar returns true)
+    // so we don't mutate the global tracer (the Noop tracer rejects, which is the CR-03 path tested
+    // separately in secondProviderRejectedRegistrationDoesNotClearFirstProviderState).
+    final Provider provider =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
     assertTrue(provider.spanEnrichmentHook() != null, "gate on => hook constructed");
     assertTrue(provider.spanEnrichmentInterceptor() != null, "gate on => interceptor constructed");
     assertTrue(provider.spanEnrichmentInterceptor().isEnabled());
@@ -327,28 +343,30 @@ class SpanEnrichmentHookTest {
     }
     assertTrue(registered, "gate on => SpanEnrichmentHook registered in getProviderHooks");
 
-    // provider close disables the interceptor (provider-close cleanup) and drains state
-    SpanEnrichmentAccumulator.STATES.put(1L, new SpanEnrichmentAccumulator());
+    // provider close disables the interceptor (provider-close cleanup) and drains ITS OWN state.
+    final SpanEnrichmentStates providerStates = provider.spanEnrichmentInterceptor().states();
+    providerStates.getOrCreate(1L);
+    assertFalse(providerStates.isEmpty());
     provider.shutdown();
     assertFalse(provider.spanEnrichmentInterceptor().isEnabled(), "shutdown disables interceptor");
-    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "shutdown drains residual state");
+    assertTrue(providerStates.isEmpty(), "shutdown drains residual state");
   }
 
   // ---- error isolation: enrichment never throws ----
 
   @Test
   void captureNeverThrowsOnNullInputs() {
-    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
     // null details handled in finallyAfter; capture with empty metadata + null variant
     hook.finallyAfter(null, null, null);
-    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty());
+    assertTrue(states.isEmpty());
   }
 
   // ---- interceptor gate-off / empty trace robustness ----
 
   @Test
   void interceptorNoOpsWhenDisabledOrEmpty() {
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor();
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
     // empty trace
     assertTrue(interceptor.onTraceComplete(Collections.emptyList()).isEmpty());
     // disabled
@@ -364,6 +382,6 @@ class SpanEnrichmentHookTest {
   @Test
   void interceptorPriorityIsUnique() {
     // Distinct from AbstractTraceInterceptor.Priority values (0,1,2,3, MAX-2, MAX-1, MAX).
-    assertEquals(4, new SpanEnrichmentInterceptor().priority());
+    assertEquals(4, new SpanEnrichmentInterceptor(states).priority());
   }
 }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
@@ -20,7 +20,11 @@ import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.HookContext;
 import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ImmutableMetadata;
+import dev.openfeature.sdk.ImmutableStructure;
+import dev.openfeature.sdk.Value;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -30,16 +34,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * L0 unit suite for APM feature-flag span enrichment (JAVA-01).
+ * Unit suite for APM feature-flag span enrichment.
  *
- * <p>Covers the seven required VALIDATION.md cases plus the explicit max-200 case and the codec
+ * <p>Covers the seven required validation cases plus the explicit max-200 case and the codec
  * golden-vector round-trip. The contract (encoding, limits, tag shapes) is FROZEN against the Node
  * reference ({@code dd-trace-js#8343}).
  */
 class SpanEnrichmentHookTest {
 
-  // Per-test instance-owned state store (replaces the former global static). The hook and the
-  // interceptor under test share this one, mirroring how a single Provider wires them (CR-03).
+  // Instance-owned state store shared by the hook and interceptor under test, mirroring how a
+  // single
+  // Provider wires them.
   private SpanEnrichmentStates states;
 
   @BeforeEach
@@ -50,9 +55,16 @@ class SpanEnrichmentHookTest {
   @AfterEach
   void clearState() {
     states.clear();
+    // The interceptor is a process-wide singleton; leave it inert for the next test.
+    SpanEnrichmentInterceptor.INSTANCE.unbind(SpanEnrichmentInterceptor.INSTANCE.activeStates());
   }
 
   // ---- helpers ----
+
+  /** The store key the production code derives from a trace id (full hex). */
+  private static String key(final long traceId) {
+    return DDTraceId.from(traceId).toHexString();
+  }
 
   private static FlagEvaluationDetails<Object> details(
       final String flagKey,
@@ -86,10 +98,10 @@ class SpanEnrichmentHookTest {
         "default");
   }
 
-  /** Drives the capture branch directly (no static tracer) for a fixed trace key. */
+  /** Drives the capture branch directly (no static tracer) for a fixed trace id. */
   private static void capture(
       final SpanEnrichmentHook hook,
-      final long traceKey,
+      final long traceId,
       final String flagKey,
       final String targetingKey,
       final String variant,
@@ -97,7 +109,7 @@ class SpanEnrichmentHookTest {
       final Integer serialId,
       final boolean doLog) {
     hook.capture(
-        traceKey,
+        key(traceId),
         ctx(flagKey, targetingKey),
         details(flagKey, variant, value, metadata(serialId, doLog)));
   }
@@ -105,12 +117,18 @@ class SpanEnrichmentHookTest {
   /**
    * Configures a mock root span to report itself as its own local root with the given trace id. The
    * returned span, passed in a singleton collection, models a FINAL flush (the root is present in
-   * the fragment), so the interceptor flushes + removes state (CR-01 final-write path).
+   * the fragment), so the interceptor flushes + removes state.
    */
   private static AgentSpan rootSpanCollection(final long traceId, final AgentSpan rootSpan) {
     when(rootSpan.getLocalRootSpan()).thenReturn(rootSpan);
     when(rootSpan.getTraceId()).thenReturn(DDTraceId.from(traceId));
     return rootSpan;
+  }
+
+  /** Binds a fresh interceptor to the given store, models a final flush, and returns it. */
+  private static SpanEnrichmentInterceptor boundInterceptor(final SpanEnrichmentStates states) {
+    SpanEnrichmentInterceptor.INSTANCE.bind(states);
+    return SpanEnrichmentInterceptor.INSTANCE;
   }
 
   // ---- 1. codec golden-vector round-trip ----
@@ -158,7 +176,7 @@ class SpanEnrichmentHookTest {
         ctx("flag", "user-1"),
         details("flag", "on", "v", metadata(42, true)),
         Collections.emptyMap());
-    final SpanEnrichmentAccumulator state = states.peek(0x77L);
+    final SpanEnrichmentAccumulator state = states.peek(key(0x77L));
     assertTrue(state != null && state.serialIdsView().contains(42));
     assertEquals(1, state.subjectCount(), "doLog=true + targeting key => subject recorded");
   }
@@ -178,9 +196,7 @@ class SpanEnrichmentHookTest {
 
     final AgentSpan root = mock(AgentSpan.class);
     rootSpanCollection(traceId, root);
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
-
-    interceptor.onTraceComplete(Collections.singletonList(root));
+    boundInterceptor(states).onTraceComplete(Collections.singletonList(root));
 
     verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZAgUAg==");
     // state cleared after flush
@@ -196,7 +212,7 @@ class SpanEnrichmentHookTest {
     // no serial id + null variant => runtime default; object value must be JSON-stringified
     final Map<String, Object> objectValue = Collections.singletonMap("k", "val");
     hook.capture(
-        traceId,
+        key(traceId),
         ctx("obj-flag", "user-1"),
         FlagEvaluationDetails.builder()
             .flagKey("obj-flag")
@@ -207,7 +223,7 @@ class SpanEnrichmentHookTest {
 
     final AgentSpan root = mock(AgentSpan.class);
     rootSpanCollection(traceId, root);
-    new SpanEnrichmentInterceptor(states).onTraceComplete(Collections.singletonList(root));
+    boundInterceptor(states).onTraceComplete(Collections.singletonList(root));
 
     // ffe_runtime_defaults is a JSON object string, NOT [object Object]/toString.
     verify(root)
@@ -216,6 +232,80 @@ class SpanEnrichmentHookTest {
             "{\"obj-flag\":\"{\\\"k\\\":\\\"val\\\"}\"}");
     // no flags tag when there are no serial ids
     verify(root, never()).setTag(eq(SpanEnrichmentAccumulator.TAG_FLAGS_ENC), anyString());
+  }
+
+  // ---- 4b. real OpenFeature object path: a Value structure default must serialize to JSON ----
+
+  /**
+   * The real object-evaluation path hands the runtime default in as a {@code
+   * dev.openfeature.sdk.Value}, not a raw {@code Map}. The accumulator must unwrap the {@code
+   * Value} and emit JSON (matching Node's {@code JSON.stringify}), never {@code Value.toString()}
+   * (which is {@code "Value(innerObject=...)"}).
+   */
+  @Test
+  void runtimeDefaultStructureValueSerializesAsJsonNotToString() {
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
+    final long traceId = 0x2468L;
+
+    // Single-key structure so the exact-string assertion does not depend on the OpenFeature SDK's
+    // internal key ordering. (The multi-key / nesting behaviour is covered by the direct
+    // stringifyDefault assertions below.)
+    final Map<String, Value> inner = new LinkedHashMap<>();
+    inner.put("enabled", new Value(true));
+    final Value structureDefault = new Value(new ImmutableStructure(inner));
+
+    hook.capture(
+        key(traceId),
+        ctx("struct-flag", "user-1"),
+        FlagEvaluationDetails.builder()
+            .flagKey("struct-flag")
+            .variant(null)
+            .value(structureDefault)
+            .flagMetadata(ImmutableMetadata.builder().build())
+            .build());
+
+    final AgentSpan root = mock(AgentSpan.class);
+    rootSpanCollection(traceId, root);
+    boundInterceptor(states).onTraceComplete(Collections.singletonList(root));
+
+    // {"struct-flag":"{\"enabled\":true}"}  — note: NO "Value(innerObject=...)".
+    verify(root)
+        .setTag(
+            SpanEnrichmentAccumulator.TAG_RUNTIME_DEFAULTS,
+            "{\"struct-flag\":\"{\\\"enabled\\\":true}\"}");
+  }
+
+  /**
+   * Direct stringify of a structured {@code Value}: asserts the value is JSON (objects + nested
+   * scalars), not {@code Value.toString()}. The structure is single-key to keep ordering
+   * deterministic across OpenFeature SDK versions.
+   */
+  @Test
+  void stringifyDefaultUnwrapsValueStructureToJson() {
+    final Map<String, Value> inner = new LinkedHashMap<>();
+    inner.put("count", new Value(42));
+    final Value structureDefault = new Value(new ImmutableStructure(inner));
+    assertEquals("{\"count\":42}", SpanEnrichmentAccumulator.stringifyDefault(structureDefault));
+  }
+
+  /**
+   * A list-valued {@code Value} default serializes to a JSON array, with nested Values unwrapped.
+   */
+  @Test
+  void runtimeDefaultListValueSerializesAsJsonArray() {
+    final Value listDefault =
+        new Value(Arrays.asList(new Value("a"), new Value(2), new Value(true)));
+    // direct stringify assertion (exact bytes)
+    assertEquals("[\"a\",2,true]", SpanEnrichmentAccumulator.stringifyDefault(listDefault));
+  }
+
+  /** Scalar Values collapse to the same string form Node's String(value) produces. */
+  @Test
+  void scalarValueDefaultsMatchNodeStringForm() {
+    assertEquals("hello", SpanEnrichmentAccumulator.stringifyDefault(new Value("hello")));
+    assertEquals("true", SpanEnrichmentAccumulator.stringifyDefault(new Value(true)));
+    assertEquals("7", SpanEnrichmentAccumulator.stringifyDefault(new Value(7)));
+    assertEquals("null", SpanEnrichmentAccumulator.stringifyDefault(new Value()));
   }
 
   // ---- 5. per-subject cap (10 subjects / 20 experiments / doLog gating) ----
@@ -228,9 +318,10 @@ class SpanEnrichmentHookTest {
     final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
     final long traceId = 0x5L;
     capture(hook, traceId, "f", "user-A", "on", "v", 1, false); // doLog=false => no subject
-    assertEquals(0, states.peek(traceId).subjectCount(), "doLog=false must not record a subject");
+    assertEquals(
+        0, states.peek(key(traceId)).subjectCount(), "doLog=false must not record a subject");
     capture(hook, traceId, "f", "user-A", "on", "v", 2, true); // doLog=true => subject recorded
-    assertEquals(1, states.peek(traceId).subjectCount());
+    assertEquals(1, states.peek(key(traceId)).subjectCount());
 
     // per-subject experiment cap: 20 max
     for (int i = 0; i < 25; i++) {
@@ -298,42 +389,54 @@ class SpanEnrichmentHookTest {
     assertEquals(1, acc.defaultCount());
   }
 
-  // ---- gate-off negative control (no ffe_*, no hook/interceptor, no state) (DG-005) ----
+  // ---- gate-off negative control (no ffe_*, no hook, no state) ----
 
   @Test
   void gateOffConstructsNothingAndAccumulatesNoState() {
     // Gate OFF via the injectable override (no static config mocking).
     final Provider provider = new Provider(new Provider.Options(), null, Boolean.FALSE);
 
-    // No hook, no interceptor constructed (DG-005 zero-idle-overhead).
+    // No hook, no state store constructed (zero idle overhead).
     assertNull(provider.spanEnrichmentHook(), "gate off => no span-enrichment hook");
-    assertNull(provider.spanEnrichmentInterceptor(), "gate off => no span-enrichment interceptor");
+    assertNull(provider.spanEnrichmentStates(), "gate off => no span-enrichment state store");
     // getProviderHooks must not contain a SpanEnrichmentHook.
     final List<Hook> hooks = provider.getProviderHooks();
     for (final Hook hook : hooks) {
       assertFalse(
           hook instanceof SpanEnrichmentHook, "gate off => SpanEnrichmentHook never registered");
     }
-    // No state store is created at all when the gate is off: the per-provider store lives only
-    // inside the gate-on branch, so a null interceptor means no store and no idle overhead
-    // (DG-005).
-    assertNull(
-        provider.spanEnrichmentInterceptor(),
-        "gate off => no interceptor, hence no state store and no accumulator state");
+  }
+
+  /**
+   * getProviderHooks() is called on every evaluation; it must return the SAME precomputed list
+   * (allocating nothing) regardless of gate state.
+   */
+  @Test
+  void getProviderHooksReturnsSameInstanceEachCall() {
+    final Provider gateOff = new Provider(new Provider.Options(), null, Boolean.FALSE);
+    assertTrue(
+        gateOff.getProviderHooks() == gateOff.getProviderHooks(),
+        "gate off => getProviderHooks allocates nothing (same instance)");
+
+    final Provider gateOn =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    assertTrue(
+        gateOn.getProviderHooks() == gateOn.getProviderHooks(),
+        "gate on => getProviderHooks allocates nothing (same instance)");
   }
 
   // ---- gate-on construction + provider-close cleanup ----
 
   @Test
-  void gateOnConstructsHookAndInterceptorThenShutdownDisables() {
-    // Gate ON via the injectable override; registration succeeds (injected registrar returns true)
-    // so we don't mutate the global tracer (the Noop tracer rejects, which is the CR-03 path tested
-    // separately in secondProviderRejectedRegistrationDoesNotClearFirstProviderState).
+  void gateOnConstructsHookAndStateThenShutdownUnbinds() {
     final Provider provider =
         new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
     assertTrue(provider.spanEnrichmentHook() != null, "gate on => hook constructed");
-    assertTrue(provider.spanEnrichmentInterceptor() != null, "gate on => interceptor constructed");
-    assertTrue(provider.spanEnrichmentInterceptor().isEnabled());
+    assertTrue(provider.spanEnrichmentStates() != null, "gate on => state store constructed");
+    // the process-wide interceptor is bound to this provider's store
+    assertTrue(
+        SpanEnrichmentInterceptor.INSTANCE.activeStates() == provider.spanEnrichmentStates(),
+        "gate on => interceptor bound to this provider's store");
     // hook registered in provider hooks
     boolean registered = false;
     for (final Hook hook : provider.getProviderHooks()) {
@@ -343,12 +446,13 @@ class SpanEnrichmentHookTest {
     }
     assertTrue(registered, "gate on => SpanEnrichmentHook registered in getProviderHooks");
 
-    // provider close disables the interceptor (provider-close cleanup) and drains ITS OWN state.
-    final SpanEnrichmentStates providerStates = provider.spanEnrichmentInterceptor().states();
-    providerStates.getOrCreate(1L);
+    // provider close unbinds + drains ITS OWN state.
+    final SpanEnrichmentStates providerStates = provider.spanEnrichmentStates();
+    providerStates.getOrCreate(key(1L));
     assertFalse(providerStates.isEmpty());
     provider.shutdown();
-    assertFalse(provider.spanEnrichmentInterceptor().isEnabled(), "shutdown disables interceptor");
+    assertNull(
+        SpanEnrichmentInterceptor.INSTANCE.activeStates(), "shutdown unbinds the active store");
     assertTrue(providerStates.isEmpty(), "shutdown drains residual state");
   }
 
@@ -362,18 +466,19 @@ class SpanEnrichmentHookTest {
     assertTrue(states.isEmpty());
   }
 
-  // ---- interceptor gate-off / empty trace robustness ----
+  // ---- interceptor inert when unbound / empty trace robustness ----
 
   @Test
-  void interceptorNoOpsWhenDisabledOrEmpty() {
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
+  void interceptorNoOpsWhenUnboundOrEmpty() {
     // empty trace
-    assertTrue(interceptor.onTraceComplete(Collections.emptyList()).isEmpty());
-    // disabled
-    interceptor.disable();
+    SpanEnrichmentInterceptor.INSTANCE.bind(states);
+    assertTrue(
+        SpanEnrichmentInterceptor.INSTANCE.onTraceComplete(Collections.emptyList()).isEmpty());
+    // unbound (inert)
+    SpanEnrichmentInterceptor.INSTANCE.unbind(states);
     final AgentSpan root = mock(AgentSpan.class);
     final List<MutableSpan> trace = Collections.singletonList(root);
-    interceptor.onTraceComplete(trace);
+    SpanEnrichmentInterceptor.INSTANCE.onTraceComplete(trace);
     verify(root, never()).setTag(anyString(), anyString());
   }
 
@@ -382,6 +487,6 @@ class SpanEnrichmentHookTest {
   @Test
   void interceptorPriorityIsUnique() {
     // Distinct from AbstractTraceInterceptor.Priority values (0,1,2,3, MAX-2, MAX-1, MAX).
-    assertEquals(4, new SpanEnrichmentInterceptor(states).priority());
+    assertEquals(4, SpanEnrichmentInterceptor.INSTANCE.priority());
   }
 }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentHookTest.java
@@ -1,0 +1,369 @@
+package datadog.trace.api.openfeature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagValueType;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.ImmutableMetadata;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * L0 unit suite for APM feature-flag span enrichment (JAVA-01).
+ *
+ * <p>Covers the seven required VALIDATION.md cases plus the explicit max-200 case and the codec
+ * golden-vector round-trip. The contract (encoding, limits, tag shapes) is FROZEN against the Node
+ * reference ({@code dd-trace-js#8343}).
+ */
+class SpanEnrichmentHookTest {
+
+  @BeforeEach
+  @AfterEach
+  void clearState() {
+    SpanEnrichmentAccumulator.STATES.clear();
+  }
+
+  // ---- helpers ----
+
+  private static FlagEvaluationDetails<Object> details(
+      final String flagKey,
+      final String variant,
+      final Object value,
+      final ImmutableMetadata metadata) {
+    return FlagEvaluationDetails.builder()
+        .flagKey(flagKey)
+        .variant(variant)
+        .value(value)
+        .flagMetadata(metadata)
+        .build();
+  }
+
+  private static ImmutableMetadata metadata(final Integer serialId, final boolean doLog) {
+    final ImmutableMetadata.ImmutableMetadataBuilder builder = ImmutableMetadata.builder();
+    if (serialId != null) {
+      builder.addString(SpanEnrichmentHook.METADATA_SERIAL_ID, serialId.toString());
+    }
+    builder.addString(SpanEnrichmentHook.METADATA_DO_LOG, String.valueOf(doLog));
+    return builder.build();
+  }
+
+  private static HookContext<Object> ctx(final String flagKey, final String targetingKey) {
+    return HookContext.from(
+        flagKey,
+        FlagValueType.STRING,
+        null,
+        null,
+        targetingKey == null ? new ImmutableContext() : new ImmutableContext(targetingKey),
+        "default");
+  }
+
+  /** Drives the capture branch directly (no static tracer) for a fixed trace key. */
+  private static void capture(
+      final SpanEnrichmentHook hook,
+      final long traceKey,
+      final String flagKey,
+      final String targetingKey,
+      final String variant,
+      final Object value,
+      final Integer serialId,
+      final boolean doLog) {
+    hook.capture(
+        traceKey,
+        ctx(flagKey, targetingKey),
+        details(flagKey, variant, value, metadata(serialId, doLog)));
+  }
+
+  private static MutableSpan rootSpanCollection(final long traceId, final MutableSpan rootSpan) {
+    when(rootSpan.getLocalRootSpan()).thenReturn(rootSpan);
+    when(((AgentSpan) rootSpan).getTraceId()).thenReturn(DDTraceId.from(traceId));
+    return rootSpan;
+  }
+
+  // ---- 1. codec golden-vector round-trip ----
+
+  @Test
+  void codecGoldenVectorAndRoundTrip() {
+    final SortedSet<Integer> ids = new TreeSet<>();
+    ids.add(100);
+    ids.add(108);
+    ids.add(128);
+    ids.add(130);
+    final String encoded = ULeb128Encoder.encodeDeltaVarint(ids);
+    assertEquals("ZAgUAg==", encoded, "golden vector must match the frozen Node contract");
+    // round-trip: decode back to the same ascending ids
+    assertEquals(ids, ULeb128Encoder.decodeDeltaVarint(encoded));
+    // empty set -> empty string (tag omitted)
+    assertEquals("", ULeb128Encoder.encodeDeltaVarint(Collections.emptySet()));
+    // dedupe is structural: a duplicate id does not change the encoding
+    final SortedSet<Integer> withDup = new TreeSet<>(ids);
+    withDup.add(100);
+    assertEquals(encoded, ULeb128Encoder.encodeDeltaVarint(withDup));
+  }
+
+  // ---- 2. no-span (no active root) ----
+
+  @Test
+  void noActiveSpanDoesNotCrashOrAccumulate() {
+    // Injected resolver returns null => no active local root (the no-span case).
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> null);
+    // Should be a no-op, never throw.
+    hook.finallyAfter(
+        ctx("flag", "user-1"),
+        details("flag", "on", "v", metadata(100, true)),
+        Collections.emptyMap());
+    assertTrue(
+        SpanEnrichmentAccumulator.STATES.isEmpty(), "no active span => no accumulator state");
+  }
+
+  @Test
+  void finallyAfterResolvesRootViaResolverAndAccumulates() {
+    // Drives finallyAfter end-to-end with an injected root resolver (no static mocks).
+    final AgentSpan root = mock(AgentSpan.class);
+    when(root.getTraceId()).thenReturn(DDTraceId.from(0x77L));
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(() -> root);
+    hook.finallyAfter(
+        ctx("flag", "user-1"),
+        details("flag", "on", "v", metadata(42, true)),
+        Collections.emptyMap());
+    final SpanEnrichmentAccumulator state = SpanEnrichmentAccumulator.STATES.get(0x77L);
+    assertTrue(state != null && state.serialIdsView().contains(42));
+    assertEquals(1, state.subjectCount(), "doLog=true + targeting key => subject recorded");
+  }
+
+  // ---- 3. finished-root (accumulate + dedupe, then flush via interceptor) ----
+
+  @Test
+  void finishedRootFlushesFlagsEncTag() {
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final long traceId = 0xABCDL;
+    // accumulate {100,108,128,130} with a duplicate 100 to prove dedupe
+    capture(hook, traceId, "f1", "user-1", "on", "v", 100, false);
+    capture(hook, traceId, "f2", "user-1", "on", "v", 108, false);
+    capture(hook, traceId, "f3", "user-1", "on", "v", 128, false);
+    capture(hook, traceId, "f4", "user-1", "on", "v", 130, false);
+    capture(hook, traceId, "f1", "user-1", "on", "v", 100, false); // dup
+
+    final AgentSpan root = mock(AgentSpan.class);
+    rootSpanCollection(traceId, root);
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor();
+
+    interceptor.onTraceComplete(Collections.singletonList(root));
+
+    verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZAgUAg==");
+    // state cleared after flush
+    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "state must be cleared on flush");
+  }
+
+  // ---- 4. error/default variant (missing variant -> ffe_runtime_defaults JSON object) ----
+
+  @Test
+  void runtimeDefaultMissingVariantWritesJsonObject() {
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final long traceId = 0x1234L;
+    // no serial id + null variant => runtime default; object value must be JSON-stringified
+    final Map<String, Object> objectValue = Collections.singletonMap("k", "val");
+    hook.capture(
+        traceId,
+        ctx("obj-flag", "user-1"),
+        FlagEvaluationDetails.builder()
+            .flagKey("obj-flag")
+            .variant(null)
+            .value(objectValue)
+            .flagMetadata(ImmutableMetadata.builder().build())
+            .build());
+
+    final AgentSpan root = mock(AgentSpan.class);
+    rootSpanCollection(traceId, root);
+    new SpanEnrichmentInterceptor().onTraceComplete(Collections.singletonList(root));
+
+    // ffe_runtime_defaults is a JSON object string, NOT [object Object]/toString.
+    verify(root)
+        .setTag(
+            SpanEnrichmentAccumulator.TAG_RUNTIME_DEFAULTS,
+            "{\"obj-flag\":\"{\\\"k\\\":\\\"val\\\"}\"}");
+    // no flags tag when there are no serial ids
+    verify(root, never()).setTag(eq(SpanEnrichmentAccumulator.TAG_FLAGS_ENC), anyString());
+  }
+
+  // ---- 5. per-subject cap (10 subjects / 20 experiments / doLog gating) ----
+
+  @Test
+  void subjectCapsAndDoLogGating() {
+    final SpanEnrichmentAccumulator acc = new SpanEnrichmentAccumulator();
+
+    // doLog gating: addSubject only happens when doLog true (driven via the hook branch below).
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    final long traceId = 0x5L;
+    capture(hook, traceId, "f", "user-A", "on", "v", 1, false); // doLog=false => no subject
+    assertEquals(
+        0,
+        SpanEnrichmentAccumulator.STATES.get(traceId).subjectCount(),
+        "doLog=false must not record a subject");
+    capture(hook, traceId, "f", "user-A", "on", "v", 2, true); // doLog=true => subject recorded
+    assertEquals(1, SpanEnrichmentAccumulator.STATES.get(traceId).subjectCount());
+
+    // per-subject experiment cap: 20 max
+    for (int i = 0; i < 25; i++) {
+      acc.addSubject("subjectX", i);
+    }
+    final Map<String, String> tags = acc.toSpanTags();
+    final SortedSet<Integer> decoded =
+        ULeb128Encoder.decodeDeltaVarint(
+            // ffe_subjects_enc is {"<sha>":"<base64>"}; extract the single base64 value
+            tags.get(SpanEnrichmentAccumulator.TAG_SUBJECTS_ENC)
+                .replaceAll("^\\{\"[a-f0-9]+\":\"", "")
+                .replaceAll("\"\\}$", ""));
+    assertEquals(SpanEnrichmentAccumulator.MAX_EXPERIMENTS_PER_SUBJECT, decoded.size());
+
+    // subject cap: 10 max distinct subjects
+    final SpanEnrichmentAccumulator acc2 = new SpanEnrichmentAccumulator();
+    for (int i = 0; i < 15; i++) {
+      acc2.addSubject("subject-" + i, i);
+    }
+    assertEquals(SpanEnrichmentAccumulator.MAX_SUBJECTS, acc2.subjectCount());
+  }
+
+  // ---- 6. max-200 serial ids ----
+
+  @Test
+  void max200SerialIdsEnforced() {
+    final SpanEnrichmentAccumulator acc = new SpanEnrichmentAccumulator();
+    for (int i = 0; i < 300; i++) {
+      acc.addSerialId(i);
+    }
+    assertEquals(
+        SpanEnrichmentAccumulator.MAX_SERIAL_IDS,
+        acc.serialIdsView().size(),
+        "serial ids must be capped at 200");
+  }
+
+  // ---- 7. JSON/object-default (json not toString + 64-char truncation) ----
+
+  @Test
+  void objectDefaultJsonAndTruncation() {
+    // object -> JSON, not toString
+    assertEquals(
+        "{\"a\":\"b\"}",
+        SpanEnrichmentAccumulator.stringifyDefault(Collections.singletonMap("a", "b")));
+    // scalar string -> as-is
+    assertEquals("hello", SpanEnrichmentAccumulator.stringifyDefault("hello"));
+    // null -> "null"
+    assertEquals("null", SpanEnrichmentAccumulator.stringifyDefault(null));
+
+    // 64-char truncation (first-wins handled separately)
+    final StringBuilder longValue = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      longValue.append('x');
+    }
+    final SpanEnrichmentAccumulator acc = new SpanEnrichmentAccumulator();
+    acc.addDefault("flag", longValue.toString());
+    final String tag = acc.toSpanTags().get(SpanEnrichmentAccumulator.TAG_RUNTIME_DEFAULTS);
+    // {"flag":"<64 x's>"}
+    final String expectedValue =
+        longValue.substring(0, SpanEnrichmentAccumulator.MAX_DEFAULT_VALUE_LENGTH);
+    assertEquals("{\"flag\":\"" + expectedValue + "\"}", tag);
+
+    // first-wins: a second addDefault for the same flag is ignored
+    acc.addDefault("flag", "second");
+    assertEquals(1, acc.defaultCount());
+  }
+
+  // ---- gate-off negative control (no ffe_*, no hook/interceptor, no state) (DG-005) ----
+
+  @Test
+  void gateOffConstructsNothingAndAccumulatesNoState() {
+    // Gate OFF via the injectable override (no static config mocking).
+    final Provider provider = new Provider(new Provider.Options(), null, Boolean.FALSE);
+
+    // No hook, no interceptor constructed (DG-005 zero-idle-overhead).
+    assertNull(provider.spanEnrichmentHook(), "gate off => no span-enrichment hook");
+    assertNull(provider.spanEnrichmentInterceptor(), "gate off => no span-enrichment interceptor");
+    // getProviderHooks must not contain a SpanEnrichmentHook.
+    final List<Hook> hooks = provider.getProviderHooks();
+    for (final Hook hook : hooks) {
+      assertFalse(
+          hook instanceof SpanEnrichmentHook, "gate off => SpanEnrichmentHook never registered");
+    }
+    // No accumulator state created.
+    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "gate off => no accumulator state");
+  }
+
+  // ---- gate-on construction + provider-close cleanup ----
+
+  @Test
+  void gateOnConstructsHookAndInterceptorThenShutdownDisables() {
+    // Gate ON via the injectable override.
+    final Provider provider = new Provider(new Provider.Options(), null, Boolean.TRUE);
+    assertTrue(provider.spanEnrichmentHook() != null, "gate on => hook constructed");
+    assertTrue(provider.spanEnrichmentInterceptor() != null, "gate on => interceptor constructed");
+    assertTrue(provider.spanEnrichmentInterceptor().isEnabled());
+    // hook registered in provider hooks
+    boolean registered = false;
+    for (final Hook hook : provider.getProviderHooks()) {
+      if (hook instanceof SpanEnrichmentHook) {
+        registered = true;
+      }
+    }
+    assertTrue(registered, "gate on => SpanEnrichmentHook registered in getProviderHooks");
+
+    // provider close disables the interceptor (provider-close cleanup) and drains state
+    SpanEnrichmentAccumulator.STATES.put(1L, new SpanEnrichmentAccumulator());
+    provider.shutdown();
+    assertFalse(provider.spanEnrichmentInterceptor().isEnabled(), "shutdown disables interceptor");
+    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty(), "shutdown drains residual state");
+  }
+
+  // ---- error isolation: enrichment never throws ----
+
+  @Test
+  void captureNeverThrowsOnNullInputs() {
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook();
+    // null details handled in finallyAfter; capture with empty metadata + null variant
+    hook.finallyAfter(null, null, null);
+    assertTrue(SpanEnrichmentAccumulator.STATES.isEmpty());
+  }
+
+  // ---- interceptor gate-off / empty trace robustness ----
+
+  @Test
+  void interceptorNoOpsWhenDisabledOrEmpty() {
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor();
+    // empty trace
+    assertTrue(interceptor.onTraceComplete(Collections.emptyList()).isEmpty());
+    // disabled
+    interceptor.disable();
+    final AgentSpan root = mock(AgentSpan.class);
+    final List<MutableSpan> trace = Collections.singletonList(root);
+    interceptor.onTraceComplete(trace);
+    verify(root, never()).setTag(anyString(), anyString());
+  }
+
+  // ---- interceptor priority uniqueness ----
+
+  @Test
+  void interceptorPriorityIsUnique() {
+    // Distinct from AbstractTraceInterceptor.Priority values (0,1,2,3, MAX-2, MAX-1, MAX).
+    assertEquals(4, new SpanEnrichmentInterceptor().priority());
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentLifecycleRegressionTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentLifecycleRegressionTest.java
@@ -1,7 +1,6 @@
 package datadog.trace.api.openfeature;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import datadog.trace.api.DD128bTraceId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -23,33 +23,40 @@ import dev.openfeature.sdk.ImmutableMetadata;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * GAP-CLOSURE regression suite for the three BLOCKER lifecycle defects found in the JAVA-01 code
- * review (02-REVIEW-java.md). Each test reproduces a bug the original L0 suite missed because that
- * suite only ever exercised a single root span, single-threaded, one provider, with the root always
- * present in the flushed collection.
+ * Regression suite for the per-root-span lifecycle and reconfiguration behaviour of span
+ * enrichment. Each test exercises a scenario the single-root, single-thread, single-provider happy
+ * path does not cover.
  *
  * <ul>
- *   <li><b>CR-01</b> — a PARTIAL flush (child spans only; the still-open root is excluded by
+ *   <li>partial flush — a fragment of child spans only (the still-open root is excluded by
  *       dd-trace-core) must NOT drain the accumulator; pre-flush flags must survive onto the root
- *       at final completion. Verified against {@code CoreTracer.write} →{@code
- *       interceptCompleteTrace} firing on every flush and {@code PendingTrace.write(isPartial)}
- *       holding the root back.
- *   <li><b>CR-02</b> — traces that never reach the interceptor (dropped / Noop / never-finishing)
- *       must not leak accumulator entries unboundedly; the per-provider store is hard-bounded.
- *   <li><b>CR-03</b> — a SECOND gate-on provider whose interceptor registration is rejected
- *       (duplicate priority) must not wire orphan state and its {@code shutdown()} must not clear
- *       the FIRST provider's in-flight state.
+ *       at final completion.
+ *   <li>unbounded leak — traces that never reach the interceptor (dropped / Noop / never-finishing)
+ *       must not leak accumulator entries unboundedly; the store is hard-bounded.
+ *   <li>reconfiguration — after a provider closes, a new gate-on provider must still enrich (the
+ *       process-wide interceptor rebinds), and a closing provider must never clobber a newer
+ *       provider's in-flight state.
+ *   <li>128-bit trace ids — two distinct 128-bit traces that share their low-order 64 bits must not
+ *       merge enrichment state.
  * </ul>
- *
- * <p>Each test is written to FAIL against the pre-fix implementation and PASS after the fix (see
- * the per-test "Fail-before" notes).
  */
 class SpanEnrichmentLifecycleRegressionTest {
 
+  @AfterEach
+  void resetInterceptor() {
+    // The interceptor is a process-wide singleton; leave it inert for the next test.
+    SpanEnrichmentInterceptor.INSTANCE.unbind(SpanEnrichmentInterceptor.INSTANCE.activeStates());
+  }
+
   // ---- helpers ----
+
+  private static String key(final long traceId) {
+    return DDTraceId.from(traceId).toHexString();
+  }
 
   private static ImmutableMetadata serialMeta(final int serialId, final boolean doLog) {
     return ImmutableMetadata.builder()
@@ -82,15 +89,19 @@ class SpanEnrichmentLifecycleRegressionTest {
   }
 
   /** A mock local-root span reporting itself as its own local root with the given trace id. */
-  private static AgentSpan rootSpan(final long traceId) {
+  private static AgentSpan rootSpan(final DDTraceId traceId) {
     final AgentSpan root = mock(AgentSpan.class);
     when(root.getLocalRootSpan()).thenReturn(root);
-    when(root.getTraceId()).thenReturn(DDTraceId.from(traceId));
+    when(root.getTraceId()).thenReturn(traceId);
     return root;
   }
 
+  private static AgentSpan rootSpan(final long traceId) {
+    return rootSpan(DDTraceId.from(traceId));
+  }
+
   // =====================================================================================
-  // CR-01: partial flush must not drop captured state or misattribute tags
+  // partial flush must not drop captured state or misattribute tags
   // =====================================================================================
 
   /**
@@ -106,26 +117,20 @@ class SpanEnrichmentLifecycleRegressionTest {
    *
    * All serial ids — both pre- and post-partial-flush — must appear on the root's {@code
    * ffe_flags_enc} tag, and nothing must be written on the partial flush.
-   *
-   * <p><b>Fail-before:</b> the pre-fix interceptor resolved the root by reference via {@code
-   * getLocalRootSpan()} (reachable even when absent from the fragment) and unconditionally {@code
-   * remove()}d the accumulator on the FIRST (partial) flush — draining {100,108} and writing them
-   * onto the not-yet-finished root, so the final flush would only emit {128,130}. The assertion of
-   * the full {100,108,128,130} golden vector ("ZAgUAg==") on the final flush, plus "no setTag on
-   * the partial flush", both fail pre-fix.
    */
   @Test
   void partialFlushExcludingRootPreservesPreFlushFlags() {
     final SpanEnrichmentStates states = new SpanEnrichmentStates();
     final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
+    final SpanEnrichmentInterceptor interceptor = SpanEnrichmentInterceptor.INSTANCE;
+    interceptor.bind(states);
 
     final long traceId = 0x10A6L;
     final AgentSpan root = rootSpan(traceId);
 
     // (1) pre-partial-flush evaluations
-    hook.capture(traceId, ctx("f1", "user-1"), serialDetails("f1", 100, false));
-    hook.capture(traceId, ctx("f2", "user-1"), serialDetails("f2", 108, false));
+    hook.capture(key(traceId), ctx("f1", "user-1"), serialDetails("f1", 100, false));
+    hook.capture(key(traceId), ctx("f2", "user-1"), serialDetails("f2", 108, false));
 
     // (2) PARTIAL flush: a fragment of children only — the open root is NOT in the collection.
     final AgentSpan child1 = childOf(root);
@@ -137,15 +142,15 @@ class SpanEnrichmentLifecycleRegressionTest {
     verify(child1, never()).setTag(anyString(), anyString());
     verify(child2, never()).setTag(anyString(), anyString());
     verify(root, never()).setTag(anyString(), anyString());
-    final SpanEnrichmentAccumulator surviving = states.peek(traceId);
-    assertNotNull(surviving, "partial flush must NOT remove the accumulator (CR-01)");
+    final SpanEnrichmentAccumulator surviving = states.peek(key(traceId));
+    assertNotNull(surviving, "partial flush must NOT remove the accumulator");
     assertTrue(
         surviving.serialIdsView().contains(100) && surviving.serialIdsView().contains(108),
-        "pre-flush serial ids must survive a partial flush (CR-01)");
+        "pre-flush serial ids must survive a partial flush");
 
     // (3) more evaluations after the partial flush
-    hook.capture(traceId, ctx("f3", "user-1"), serialDetails("f3", 128, false));
-    hook.capture(traceId, ctx("f4", "user-1"), serialDetails("f4", 130, false));
+    hook.capture(key(traceId), ctx("f3", "user-1"), serialDetails("f3", 128, false));
+    hook.capture(key(traceId), ctx("f4", "user-1"), serialDetails("f4", 130, false));
 
     // (4) FINAL flush: the root is present in the fragment (alongside a late child).
     final AgentSpan lateChild = childOf(root);
@@ -153,48 +158,41 @@ class SpanEnrichmentLifecycleRegressionTest {
 
     // The full set {100,108,128,130} -> golden "ZAgUAg==" must land on the root.
     verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZAgUAg==");
-    assertTrue(states.isEmpty(), "state must be removed only on the final flush (CR-01)");
+    assertTrue(states.isEmpty(), "state must be removed only on the final flush");
   }
 
   /**
    * A partial flush whose first span reports a non-null local root that is absent from the fragment
    * must be treated as "not the final write" and leave state intact — even when there are several
-   * children. Guards the WR-02 "never tag a non-root span" concern together with CR-01.
-   *
-   * <p><b>Fail-before:</b> {@code findLocalRoot} returned {@code first.getLocalRootSpan()} (the
-   * absent root) and the interceptor wrote tags onto it / removed state on this partial fragment.
+   * children. Guards the "never tag a non-root span" concern.
    */
   @Test
   void partialFlushNeverWritesTagsOnAChildSpan() {
     final SpanEnrichmentStates states = new SpanEnrichmentStates();
     final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
-    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
+    final SpanEnrichmentInterceptor interceptor = SpanEnrichmentInterceptor.INSTANCE;
+    interceptor.bind(states);
 
     final long traceId = 0xC0DEL;
     final AgentSpan root = rootSpan(traceId);
-    hook.capture(traceId, ctx("f", "user-1"), serialDetails("f", 7, false));
+    hook.capture(key(traceId), ctx("f", "user-1"), serialDetails("f", 7, false));
 
     final AgentSpan child = childOf(root);
     interceptor.onTraceComplete(Collections.singletonList(child));
 
     verify(child, never()).setTag(anyString(), anyString());
     verify(root, never()).setTag(anyString(), anyString());
-    assertNotNull(states.peek(traceId), "child-only fragment must keep state (CR-01/WR-02)");
+    assertNotNull(states.peek(key(traceId)), "child-only fragment must keep state");
   }
 
   // =====================================================================================
-  // CR-02: never-completing traces must not leak accumulator entries unboundedly
+  // never-completing traces must not leak accumulator entries unboundedly
   // =====================================================================================
 
   /**
    * Simulates a sustained stream of traces that each evaluate a flag but never reach the
-   * interceptor (dropped traces / Noop tracer / never-finishing roots). The per-provider store must
-   * stay bounded by {@link SpanEnrichmentStates#MAX_TRACES} rather than growing without limit.
-   *
-   * <p><b>Fail-before:</b> state lived in an unbounded {@code static ConcurrentHashMap} with no TTL
-   * or cap; the only removal paths were trace-complete and shutdown. Driving 3x the cap distinct,
-   * never-flushed trace ids grew the map to 3x the cap — the assertion that size never exceeds the
-   * cap fails pre-fix (the #4844 leak class).
+   * interceptor (dropped traces / Noop tracer / never-finishing roots). The store must stay bounded
+   * by {@link SpanEnrichmentStates#MAX_TRACES} rather than growing without limit.
    */
   @Test
   void neverCompletingTracesDoNotLeakUnbounded() {
@@ -204,126 +202,135 @@ class SpanEnrichmentLifecycleRegressionTest {
     final int churn = SpanEnrichmentStates.MAX_TRACES * 3;
     for (int i = 0; i < churn; i++) {
       // Each distinct trace id accumulates once and is NEVER flushed (no interceptor call).
-      hook.capture(i, ctx("f", "user-" + i), serialDetails("f", i % 1000 + 1, false));
+      hook.capture(key(i), ctx("f", "user-" + i), serialDetails("f", i % 1000 + 1, false));
       assertTrue(
           states.size() <= SpanEnrichmentStates.MAX_TRACES,
-          "state store must stay bounded for never-completing traces (CR-02)");
+          "state store must stay bounded for never-completing traces");
     }
     assertEquals(
-        SpanEnrichmentStates.MAX_TRACES,
-        states.size(),
-        "store saturates at the cap, never beyond (CR-02)");
+        SpanEnrichmentStates.MAX_TRACES, states.size(), "store saturates at the cap, never beyond");
   }
 
   /**
    * Bounding is FIFO by insertion: once the cap is reached, the oldest entries are evicted so the
-   * newest in-flight traces are retained. Proves eviction targets the leak (oldest, likely
-   * abandoned) rather than the live tail.
-   *
-   * <p><b>Fail-before:</b> no eviction existed at all, so this behavior was absent.
+   * newest in-flight traces are retained.
    */
   @Test
   void boundedStoreEvictsOldestFirst() {
     final SpanEnrichmentStates states = new SpanEnrichmentStates();
     // Fill exactly to the cap with ids [0, MAX).
     for (long i = 0; i < SpanEnrichmentStates.MAX_TRACES; i++) {
-      states.getOrCreate(i);
+      states.getOrCreate(key(i));
     }
     assertEquals(SpanEnrichmentStates.MAX_TRACES, states.size());
     // One more distinct id evicts the oldest (id 0) and keeps the rest + the new one.
-    final long overflowKey = SpanEnrichmentStates.MAX_TRACES;
-    states.getOrCreate(overflowKey);
+    final long overflow = SpanEnrichmentStates.MAX_TRACES;
+    states.getOrCreate(key(overflow));
     assertEquals(SpanEnrichmentStates.MAX_TRACES, states.size(), "size stays at the cap");
-    assertNull(states.peek(0L), "oldest entry evicted first (CR-02 FIFO)");
-    assertNotNull(states.peek(overflowKey), "newest entry retained");
-    assertNotNull(states.peek(1L), "second-oldest still present");
+    assertNull(states.peek(key(0L)), "oldest entry evicted first (FIFO)");
+    assertNotNull(states.peek(key(overflow)), "newest entry retained");
+    assertNotNull(states.peek(key(1L)), "second-oldest still present");
   }
 
   // =====================================================================================
-  // CR-03: a rejected second provider must not corrupt the first provider's state
+  // reconfiguration: a closing provider must not permanently disable enrichment, nor
+  // clobber a newer provider's state
   // =====================================================================================
 
   /**
-   * Models reconfiguration: a first gate-on provider registers successfully; a SECOND gate-on
-   * provider's interceptor registration is REJECTED (duplicate priority 4 — what {@code
-   * CoreTracer.addTraceInterceptor} returns false for). The second provider must wire NO hook /
-   * interceptor, and its {@code shutdown()} must leave the first provider's in-flight state intact.
-   *
-   * <p><b>Fail-before:</b> the {@code addTraceInterceptor} return value was ignored, so the second
-   * provider kept a non-null hook+interceptor and shared the same global {@code STATES}; its {@code
-   * shutdown()} called {@code STATES.clear()}, wiping the first provider's live per-trace state.
-   * The assertions "second provider has null hook/interceptor" and "first provider's state survives
-   * the second's shutdown" both fail pre-fix.
+   * The core reconfiguration regression: a first gate-on provider shuts down, then a second gate-on
+   * provider is created. Enrichment must still work for the second provider. The process-wide
+   * interceptor is registered once and rebound, so the second provider is NOT rejected as a
+   * duplicate (which would permanently disable enrichment).
    */
   @Test
-  void secondProviderRejectedRegistrationDoesNotClearFirstProviderState() {
-    // First provider: registration succeeds.
+  void newProviderAfterShutdownStillEnriches() {
+    // First provider registers and binds.
     final Provider first =
         new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
-    assertNotNull(first.spanEnrichmentInterceptor(), "first provider registers");
-    assertNotNull(first.spanEnrichmentHook(), "first provider wires a hook");
+    assertNotNull(first.spanEnrichmentStates(), "first provider wires a store");
+    first.shutdown();
+    assertNull(
+        SpanEnrichmentInterceptor.INSTANCE.activeStates(),
+        "first provider's shutdown leaves the interceptor inert");
 
-    // First provider captures live state for an in-flight trace.
-    final SpanEnrichmentStates firstStates = first.spanEnrichmentInterceptor().states();
-    final long liveTrace = 0xA11FEL;
-    first.spanEnrichmentHook().capture(liveTrace, ctx("f", "user-1"), serialDetails("f", 5, true));
-    assertNotNull(firstStates.peek(liveTrace), "first provider has in-flight state");
-
-    // Second provider: registration is REJECTED (duplicate). It must wire nothing.
+    // Second provider is created AFTER the first closed. With the old per-provider interceptor
+    // model
+    // this registration would be rejected as a duplicate and enrichment would be permanently off.
     final Provider second =
-        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> false);
-    assertNull(
-        second.spanEnrichmentInterceptor(),
-        "rejected registration => no interceptor on the second provider (CR-03)");
-    assertNull(
-        second.spanEnrichmentHook(),
-        "rejected registration => no orphan hook on the second provider (CR-03)");
-
-    // Second provider shuts down. The first provider's live state MUST be untouched.
-    second.shutdown();
-    assertNotNull(
-        firstStates.peek(liveTrace),
-        "second provider's shutdown must NOT clear the first provider's state (CR-03)");
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    final SpanEnrichmentStates secondStates = second.spanEnrichmentStates();
+    assertNotNull(secondStates, "second provider wires a store");
     assertTrue(
-        first.spanEnrichmentInterceptor().isEnabled(),
-        "first provider's interceptor must remain enabled after the second's shutdown (CR-03)");
+        SpanEnrichmentInterceptor.INSTANCE.activeStates() == secondStates,
+        "the interceptor must rebind to the second provider's store");
 
-    // Sanity: the first provider can still flush its own state correctly afterward.
-    final AgentSpan root = rootSpan(liveTrace);
-    first.spanEnrichmentInterceptor().onTraceComplete(Collections.singletonList(root));
-    verify(root)
-        .setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "BQ=="); // {5} -> delta {5} -> 0x05
-    assertTrue(firstStates.isEmpty(), "first provider flushes + clears its own state");
+    // End-to-end: the second provider captures and the interceptor flushes onto the root.
+    final long traceId = 0xBEE5L;
+    second
+        .spanEnrichmentHook()
+        .capture(key(traceId), ctx("f", "user-1"), serialDetails("f", 5, false));
+    final AgentSpan root = rootSpan(traceId);
+    SpanEnrichmentInterceptor.INSTANCE.onTraceComplete(Collections.singletonList(root));
+    verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "BQ=="); // {5} -> 0x05
   }
 
   /**
-   * The two providers must own DISTINCT state stores — the structural guarantee behind CR-03. Even
-   * when both register successfully (independent tracers / test seam), one's store is never the
-   * other's.
-   *
-   * <p><b>Fail-before:</b> both providers shared the single global static {@code STATES}, so this
-   * "distinct instance" guarantee did not hold.
+   * Overlapping reconfiguration: a second provider rebinds the interceptor while the first is still
+   * "open"; when the FIRST provider later shuts down, it must NOT clear the second provider's
+   * in-flight state (its unbind is a no-op because it is no longer the active provider).
    */
+  @Test
+  void lateShutdownOfDisplacedProviderDoesNotClobberActiveProvider() {
+    final Provider first =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    final Provider second =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    final SpanEnrichmentStates secondStates = second.spanEnrichmentStates();
+
+    // Second provider is now the active one and has live state.
+    final long liveTrace = 0xA11FEL;
+    second
+        .spanEnrichmentHook()
+        .capture(key(liveTrace), ctx("f", "user-1"), serialDetails("f", 9, false));
+    assertNotNull(secondStates.peek(key(liveTrace)), "second provider has in-flight state");
+    assertTrue(SpanEnrichmentInterceptor.INSTANCE.activeStates() == secondStates);
+
+    // The DISPLACED first provider shuts down late. The active (second) provider must be untouched.
+    first.shutdown();
+    assertTrue(
+        SpanEnrichmentInterceptor.INSTANCE.activeStates() == secondStates,
+        "late shutdown of a displaced provider must not unbind the active provider");
+    assertNotNull(
+        secondStates.peek(key(liveTrace)),
+        "late shutdown of a displaced provider must not clear the active provider's state");
+
+    // Sanity: the second provider still flushes correctly.
+    final AgentSpan root = rootSpan(liveTrace);
+    SpanEnrichmentInterceptor.INSTANCE.onTraceComplete(Collections.singletonList(root));
+    verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "CQ=="); // {9} -> 0x09
+  }
+
+  /** Each provider owns a DISTINCT state store, so they never share mutable state. */
   @Test
   void eachProviderOwnsADistinctStateStore() {
     final Provider a =
         new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
     final Provider b =
         new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
-    assertNotNull(a.spanEnrichmentInterceptor());
-    assertNotNull(b.spanEnrichmentInterceptor());
-    assertFalse(
-        a.spanEnrichmentInterceptor().states() == b.spanEnrichmentInterceptor().states(),
-        "providers must own distinct state stores (CR-03)");
+    assertNotNull(a.spanEnrichmentStates());
+    assertNotNull(b.spanEnrichmentStates());
+    assertTrue(
+        a.spanEnrichmentStates() != b.spanEnrichmentStates(),
+        "providers must own distinct state stores");
 
-    // Mutating a's store does not affect b's.
-    a.spanEnrichmentInterceptor().states().getOrCreate(1L);
-    assertTrue(b.spanEnrichmentInterceptor().states().isEmpty(), "stores are isolated");
+    a.spanEnrichmentStates().getOrCreate(key(1L));
+    assertTrue(b.spanEnrichmentStates().isEmpty(), "stores are isolated");
   }
 
   /**
-   * Within ONE provider, the capture hook and the write interceptor must share the SAME store, so a
-   * capture is visible to the flush. (The cross-thread capture→flush handoff depends on this.)
+   * Within ONE provider, the capture hook and the bound interceptor must share the SAME store, so a
+   * capture is visible to the flush.
    */
   @Test
   void hookAndInterceptorOfOneProviderShareTheSameStore() {
@@ -332,10 +339,50 @@ class SpanEnrichmentLifecycleRegressionTest {
     final long traceId = 0xBEEFL;
     provider
         .spanEnrichmentHook()
-        .capture(traceId, ctx("f", "user-1"), serialDetails("f", 9, false));
-    // The interceptor's store must see what the hook captured (same instance).
+        .capture(key(traceId), ctx("f", "user-1"), serialDetails("f", 9, false));
     assertNotNull(
-        provider.spanEnrichmentInterceptor().states().peek(traceId),
-        "hook capture must be visible in the interceptor's store (same instance)");
+        SpanEnrichmentInterceptor.INSTANCE.activeStates().peek(key(traceId)),
+        "hook capture must be visible in the bound store (same instance)");
+  }
+
+  // =====================================================================================
+  // 128-bit trace ids that share their low-order 64 bits must not merge
+  // =====================================================================================
+
+  /**
+   * Two distinct 128-bit trace ids whose low-order 64 bits are identical (so {@code toLong()}
+   * collides) must keep SEPARATE accumulators. Keying by {@code toLong()} would merge them; keying
+   * by the full hex string keeps them apart.
+   */
+  @Test
+  void distinct128BitTraceIdsSharingLowBitsDoNotMerge() {
+    final SpanEnrichmentStates states = new SpanEnrichmentStates();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
+    final SpanEnrichmentInterceptor interceptor = SpanEnrichmentInterceptor.INSTANCE;
+    interceptor.bind(states);
+
+    // Same low 64 bits (0xABCD), different high 64 bits — toLong() is identical for both.
+    final long lowBits = 0xABCDL;
+    final DDTraceId idA = DD128bTraceId.from(0x1111L, lowBits);
+    final DDTraceId idB = DD128bTraceId.from(0x2222L, lowBits);
+    assertEquals(idA.toLong(), idB.toLong(), "precondition: low 64 bits collide");
+    assertTrue(!idA.toHexString().equals(idB.toHexString()), "precondition: full ids differ");
+
+    // Capture distinct serial ids under each full trace id.
+    hook.capture(idA.toHexString(), ctx("fa", "user-A"), serialDetails("fa", 100, false));
+    hook.capture(idB.toHexString(), ctx("fb", "user-B"), serialDetails("fb", 130, false));
+
+    // They must NOT have merged into one accumulator.
+    assertEquals(2, states.size(), "distinct 128-bit traces must not share an accumulator");
+
+    // Flush trace A: only {100} (not {100,130}).
+    final AgentSpan rootA = rootSpan(idA);
+    interceptor.onTraceComplete(Collections.singletonList(rootA));
+    verify(rootA).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZA=="); // {100} -> 0x64
+
+    // Flush trace B: only {130}.
+    final AgentSpan rootB = rootSpan(idB);
+    interceptor.onTraceComplete(Collections.singletonList(rootB));
+    verify(rootB).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ggE="); // {130} -> 0x82 0x01
   }
 }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentLifecycleRegressionTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/SpanEnrichmentLifecycleRegressionTest.java
@@ -1,0 +1,341 @@
+package datadog.trace.api.openfeature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagValueType;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.ImmutableMetadata;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GAP-CLOSURE regression suite for the three BLOCKER lifecycle defects found in the JAVA-01 code
+ * review (02-REVIEW-java.md). Each test reproduces a bug the original L0 suite missed because that
+ * suite only ever exercised a single root span, single-threaded, one provider, with the root always
+ * present in the flushed collection.
+ *
+ * <ul>
+ *   <li><b>CR-01</b> — a PARTIAL flush (child spans only; the still-open root is excluded by
+ *       dd-trace-core) must NOT drain the accumulator; pre-flush flags must survive onto the root
+ *       at final completion. Verified against {@code CoreTracer.write} →{@code
+ *       interceptCompleteTrace} firing on every flush and {@code PendingTrace.write(isPartial)}
+ *       holding the root back.
+ *   <li><b>CR-02</b> — traces that never reach the interceptor (dropped / Noop / never-finishing)
+ *       must not leak accumulator entries unboundedly; the per-provider store is hard-bounded.
+ *   <li><b>CR-03</b> — a SECOND gate-on provider whose interceptor registration is rejected
+ *       (duplicate priority) must not wire orphan state and its {@code shutdown()} must not clear
+ *       the FIRST provider's in-flight state.
+ * </ul>
+ *
+ * <p>Each test is written to FAIL against the pre-fix implementation and PASS after the fix (see
+ * the per-test "Fail-before" notes).
+ */
+class SpanEnrichmentLifecycleRegressionTest {
+
+  // ---- helpers ----
+
+  private static ImmutableMetadata serialMeta(final int serialId, final boolean doLog) {
+    return ImmutableMetadata.builder()
+        .addString(SpanEnrichmentHook.METADATA_SERIAL_ID, Integer.toString(serialId))
+        .addString(SpanEnrichmentHook.METADATA_DO_LOG, String.valueOf(doLog))
+        .build();
+  }
+
+  private static FlagEvaluationDetails<Object> serialDetails(
+      final String flagKey, final int serialId, final boolean doLog) {
+    return FlagEvaluationDetails.builder()
+        .flagKey(flagKey)
+        .variant("on")
+        .value("v")
+        .flagMetadata(serialMeta(serialId, doLog))
+        .build();
+  }
+
+  private static HookContext<Object> ctx(final String flagKey, final String targetingKey) {
+    final EvaluationContext ec =
+        targetingKey == null ? new ImmutableContext() : new ImmutableContext(targetingKey);
+    return HookContext.from(flagKey, FlagValueType.STRING, null, null, ec, "default");
+  }
+
+  /** A mock child span whose local root is {@code root} but which is itself NOT the root. */
+  private static AgentSpan childOf(final AgentSpan root) {
+    final AgentSpan child = mock(AgentSpan.class);
+    when(child.getLocalRootSpan()).thenReturn(root);
+    return child;
+  }
+
+  /** A mock local-root span reporting itself as its own local root with the given trace id. */
+  private static AgentSpan rootSpan(final long traceId) {
+    final AgentSpan root = mock(AgentSpan.class);
+    when(root.getLocalRootSpan()).thenReturn(root);
+    when(root.getTraceId()).thenReturn(DDTraceId.from(traceId));
+    return root;
+  }
+
+  // =====================================================================================
+  // CR-01: partial flush must not drop captured state or misattribute tags
+  // =====================================================================================
+
+  /**
+   * Models the real dd-trace-core sequence for a long-running trace:
+   *
+   * <ol>
+   *   <li>flags are evaluated (captured into the accumulator),
+   *   <li>a PARTIAL flush fires {@code onTraceComplete} with a fragment of CHILD spans only — the
+   *       still-open local root is excluded (held back via {@code rootSpanWritten}),
+   *   <li>more flags are evaluated,
+   *   <li>the FINAL flush fires {@code onTraceComplete} with the root present.
+   * </ol>
+   *
+   * All serial ids — both pre- and post-partial-flush — must appear on the root's {@code
+   * ffe_flags_enc} tag, and nothing must be written on the partial flush.
+   *
+   * <p><b>Fail-before:</b> the pre-fix interceptor resolved the root by reference via {@code
+   * getLocalRootSpan()} (reachable even when absent from the fragment) and unconditionally {@code
+   * remove()}d the accumulator on the FIRST (partial) flush — draining {100,108} and writing them
+   * onto the not-yet-finished root, so the final flush would only emit {128,130}. The assertion of
+   * the full {100,108,128,130} golden vector ("ZAgUAg==") on the final flush, plus "no setTag on
+   * the partial flush", both fail pre-fix.
+   */
+  @Test
+  void partialFlushExcludingRootPreservesPreFlushFlags() {
+    final SpanEnrichmentStates states = new SpanEnrichmentStates();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
+
+    final long traceId = 0x10A6L;
+    final AgentSpan root = rootSpan(traceId);
+
+    // (1) pre-partial-flush evaluations
+    hook.capture(traceId, ctx("f1", "user-1"), serialDetails("f1", 100, false));
+    hook.capture(traceId, ctx("f2", "user-1"), serialDetails("f2", 108, false));
+
+    // (2) PARTIAL flush: a fragment of children only — the open root is NOT in the collection.
+    final AgentSpan child1 = childOf(root);
+    final AgentSpan child2 = childOf(root);
+    final List<MutableSpan> partialFragment = Arrays.asList(child1, child2);
+    interceptor.onTraceComplete(partialFragment);
+
+    // No tags may be written on a partial flush, and the accumulator must survive intact.
+    verify(child1, never()).setTag(anyString(), anyString());
+    verify(child2, never()).setTag(anyString(), anyString());
+    verify(root, never()).setTag(anyString(), anyString());
+    final SpanEnrichmentAccumulator surviving = states.peek(traceId);
+    assertNotNull(surviving, "partial flush must NOT remove the accumulator (CR-01)");
+    assertTrue(
+        surviving.serialIdsView().contains(100) && surviving.serialIdsView().contains(108),
+        "pre-flush serial ids must survive a partial flush (CR-01)");
+
+    // (3) more evaluations after the partial flush
+    hook.capture(traceId, ctx("f3", "user-1"), serialDetails("f3", 128, false));
+    hook.capture(traceId, ctx("f4", "user-1"), serialDetails("f4", 130, false));
+
+    // (4) FINAL flush: the root is present in the fragment (alongside a late child).
+    final AgentSpan lateChild = childOf(root);
+    interceptor.onTraceComplete(Arrays.asList(lateChild, root));
+
+    // The full set {100,108,128,130} -> golden "ZAgUAg==" must land on the root.
+    verify(root).setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "ZAgUAg==");
+    assertTrue(states.isEmpty(), "state must be removed only on the final flush (CR-01)");
+  }
+
+  /**
+   * A partial flush whose first span reports a non-null local root that is absent from the fragment
+   * must be treated as "not the final write" and leave state intact — even when there are several
+   * children. Guards the WR-02 "never tag a non-root span" concern together with CR-01.
+   *
+   * <p><b>Fail-before:</b> {@code findLocalRoot} returned {@code first.getLocalRootSpan()} (the
+   * absent root) and the interceptor wrote tags onto it / removed state on this partial fragment.
+   */
+  @Test
+  void partialFlushNeverWritesTagsOnAChildSpan() {
+    final SpanEnrichmentStates states = new SpanEnrichmentStates();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
+    final SpanEnrichmentInterceptor interceptor = new SpanEnrichmentInterceptor(states);
+
+    final long traceId = 0xC0DEL;
+    final AgentSpan root = rootSpan(traceId);
+    hook.capture(traceId, ctx("f", "user-1"), serialDetails("f", 7, false));
+
+    final AgentSpan child = childOf(root);
+    interceptor.onTraceComplete(Collections.singletonList(child));
+
+    verify(child, never()).setTag(anyString(), anyString());
+    verify(root, never()).setTag(anyString(), anyString());
+    assertNotNull(states.peek(traceId), "child-only fragment must keep state (CR-01/WR-02)");
+  }
+
+  // =====================================================================================
+  // CR-02: never-completing traces must not leak accumulator entries unboundedly
+  // =====================================================================================
+
+  /**
+   * Simulates a sustained stream of traces that each evaluate a flag but never reach the
+   * interceptor (dropped traces / Noop tracer / never-finishing roots). The per-provider store must
+   * stay bounded by {@link SpanEnrichmentStates#MAX_TRACES} rather than growing without limit.
+   *
+   * <p><b>Fail-before:</b> state lived in an unbounded {@code static ConcurrentHashMap} with no TTL
+   * or cap; the only removal paths were trace-complete and shutdown. Driving 3x the cap distinct,
+   * never-flushed trace ids grew the map to 3x the cap — the assertion that size never exceeds the
+   * cap fails pre-fix (the #4844 leak class).
+   */
+  @Test
+  void neverCompletingTracesDoNotLeakUnbounded() {
+    final SpanEnrichmentStates states = new SpanEnrichmentStates();
+    final SpanEnrichmentHook hook = new SpanEnrichmentHook(states);
+
+    final int churn = SpanEnrichmentStates.MAX_TRACES * 3;
+    for (int i = 0; i < churn; i++) {
+      // Each distinct trace id accumulates once and is NEVER flushed (no interceptor call).
+      hook.capture(i, ctx("f", "user-" + i), serialDetails("f", i % 1000 + 1, false));
+      assertTrue(
+          states.size() <= SpanEnrichmentStates.MAX_TRACES,
+          "state store must stay bounded for never-completing traces (CR-02)");
+    }
+    assertEquals(
+        SpanEnrichmentStates.MAX_TRACES,
+        states.size(),
+        "store saturates at the cap, never beyond (CR-02)");
+  }
+
+  /**
+   * Bounding is FIFO by insertion: once the cap is reached, the oldest entries are evicted so the
+   * newest in-flight traces are retained. Proves eviction targets the leak (oldest, likely
+   * abandoned) rather than the live tail.
+   *
+   * <p><b>Fail-before:</b> no eviction existed at all, so this behavior was absent.
+   */
+  @Test
+  void boundedStoreEvictsOldestFirst() {
+    final SpanEnrichmentStates states = new SpanEnrichmentStates();
+    // Fill exactly to the cap with ids [0, MAX).
+    for (long i = 0; i < SpanEnrichmentStates.MAX_TRACES; i++) {
+      states.getOrCreate(i);
+    }
+    assertEquals(SpanEnrichmentStates.MAX_TRACES, states.size());
+    // One more distinct id evicts the oldest (id 0) and keeps the rest + the new one.
+    final long overflowKey = SpanEnrichmentStates.MAX_TRACES;
+    states.getOrCreate(overflowKey);
+    assertEquals(SpanEnrichmentStates.MAX_TRACES, states.size(), "size stays at the cap");
+    assertNull(states.peek(0L), "oldest entry evicted first (CR-02 FIFO)");
+    assertNotNull(states.peek(overflowKey), "newest entry retained");
+    assertNotNull(states.peek(1L), "second-oldest still present");
+  }
+
+  // =====================================================================================
+  // CR-03: a rejected second provider must not corrupt the first provider's state
+  // =====================================================================================
+
+  /**
+   * Models reconfiguration: a first gate-on provider registers successfully; a SECOND gate-on
+   * provider's interceptor registration is REJECTED (duplicate priority 4 — what {@code
+   * CoreTracer.addTraceInterceptor} returns false for). The second provider must wire NO hook /
+   * interceptor, and its {@code shutdown()} must leave the first provider's in-flight state intact.
+   *
+   * <p><b>Fail-before:</b> the {@code addTraceInterceptor} return value was ignored, so the second
+   * provider kept a non-null hook+interceptor and shared the same global {@code STATES}; its {@code
+   * shutdown()} called {@code STATES.clear()}, wiping the first provider's live per-trace state.
+   * The assertions "second provider has null hook/interceptor" and "first provider's state survives
+   * the second's shutdown" both fail pre-fix.
+   */
+  @Test
+  void secondProviderRejectedRegistrationDoesNotClearFirstProviderState() {
+    // First provider: registration succeeds.
+    final Provider first =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    assertNotNull(first.spanEnrichmentInterceptor(), "first provider registers");
+    assertNotNull(first.spanEnrichmentHook(), "first provider wires a hook");
+
+    // First provider captures live state for an in-flight trace.
+    final SpanEnrichmentStates firstStates = first.spanEnrichmentInterceptor().states();
+    final long liveTrace = 0xA11FEL;
+    first.spanEnrichmentHook().capture(liveTrace, ctx("f", "user-1"), serialDetails("f", 5, true));
+    assertNotNull(firstStates.peek(liveTrace), "first provider has in-flight state");
+
+    // Second provider: registration is REJECTED (duplicate). It must wire nothing.
+    final Provider second =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> false);
+    assertNull(
+        second.spanEnrichmentInterceptor(),
+        "rejected registration => no interceptor on the second provider (CR-03)");
+    assertNull(
+        second.spanEnrichmentHook(),
+        "rejected registration => no orphan hook on the second provider (CR-03)");
+
+    // Second provider shuts down. The first provider's live state MUST be untouched.
+    second.shutdown();
+    assertNotNull(
+        firstStates.peek(liveTrace),
+        "second provider's shutdown must NOT clear the first provider's state (CR-03)");
+    assertTrue(
+        first.spanEnrichmentInterceptor().isEnabled(),
+        "first provider's interceptor must remain enabled after the second's shutdown (CR-03)");
+
+    // Sanity: the first provider can still flush its own state correctly afterward.
+    final AgentSpan root = rootSpan(liveTrace);
+    first.spanEnrichmentInterceptor().onTraceComplete(Collections.singletonList(root));
+    verify(root)
+        .setTag(SpanEnrichmentAccumulator.TAG_FLAGS_ENC, "BQ=="); // {5} -> delta {5} -> 0x05
+    assertTrue(firstStates.isEmpty(), "first provider flushes + clears its own state");
+  }
+
+  /**
+   * The two providers must own DISTINCT state stores — the structural guarantee behind CR-03. Even
+   * when both register successfully (independent tracers / test seam), one's store is never the
+   * other's.
+   *
+   * <p><b>Fail-before:</b> both providers shared the single global static {@code STATES}, so this
+   * "distinct instance" guarantee did not hold.
+   */
+  @Test
+  void eachProviderOwnsADistinctStateStore() {
+    final Provider a =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    final Provider b =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    assertNotNull(a.spanEnrichmentInterceptor());
+    assertNotNull(b.spanEnrichmentInterceptor());
+    assertFalse(
+        a.spanEnrichmentInterceptor().states() == b.spanEnrichmentInterceptor().states(),
+        "providers must own distinct state stores (CR-03)");
+
+    // Mutating a's store does not affect b's.
+    a.spanEnrichmentInterceptor().states().getOrCreate(1L);
+    assertTrue(b.spanEnrichmentInterceptor().states().isEmpty(), "stores are isolated");
+  }
+
+  /**
+   * Within ONE provider, the capture hook and the write interceptor must share the SAME store, so a
+   * capture is visible to the flush. (The cross-thread capture→flush handoff depends on this.)
+   */
+  @Test
+  void hookAndInterceptorOfOneProviderShareTheSameStore() {
+    final Provider provider =
+        new Provider(new Provider.Options(), null, Boolean.TRUE, interceptor -> true);
+    final long traceId = 0xBEEFL;
+    provider
+        .spanEnrichmentHook()
+        .capture(traceId, ctx("f", "user-1"), serialDetails("f", 9, false));
+    // The interceptor's store must see what the hook captured (same instance).
+    assertNotNull(
+        provider.spanEnrichmentInterceptor().states().peek(traceId),
+        "hook capture must be visible in the interceptor's store (same instance)");
+  }
+}

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Split.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Split.java
@@ -7,11 +7,19 @@ public class Split {
   public final List<Shard> shards;
   public final String variationKey;
   public final Map<String, String> extraLogging;
+  // Nullable Integer (not primitive int): the serialId is absent in some UFC shapes. Populated by
+  // Moshi reflective deserialization from the UFC "serialId" JSON field. Surfaced as
+  // __dd_split_serial_id in eval metadata for APM span enrichment (JAVA-01).
+  public final Integer serialId;
 
   public Split(
-      final List<Shard> shards, final String variationKey, final Map<String, String> extraLogging) {
+      final List<Shard> shards,
+      final String variationKey,
+      final Map<String, String> extraLogging,
+      final Integer serialId) {
     this.shards = shards;
     this.variationKey = variationKey;
     this.extraLogging = extraLogging;
+    this.serialId = serialId;
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Split.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Split.java
@@ -9,7 +9,7 @@ public class Split {
   public final Map<String, String> extraLogging;
   // Nullable Integer (not primitive int): the serialId is absent in some UFC shapes. Populated by
   // Moshi reflective deserialization from the UFC "serialId" JSON field. Surfaced as
-  // __dd_split_serial_id in eval metadata for APM span enrichment (JAVA-01).
+  // __dd_split_serial_id in eval metadata for APM span enrichment.
   public final Integer serialId;
 
   public Split(

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
@@ -173,6 +173,62 @@ class RemoteConfigServiceImplTest {
     assertEquals("expected", config.flags.get("valid-flag").variations.get("expected").value);
   }
 
+  @Test
+  void serialIdPresentInSplitDeserializesCorrectly() throws Exception {
+    final ServerConfiguration config =
+        deserialize(
+            "{"
+                + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+                + "\"format\":\"SERVER\","
+                + "\"environment\":{\"name\":\"Test\"},"
+                + "\"flags\":{"
+                + "\"serial-flag\":{"
+                + "\"key\":\"serial-flag\","
+                + "\"enabled\":true,"
+                + "\"variationType\":\"STRING\","
+                + "\"variations\":{\"on\":{\"key\":\"on\",\"value\":\"on\"}},"
+                + "\"allocations\":[{"
+                + "\"key\":\"alloc\","
+                + "\"splits\":[{\"variationKey\":\"on\",\"shards\":[],\"serialId\":42}],"
+                + "\"doLog\":false"
+                + "}]"
+                + "}"
+                + "}"
+                + "}");
+
+    assertNotNull(config);
+    assertEquals(
+        Integer.valueOf(42),
+        config.flags.get("serial-flag").allocations.get(0).splits.get(0).serialId);
+  }
+
+  @Test
+  void serialIdAbsentInSplitDeserializesToNull() throws Exception {
+    final ServerConfiguration config =
+        deserialize(
+            "{"
+                + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+                + "\"format\":\"SERVER\","
+                + "\"environment\":{\"name\":\"Test\"},"
+                + "\"flags\":{"
+                + "\"no-serial-flag\":{"
+                + "\"key\":\"no-serial-flag\","
+                + "\"enabled\":true,"
+                + "\"variationType\":\"STRING\","
+                + "\"variations\":{\"on\":{\"key\":\"on\",\"value\":\"on\"}},"
+                + "\"allocations\":[{"
+                + "\"key\":\"alloc\","
+                + "\"splits\":[{\"variationKey\":\"on\",\"shards\":[]}],"
+                + "\"doLog\":false"
+                + "}]"
+                + "}"
+                + "}"
+                + "}");
+
+    assertNotNull(config);
+    assertNull(config.flags.get("no-serial-flag").allocations.get(0).splits.get(0).serialId);
+  }
+
   @TableTest({
     "scenario                                  | value                            | expectedEpochMilli",
     "utc second                                | '2023-01-01T00:00:00Z'           | 1672531200000     ",


### PR DESCRIPTION
# feat(feature-flagging): FFE APM feature-flag span enrichment

> ⚠️ Experimental, opt-in, gated behind `DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED` (off by default).

## Summary

Adds Feature Flag Events (FFE) span enrichment to the OpenFeature integration. When feature
flags are evaluated, the evaluation metadata is attached to the root APM span so APM customers
can filter traces and errors by active flag variant, and the FFE/Experimentation platform can
correlate spans with experiments. The wire format matches the merged reference implementation
(`dd-trace-js#8343`) so backend/Trino decode is identical.

## How it works

1. A flag is evaluated through the OpenFeature client.
2. The `finally` hook captures the evaluation (serial ID, targeting key, runtime default).
3. Evaluations are accumulated against the local root span (resolved via `SpanEnrichmentInterceptor.findLocalRootInFragment`).
4. On root-span finish, the accumulated state is encoded and written as `ffe_*` tags.

## Configuration

Opt-in, off by default:

```bash
DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED=true
```

This is distinct from `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED`.

## Span tags added

| Tag | Description | Format |
|-----|-------------|--------|
| `ffe_flags_enc` | All evaluated flag serial IDs | base64 delta-varint |
| `ffe_subjects_enc` | Subject → flags mapping (when `doLog=true`) | JSON `{ sha256(key): encodedIds }` |
| `ffe_runtime_defaults` | Fallback values for flags not in UFC | JSON `{ flagKey: value }` |

Limits: 200 serial IDs, 10 subjects, 20 experiments/subject, 5 runtime defaults, 64 chars/runtime-default value (UTF-8-safe truncation).

## Changes

- **Gate + config**: add `DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED` (`FeatureFlaggingConfig`), off by default; surface the split `serialId` in eval metadata (`ufc/v1/Split.java`).
- **Codec**: `ULeb128Encoder` — delta-varint serial IDs, SHA256-hashed subject keys.
- **Accumulator + hook + interceptor**: `SpanEnrichmentAccumulator`, `SpanEnrichmentHook`, `SpanEnrichmentInterceptor`, `SpanEnrichmentStates` — accumulate evaluations and write `ffe_*` tags onto the local root span.
- **Tests**: JUnit 5 L0 suite (7 required cases + golden round-trip) + lifecycle regression tests (partial-flush, leak, reconfiguration).

## Decisions

- **No idle per-span overhead when the gate is off** — the accumulator is absent and spans carry no `ffe_*` tags.
- **Lifecycle**: state cleaned up on local-root finish and provider close; regression tests cover partial-flush, leak, and reconfiguration paths.
- `ffe_*` are bare tag names on span `meta` (not `_dd.`-prefixed); subject keys are SHA256 hashes emitted only when logging is authorized.

## Validation

Ran the frozen `system-tests` parametric suite (`tests/parametric/test_ffe/test_span_enrichment.py`) against `dd-java-agent 1.63.0-SNAPSHOT` (HEAD `109eab80bc`):

All 18 cases pass, covering `ffe_flags_enc` / `ffe_subjects_enc` / `ffe_runtime_defaults`, delta-varint encoding, SHA256 subject keys with doLog gating, and the 200/10/20/5/64 limits. The system-tests enablement is tracked in `DataDog/system-tests#7204`.

Deterministic regression suite (`SpanEnrichmentHookTest` + `SpanEnrichmentLifecycleRegressionTest`, **31 cases, all pass**) covers: 128-bit trace ID keying, reconfiguration (new provider after shutdown, late shutdown of displaced provider), per-provider state isolation, partial-flush child-span safety, bounded store eviction, gate-off zero allocation, and `Value`→JSON runtime-default encoding.