### PR TITLE
Improve Java testing experience with eventually / within and parent span index reference

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
@@ -53,6 +53,7 @@ public final class SpanMatcher {
   private Matcher<DDTraceId> traceIdMatcher;
   private Matcher<Long> idMatcher;
   private Matcher<Long> parentIdMatcher;
+  private int parentSpanIndex;
   private Matcher<String> serviceNameMatcher;
   private Matcher<CharSequence> operationNameMatcher;
   private Matcher<CharSequence> resourceNameMatcher;
@@ -65,6 +66,7 @@ public final class SpanMatcher {
   private static final Matcher<Long> CHILD_OF_PREVIOUS_MATCHER = is(0L);
 
   private SpanMatcher() {
+    this.parentSpanIndex = -1;
     this.serviceNameMatcher = validates(s -> s != null && !s.isEmpty());
     this.typeMatcher = isNull();
     this.errorMatcher = isFalse();
@@ -120,6 +122,7 @@ public final class SpanMatcher {
    */
   public SpanMatcher childOf(long parentId) {
     this.parentIdMatcher = is(parentId);
+    this.parentSpanIndex = -1;
     return this;
   }
 
@@ -130,6 +133,19 @@ public final class SpanMatcher {
    */
   public SpanMatcher childOfPrevious() {
     this.parentIdMatcher = CHILD_OF_PREVIOUS_MATCHER;
+    this.parentSpanIndex = -1;
+    return this;
+  }
+
+  /**
+   * Checks the span is a direct child of the span at the specified index in the trace.
+   *
+   * @param parentSpanIndex The index of the parent span in the trace.
+   * @return The current {@link SpanMatcher} instance with the child-of constraint applied.
+   */
+  public SpanMatcher childOfIndex(int parentSpanIndex) {
+    this.parentIdMatcher = null;
+    this.parentSpanIndex = parentSpanIndex;
     return this;
   }
 
@@ -301,9 +317,18 @@ public final class SpanMatcher {
     return this;
   }
 
-  void assertSpan(DDSpan span, DDSpan previousSpan) {
+  void assertSpan(List<DDSpan> trace, int spanIndex) {
+    DDSpan span = trace.get(spanIndex);
+    // Apply parent span index
+    if (this.parentSpanIndex >= 0) {
+      this.parentIdMatcher = is(trace.get(this.parentSpanIndex).getSpanId());
+    }
     // Apply parent id matcher from the previous span
-    if (this.parentIdMatcher == CHILD_OF_PREVIOUS_MATCHER) {
+    else if (this.parentIdMatcher == CHILD_OF_PREVIOUS_MATCHER) {
+      if (spanIndex == 0) {
+        throw new IllegalStateException("Cannot use childOfPrevious() matcher on the first span");
+      }
+      DDSpan previousSpan = trace.get(spanIndex - 1);
       this.parentIdMatcher = is(previousSpan.getSpanId());
     }
     // Assert span values

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/SpanMatcher.java
@@ -332,15 +332,15 @@ public final class SpanMatcher {
       this.parentIdMatcher = is(previousSpan.getSpanId());
     }
     // Assert span values
-    assertValue(this.traceIdMatcher, span.getTraceId(), "Expected trace identifier");
-    assertValue(this.idMatcher, span.getSpanId(), "Expected identifier");
-    assertValue(this.parentIdMatcher, span.getParentId(), "Expected parent identifier");
-    assertValue(this.serviceNameMatcher, span.getServiceName(), "Expected service name");
-    assertValue(this.operationNameMatcher, span.getOperationName(), "Expected operation name");
-    assertValue(this.resourceNameMatcher, span.getResourceName(), "Expected resource name");
-    assertValue(this.durationMatcher, ofNanos(span.getDurationNano()), "Expected duration");
-    assertValue(this.typeMatcher, span.getSpanType(), "Expected span type");
-    assertValue(this.errorMatcher, span.isError(), "Expected error status");
+    assertValue(this.traceIdMatcher, span.getTraceId(), "Unexpected trace identifier");
+    assertValue(this.idMatcher, span.getSpanId(), "Unexpected identifier");
+    assertValue(this.parentIdMatcher, span.getParentId(), "Unexpected parent identifier");
+    assertValue(this.serviceNameMatcher, span.getServiceName(), "Unexpected service name");
+    assertValue(this.operationNameMatcher, span.getOperationName(), "Unexpected operation name");
+    assertValue(this.resourceNameMatcher, span.getResourceName(), "Unexpected resource name");
+    assertValue(this.durationMatcher, ofNanos(span.getDurationNano()), "Unexpected duration");
+    assertValue(this.typeMatcher, span.getSpanType(), "Unexpected span type");
+    assertValue(this.errorMatcher, span.isError(), "Unexpected error status");
     assertSpanTags(span.getTags());
     assertSpanLinks(spanLinks(span));
   }

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TraceMatcher.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/assertions/TraceMatcher.java
@@ -68,11 +68,8 @@ public final class TraceMatcher {
     if (this.options.sorter != null) {
       trace.sort(this.options.sorter);
     }
-    DDSpan previousSpan = null;
-    for (int i = 0; i < spanCount; i++) {
-      DDSpan span = trace.get(i);
-      this.matchers[i].assertSpan(span, previousSpan);
-      previousSpan = span;
+    for (int spanIndex = 0; spanIndex < spanCount; spanIndex++) {
+      this.matchers[spanIndex].assertSpan(trace, spanIndex);
     }
   }
 

--- a/utils/test-utils/build.gradle.kts
+++ b/utils/test-utils/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
   api(project(":utils:junit-utils"))
   api(group = "commons-fileupload", name = "commons-fileupload", version = "1.5")
 
+  compileOnly(project(":components:annotations"))
   compileOnly(libs.junit.jupiter)
   compileOnly(libs.logback.core)
   compileOnly(libs.logback.classic)

--- a/utils/test-utils/build.gradle.kts
+++ b/utils/test-utils/build.gradle.kts
@@ -4,6 +4,27 @@ plugins {
 
 apply(from = "$rootDir/gradle/java.gradle")
 
+extra["excludedClassesCoverage"] = listOf(
+  "datadog.trace.test.logging.*",
+  "external.util.stacktrace.*",
+  "datadog.trace.test.util.AnyStackRunner*",
+  "datadog.trace.test.util.AssertionsUtils",
+  "datadog.trace.test.util.CircularBuffer",
+  "datadog.trace.test.util.CleanConfigStateExtension",
+  "datadog.trace.test.util.DDJavaSpecification",
+  "datadog.trace.test.util.ForkedTestUtils",
+  "datadog.trace.test.util.GCUtils",
+  "datadog.trace.test.util.ThreadUtils*",
+  "datadog.trace.test.util.ConfigInstrumentationFailedListener",
+  "datadog.trace.test.util.ConfigTransformSpockExtension*",
+  "datadog.trace.test.util.ControllableEnvironmentVariables*",
+  "datadog.trace.test.util.DDSpecification*",
+  "datadog.trace.test.util.Flaky*",
+  "datadog.trace.test.util.FlakySpockExtension*",
+  "datadog.trace.test.util.MultipartRequestParser*",
+  "datadog.trace.test.util.NonRetryable",
+)
+
 dependencies {
   api(libs.bytebuddy)
   api(libs.bytebuddyagent)

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
@@ -1,5 +1,6 @@
 package datadog.trace.test.util;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import datadog.trace.test.util.ThreadUtils.ThrowingRunnable;
 
 /**
@@ -119,7 +120,9 @@ public class PollingConditions {
     return Math.round(seconds * 1000);
   }
 
-  private static void sleep(final long millis) {
+  // VisibleForTesting to allow test code to override it and avoid flaky timing-based assertions.
+  @VisibleForTesting
+  void sleep(final long millis) {
     try {
       Thread.sleep(millis);
     } catch (final InterruptedException e) {

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
@@ -35,16 +35,17 @@ public class PollingConditions {
 
   /**
    * @param timeoutSeconds the timeout in seconds (the most common single setting).
+   * @throws IllegalArgumentException if {@code timeoutSeconds} is negative.
    */
   public PollingConditions(double timeoutSeconds) {
-    this.timeout = timeoutSeconds;
+    this.timeout = requireNonNegative(timeoutSeconds, "timeout");
   }
 
   /**
    * @param seconds how long to keep retrying before failing. Defaults to {@code 1}.
    */
   public PollingConditions timeout(double seconds) {
-    this.timeout = seconds;
+    this.timeout = requireNonNegative(seconds, "timeout");
     return this;
   }
 
@@ -52,7 +53,7 @@ public class PollingConditions {
    * @param seconds how long to wait before the very first attempt. Defaults to {@code 0}.
    */
   public PollingConditions initialDelay(double seconds) {
-    this.initialDelay = seconds;
+    this.initialDelay = requireNonNegative(seconds, "initialDelay");
     return this;
   }
 
@@ -60,7 +61,7 @@ public class PollingConditions {
    * @param seconds how long to wait between attempts. Defaults to {@code 0.1}.
    */
   public PollingConditions delay(double seconds) {
-    this.delay = seconds;
+    this.delay = requireNonNegative(seconds, "delay");
     return this;
   }
 
@@ -69,7 +70,7 @@ public class PollingConditions {
    *     Defaults to {@code 1.0} (constant delay).
    */
   public PollingConditions factor(double factor) {
-    this.factor = factor;
+    this.factor = requireNonNegative(factor, "factor");
     return this;
   }
 
@@ -83,7 +84,7 @@ public class PollingConditions {
    * {@link #timeout} for this call.
    */
   public void within(double seconds, ThrowingRunnable conditions) {
-    final long timeoutMillis = toMillis(seconds);
+    final long timeoutMillis = toMillis(requireNonNegative(seconds, "timeout"));
     final long start = System.currentTimeMillis();
     if (this.initialDelay > 0) {
       sleep(toMillis(this.initialDelay));
@@ -118,6 +119,13 @@ public class PollingConditions {
 
   private static long toMillis(final double seconds) {
     return Math.round(seconds * 1000);
+  }
+
+  private static double requireNonNegative(double value, String name) {
+    if (value < 0) {
+      throw new IllegalArgumentException(name + " must be >= 0 but was " + value);
+    }
+    return value;
   }
 
   // VisibleForTesting to allow test code to override it and avoid flaky timing-based assertions.

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/PollingConditions.java
@@ -1,0 +1,130 @@
+package datadog.trace.test.util;
+
+import datadog.trace.test.util.ThreadUtils.ThrowingRunnable;
+
+/**
+ * A small Java port of Spock's {@code spock.util.concurrent.PollingConditions}. It repeatedly
+ * evaluates a block of assertions until they pass or a timeout elapses.
+ *
+ * <p>The condition block is a {@link ThrowingRunnable}, so it may throw checked exceptions. Any
+ * {@link Throwable} it throws is treated as "not satisfied yet" and triggers another attempt.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * // timeout defaults to 1 second
+ * new PollingConditions().eventually(() -> assertTrue(done.get()));
+ *
+ * // timeout-only is the common case
+ * new PollingConditions(5).eventually(() -> assertEquals(2, requests.size()));
+ *
+ * // all knobs, chained
+ * new PollingConditions()
+ *     .timeout(15).initialDelay(1).delay(0.5).factor(1)
+ *     .eventually(() -> assertTrue(done.get()));
+ * }</pre>
+ */
+public class PollingConditions {
+  private double timeout = 1; // seconds
+  private double initialDelay = 0; // seconds
+  private double delay = 0.1; // seconds
+  private double factor = 1.0; // delay multiplier between attempts
+
+  public PollingConditions() {}
+
+  /**
+   * @param timeoutSeconds the timeout in seconds (the most common single setting).
+   */
+  public PollingConditions(double timeoutSeconds) {
+    this.timeout = timeoutSeconds;
+  }
+
+  /**
+   * @param seconds how long to keep retrying before failing. Defaults to {@code 1}.
+   */
+  public PollingConditions timeout(double seconds) {
+    this.timeout = seconds;
+    return this;
+  }
+
+  /**
+   * @param seconds how long to wait before the very first attempt. Defaults to {@code 0}.
+   */
+  public PollingConditions initialDelay(double seconds) {
+    this.initialDelay = seconds;
+    return this;
+  }
+
+  /**
+   * @param seconds how long to wait between attempts. Defaults to {@code 0.1}.
+   */
+  public PollingConditions delay(double seconds) {
+    this.delay = seconds;
+    return this;
+  }
+
+  /**
+   * @param factor multiplier applied to the delay after each attempt (exponential back-off).
+   *     Defaults to {@code 1.0} (constant delay).
+   */
+  public PollingConditions factor(double factor) {
+    this.factor = factor;
+    return this;
+  }
+
+  /** Retries {@code conditions} until it passes or the configured {@link #timeout} elapses. */
+  public void eventually(ThrowingRunnable conditions) {
+    within(this.timeout, conditions);
+  }
+
+  /**
+   * Retries {@code conditions} until it passes or {@code seconds} elapse, overriding the configured
+   * {@link #timeout} for this call.
+   */
+  public void within(double seconds, ThrowingRunnable conditions) {
+    final long timeoutMillis = toMillis(seconds);
+    final long start = System.currentTimeMillis();
+    if (this.initialDelay > 0) {
+      sleep(toMillis(this.initialDelay));
+    }
+    long currDelay = toMillis(this.delay);
+    int attempts = 0;
+    long elapsed = 0;
+    Throwable lastFailure = null;
+    while (elapsed <= timeoutMillis) {
+      try {
+        attempts++;
+        conditions.run();
+        return;
+      } catch (final Throwable e) {
+        elapsed = System.currentTimeMillis() - start;
+        lastFailure = e;
+        // Never sleep past the deadline.
+        final long sleepMillis =
+            Math.min(currDelay, start + timeoutMillis - System.currentTimeMillis());
+        if (sleepMillis > 0) {
+          sleep(sleepMillis);
+        }
+        currDelay = (long) (currDelay * factor);
+      }
+    }
+    throw new AssertionError(
+        String.format(
+            "Condition not satisfied after %1.2f seconds and %d attempts",
+            elapsed / 1000d, attempts),
+        lastFailure);
+  }
+
+  private static long toMillis(final double seconds) {
+    return Math.round(seconds * 1000);
+  }
+
+  private static void sleep(final long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for condition", e);
+    }
+  }
+}

--- a/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
+++ b/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
@@ -7,6 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -78,37 +81,24 @@ class PollingConditionsTest {
   }
 
   @Test
-  void factorBackOffReducesAttemptCount() {
-    // Constant delay: many attempts fit in the window.
-    AtomicInteger constant = new AtomicInteger();
-    assertThrows(
-        AssertionError.class,
-        () ->
-            new PollingConditions(0.3)
-                .delay(0.02)
-                .factor(1)
-                .eventually(
-                    () -> {
-                      constant.incrementAndGet();
-                      fail("nope");
-                    }));
+  void factorMultipliesDelayBetweenAttempts() {
+    // Large timeout so the run ends by success (after 4 attempts), never by the deadline; the
+    // recording subclass captures the requested delays without actually sleeping, so this is
+    // deterministic rather than dependent on wall-clock scheduling.
+    RecordingPollingConditions conditions = new RecordingPollingConditions(100);
+    conditions.delay(0.02).factor(4); // 20ms base delay, multiplied by 4 after each attempt
 
-    // Exponential back-off: the delay grows quickly, so far fewer attempts fit.
-    AtomicInteger growing = new AtomicInteger();
-    assertThrows(
-        AssertionError.class,
-        () ->
-            new PollingConditions(0.3)
-                .delay(0.02)
-                .factor(4)
-                .eventually(
-                    () -> {
-                      growing.incrementAndGet();
-                      fail("nope");
-                    }));
+    AtomicInteger attempts = new AtomicInteger();
+    conditions.eventually(
+        () -> {
+          if (attempts.incrementAndGet() < 4) {
+            fail("not yet");
+          }
+        });
 
-    assertTrue(
-        growing.get() < constant.get(), "growing=" + growing.get() + " constant=" + constant.get());
+    assertEquals(4, attempts.get());
+    // Three failed attempts -> three delays, each 4x the previous.
+    assertEquals(Arrays.asList(20L, 80L, 320L), conditions.requestedSleeps);
   }
 
   @Test
@@ -141,6 +131,20 @@ class PollingConditionsTest {
     } finally {
       // Clear the flag so it does not leak into other tests sharing this thread.
       Thread.interrupted();
+    }
+  }
+
+  /** Captures the requested delays instead of sleeping, for deterministic back-off assertions. */
+  private static final class RecordingPollingConditions extends PollingConditions {
+    final List<Long> requestedSleeps = new ArrayList<>();
+
+    RecordingPollingConditions(double timeoutSeconds) {
+      super(timeoutSeconds);
+    }
+
+    @Override
+    void sleep(long millis) {
+      requestedSleeps.add(millis);
     }
   }
 }

--- a/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
+++ b/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
@@ -1,0 +1,146 @@
+package datadog.trace.test.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class PollingConditionsTest {
+
+  @Test
+  void passesOnFirstAttempt() {
+    AtomicInteger attempts = new AtomicInteger();
+    new PollingConditions().eventually(attempts::incrementAndGet);
+    assertEquals(1, attempts.get());
+  }
+
+  @Test
+  void succeedsAfterSeveralRetries() {
+    AtomicInteger attempts = new AtomicInteger();
+    new PollingConditions(2)
+        .delay(0.01)
+        .eventually(
+            () -> {
+              if (attempts.incrementAndGet() < 5) {
+                fail("not yet");
+              }
+            });
+    assertEquals(5, attempts.get());
+  }
+
+  @Test
+  void timesOutWithFormattedMessageAndUnderlyingCause() {
+    AssertionError error =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                new PollingConditions(0.1)
+                    .delay(0.01)
+                    .eventually(() -> assertEquals(1, 2, "still wrong")));
+
+    assertTrue(error.getMessage().startsWith("Condition not satisfied after"), error.getMessage());
+    assertTrue(error.getMessage().contains("attempts"), error.getMessage());
+
+    Throwable cause = error.getCause();
+    assertInstanceOf(AssertionError.class, cause);
+    assertTrue(cause.getMessage().contains("still wrong"), cause.getMessage());
+  }
+
+  @Test
+  void withinOverridesConfiguredTimeout() {
+    // The instance timeout is huge, but within() must use its own (tiny) timeout and fail fast.
+    long start = System.currentTimeMillis();
+    assertThrows(
+        AssertionError.class,
+        () -> new PollingConditions(60).delay(0.01).within(0.1, () -> fail("never")));
+    long elapsed = System.currentTimeMillis() - start;
+    assertTrue(
+        elapsed < 5_000, "within() should honor its own short timeout, took " + elapsed + "ms");
+  }
+
+  @Test
+  void retriesWhenConditionThrowsCheckedException() {
+    AtomicInteger attempts = new AtomicInteger();
+    new PollingConditions(2)
+        .delay(0.01)
+        .eventually(
+            () -> {
+              if (attempts.incrementAndGet() < 3) {
+                throw new IOException("not ready");
+              }
+            });
+    assertEquals(3, attempts.get());
+  }
+
+  @Test
+  void factorBackOffReducesAttemptCount() {
+    // Constant delay: many attempts fit in the window.
+    AtomicInteger constant = new AtomicInteger();
+    assertThrows(
+        AssertionError.class,
+        () ->
+            new PollingConditions(0.3)
+                .delay(0.02)
+                .factor(1)
+                .eventually(
+                    () -> {
+                      constant.incrementAndGet();
+                      fail("nope");
+                    }));
+
+    // Exponential back-off: the delay grows quickly, so far fewer attempts fit.
+    AtomicInteger growing = new AtomicInteger();
+    assertThrows(
+        AssertionError.class,
+        () ->
+            new PollingConditions(0.3)
+                .delay(0.02)
+                .factor(4)
+                .eventually(
+                    () -> {
+                      growing.incrementAndGet();
+                      fail("nope");
+                    }));
+
+    assertTrue(
+        growing.get() < constant.get(), "growing=" + growing.get() + " constant=" + constant.get());
+  }
+
+  @Test
+  void appliesInitialDelayBeforeFirstAttempt() {
+    AtomicInteger attempts = new AtomicInteger();
+    long start = System.currentTimeMillis();
+    new PollingConditions()
+        .timeout(2)
+        .initialDelay(0.05)
+        .delay(0.01)
+        .factor(1)
+        .eventually(attempts::incrementAndGet);
+    long elapsed = System.currentTimeMillis() - start;
+    assertEquals(1, attempts.get());
+    assertTrue(elapsed >= 40, "initial delay should have been applied, took " + elapsed + "ms");
+  }
+
+  @Test
+  void interruptedWhileWaitingFailsAndRestoresInterruptFlag() {
+    // Pre-interrupt so the first inter-attempt sleep throws InterruptedException immediately.
+    Thread.currentThread().interrupt();
+    try {
+      AssertionError error =
+          assertThrows(
+              AssertionError.class,
+              () -> new PollingConditions(2).delay(0.05).eventually(() -> fail("retry")));
+      assertEquals("Interrupted while waiting for condition", error.getMessage());
+      assertTrue(
+          Thread.currentThread().isInterrupted(), "interrupt flag should have been restored");
+    } finally {
+      // Clear the flag so it does not leak into other tests sharing this thread.
+      Thread.interrupted();
+    }
+  }
+}

--- a/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
+++ b/utils/test-utils/src/test/java/datadog/trace/test/util/PollingConditionsTest.java
@@ -134,6 +134,22 @@ class PollingConditionsTest {
     }
   }
 
+  @Test
+  void rejectsNegativeOrNanConfiguration() {
+    // Check conditions parameters
+    assertThrows(IllegalArgumentException.class, () -> new PollingConditions(-1));
+    assertThrows(IllegalArgumentException.class, () -> new PollingConditions().timeout(-1));
+    assertThrows(IllegalArgumentException.class, () -> new PollingConditions().initialDelay(-1));
+    assertThrows(IllegalArgumentException.class, () -> new PollingConditions().factor(-2));
+    // Check delay and within
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, () -> new PollingConditions().delay(-0.5));
+    assertTrue(error.getMessage().contains("delay"), error.getMessage());
+    assertTrue(error.getMessage().contains("-0.5"), error.getMessage());
+    assertThrows(
+        IllegalArgumentException.class, () -> new PollingConditions().within(-1, () -> {}));
+  }
+
   /** Captures the requested delays instead of sleeping, for deterministic back-off assertions. */
   private static final class RecordingPollingConditions extends PollingConditions {
     final List<Long> requestedSleeps = new ArrayList<>();


### PR DESCRIPTION
# What Does This Do

This PR improves Java testing capabilities.

It first adds a port of `PollingConditions` which is a way to repeatedly evaluates a block of assertions until they pass or a timeout elapses (`eventually(runnable)` - using default / configured timeout and `within(timeout, runnable)`).

Then it improves the trace / span matcher API to define parent span relation from span trace index - use the sorter option to define deterministic order first. It covers Groovy case like `childOf span(2)` with `childOfIndex(2)`.

# Motivation

Keep improving the testing experience.

# Additional Notes

The `test-utils` module was untested. So as I added a single tests, I had to exclude all other utils classes now that the code coverage tool is running on this module.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
