### PR TITLE
Fix buildSrc Gradle warnings

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPlugin.kt
@@ -56,7 +56,6 @@ class BuildTimeInstrumentationPlugin : Plugin<Project> {
       project.extensions.create<BuildTimeInstrumentationExtension>("buildTimeInstrumentation")
 
     project.configurations.register(BUILD_TIME_INSTRUMENTATION_PLUGIN_CONFIGURATION) {
-      isVisible = false
       isCanBeConsumed = false
       isCanBeResolved = true
     }

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/sca/ScaEnrichmentsPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/sca/ScaEnrichmentsPlugin.kt
@@ -4,7 +4,7 @@ import datadog.gradle.sca.GhsaEnrichmentParser
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import java.net.HttpURLConnection
-import java.net.URL
+import java.net.URI
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -90,7 +90,7 @@ class ScaEnrichmentsPlugin : Plugin<Project> {
   }
 
   private fun githubConnect(url: String, token: String?): HttpURLConnection {
-    val connection = URL(url).openConnection() as HttpURLConnection
+    val connection = URI.create(url).toURL().openConnection() as HttpURLConnection
     connection.setRequestProperty("Accept", "application/vnd.github+json")
     connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
     if (!token.isNullOrEmpty()) {

--- a/buildSrc/src/main/kotlin/dd-trace-java.gradle-debug.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.gradle-debug.gradle.kts
@@ -41,7 +41,7 @@ fun getJdkFromCompilerOptions(co: CompileOptions): String? {
 fun printJdkForProjectTasks(project: Project, logFile: File) {
   project.tasks.forEach { task ->
     val data = mutableMapOf<String, String>()
-    data["task"] = task.path.toString()
+    data["task"] = task.path
     if (task is JavaExec) {
       val launcher = task.javaLauncher.get()
       data["jdk"] = launcher.metadata.languageVersion.toString()


### PR DESCRIPTION
# What Does This Do
Fixes `buildSrc` Kotlin/Gradle warnings
1. `removed isVisible = false` - is deprecated and slated for removal in Gradle; the official guidance is simply to drop the call.
2. `URL(url) → URI.create(url).toURL()` - recommended way of fixing deprecated constructor.
3. `task.path.toString() → task.pat` - Task.getPath() already returns String, so .toString() was a redundant no-op.

# Motivation
Clean build log, without warnings.

# Additional Notes
Original warnings:
```
 > Task :compileKotlin                                                                                                                                                                                                                                         
    w: file:///Users/alexey.kuznetsov/work/dd-trace-java/buildSrc/src/main/kotlin/datadog/gradle/plugin/instrument/BuildTimeInstrumentationPlugin.kt:59:7 'var isVisible: Boolean' is deprecated. Deprecated in Java.
    w: file:///Users/alexey.kuznetsov/work/dd-trace-java/buildSrc/src/main/kotlin/datadog/gradle/plugin/sca/ScaEnrichmentsPlugin.kt:93:22 'constructor(p0: String!): URL' is deprecated. Deprecated in Java.
    w: file:///Users/alexey.kuznetsov/work/dd-trace-java/buildSrc/src/main/kotlin/dd-trace-java.gradle-debug.gradle.kts:44:30 Redundant call of conversion method.
```


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
