### PR TITLE
Fix javadoc warnings across modules

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/GenerationalUtf8Cache.java
+++ b/communication/src/main/java/datadog/communication/serialization/GenerationalUtf8Cache.java
@@ -136,7 +136,7 @@ public final class GenerationalUtf8Cache implements EncodingCache {
     return this.tenuredEntries.length;
   }
 
-  /** Updates access time used @link {@link #getUtf8(String, String)} to the provided value */
+  /** Updates the access time used by {@link #getUtf8(String)} to the provided value. */
   @SuppressFBWarnings("AT_NONATOMIC_64BIT_PRIMITIVE")
   public void updateAccessTime(long accessTimeMs) {
     this.accessTimeMs = accessTimeMs;

--- a/components/context/src/main/java/datadog/context/ContextKey.java
+++ b/components/context/src/main/java/datadog/context/ContextKey.java
@@ -3,7 +3,7 @@ package datadog.context;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * {@link Context} key that maps to a value of type {@link T}.
+ * {@link Context} key that maps to a value of type {@code T}.
  *
  * <p>Keys are compared by identity rather than by name. Each stored context type should either
  * share its key for re-use or implement {@link ImplicitContextKeyed} to keep its key private.

--- a/components/environment/src/main/java/datadog/environment/ThreadSupport.java
+++ b/components/environment/src/main/java/datadog/environment/ThreadSupport.java
@@ -24,8 +24,8 @@ public final class ThreadSupport {
   private ThreadSupport() {}
 
   /**
-   * Provides the best identifier available for the current {@link Thread}. Uses {@link
-   * Thread#threadId()} on 19+ or {@link Thread#getId()} on older JVMs.
+   * Provides the best identifier available for the current {@link Thread}. Uses {@code
+   * Thread.threadId()} on 19+ or {@link Thread#getId()} on older JVMs.
    *
    * @return The best identifier available for the current {@link Thread}.
    */
@@ -34,8 +34,8 @@ public final class ThreadSupport {
   }
 
   /**
-   * Provides the best identifier available for the given {@link Thread}. Uses {@link
-   * Thread#threadId()} on 19+ or {@link Thread#getId()} on older JVMs.
+   * Provides the best identifier available for the given {@link Thread}. Uses {@code
+   * Thread.threadId()} on 19+ or {@link Thread#getId()} on older JVMs.
    *
    * @return The best identifier available for the given {@link Thread}.
    */

--- a/components/json/src/main/java/datadog/json/JsonMapper.java
+++ b/components/json/src/main/java/datadog/json/JsonMapper.java
@@ -69,7 +69,7 @@ public final class JsonMapper {
   }
 
   /**
-   * Converts a {@link Iterable<String>} to a JSON array.
+   * Converts a {@code Iterable<String>} to a JSON array.
    *
    * @param items The iterable to convert.
    * @return The converted JSON array as Java string.
@@ -132,10 +132,10 @@ public final class JsonMapper {
   }
 
   /**
-   * Parses a JSON string array into a {@link List<String>}.
+   * Parses a JSON string array into a {@code List<String>}.
    *
    * @param json The JSON string array to parse.
-   * @return A {@link List<String>} containing the parsed JSON strings.
+   * @return A {@code List<String>} containing the parsed JSON strings.
    * @throws IOException If the JSON is invalid or a reader error occurs.
    */
   public static List<String> fromJsonToList(String json) throws IOException {

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
@@ -61,8 +61,8 @@ public class Blocking {
   }
 
   /**
-   * Equivalent to calling {@link #tryCommitBlockingResponse(int, BlockingContentType, Map<String,
-   * String>)} with the last parameter being an empty map.
+   * Equivalent to calling {@link #tryCommitBlockingResponse(int, BlockingContentType, Map)} with
+   * the last parameter being an empty map.
    *
    * @param statusCode the status code of the response
    * @param contentType the content-type of the response.

--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -86,7 +86,7 @@ public class GlobalTracer {
   }
 
   /**
-   * @deprecated use static methods in {@link EventTrackerV2} directly
+   * @deprecated use static methods in {@link datadog.appsec.api.login.EventTrackerV2} directly
    */
   @Deprecated
   public static EventTracker getEventTracker() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -29,9 +29,9 @@ public interface MutableSpan {
   Integer getSamplingPriority();
 
   /**
-   * @param newPriority
-   * @return
-   * @deprecated Use {@link io.opentracing.Span#setTag(String, boolean)} instead using either tag
+   * @param newPriority the sampling priority to set
+   * @return this {@link MutableSpan} instance, for chaining
+   * @deprecated Use {@code io.opentracing.Span#setTag(String, boolean)} instead using either tag
    *     names {@link datadog.trace.api.DDTags#MANUAL_KEEP} or {@link
    *     datadog.trace.api.DDTags#MANUAL_DROP}.
    */

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
@@ -132,8 +132,8 @@ public interface TraceSegment {
    *
    * @param field field name
    * @param value value of the data
-   * @see datadog.trace.common.writer.ddagent.TraceMapperV0_4.MetaStructWriter
-   * @see datadog.trace.core.CoreSpan#setMetaStruct(String, Object)
+   * @see "datadog.trace.common.writer.ddagent.TraceMapperV0_4.MetaStructWriter"
+   * @see "datadog.trace.core.CoreSpan#setMetaStruct(String, Object)"
    */
   void setMetaStructCurrent(String field, Object value);
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -108,10 +108,10 @@ public class SpanSamplingRules {
     }
 
     /**
-     * Validate and create a {@link Rule} from its {@link JsonRule} representation.
+     * Validate and create a {@link Rule} from its {@code JsonRule} representation.
      *
-     * @param jsonRule The {@link JsonRule} to validate.
-     * @return A {@link Rule} if the {@link JsonRule} is valid, {@code null} otherwise.
+     * @param jsonRule The {@code JsonRule} to validate.
+     * @return A {@link Rule} if the {@code JsonRule} is valid, {@code null} otherwise.
      */
     public static Rule create(JsonRule jsonRule) {
       String service = SamplingRule.normalizeGlob(jsonRule.service);

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -87,10 +87,10 @@ public class TraceSamplingRules {
     }
 
     /**
-     * Validate and create a {@link Rule} from its {@link JsonRule} representation.
+     * Validate and create a {@link Rule} from its {@code JsonRule} representation.
      *
-     * @param jsonRule The {@link JsonRule} to validate.
-     * @return A {@link Rule} if the {@link JsonRule} is valid, {@code null} otherwise.
+     * @param jsonRule The {@code JsonRule} to validate.
+     * @return A {@link Rule} if the {@code JsonRule} is valid, {@code null} otherwise.
      */
     public static Rule create(JsonRule jsonRule) {
       String service = SamplingRule.normalizeGlob(jsonRule.service);

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -5657,9 +5657,9 @@ public class Config {
   }
 
   /**
-   * @param integrationNames
-   * @param defaultEnabled
-   * @return
+   * @param integrationNames the integration names to check
+   * @param defaultEnabled the value to return when no integration name is configured
+   * @return {@code true} if the JMX fetch integration is enabled
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
    *     #isJmxFetchIntegrationEnabled(Iterable, boolean)}.
    */
@@ -5826,9 +5826,9 @@ public class Config {
   }
 
   /**
-   * @param integrationNames
-   * @param defaultEnabled
-   * @return
+   * @param integrationNames the integration names to check
+   * @param defaultEnabled the value to return when no integration name is configured
+   * @return {@code true} if the trace analytics integration is enabled
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
    *     #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
    */

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -198,8 +198,8 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
    * Similar to {@link Map#putAll(Map)} but optimized to quickly copy from one TagMap to another
    *
    * <p>For optimized TagMaps, this method takes advantage of the consistent TagMap layout to
-   * quickly handle each bucket. And similar to {@link TagMap#(Entry)} this method shares Entry
-   * objects from the source TagMap
+   * quickly handle each bucket. And similar to {@link TagMap#getAndSet(Entry)} this method shares
+   * Entry objects from the source TagMap
    */
   void putAll(TagMap that);
 
@@ -989,7 +989,7 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
      * Provides the estimated size of the map created by the ledger Doesn't account for overwritten
      * entries or entry removal
      *
-     * @return
+     * @return the estimated size of the map created by the ledger
      */
     public int estimateSize() {
       return this.nextPos;

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -51,14 +51,14 @@ public interface NamingSchema {
   /**
    * Policy for peer service tags calculation
    *
-   * @return
+   * @return the peer service naming policy
    */
   ForPeerService peerService();
 
   /**
    * If true, the schema allows having service names != DD_SERVICE
    *
-   * @return
+   * @return {@code true} if the schema allows service names different from {@code DD_SERVICE}
    */
   boolean allowInferredServices();
 
@@ -222,7 +222,7 @@ public interface NamingSchema {
     /**
      * Whenever the schema supports peer service calculation
      *
-     * @return
+     * @return {@code true} if the schema supports peer service calculation
      */
     boolean supports();
 

--- a/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
@@ -57,7 +57,7 @@ public class ServiceNameCollector {
    * Get the list of unique services deduplicated by case. There is no locking on the addService map
    * so, the method is not thread safe.
    *
-   * @return
+   * @return the list of unique services, or {@code null} if none have been collected
    */
   @Nullable
   public List<String> getServices() {

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -74,9 +74,9 @@ public class SamplingMechanism {
   /**
    * Returns true if sampling priority lock can be avoided for the given mechanism and priority
    *
-   * @param mechanism
-   * @param priority
-   * @return
+   * @param priority the sampling priority
+   * @param mechanism the sampling mechanism
+   * @return {@code true} if the sampling priority lock can be avoided, {@code false} otherwise
    */
   public static boolean canAvoidSamplingPriorityLock(int priority, int mechanism) {
     return (!Config.get().isApmTracingEnabled() && mechanism == SamplingMechanism.APPSEC)

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
@@ -37,7 +37,7 @@ public interface URIDataAdapter {
   /**
    * The URI is a valid one or not (looks malformed)
    *
-   * @return
+   * @return {@code true} if the URI is valid, {@code false} if it looks malformed
    */
   boolean isValid();
 }

--- a/internal-api/src/main/java/datadog/trace/util/Hashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/Hashtable.java
@@ -618,8 +618,7 @@ public final class Hashtable {
 
   /**
    * Mutating iterator over entries in a single bucket whose {@code keyHash} matches a specific
-   * search hash. Supports {@link #remove()} and {@link #replace(Entry)} to splice the chain in
-   * place.
+   * search hash. Supports {@link #remove()} and {@link #replace} to splice the chain in place.
    *
    * <p>Carries previous-node pointers for the current entry and the next-match entry so that {@code
    * remove} and {@code replace} can fix up the chain in O(1) without re-walking from the bucket

--- a/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
+++ b/utils/junit-utils/src/main/java/datadog/trace/junit/utils/config/WithConfig.java
@@ -18,16 +18,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <p>Examples:
  *
- * <pre>{@code
- * @WithConfig(key = "service", value = "my_service")
- * @WithConfig(key = "trace.resolver.enabled", value = "false")
+ * <pre>
+ * &#64;WithConfig(key = "service", value = "my_service")
+ * &#64;WithConfig(key = "trace.resolver.enabled", value = "false")
  * class MyTest extends DDJavaSpecification {
  *
- *   @Test
- *   @WithConfig(key = "AGENT_HOST", value = "localhost", env = true)
+ *   &#64;Test
+ *   &#64;WithConfig(key = "AGENT_HOST", value = "localhost", env = true)
  *   void testWithEnv() { ... }
  * }
- * }</pre>
+ * </pre>
  */
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
@@ -15,6 +15,26 @@ public class ThreadUtils {
     void run() throws Throwable;
   }
 
+  /**
+   * Utility to easily run a piece of code in parallel, e.g. in a JUnit test like this:
+   *
+   * <pre>{@code
+   * runConcurrently(
+   *     10,
+   *     100,
+   *     () -> {
+   *       Object something = computeSomething();
+   *       Object other = computeOther();
+   *       assertEquals(something, other);
+   *     });
+   * }</pre>
+   *
+   * @param concurrency the number of concurrent invocations
+   * @param totalInvocations the total number of invocations
+   * @param runnable the code to run
+   * @return {@code true} if everything went well
+   * @throws Throwable if anything went wrong
+   */
   public static boolean runConcurrently(
       final int concurrency, final int totalInvocations, final ThrowingRunnable runnable)
       throws Throwable {
@@ -36,30 +56,7 @@ public class ThreadUtils {
         });
   }
 
-  /**
-   * Utility to easily run a Closure in parallel, i.e. in spock like this:
-   *
-   * <pre>{@code
-   * def "some test"() {
-   *   expect:
-   *   runConcurrently(10, 100, {
-   *     def something = ...
-   *     def other = ...
-   *     assert something == other
-   *   })
-   * }
-   * }</pre>
-   *
-   * Writing a spock extension was investigated, but it is not possible to run an Invocation
-   * multiple times concurrently since a lot of the spock internal state and mock scoping is not
-   * thread safe.
-   *
-   * @param concurrency the number of concurrent invocations
-   * @param totalInvocations the total number of invocations
-   * @param closure the closure to run
-   * @return {@code true} if everything went well
-   * @throws Throwable if anything went wrong
-   */
+  /** Groovy/Spock variant of {@link #runConcurrently(int, int, ThrowingRunnable)}. */
   public static boolean runConcurrently(
       final int concurrency, final int totalInvocations, final Closure<Void> closure)
       throws Throwable {

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
@@ -56,7 +56,6 @@ public class ThreadUtils {
         });
   }
 
-  /** Groovy/Spock variant of {@link #runConcurrently(int, int, ThrowingRunnable)}. */
   public static boolean runConcurrently(
       final int concurrency, final int totalInvocations, final Closure<Void> closure)
       throws Throwable {

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ThreadUtils.java
@@ -9,30 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ThreadUtils {
 
-  /**
-   * Utility to easily run a Closure in parallel, i.e. in spock like this:
-   *
-   * <pre>{@code
-   * def "some test"() {
-   *   expect:
-   *   runConcurrently(10, 100, {
-   *     def something = ...
-   *     def other = ...
-   *     assert something == other
-   *   })
-   * }
-   * }</pre>
-   *
-   * Writing a spock extension was investigated, but it is not possible to run an Invocation
-   * multiple times concurrently since a lot of the spock internal state and mock scoping is not
-   * thread safe.
-   *
-   * @param concurrency the number of concurrent invocations
-   * @param totalInvocations the total number of invocations
-   * @param closure the closure to run
-   * @return true if everything went well
-   * @throws Throwable if anything went wrong
-   */
+  /** A {@link Runnable} whose {@link #run()} may throw a checked exception. */
   @FunctionalInterface
   public interface ThrowingRunnable {
     void run() throws Throwable;
@@ -59,6 +36,30 @@ public class ThreadUtils {
         });
   }
 
+  /**
+   * Utility to easily run a Closure in parallel, i.e. in spock like this:
+   *
+   * <pre>{@code
+   * def "some test"() {
+   *   expect:
+   *   runConcurrently(10, 100, {
+   *     def something = ...
+   *     def other = ...
+   *     assert something == other
+   *   })
+   * }
+   * }</pre>
+   *
+   * Writing a spock extension was investigated, but it is not possible to run an Invocation
+   * multiple times concurrently since a lot of the spock internal state and mock scoping is not
+   * thread safe.
+   *
+   * @param concurrency the number of concurrent invocations
+   * @param totalInvocations the total number of invocations
+   * @param closure the closure to run
+   * @return {@code true} if everything went well
+   * @throws Throwable if anything went wrong
+   */
   public static boolean runConcurrently(
       final int concurrency, final int totalInvocations, final Closure<Void> closure)
       throws Throwable {


### PR DESCRIPTION
# What Does This Do

Fixes javadoc warnings reported by `./gradlew javadoc` across several modules. Doc-only changes — no behavior change. Fixes fall into a few categories:

- **Broken `{@link}` references**: type variables (`{@link T}`), generics in links (`{@link List<String>}`), wrong/missing method signatures, and references to types not on the module's javadoc classpath (e.g. `io.opentracing.*`, JDK 19+ `Thread.threadId()`, cross-module classes). Replaced with `{@code …}`, fully-qualified names, or erasure-style method links as appropriate.
- **Empty `@return`/`@param` tags**: filled with concise descriptions, wrapping literals like `true`/`false`/`null` and constants in `{@code}`.
- **Annotations inside `{@code}` blocks** (`WithConfig.java`): leading `@` on a line is parsed as a block tag even inside `{@code}`, so switched to `<pre>` with `&#64;`-escaped annotations.
- **Misplaced method tags** (`ThreadUtils.java`): moved a doc comment with `@param`/`@return`/`@throws` off the `ThrowingRunnable` interface onto the `runConcurrently(…, Closure)` method it actually describes.

# Motivation

Reduce build noise so real javadoc problems are easier to spot.

# Additional Notes

- Verified with `./gradlew javadoc --rerun-tasks --continue`: no remaining doc warnings (only pre-existing `source/target value 8 is obsolete` and `sun.misc.*`/`sun.rmi.*` internal-API warnings remain, unrelated to this change).
- `spotlessCheck` passes on all touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)