### PR TITLE
Fix gradle-debug failing on configuration resolution

### DIFF
--- a/buildSrc/src/main/kotlin/dd-trace-java.gradle-debug.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.gradle-debug.gradle.kts
@@ -1,6 +1,26 @@
 /*
  * Gradle debugging plugin for dd-trace-java builds.
+ *
+ * Logs the JDK used by each scheduled task to diagnose unexpected Java versions.
+ *
+ * Usage:
+ *   ./gradlew <task> -PddGradleDebug      e.g. ./gradlew assemble -PddGradleDebug
+ *
+ * Only tasks in the execution graph of the requested command are reported, so run it
+ * against a real task (e.g. `build`, `:module:test`); `help` reports almost nothing.
+ *
+ * Output: build/datadog.gradle-debug.log (one JSON object per task), e.g.
+ *   {"task":":dd-trace-api:compileJava", "jdk":"8"}
+ *   {"task":":dd-trace-api:test", "jdk":"11"}
+ *
+ * "jdk":"unknown" means the task type carries no JVM (e.g. lifecycle/aggregate tasks like
+ * `classes` or `assemble`, copy/`Sync` tasks); only Java/Groovy/Scala compile, Test, JavaExec,
+ * Javadoc and Exec tasks report a version.
  */
+
+import org.gradle.api.Action
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionGraph
 
 val ddGradleDebugEnabled = project.hasProperty("ddGradleDebug")
 val logPath = rootProject.layout.buildDirectory.file("datadog.gradle-debug.log")
@@ -38,8 +58,8 @@ fun getJdkFromCompilerOptions(co: CompileOptions): String? {
   return null
 }
 
-fun printJdkForProjectTasks(project: Project, logFile: File) {
-  project.tasks.forEach { task ->
+fun printJdkForTasks(tasks: Iterable<Task>, logFile: File) {
+  tasks.forEach { task ->
     val data = mutableMapOf<String, String>()
     data["task"] = task.path
     if (task is JavaExec) {
@@ -83,23 +103,12 @@ fun printJdkForProjectTasks(project: Project, logFile: File) {
   }
 }
 
-class DebugBuildListener : org.gradle.BuildListener {
-  override fun settingsEvaluated(settings: Settings) = Unit
-
-  override fun projectsLoaded(gradle: Gradle) = Unit
-
-  override fun buildFinished(result: BuildResult) = Unit
-
-  override fun projectsEvaluated(gradle: Gradle) {
-    val logFile = logPath.get().asFile
-    logFile.writeText("")
-    gradle.rootProject.allprojects.forEach { project ->
-      printJdkForProjectTasks(project, logFile)
-    }
-  }
-}
-
 if (ddGradleDebugEnabled) {
   logger.lifecycle("datadog.gradle-debug plugin is enabled")
-  gradle.addListener(DebugBuildListener())
+  // Inspect tasks once the execution graph is ready, when scheduled tasks are fully configured.
+  gradle.taskGraph.whenReady(Action<TaskExecutionGraph> {
+    val logFile = logPath.get().asFile
+    logFile.writeText("")
+    printJdkForTasks(allTasks, logFile)
+  })
 }


### PR DESCRIPTION
# What Does This Do

Fixes `./gradlew <task> -PddGradleDebug` failing with:

```
Could not create task ':...:mule-4.5:extractMuleServices'.
> Resolution of the configuration ':...:mule-4.5:muleServices' was attempted without an exclusive lock. This is unsafe and not allowed.
```

The `gradle-debug` plugin now inspects tasks from `gradle.taskGraph.whenReady` (after the execution graph is built and scheduled tasks are fully configured) instead of force-realizing every task in every project from `projectsEvaluated`.

# Motivation

The old code iterated `project.tasks` inside a `projectsEvaluated` `BuildListener`. Iterating the task container *realizes* every lazily-registered task, running its configuration action. Some tasks (e.g. mule's `extractMuleServices`, a `Sync` task) resolve a configuration in that action via `resolvedConfiguration.resolvedArtifacts`. `projectsEvaluated` runs **without the project's exclusive lock**, and current Gradle forbids resolving a configuration there — so the whole build aborted, even for unrelated commands like `help`.

Moving to `taskGraph.whenReady` fixes the root cause: at that point the scheduled tasks are already configured under the proper lock, so reading them is safe. It also avoids needlessly realizing every task in the ~200-module tree.

# Additional Notes

- Behavioral change: the log now covers tasks in the **execution graph** of the requested command rather than literally every task. Run it against a real task (`build`, `:module:test`); `help` reports almost nothing.
- Added short usage docs to the plugin header (how to run, where the log lands, meaning of `"jdk":"unknown"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)