### PR TITLE
Allow Maven deployment to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1238,6 +1238,7 @@ deploy_to_maven_central:
     # Do not deploy release candidate versions
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
+      allow_failure: true
     - when: manual
       allow_failure: true
   script:


### PR DESCRIPTION
# What Does This Do

Allow Maven Central deployment job to fail. 

The result of this change is that the `verify_maven_central_deployment` job that depends on `deploy_to_maven_central` will run as long as `deploy_to_maven_central` _completes_. Without this change, the `verify_maven_central_deployment` job only runs if `deploy_to_maven_central` _succeeds._

# Motivation

With the `1.63.1` patch release, pipeline failures resulted in the successful publishing of artifacts onto Maven Central but not of OCI images. Also, OCI image publishing is gated via a `publishing-job` that is gated by Maven Central deployment verification.

After fixing the pipeline issue, we wanted to re-run the pipeline and override the Maven Central deployment verification to allow the OCI publishing. This should be possible with the manually triggered `override_verify_maven_central` job, but since `deploy_to_maven_central` failed (release already exists), `verify_maven_central_deployment` could never run.

By allowing the deployment to fail and the verification to run regardless, the override should now work. 

# Additional Notes

If the override job is not run and the initial deployment fails, the verification would run and still fail as well, still properly gating the `publishing-gate`.

The Maven Central publishing jobs only run on protected git tags.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
