### PR TITLE
Extend OTLP HTTP coverage to GRPC

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -54,7 +54,12 @@ excludedClassesCoverage += [
   // TODO CorePropagation will be removed during context refactoring
   'datadog.trace.core.propagation.CorePropagation',
   // TODO DSM propagator will be tested once fully migrated
-  'datadog.trace.core.datastreams.DataStreamPropagator'
+  'datadog.trace.core.datastreams.DataStreamPropagator',
+  // send() requires live HTTP/2 server
+  'datadog.trace.core.otlp.common.OtlpGrpcSender',
+  // covered by OTLP system-tests
+  'datadog.trace.core.otlp.logs.OtlpLogsService',
+  'datadog.trace.core.otlp.metrics.OtlpMetricsService'
 ]
 
 addTestSuite('traceAgentTest')

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpGrpcRequestBodyTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpGrpcRequestBodyTest.java
@@ -1,0 +1,91 @@
+package datadog.trace.core.otlp.common;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPInputStream;
+import okhttp3.MediaType;
+import okio.Buffer;
+import org.junit.jupiter.api.Test;
+
+class OtlpGrpcRequestBodyTest {
+
+  @Test
+  void contentTypeIsApplicationGrpc() {
+    OtlpGrpcRequestBody body =
+        new OtlpGrpcRequestBody(
+            new OtlpPayload(ByteBuffer.wrap(new byte[] {1, 2, 3}), "application/grpc+proto"),
+            false);
+
+    assertEquals(MediaType.get("application/grpc"), body.contentType());
+  }
+
+  @Test
+  void contentLengthIsHeaderPlusPayloadWhenUncompressed() {
+    OtlpGrpcRequestBody body =
+        new OtlpGrpcRequestBody(
+            new OtlpPayload(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}), "application/grpc+proto"),
+            false);
+
+    // 5-byte header (1 flag + 4 length) + 4-byte payload = 9
+    assertEquals(9, body.contentLength());
+  }
+
+  @Test
+  void contentLengthIsNegativeOneWhenGzipped() {
+    OtlpGrpcRequestBody body =
+        new OtlpGrpcRequestBody(
+            new OtlpPayload(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}), "application/grpc+proto"),
+            true);
+
+    assertEquals(-1, body.contentLength());
+  }
+
+  @Test
+  void writeToProducesGrpcFrameWithUncompressedFlagWhenNotGzipped() throws IOException {
+    byte[] data = {10, 20, 30, 40, 50};
+    OtlpGrpcRequestBody body =
+        new OtlpGrpcRequestBody(
+            new OtlpPayload(ByteBuffer.wrap(data), "application/grpc+proto"), false);
+    Buffer sink = new Buffer();
+
+    body.writeTo(sink);
+
+    assertEquals(0, sink.readByte()); // uncompressed flag
+    assertEquals(data.length, sink.readInt()); // 4-byte big-endian length
+    assertArrayEquals(data, sink.readByteArray()); // payload
+  }
+
+  @Test
+  void writeToProducesGrpcFrameWithCompressedFlagAndGzipDataWhenGzipped() throws IOException {
+    byte[] data = "the quick brown fox jumps over the lazy dog".getBytes();
+    OtlpGrpcRequestBody body =
+        new OtlpGrpcRequestBody(
+            new OtlpPayload(ByteBuffer.wrap(data), "application/grpc+proto"), true);
+    Buffer sink = new Buffer();
+
+    body.writeTo(sink);
+
+    assertEquals(1, sink.readByte()); // compressed flag
+    int gzipLength = sink.readInt(); // 4-byte big-endian gzip content length
+    byte[] gzipped = sink.readByteArray(gzipLength);
+    assertArrayEquals(data, gunzip(gzipped));
+  }
+
+  private static byte[] gunzip(byte[] gzipped) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (InputStream gz = new GZIPInputStream(new ByteArrayInputStream(gzipped))) {
+      byte[] buf = new byte[256];
+      int n;
+      while ((n = gz.read(buf)) > 0) {
+        out.write(buf, 0, n);
+      }
+    }
+    return out.toByteArray();
+  }
+}


### PR DESCRIPTION
# Motivation

Close the coverage gap for OTLP GRPC classes.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
