### PR TITLE
Add coverage and exclusions for dsm classes

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -51,6 +51,12 @@ excludedClassesCoverage += [
   'datadog.trace.core.TracingConfigPoller.Updater',
   // covered with dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/CheckpointerTest.groovy
   'datadog.trace.core.datastreams.DefaultDataStreamsMonitoring',
+  // no-op
+  'datadog.trace.core.datastreams.DisabledDataStreamsMonitoring',
+  // pojo
+  'datadog.trace.core.datastreams.DataStreamsTransactionExtractors.DataStreamsTransactionExtractorImpl',
+  // it's a private inner class. Tested indirectly via deserialize in DataStreamsTransactionExtractorsTest
+  'datadog.trace.core.datastreams.DataStreamsTransactionExtractors.JsonDataStreamsTransactionExtractor',
   // TODO CorePropagation will be removed during context refactoring
   'datadog.trace.core.propagation.CorePropagation',
   // TODO DSM propagator will be tested once fully migrated

--- a/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsTransactionExtractorsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsTransactionExtractorsTest.java
@@ -2,7 +2,11 @@ package datadog.trace.core.datastreams;
 
 import static datadog.trace.api.datastreams.DataStreamsTransactionExtractor.Type.HTTP_IN_HEADERS;
 import static datadog.trace.api.datastreams.DataStreamsTransactionExtractor.Type.HTTP_OUT_HEADERS;
+import static datadog.trace.api.datastreams.DataStreamsTransactionExtractor.Type.KAFKA_CONSUME_HEADERS;
+import static datadog.trace.api.datastreams.DataStreamsTransactionExtractor.Type.KAFKA_PRODUCE_HEADERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.api.datastreams.DataStreamsTransactionExtractor;
 import datadog.trace.core.DDCoreJavaSpecification;
@@ -27,5 +31,65 @@ public class DataStreamsTransactionExtractorsTest extends DDCoreJavaSpecificatio
     assertEquals("second_extractor", extractors.get(1).getName());
     assertEquals(HTTP_IN_HEADERS, extractors.get(1).getType());
     assertEquals("transaction_id", extractors.get(1).getValue());
+  }
+
+  @Test
+  void deserializeKafkaTypes() {
+    DataStreamsTransactionExtractors list =
+        DataStreamsTransactionExtractors.deserialize(
+            "["
+                + "{\"name\": \"consume\", \"type\": \"KAFKA_CONSUME_HEADERS\", \"value\": \"txn\"},"
+                + "{\"name\": \"produce\", \"type\": \"KAFKA_PRODUCE_HEADERS\", \"value\": \"txn\"}"
+                + "]");
+    List<DataStreamsTransactionExtractor> extractors = list.getExtractors();
+
+    assertEquals(2, extractors.size());
+    assertEquals(KAFKA_CONSUME_HEADERS, extractors.get(0).getType());
+    assertEquals(KAFKA_PRODUCE_HEADERS, extractors.get(1).getType());
+  }
+
+  @Test
+  void deserializeUnknownTypeReturnsEmpty() {
+    DataStreamsTransactionExtractors list =
+        DataStreamsTransactionExtractors.deserialize(
+            "[{\"name\": \"ext\", \"type\": \"NOT_A_REAL_TYPE\", \"value\": \"v\"}]");
+
+    assertSame(DataStreamsTransactionExtractors.EMPTY, list);
+    assertTrue(list.getExtractors().isEmpty());
+  }
+
+  @Test
+  void deserializeEmptyArrayReturnsEmptyList() {
+    DataStreamsTransactionExtractors list = DataStreamsTransactionExtractors.deserialize("[]");
+
+    assertTrue(list.getExtractors().isEmpty());
+  }
+
+  @Test
+  void deserializeInvalidJsonReturnsEmpty() {
+    DataStreamsTransactionExtractors list =
+        DataStreamsTransactionExtractors.deserialize("not valid json");
+
+    assertSame(DataStreamsTransactionExtractors.EMPTY, list);
+    assertTrue(list.getExtractors().isEmpty());
+  }
+
+  @Test
+  void deserializeNullJsonReturnsEmpty() {
+    DataStreamsTransactionExtractors list = DataStreamsTransactionExtractors.deserialize("null");
+
+    assertTrue(list.getExtractors().isEmpty());
+  }
+
+  @Test
+  void implToStringContainsFields() {
+    DataStreamsTransactionExtractors list =
+        DataStreamsTransactionExtractors.deserialize(
+            "[{\"name\": \"myext\", \"type\": \"HTTP_OUT_HEADERS\", \"value\": \"myval\"}]");
+    String str = list.getExtractors().get(0).toString();
+
+    assertTrue(str.contains("myext"));
+    assertTrue(str.contains("HTTP_OUT_HEADERS"));
+    assertTrue(str.contains("myval"));
   }
 }

--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -66,7 +66,9 @@ extra["excludedClassesCoverage"] = listOf(
   "datadog.trace.api.profiling.RecordingType",
   // Data Streams Monitoring
   "datadog.trace.api.datastreams.Backlog",
+  "datadog.trace.api.datastreams.DataStreamsTransactionExtractor.Type", // enum
   "datadog.trace.api.datastreams.InboxItem",
+  "datadog.trace.api.datastreams.KafkaConfigReport", // pojo
   "datadog.trace.api.datastreams.NoopDataStreamsMonitoring",
   "datadog.trace.api.datastreams.NoopPathwayContext",
   "datadog.trace.api.datastreams.SchemaRegistryUsage",


### PR DESCRIPTION
# What Does This Do

Add coverage and exclusions for dsm classes

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
