### PR TITLE
Update Code Coverage for `config-utils`

### DIFF
--- a/utils/config-utils/build.gradle.kts
+++ b/utils/config-utils/build.gradle.kts
@@ -32,7 +32,8 @@ extra["excludedClassesCoverage"] = listOf(
   "datadog.trace.bootstrap.config.provider.stableconfig.Selector",
   // tested in internal-api
   "datadog.trace.bootstrap.config.provider.StableConfigParser",
-  "datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource"
+  "datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource",
+  "datadog.trace.config.inversion.SupportedConfiguration"
 )
 
 extra["excludedClassesBranchCoverage"] = listOf(

--- a/utils/config-utils/src/test/java/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.java
+++ b/utils/config-utils/src/test/java/datadog/trace/bootstrap/config/provider/StableConfigSourceTest.java
@@ -294,6 +294,34 @@ public class StableConfigSourceTest extends DDJavaSpecification {
     }
   }
 
+  @Test
+  void testStableConfigGetHandlesPresentAndMissingKeys() {
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put("DD_SERVICE", "test-service");
+    configMap.put("DD_PORT", 8126);
+
+    StableConfigSource.StableConfig config =
+        new StableConfigSource.StableConfig("config-123", configMap);
+
+    // Present String value: hits the non-null branch of the ternary in get()
+    assertEquals("test-service", config.get("DD_SERVICE"));
+    // Present non-String value: exercises String.valueOf on a non-null, non-String object
+    assertEquals("8126", config.get("DD_PORT"));
+    // Missing key: hits the null branch of the ternary in get()
+    assertNull(config.get("DD_MISSING"));
+
+    assertEquals("config-123", config.getConfigId());
+    assertEquals(configMap.keySet(), config.getKeys());
+  }
+
+  @Test
+  void testStableConfigEmpty() {
+    StableConfigSource.StableConfig empty = StableConfigSource.StableConfig.EMPTY;
+    assertNull(empty.get("DD_SERVICE"));
+    assertNull(empty.getConfigId());
+    assertEquals(0, empty.getKeys().size());
+  }
+
   private static void writeFileYaml(
       Path filePath, String configId, Map<String, String> defaultConfigs) throws IOException {
     Map<String, Object> yamlData = new HashMap<>();

--- a/utils/config-utils/src/test/java/datadog/trace/bootstrap/config/provider/stableconfig/RuleTest.java
+++ b/utils/config-utils/src/test/java/datadog/trace/bootstrap/config/provider/stableconfig/RuleTest.java
@@ -1,0 +1,85 @@
+package datadog.trace.bootstrap.config.provider.stableconfig;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RuleTest {
+
+  @Test
+  void testNoArgConstructorYieldsEmptyState() {
+    Rule rule = new Rule();
+    assertTrue(rule.getSelectors().isEmpty());
+    assertTrue(rule.getConfiguration().isEmpty());
+  }
+
+  @Test
+  void testConstructorExposesValuesViaGetters() {
+    Selector selector = new Selector("process_arguments", "-Dfoo", asList("bar"), "equals");
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("DD_SERVICE", "test");
+
+    Rule rule = new Rule(asList(selector), configuration);
+
+    assertEquals(1, rule.getSelectors().size());
+    assertSame(selector, rule.getSelectors().get(0));
+    assertSame(configuration, rule.getConfiguration());
+  }
+
+  @Test
+  void testFromParsesValidRule() {
+    Map<String, Object> selectorMap = new LinkedHashMap<>();
+    selectorMap.put("origin", "process_arguments");
+    selectorMap.put("key", "-Dfoo");
+    selectorMap.put("matches", asList("bar"));
+    selectorMap.put("operator", "equals");
+
+    Map<String, Object> configuration = new LinkedHashMap<>();
+    configuration.put("DD_SERVICE", "test");
+
+    Map<String, Object> ruleMap = new LinkedHashMap<>();
+    ruleMap.put("selectors", asList(selectorMap));
+    ruleMap.put("configuration", configuration);
+
+    Rule rule = Rule.from(ruleMap);
+
+    List<Selector> selectors = rule.getSelectors();
+    assertEquals(1, selectors.size());
+    Selector selector = selectors.get(0);
+    assertEquals("process_arguments", selector.getOrigin());
+    assertEquals("-Dfoo", selector.getKey());
+    assertEquals(asList("bar"), selector.getMatches());
+    assertEquals("equals", selector.getOperator());
+
+    assertEquals("test", rule.getConfiguration().get("DD_SERVICE"));
+  }
+
+  @Test
+  void testFromSkipsNullSelectorEntries() {
+    Map<String, Object> selectorMap = new LinkedHashMap<>();
+    selectorMap.put("origin", "process_arguments");
+    selectorMap.put("key", "-Dfoo");
+    selectorMap.put("matches", asList("bar"));
+    selectorMap.put("operator", "equals");
+
+    Map<String, Object> configuration = new LinkedHashMap<>();
+    configuration.put("DD_SERVICE", "test");
+
+    Map<String, Object> ruleMap = new LinkedHashMap<>();
+    ruleMap.put("selectors", asList(null, selectorMap));
+    ruleMap.put("configuration", configuration);
+
+    Rule rule = Rule.from(ruleMap);
+
+    // The null entry is filtered out, leaving only the valid selector.
+    assertEquals(1, rule.getSelectors().size());
+    assertEquals("process_arguments", rule.getSelectors().get(0).getOrigin());
+  }
+}


### PR DESCRIPTION
# What Does This Do
Update Code Coverage for `config-utils`
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
