### PR TITLE
Remove default methods from CoreSpan; implement them in test doubles

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -36,8 +36,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.DDSpan.1',
   'datadog.trace.core.tagprocessor.QueryObfuscator.1',
   'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler',
-  // Interfaces with default methods that are overridden by all concrete implementations
-  'datadog.trace.core.CoreSpan',
+  // Interface with an empty defender method
   'datadog.trace.core.propagation.HttpCodec.Extractor',
   'datadog.trace.llmobs.writer.ddintake.LLMObsSpanMapper',
   'datadog.trace.llmobs.writer.ddintake.LLMObsSpanMapper.PayloadV1',

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -36,7 +36,8 @@ excludedClassesCoverage += [
   'datadog.trace.core.DDSpan.1',
   'datadog.trace.core.tagprocessor.QueryObfuscator.1',
   'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler',
-  // Interface with an empty defender method
+  // Interfaces with default methods that are overridden by all concrete implementations
+  'datadog.trace.core.CoreSpan',
   'datadog.trace.core.propagation.HttpCodec.Extractor',
   'datadog.trace.llmobs.writer.ddintake.LLMObsSpanMapper',
   'datadog.trace.llmobs.writer.ddintake.LLMObsSpanMapper.PayloadV1',

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -1,7 +1,6 @@
 package datadog.trace.core;
 
 import datadog.trace.api.DDTraceId;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.util.Map;
 
 public interface CoreSpan<T extends CoreSpan<T>> {
@@ -10,9 +9,7 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   String getServiceName();
 
-  default CharSequence getServiceNameSource() {
-    return null;
-  }
+  CharSequence getServiceNameSource();
 
   CharSequence getOperationName();
 
@@ -62,13 +59,9 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   <U> U getTag(CharSequence name);
 
-  default <U> U unsafeGetTag(CharSequence name, U defaultValue) {
-    return getTag(name, defaultValue);
-  }
+  <U> U unsafeGetTag(CharSequence name, U defaultValue);
 
-  default <U> U unsafeGetTag(CharSequence name) {
-    return getTag(name);
-  }
+  <U> U unsafeGetTag(CharSequence name);
 
   boolean hasSamplingPriority();
 
@@ -81,10 +74,7 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   boolean isForceKeep();
 
-  default boolean isKind(SpanKindFilter filter) {
-    Object kind = unsafeGetTag(Tags.SPAN_KIND);
-    return filter.matches(kind == null ? null : kind.toString());
-  }
+  boolean isKind(SpanKindFilter filter);
 
   CharSequence getType();
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -200,6 +200,16 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  <U> U unsafeGetTag(CharSequence name, U defaultValue) {
+    return getTag(name, defaultValue)
+  }
+
+  @Override
+  <U> U unsafeGetTag(CharSequence name) {
+    return getTag(name)
+  }
+
+  @Override
   boolean hasSamplingPriority() {
     return false
   }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
@@ -11,10 +11,12 @@ import datadog.trace.api.ProcessTags;
 import datadog.trace.api.TagMap;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.Metadata;
 import datadog.trace.core.MetadataConsumer;
+import datadog.trace.core.SpanKindFilter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -501,6 +503,27 @@ public class TraceGenerator {
     @Override
     public int getLongRunningVersion() {
       return 0;
+    }
+
+    @Override
+    public CharSequence getServiceNameSource() {
+      return null;
+    }
+
+    @Override
+    public boolean isKind(SpanKindFilter filter) {
+      Object kind = unsafeGetTag(Tags.SPAN_KIND);
+      return filter.matches(kind == null ? null : kind.toString());
+    }
+
+    @Override
+    public <U> U unsafeGetTag(CharSequence name, U defaultValue) {
+      return getTag(name, defaultValue);
+    }
+
+    @Override
+    public <U> U unsafeGetTag(CharSequence name) {
+      return getTag(name);
     }
   }
 }

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -1,6 +1,7 @@
 import static datadog.trace.api.ProcessTags.tagsForSerialization
 import static datadog.trace.api.TagMap.fromMap
 import static datadog.trace.api.sampling.PrioritySampling.UNSET
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
 import static java.lang.Thread.currentThread
 import static java.util.Collections.emptyList
 
@@ -13,6 +14,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.Metadata
 import datadog.trace.core.MetadataConsumer
+import datadog.trace.core.SpanKindFilter
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 
@@ -174,6 +176,11 @@ class TraceGenerator {
     }
 
     @Override
+    CharSequence getServiceNameSource() {
+      return null
+    }
+
+    @Override
     CharSequence getOperationName() {
       return operationName
     }
@@ -298,6 +305,12 @@ class TraceGenerator {
       return false
     }
 
+    @Override
+    boolean isKind(SpanKindFilter filter) {
+      Object kind = unsafeGetTag(SPAN_KIND)
+      return filter.matches(kind == null ? null : kind.toString())
+    }
+
     Map<String, String> getBaggage() {
       return metadata.getBaggage()
     }
@@ -392,6 +405,16 @@ class TraceGenerator {
           value = tags.get(tag)
       }
       return value as U
+    }
+
+    @Override
+    <U> U unsafeGetTag(CharSequence name, U defaultValue) {
+      return getTag(name, defaultValue)
+    }
+
+    @Override
+    <U> U unsafeGetTag(CharSequence name) {
+      return getTag(name)
     }
 
     @Override


### PR DESCRIPTION
## What This Does

Removes the default methods from `CoreSpan`

## Motivation

The default methods on `CoreSpan` were effectively test-only methods, since they are overwritten by `DDSpan`

My preference is to not have test-only code in production classes.  Given that these methods were causing coverage checks to fail, I thought it best to simply remove them.

## Test plan
- [ ] `./gradlew :dd-trace-core:jacocoTestCoverageVerification -PcheckCoverage` no longer flags `CoreSpan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)