### PR TITLE
Increase SCA vulnerability test coverage

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -89,7 +89,9 @@ ext {
     'com.datadog.appsec.config.AppSecFeatures.AutoUserInstrum',
     'com.datadog.appsec.AppSecModule.AppSecModuleActivationException',
     'com.datadog.appsec.event.ReplaceableEventProducerService',
+    'com.datadog.appsec.event.data.IntrospectionExcludedTypesTrie',
     'com.datadog.appsec.api.security.ApiSecuritySampler.NoOp',
+    'com.datadog.appsec.sca.ScaStackExclusionTrie',
   ]
   excludedClassesBranchCoverage = [
     'com.datadog.appsec.gateway.GatewayBridge',

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaBytecodeTestUtils.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaBytecodeTestUtils.java
@@ -1,0 +1,42 @@
+package com.datadog.appsec.sca;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import net.bytebuddy.jar.asm.ClassReader;
+import net.bytebuddy.jar.asm.ClassWriter;
+
+final class ScaBytecodeTestUtils {
+
+  private ScaBytecodeTestUtils() {}
+
+  static byte[] bytecodeOf(Class<?> clazz) throws Exception {
+    String path = clazz.getName().replace('.', '/') + ".class";
+    try (InputStream is = clazz.getClassLoader().getResourceAsStream(path)) {
+      assertNotNull(is, "Cannot load bytecode for " + clazz.getName());
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      byte[] chunk = new byte[4096];
+      int n;
+      while ((n = is.read(chunk)) != -1) {
+        buf.write(chunk, 0, n);
+      }
+      return buf.toByteArray();
+    }
+  }
+
+  static Class<?> loadModified(byte[] bytecode) {
+    return new ClassLoader(ScaBytecodeTestUtils.class.getClassLoader()) {
+      Class<?> define() {
+        return defineClass(null, bytecode, 0, bytecode.length);
+      }
+    }.define();
+  }
+
+  static byte[] bytecodeWithoutDebugInfo(Class<?> clazz) throws Exception {
+    ClassReader cr = new ClassReader(bytecodeOf(clazz));
+    ClassWriter cw = new ClassWriter(0);
+    cr.accept(cw, ClassReader.SKIP_DEBUG);
+    return cw.toByteArray();
+  }
+}

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +126,22 @@ class ScaCveDatabaseTest {
     List<ScaEntry> entries = db.entriesForClass("com/example/Shared");
     assertNotNull(entries);
     assertEquals(2, entries.size());
+  }
+
+  @Test
+  void scaEntryExposesImmutableListsAndMatchesVersions() {
+    List<String> ranges = new ArrayList<>(Collections.singletonList("< 2.0.0"));
+    List<ScaSymbol> symbols =
+        new ArrayList<>(Collections.singletonList(new ScaSymbol("com/example/Foo", "op")));
+    ScaEntry entry = new ScaEntry("GHSA-entry", "com.example:lib", ranges, symbols);
+
+    assertEquals(Collections.singletonList("< 2.0.0"), entry.versionRanges());
+    assertTrue(entry.isVersionVulnerable("1.9.9"));
+    assertFalse(entry.isVersionVulnerable("2.0.0"));
+    assertThrows(UnsupportedOperationException.class, () -> entry.versionRanges().add("< 3.0.0"));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> entry.symbols().add(new ScaSymbol("com/example/Bar", "op")));
   }
 
   @Test

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
@@ -1,5 +1,6 @@
 package com.datadog.appsec.sca;
 
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -130,12 +130,12 @@ class ScaCveDatabaseTest {
 
   @Test
   void scaEntryExposesImmutableListsAndMatchesVersions() {
-    List<String> ranges = new ArrayList<>(Collections.singletonList("< 2.0.0"));
-    List<ScaSymbol> symbols =
-        new ArrayList<>(Collections.singletonList(new ScaSymbol("com/example/Foo", "op")));
+    List<String> expectedRanges = singletonList("< 2.0.0");
+    List<String> ranges = new ArrayList<>(expectedRanges);
+    List<ScaSymbol> symbols = singletonList(new ScaSymbol("com/example/Foo", "op"));
     ScaEntry entry = new ScaEntry("GHSA-entry", "com.example:lib", ranges, symbols);
 
-    assertEquals(Collections.singletonList("< 2.0.0"), entry.versionRanges());
+    assertEquals(expectedRanges, entry.versionRanges());
     assertTrue(entry.isVersionVulnerable("1.9.9"));
     assertFalse(entry.isVersionVulnerable("2.0.0"));
     assertThrows(UnsupportedOperationException.class, () -> entry.versionRanges().add("< 3.0.0"));

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaCveDatabaseTest.java
@@ -129,15 +129,22 @@ class ScaCveDatabaseTest {
   }
 
   @Test
-  void scaEntryExposesImmutableListsAndMatchesVersions() {
+  void scaEntryMatchesVersions() {
     List<String> expectedRanges = singletonList("< 2.0.0");
-    List<String> ranges = new ArrayList<>(expectedRanges);
     List<ScaSymbol> symbols = singletonList(new ScaSymbol("com/example/Foo", "op"));
-    ScaEntry entry = new ScaEntry("GHSA-entry", "com.example:lib", ranges, symbols);
+    ScaEntry entry = new ScaEntry("GHSA-entry", "com.example:lib", expectedRanges, symbols);
 
     assertEquals(expectedRanges, entry.versionRanges());
     assertTrue(entry.isVersionVulnerable("1.9.9"));
     assertFalse(entry.isVersionVulnerable("2.0.0"));
+  }
+
+  @Test
+  void scaEntryExposesImmutableLists() {
+    List<String> ranges = singletonList("< 2.0.0");
+    List<ScaSymbol> symbols = singletonList(new ScaSymbol("com/example/Foo", "op"));
+    ScaEntry entry = new ScaEntry("GHSA-entry", "com.example:lib", ranges, symbols);
+
     assertThrows(UnsupportedOperationException.class, () -> entry.versionRanges().add("< 3.0.0"));
     assertThrows(
         UnsupportedOperationException.class,

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityMethodLevelTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityMethodLevelTest.java
@@ -44,11 +44,13 @@ class ScaReachabilityMethodLevelTest {
     }
   }
 
+  /** Fixture compiled normally, then stripped of line numbers before callback injection. */
   public static class ClassToBeStrippedOfLineNumber {
-    public static int value = 7;
+    // Intentionally non-final so javac emits a field read instead of inlining a constant.
+    private static int runtimeFieldValue = 7;
 
     public static int readField() {
-      return value;
+      return runtimeFieldValue;
     }
 
     public static Object returnArgument(Object value) {

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityMethodLevelTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityMethodLevelTest.java
@@ -1,5 +1,8 @@
 package com.datadog.appsec.sca;
 
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.bytecodeOf;
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.bytecodeWithoutDebugInfo;
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.loadModified;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -10,8 +13,6 @@ import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry;
 import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry.DependencySnapshot;
 import datadog.trace.api.telemetry.ScaReachabilityHit;
 import datadog.trace.bootstrap.appsec.sca.ScaReachabilityCallback;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -40,6 +41,22 @@ class ScaReachabilityMethodLevelTest {
 
     public String safeMethod() {
       return "safe";
+    }
+  }
+
+  public static class ClassToBeStrippedOfLineNumber {
+    public static int value = 7;
+
+    public static int readField() {
+      return value;
+    }
+
+    public static Object returnArgument(Object value) {
+      return value;
+    }
+
+    public static String callToString(Object value) {
+      return value.toString();
     }
   }
 
@@ -169,6 +186,38 @@ class ScaReachabilityMethodLevelTest {
     assertEquals(2, hits.size(), "Each instrumented method produces its own hit");
     assertTrue(hits.stream().anyMatch(h -> h.symbolName().equals("vulnerableMethod")));
     assertTrue(hits.stream().anyMatch(h -> h.symbolName().equals("safeMethod")));
+  }
+
+  @Test
+  void inject_withoutLineNumbersInjectsBeforeFirstInstruction() throws Exception {
+    byte[] original = bytecodeWithoutDebugInfo(ClassToBeStrippedOfLineNumber.class);
+    String className = ClassToBeStrippedOfLineNumber.class.getName();
+    Map<String, List<ScaMethodCallbackInjector.MethodCallbackSpec>> callbacks = new HashMap<>();
+    callbacks.put(
+        "readField",
+        Collections.singletonList(
+            spec("GHSA-field", "com.example:lib", "1.0.0", className, "readField")));
+    callbacks.put(
+        "returnArgument",
+        Collections.singletonList(
+            spec("GHSA-var", "com.example:lib", "1.0.0", className, "returnArgument")));
+    callbacks.put(
+        "callToString",
+        Collections.singletonList(
+            spec("GHSA-method", "com.example:lib", "1.0.0", className, "callToString")));
+
+    Class<?> cls = loadModified(ScaMethodCallbackInjector.inject(original, callbacks));
+
+    assertEquals(7, cls.getMethod("readField").invoke(null));
+    assertEquals("value", cls.getMethod("returnArgument", Object.class).invoke(null, "value"));
+    assertEquals("value", cls.getMethod("callToString", Object.class).invoke(null, "value"));
+
+    List<ScaReachabilityHit> hits = drainHits();
+    assertEquals(3, hits.size());
+    assertTrue(hits.stream().allMatch(hit -> hit.line() == 1));
+    assertTrue(hits.stream().anyMatch(hit -> hit.symbolName().equals("readField")));
+    assertTrue(hits.stream().anyMatch(hit -> hit.symbolName().equals("returnArgument")));
+    assertTrue(hits.stream().anyMatch(hit -> hit.symbolName().equals("callToString")));
   }
 
   @Test
@@ -324,25 +373,5 @@ class ScaReachabilityMethodLevelTest {
       String vulnId, String artifact, String version, String dotClass, String method) {
     return new ScaMethodCallbackInjector.MethodCallbackSpec(
         vulnId, artifact, version, dotClass, method);
-  }
-
-  private static byte[] bytecodeOf(Class<?> clazz) throws Exception {
-    String path = clazz.getName().replace('.', '/') + ".class";
-    try (InputStream is = clazz.getClassLoader().getResourceAsStream(path)) {
-      assertNotNull(is, "Cannot load bytecode for " + clazz.getName());
-      ByteArrayOutputStream buf = new ByteArrayOutputStream();
-      byte[] chunk = new byte[4096];
-      int n;
-      while ((n = is.read(chunk)) != -1) buf.write(chunk, 0, n);
-      return buf.toByteArray();
-    }
-  }
-
-  private static Class<?> loadModified(byte[] bytecode) {
-    return new ClassLoader(ScaReachabilityMethodLevelTest.class.getClassLoader()) {
-      Class<?> define() {
-        return defineClass(null, bytecode, 0, bytecode.length);
-      }
-    }.define();
   }
 }

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilitySystemCallsiteTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilitySystemCallsiteTest.java
@@ -34,6 +34,20 @@ class ScaReachabilitySystemCallsiteTest {
   }
 
   @Test
+  void findCallsite_skipsRepeatedVulnerableFrames() {
+    StackTraceElement[] stack = {
+      frame(VULNERABLE_CLASS, "load"),
+      frame(VULNERABLE_CLASS, "loadAll"),
+      frame("sca.test.TestController", "yamlHitRecursive"),
+    };
+
+    StackTraceElement result = ScaReachabilitySystem.findCallsite(VULNERABLE_CLASS, stack);
+
+    assertEquals("sca.test.TestController", result.getClassName());
+    assertEquals("yamlHitRecursive", result.getMethodName());
+  }
+
+  @Test
   void findCallsite_skipsIntermediateLibraryFrameAndReturnsClientCode() {
     // com.google.* is excluded by the SCA trie (value >= 1)
     StackTraceElement[] stack = {

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilitySystemTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilitySystemTest.java
@@ -1,0 +1,53 @@
+package com.datadog.appsec.sca;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry;
+import datadog.trace.api.telemetry.ScaReachabilityHit;
+import datadog.trace.bootstrap.appsec.sca.ScaReachabilityCallback;
+import java.lang.instrument.Instrumentation;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ScaReachabilitySystemTest {
+
+  @AfterEach
+  void tearDown() {
+    ScaReachabilityDependencyRegistry.INSTANCE.resetForTesting();
+    ScaReachabilityCallback.register(null);
+  }
+
+  @Test
+  void startRegistersTransformerCallbackAndPeriodicWork() {
+    Instrumentation instrumentation = mock(Instrumentation.class);
+    when(instrumentation.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+
+    ScaReachabilitySystem.start(instrumentation);
+
+    verify(instrumentation).addTransformer(any(ScaReachabilityTransformer.class), eq(true));
+    assertNotNull(ScaReachabilityDependencyRegistry.INSTANCE.getPeriodicWorkCallback());
+
+    ScaReachabilityCallback.onMethodHit(
+        "GHSA-start", "com.example:lib", "1.0.0", "missing.Vulnerable", "danger", 42);
+
+    List<ScaReachabilityDependencyRegistry.DependencySnapshot> snapshots =
+        ScaReachabilityDependencyRegistry.INSTANCE.drainPendingDependencies();
+    assertEquals(1, snapshots.size());
+    assertEquals("com.example:lib", snapshots.get(0).artifact);
+    assertEquals("1.0.0", snapshots.get(0).version);
+    assertEquals(1, snapshots.get(0).cves.size());
+    ScaReachabilityHit hit = snapshots.get(0).cves.get(0).hit;
+    assertNotNull(hit);
+    assertEquals("GHSA-start", hit.vulnId());
+    assertEquals("missing.Vulnerable", hit.className());
+    assertEquals("danger", hit.symbolName());
+    assertEquals(42, hit.line());
+  }
+}

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityTransformerJava9Test.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityTransformerJava9Test.java
@@ -1,6 +1,8 @@
 package com.datadog.appsec.sca;
 
 import static com.datadog.appsec.sca.ScaBytecodeTestUtils.bytecodeOf;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,7 +19,6 @@ import java.io.StringReader;
 import java.lang.instrument.Instrumentation;
 import java.net.URLClassLoader;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -114,8 +115,7 @@ class ScaReachabilityTransformerJava9Test {
     Dependency dep = new Dependency("com.github.junrar:junrar", "7.5.5", "junrar-7.5.5.jar", null);
     assertEquals(
         "7.5.5",
-        ScaReachabilityTransformer.matchVersion(
-            "com.github.junrar:junrar", Collections.singletonList(dep)));
+        ScaReachabilityTransformer.matchVersion("com.github.junrar:junrar", singletonList(dep)));
   }
 
   @Test
@@ -125,8 +125,7 @@ class ScaReachabilityTransformerJava9Test {
     Dependency dep = new Dependency("junrar", "7.5.5", "junrar-7.5.5.jar", null);
     assertEquals(
         "7.5.5",
-        ScaReachabilityTransformer.matchVersion(
-            "com.github.junrar:junrar", Collections.singletonList(dep)),
+        ScaReachabilityTransformer.matchVersion("com.github.junrar:junrar", singletonList(dep)),
         "artifact-ID fallback must match 'junrar' against 'com.github.junrar:junrar'");
   }
 
@@ -136,16 +135,13 @@ class ScaReachabilityTransformerJava9Test {
     // "org.other:junrar" should NOT match "com.github.junrar:junrar".
     Dependency dep = new Dependency("org.other:junrar", "1.0.0", "junrar-1.0.0.jar", null);
     assertNull(
-        ScaReachabilityTransformer.matchVersion(
-            "com.github.junrar:junrar", Collections.singletonList(dep)),
+        ScaReachabilityTransformer.matchVersion("com.github.junrar:junrar", singletonList(dep)),
         "artifact-ID fallback must not fire when dep.name already has a group ID");
   }
 
   @Test
   void matchVersion_emptyListReturnsNull() {
-    assertNull(
-        ScaReachabilityTransformer.matchVersion(
-            "com.github.junrar:junrar", Collections.emptyList()));
+    assertNull(ScaReachabilityTransformer.matchVersion("com.github.junrar:junrar", emptyList()));
   }
 
   @Test
@@ -261,7 +257,7 @@ class ScaReachabilityTransformerJava9Test {
             .getCodeSource()
             .getLocation()
             .toURI(),
-        Collections.singletonList(new Dependency("com.example:lib", "1.2.3", "test.jar", null)));
+        singletonList(new Dependency("com.example:lib", "1.2.3", "test.jar", null)));
 
     byte[] transformed =
         transformer.transform(
@@ -334,16 +330,14 @@ class ScaReachabilityTransformerJava9Test {
     Dependency cached = new Dependency("com.example:lib", "1.0.0", "lib.jar", null);
     transformer.classpathArtifactCache.put("com.example:lib", cached);
 
-    assertSame(cached, transformer.resolveArtifactDep("com.example:lib", Collections.emptyList()));
+    assertSame(cached, transformer.resolveArtifactDep("com.example:lib", emptyList()));
   }
 
   @Test
   void matchVersion_nullDepNameDoesNotThrow() {
     // guessFallbackNoPom can produce Dependency(name=null, ...) for JARs with unrecognizable names.
     Dependency nullName = new Dependency(null, "1.0", "foo.jar", null);
-    assertNull(
-        ScaReachabilityTransformer.matchVersion(
-            "com.example:foo", Collections.singletonList(nullName)));
+    assertNull(ScaReachabilityTransformer.matchVersion("com.example:foo", singletonList(nullName)));
   }
 
   /**
@@ -369,7 +363,7 @@ class ScaReachabilityTransformerJava9Test {
 
     Dependency resolved =
         transformer.resolveArtifactDep(
-            "com.fasterxml.jackson.core:jackson-databind", Collections.singletonList(noPomDep));
+            "com.fasterxml.jackson.core:jackson-databind", singletonList(noPomDep));
 
     assertNotNull(resolved, "should resolve via artifactId-only fallback");
     assertEquals(

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityTransformerJava9Test.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaReachabilityTransformerJava9Test.java
@@ -1,19 +1,25 @@
 package com.datadog.appsec.sca;
 
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.bytecodeOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import datadog.telemetry.dependency.Dependency;
+import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry;
 import java.io.StringReader;
 import java.lang.instrument.Instrumentation;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
@@ -51,6 +57,11 @@ class ScaReachabilityTransformerJava9Test {
           + "\"version_ranges\":[\"< 999.0.0\"],"
           + "\"symbols\":[{\"class\":\"com/fasterxml/jackson/databind/ObjectMapper\",\"method\":\"readValue\"}]"
           + "}]}";
+
+  @AfterEach
+  void resetRegistry() {
+    ScaReachabilityDependencyRegistry.INSTANCE.resetForTesting();
+  }
 
   @Test
   @EnabledForJreRange(min = JRE.JAVA_9)
@@ -227,6 +238,103 @@ class ScaReachabilityTransformerJava9Test {
         transformer.classpathArtifactCache.get("com.fasterxml.jackson.core:jackson-core"),
         "classpathArtifactCache must be populated during pre-warm for aggregator artifacts; "
             + "if empty, findArtifactVersionInClasspath() would run under JVM retransform locks");
+  }
+
+  @Test
+  void transform_retransform_injectsCallbacksWhenVersionResolvedFromCache() throws Exception {
+    String internalName =
+        ScaReachabilityMethodLevelTest.TargetClass.class.getName().replace('.', '/');
+    String json =
+        "{\"version\":1,\"entries\":[{"
+            + "\"vuln_id\":\"GHSA-transform\","
+            + "\"artifact\":\"com.example:lib\","
+            + "\"version_ranges\":[\"< 999.0.0\"],"
+            + "\"symbols\":[{\"class\":\""
+            + internalName
+            + "\",\"method\":\"vulnerableMethod\"}]"
+            + "}]}";
+    ScaCveDatabase db = ScaCveDatabase.parse(new StringReader(json));
+    ScaReachabilityTransformer transformer = new ScaReachabilityTransformer(db, null);
+    transformer.jarCache.put(
+        ScaReachabilityMethodLevelTest.TargetClass.class
+            .getProtectionDomain()
+            .getCodeSource()
+            .getLocation()
+            .toURI(),
+        Collections.singletonList(new Dependency("com.example:lib", "1.2.3", "test.jar", null)));
+
+    byte[] transformed =
+        transformer.transform(
+            null,
+            internalName,
+            ScaReachabilityMethodLevelTest.TargetClass.class,
+            ScaReachabilityMethodLevelTest.TargetClass.class.getProtectionDomain(),
+            bytecodeOf(ScaReachabilityMethodLevelTest.TargetClass.class));
+
+    assertNotNull(transformed);
+    assertTrue(transformer.pendingRetransformNames.isEmpty());
+    List<ScaReachabilityDependencyRegistry.DependencySnapshot> snapshots =
+        ScaReachabilityDependencyRegistry.INSTANCE.drainPendingDependencies();
+    assertEquals(1, snapshots.size());
+    assertEquals("com.example:lib", snapshots.get(0).artifact);
+    assertEquals("1.2.3", snapshots.get(0).version);
+    assertEquals("GHSA-transform", snapshots.get(0).cves.get(0).vulnId);
+    assertNull(snapshots.get(0).cves.get(0).hit);
+  }
+
+  @Test
+  void checkAlreadyLoadedClassesSchedulesOnlyMatchingNonBootstrapClasses() throws Exception {
+    String internalName =
+        ScaReachabilityMethodLevelTest.TargetClass.class.getName().replace('.', '/');
+    String json =
+        "{\"version\":1,\"entries\":["
+            + "{\"vuln_id\":\"GHSA-target\",\"artifact\":\"com.example:lib\","
+            + "\"version_ranges\":[\"< 999.0.0\"],"
+            + "\"symbols\":[{\"class\":\""
+            + internalName
+            + "\",\"method\":\"vulnerableMethod\"}]},"
+            + "{\"vuln_id\":\"GHSA-jdk\",\"artifact\":\"com.example:jdk\","
+            + "\"version_ranges\":[\"< 999.0.0\"],"
+            + "\"symbols\":[{\"class\":\"java/lang/String\",\"method\":\"substring\"}]}"
+            + "]}";
+
+    Instrumentation mockInstr = mock(Instrumentation.class);
+    when(mockInstr.getAllLoadedClasses())
+        .thenReturn(
+            new Class<?>[] {
+              null, String[].class, String.class, ScaReachabilityMethodLevelTest.TargetClass.class,
+            });
+    ScaReachabilityTransformer transformer =
+        new ScaReachabilityTransformer(ScaCveDatabase.parse(new StringReader(json)), mockInstr);
+
+    transformer.checkAlreadyLoadedClasses();
+
+    assertEquals(1, transformer.pendingRetransform.size());
+    assertSame(
+        ScaReachabilityMethodLevelTest.TargetClass.class, transformer.pendingRetransform.peek());
+  }
+
+  @Test
+  void performPendingRetransforms_noopsWithoutInstrumentation() throws Exception {
+    ScaReachabilityTransformer transformer =
+        new ScaReachabilityTransformer(
+            ScaCveDatabase.parse(new StringReader("{\"version\":1,\"entries\":[]}")), null);
+    transformer.pendingRetransform.add(ScaReachabilityMethodLevelTest.TargetClass.class);
+
+    transformer.performPendingRetransforms();
+
+    assertSame(
+        ScaReachabilityMethodLevelTest.TargetClass.class, transformer.pendingRetransform.peek());
+  }
+
+  @Test
+  void resolveArtifactDep_returnsCachedClasspathArtifact() throws Exception {
+    ScaReachabilityTransformer transformer =
+        new ScaReachabilityTransformer(ScaCveDatabase.parse(new StringReader(JACKSON_JSON)), null);
+    Dependency cached = new Dependency("com.example:lib", "1.0.0", "lib.jar", null);
+    transformer.classpathArtifactCache.put("com.example:lib", cached);
+
+    assertSame(cached, transformer.resolveArtifactDep("com.example:lib", Collections.emptyList()));
   }
 
   @Test

--- a/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaRealLibraryBytecodeTest.java
+++ b/dd-java-agent/appsec/src/test/java/com/datadog/appsec/sca/ScaRealLibraryBytecodeTest.java
@@ -1,5 +1,7 @@
 package com.datadog.appsec.sca;
 
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.bytecodeOf;
+import static com.datadog.appsec.sca.ScaBytecodeTestUtils.loadModified;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,9 +11,7 @@ import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry.CveSnapshot
 import datadog.trace.api.telemetry.ScaReachabilityDependencyRegistry.DependencySnapshot;
 import datadog.trace.api.telemetry.ScaReachabilityHit;
 import datadog.trace.bootstrap.appsec.sca.ScaReachabilityCallback;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -197,25 +197,5 @@ class ScaRealLibraryBytecodeTest {
       String vulnId, String artifact, String version, String dotClass, String method) {
     return new ScaMethodCallbackInjector.MethodCallbackSpec(
         vulnId, artifact, version, dotClass, method);
-  }
-
-  private static byte[] bytecodeOf(Class<?> clazz) throws Exception {
-    String path = clazz.getName().replace('.', '/') + ".class";
-    try (InputStream is = clazz.getClassLoader().getResourceAsStream(path)) {
-      assertNotNull(is, "Cannot load bytecode for " + clazz.getName());
-      ByteArrayOutputStream buf = new ByteArrayOutputStream();
-      byte[] chunk = new byte[4096];
-      int n;
-      while ((n = is.read(chunk)) != -1) buf.write(chunk, 0, n);
-      return buf.toByteArray();
-    }
-  }
-
-  private static Class<?> loadModified(byte[] bytecode) {
-    return new ClassLoader(ScaRealLibraryBytecodeTest.class.getClassLoader()) {
-      Class<?> define() {
-        return defineClass(null, bytecode, 0, bytecode.length);
-      }
-    }.define();
   }
 }


### PR DESCRIPTION
# What Does This Do
Expands the test coverage for SCA (Software Composition Analysis) vulnerabilities.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]