### PR TITLE
inject ol_env into ol spark run tags

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark-common/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark-common/build.gradle
@@ -29,5 +29,9 @@ dependencies {
 
   testImplementation project(':dd-java-agent:instrumentation-testing')
   testImplementation group: 'org.apache.spark', name: 'spark-launcher_2.12', version: '2.4.0'
+  testImplementation libs.bundles.junit5
+  testImplementation libs.bundles.mockito
+  testImplementation group: 'org.apache.spark', name: 'spark-core_2.12', version: '2.4.0'
+  testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: '2.4.0'
 }
 

--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -191,8 +191,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
       openLineageSparkConf.set(
           "spark.openlineage.transport.transports.agent.endpoint", AGENT_OL_ENDPOINT);
       openLineageSparkConf.set("spark.openlineage.transport.transports.agent.compression", "gzip");
-      openLineageSparkConf.set(
-          "spark.openlineage.run.tags",
+      String runTags =
           "_dd.trace_id:"
               + traceId.toString()
               + ";_dd.ol_intake.emit_spans:false;_dd.ol_service:"
@@ -200,7 +199,17 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
               + ";_dd.ol_intake.process_tags:"
               + ProcessTags.getTagsForSerialization()
               + ";_dd.ol_app_id:"
-              + appId);
+              + appId;
+      // _dd.ol_env carries the run environment so the lineage-processor can use it
+      // as the Spark application's UGP namespace, letting the OpenLineage-created
+      // node and the tracer-only node (djm-span-processor) resolve to the same
+      // entity_id. Omitted when env is unset so the consumer falls back to the
+      // OpenLineage namespace.
+      String olEnv = Config.get().getEnv();
+      if (!olEnv.isEmpty()) {
+        runTags += ";_dd.ol_env:" + olEnv;
+      }
+      openLineageSparkConf.set("spark.openlineage.run.tags", runTags);
       setupOpenLineageCircuitBreaker();
       return;
     }

--- a/dd-java-agent/instrumentation/spark/spark-common/src/test/java/datadog/trace/instrumentation/spark/SetupOpenLineageTest.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/test/java/datadog/trace/instrumentation/spark/SetupOpenLineageTest.java
@@ -1,0 +1,133 @@
+package datadog.trace.instrumentation.spark;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTraceId;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.SparkConf;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.scheduler.SparkListenerInterface;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.StageInfo;
+import org.apache.spark.sql.execution.SparkPlanInfo;
+import org.apache.spark.sql.execution.metric.SQLMetricInfo;
+import org.apache.spark.util.AccumulatorV2;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class SetupOpenLineageTest {
+
+  private static TestListener newListenerWithOpenLineage() {
+    TestListener listener = new TestListener(new SparkConf(), "some_app_id", "some_version");
+    // The constructor registers a JVM shutdown hook that finishes the application trace. In a plain
+    // unit test there is no registered tracer, so that hook would NPE at JVM exit. Mark the
+    // application as already ended so the hook short-circuits.
+    markApplicationEnded(listener);
+    listener.openLineageSparkListener = mock(SparkListenerInterface.class);
+    listener.openLineageSparkConf = new SparkConf();
+    return listener;
+  }
+
+  private static void markApplicationEnded(AbstractDatadogSparkListener listener) {
+    try {
+      Field applicationEnded =
+          AbstractDatadogSparkListener.class.getDeclaredField("applicationEnded");
+      applicationEnded.setAccessible(true);
+      applicationEnded.setBoolean(listener, true);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Could not mark application as ended", e);
+    }
+  }
+
+  private static List<String> runTags(TestListener listener) {
+    return Arrays.asList(
+        listener.openLineageSparkConf.get("spark.openlineage.run.tags").split(";"));
+  }
+
+  @Test
+  void addsOlEnvTagWhenEnvIsSet() {
+    TestListener listener = newListenerWithOpenLineage();
+
+    Config config = mock(Config.class);
+    when(config.getEnv()).thenReturn("my-env");
+    try (MockedStatic<Config> configMock = mockStatic(Config.class)) {
+      configMock.when(Config::get).thenReturn(config);
+      listener.setupOpenLineage(mock(DDTraceId.class));
+    }
+
+    assertTrue(runTags(listener).contains("_dd.ol_env:my-env"));
+  }
+
+  @Test
+  void omitsOlEnvTagWhenEnvIsEmpty() {
+    TestListener listener = newListenerWithOpenLineage();
+
+    Config config = mock(Config.class);
+    when(config.getEnv()).thenReturn("");
+    try (MockedStatic<Config> configMock = mockStatic(Config.class)) {
+      configMock.when(Config::get).thenReturn(config);
+      listener.setupOpenLineage(mock(DDTraceId.class));
+    }
+
+    assertFalse(
+        runTags(listener).stream().anyMatch(tag -> tag.startsWith("_dd.ol_env:")),
+        "No _dd.ol_env tag should be set when env is empty");
+  }
+
+  /**
+   * Minimal concrete listener so the version-agnostic {@link
+   * AbstractDatadogSparkListener#setupOpenLineage} logic can be exercised without a running Spark
+   * context. The scala-version-specific abstract methods are irrelevant here and return empty
+   * results.
+   */
+  private static class TestListener extends AbstractDatadogSparkListener {
+    TestListener(SparkConf sparkConf, String appId, String sparkVersion) {
+      super(sparkConf, appId, sparkVersion);
+    }
+
+    @Override
+    protected String getSparkJobName(SparkListenerJobStart jobStart) {
+      return null;
+    }
+
+    @Override
+    protected ArrayList<Integer> getSparkJobStageIds(SparkListenerJobStart jobStart) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    protected int getStageCount(SparkListenerJobStart jobStart) {
+      return 0;
+    }
+
+    @Override
+    protected Collection<SparkPlanInfo> getPlanInfoChildren(SparkPlanInfo info) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    protected List<SQLMetricInfo> getPlanInfoMetrics(SparkPlanInfo info) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    protected int[] getStageParentIds(StageInfo info) {
+      return new int[0];
+    }
+
+    @Override
+    protected List<AccumulatorV2> getExternalAccumulators(TaskMetrics metrics) {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spark/spark-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/dd-java-agent/instrumentation/spark/spark-common/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
@@ -642,6 +642,22 @@ abstract class AbstractSparkListenerTest extends InstrumentationSpecification {
     .contains("_dd.ol_service:databricks.job-cluster.some-run-name")
   }
 
+  def "test setupOpenLineage sets ol_env from dd.env"() {
+    setup:
+    injectSysConfig("dd.env", "my-env")
+    def listener = getTestDatadogSparkListener()
+    listener.openLineageSparkListener = Mock(SparkListenerInterface)
+    listener.openLineageSparkConf = new SparkConf()
+    listener.setupOpenLineage(Mock(DDTraceId))
+
+    expect:
+    assert listener
+    .openLineageSparkConf
+    .get("spark.openlineage.run.tags")
+    .split(";")
+    .contains("_dd.ol_env:my-env")
+  }
+
   def "test setupOpenLineage fills ProcessTags"() {
     setup:
     def listener = getTestDatadogSparkListener()

--- a/dd-java-agent/instrumentation/spark/spark-common/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkListenerTest.groovy
@@ -642,22 +642,6 @@ abstract class AbstractSparkListenerTest extends InstrumentationSpecification {
     .contains("_dd.ol_service:databricks.job-cluster.some-run-name")
   }
 
-  def "test setupOpenLineage sets ol_env from dd.env"() {
-    setup:
-    injectSysConfig("dd.env", "my-env")
-    def listener = getTestDatadogSparkListener()
-    listener.openLineageSparkListener = Mock(SparkListenerInterface)
-    listener.openLineageSparkConf = new SparkConf()
-    listener.setupOpenLineage(Mock(DDTraceId))
-
-    expect:
-    assert listener
-    .openLineageSparkConf
-    .get("spark.openlineage.run.tags")
-    .split(";")
-    .contains("_dd.ol_env:my-env")
-  }
-
   def "test setupOpenLineage fills ProcessTags"() {
     setup:
     def listener = getTestDatadogSparkListener()


### PR DESCRIPTION
Fixes DET-109

Adds `_dd.ol_env:<env>` to the `spark.openlineage.run.tags` set in
`setupOpenLineage`, alongside the existing `_dd.ol_service` / `_dd.ol_app_id`.
The value comes from `Config.get().getEnv()`, and the tag is omitted when env
is empty.

## Motivation

Downstream (dd-source `lineage-processor`) uses the run environment as the
Spark **application** UGP node's `namespace`. A node's `entity_id` is
`hash(name, type, namespace)`; today the OpenLineage path and the tracer-only
path (`djm-span-processor`) derive `namespace` differently, so the same Spark
application resolves to two different entities. Carrying env here lets both
paths key the namespace off the same value (env) and converge on one
`entity_id`. `_dd.ol_service` already aligns name; this aligns namespace.

When env is unset the tag is omitted so the consumer falls back to the
OpenLineage namespace (no empty-namespace).

## Additional Notes

- [Consumer side](https://github.com/ddoghq/dd-source/pull/5583)
- Existing `setupOpenLineage` tests assert via `.contains(...)`, so the new tag
  doesn't affect them; added a test asserting `_dd.ol_env:<env>` is present when
  `dd.env` is set.