### PR TITLE
Exclude OptimizedTagMap.EmptyHolder from coverage checks

### DIFF
--- a/internal-api/build.gradle.kts
+++ b/internal-api/build.gradle.kts
@@ -55,6 +55,8 @@ extra["excludedClassesCoverage"] = listOf(
   "datadog.trace.api.EndpointCheckpointerHolder",
   "datadog.trace.api.iast.IastAdvice.Kind",
   "datadog.trace.api.UserEventTrackingMode",
+  // Lazy holder idiom; exercised indirectly via TagMap.EMPTY
+  "datadog.trace.api.OptimizedTagMap.EmptyHolder",
   // These are almost fully abstract classes so nothing to test
   "datadog.trace.api.profiling.RecordingData",
   "datadog.trace.api.appsec.AppSecEventTracker",

--- a/internal-api/src/test/java/datadog/trace/util/HashtableD2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/HashtableD2Test.java
@@ -1,6 +1,7 @@
 package datadog.trace.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -116,6 +117,38 @@ class HashtableD2Test {
     assertSame(seeded, got);
     assertEquals(1, table.size());
     assertEquals(0, createCount[0]);
+  }
+
+  @Test
+  void entryMatchesTrueWhenBothKeysEqual() {
+    PairEntry entry = new PairEntry("a", 1, 100);
+    assertTrue(entry.matches("a", 1));
+  }
+
+  @Test
+  void entryMatchesFalseWhenKey1Differs() {
+    PairEntry entry = new PairEntry("a", 1, 100);
+    assertFalse(entry.matches("b", 1));
+  }
+
+  @Test
+  void entryMatchesFalseWhenKey2Differs() {
+    PairEntry entry = new PairEntry("a", 1, 100);
+    assertFalse(entry.matches("a", 2));
+  }
+
+  @Test
+  void entryHashIsConsistentForSameKeys() {
+    long h1 = Hashtable.D2.Entry.hash("x", 42);
+    long h2 = Hashtable.D2.Entry.hash("x", 42);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  void entryHashDiffersForDifferentKeys() {
+    long h1 = Hashtable.D2.Entry.hash("x", 1);
+    long h2 = Hashtable.D2.Entry.hash("x", 2);
+    assertFalse(h1 == h2);
   }
 
   @Test


### PR DESCRIPTION
## What Does This Do
Adds `OptimizedTagMap.EmptyHolder` to the coverage exclusion list in `internal-api/build.gradle.kts`

## Motivation
`EmptyHolder` is a lazy-holder idiom class (no methods, just a static initializer) used to avoid class-init ordering issues between `TagMap` and `OptimizedTagMap`; it is exercised indirectly via `TagMap.EMPTY` but JaCoCo tracks it as a separate class

## Additional Notes


🤖 Generated with [Claude Code](https://claude.com/claude-code)