### PR TITLE
Add MessageAdapter content parts serialization test coverage

### DIFF
--- a/dd-java-agent/agent-aiguard/src/test/groovy/com/datadog/aiguard/AIGuardInternalTests.groovy
+++ b/dd-java-agent/agent-aiguard/src/test/groovy/com/datadog/aiguard/AIGuardInternalTests.groovy
@@ -861,6 +861,28 @@ class AIGuardInternalTests extends DDSpecification {
     }
   }
 
+  void 'test adapter serializes content parts'() {
+    given:
+    final adapter = new Moshi.Builder().add(new AIGuardInternal.AIGuardFactory()).build()
+    .adapter(AIGuard.Message)
+
+    expect:
+    // STRICT enforces array element ordering (object key order is always ignored), so a regression
+    // that serialized the content parts out of sequence would be caught here
+    JSONAssert.assertEquals(expected, adapter.toJson(message), JSONCompareMode.STRICT)
+
+    where:
+    message                                                                            | expected
+    AIGuard.Message.message('user', [] as List<AIGuard.ContentPart>)                    | '{"role": "user", "content": []}'
+    AIGuard.Message.message('user', [AIGuard.ContentPart.text('Hello world')])         | '{"role": "user", "content": [{"type": "text", "text": "Hello world"}]}'
+    AIGuard.Message.message('user', [AIGuard.ContentPart.imageUrl('https://example.com/image.jpg')]) | '{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}]}'
+    AIGuard.Message.message('user', [
+      AIGuard.ContentPart.text('Describe this image:'),
+      AIGuard.ContentPart.imageUrl('https://example.com/image.jpg'),
+      AIGuard.ContentPart.text('What do you see?')
+    ]) | '{"role": "user", "content": [{"type": "text", "text": "Describe this image:"}, {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}, {"type": "text", "text": "What do you see?"}]}'
+  }
+
   void 'test backward compatibility with string content'() {
     given:
     final aiguard = mockClient(200, [data: [attributes: [action: 'ALLOW', reason: 'Good']]])


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
