### PR TITLE
Introduces the api-management inferred proxy spans to Azure

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/gateway/InferredProxySpan.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InferredProxySpan.java
@@ -47,6 +47,7 @@ public class InferredProxySpan implements ImplicitContextKeyed {
     SUPPORTED_PROXIES = new HashMap<>();
     SUPPORTED_PROXIES.put("aws-apigateway", "aws.apigateway");
     SUPPORTED_PROXIES.put("aws-httpapi", "aws.httpapi");
+    SUPPORTED_PROXIES.put("azure-apim", "azure.apim");
   }
 
   private final Map<String, String> headers;

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
@@ -241,7 +241,10 @@ class InferredProxySpanTests {
   }
 
   static Stream<Arguments> supportedProxySystems() {
-    return Stream.of(of("aws-apigateway", "aws.apigateway"), of("aws-httpapi", "aws.httpapi"), of("azure-apim", "azure.apim"));
+    return Stream.of(
+        of("aws-apigateway", "aws.apigateway"),
+        of("aws-httpapi", "aws.httpapi"),
+        of("azure-apim", "azure.apim"));
   }
 
   @Test

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InferredProxySpanTests.java
@@ -241,7 +241,7 @@ class InferredProxySpanTests {
   }
 
   static Stream<Arguments> supportedProxySystems() {
-    return Stream.of(of("aws-apigateway", "aws.apigateway"), of("aws-httpapi", "aws.httpapi"));
+    return Stream.of(of("aws-apigateway", "aws.apigateway"), of("aws-httpapi", "aws.httpapi"), of("azure-apim", "azure.apim"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
This PR introduces the api-management inferred proxy spans to Azure. It leverages the existing inferred proxy span component. This works by looking for a magic value in one of the received headers. 
[APMSVLS-539](https://datadoghq.atlassian.net/browse/APMSVLS-539)
<img width="835" height="316" alt="image" src="https://github.com/user-attachments/assets/741dfd12-3b4d-4a6c-b337-ad05aa669c5a" />

In the headers we also add metadata for Http Method, Path, Region and origin domain name. 

# Motivation
My motivation for this is have the java-tracer have feature parity with Node, Python and .Net that already support this inferred span.

# Additional Notes
For testing I have setup a multi service distributed trace with another service upstream from the Api Management span. 

<img width="2292" height="525" alt="image" src="https://github.com/user-attachments/assets/9d0a75c7-b205-4e1f-b3c3-df37a2e65b53" />


[APMSVLS-539]: https://datadoghq.atlassian.net/browse/APMSVLS-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ