### PR TITLE
Exclude `OtelSpiMetricPeriodicAction` from code coverage

### DIFF
--- a/telemetry/build.gradle.kts
+++ b/telemetry/build.gradle.kts
@@ -17,7 +17,8 @@ extra["excludedClassesCoverage"] = listOf(
   "datadog.telemetry.RequestBuilderSupplier",
   "datadog.telemetry.TelemetrySystem",
   "datadog.telemetry.api.*",
-  "datadog.telemetry.metric.CiVisibilityMetricPeriodicAction"
+  "datadog.telemetry.metric.CiVisibilityMetricPeriodicAction",
+  "datadog.telemetry.metric.OtelSpiMetricPeriodicAction"
 )
 extra["excludedClassesBranchCoverage"] = listOf(
   "datadog.telemetry.PolymorphicAdapterFactory.1",


### PR DESCRIPTION
# What Does This Do

Excludes the `OtelSpiMetricPeriodicAction` class from code coverage.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]