### PR TITLE
Unify usage of OperatingSystem.architecture()

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/EnvironmentChecker.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/EnvironmentChecker.java
@@ -1,7 +1,5 @@
 package com.datadog.profiling.controller;
 
-import static datadog.environment.OperatingSystem.architecture;
-
 import datadog.environment.JavaVirtualMachine;
 import datadog.environment.OperatingSystem;
 import datadog.environment.SystemProperties;
@@ -238,7 +236,8 @@ public final class EnvironmentChecker {
   @SuppressForbidden
   private static boolean extractSoFromJar(Path target, StringBuilder sb) throws Exception {
     URL jarUrl = EnvironmentChecker.class.getProtectionDomain().getCodeSource().getLocation();
-    String linuxArchFolder = architecture().isArm64() ? "/linux-arm64/" : "/linux-x64/";
+    String linuxArchFolder =
+        OperatingSystem.architecture().isArm64() ? "/linux-arm64/" : "/linux-x64/";
     try (JarFile jarFile = new JarFile(new File(jarUrl.toURI()))) {
       return jarFile.stream()
           .filter(e -> e.getName().contains("libjavaProfiler.so"))

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
@@ -1,6 +1,5 @@
 package executor
 
-import static datadog.environment.OperatingSystem.architecture
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 
 import datadog.environment.OperatingSystem
@@ -23,7 +22,7 @@ import spock.lang.Shared
 
 // TODO: netty-all 4.1.9 only ships linux-x86_64 epoll native libraries.
 @IgnoreIf({
-  OperatingSystem.isLinux() && architecture().isArm64()
+  OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64()
 })
 class NettyExecutorInstrumentationTest extends InstrumentationSpecification {
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -2,7 +2,6 @@ import static DbType.MYSQL
 import static DbType.ORACLE
 import static DbType.POSTGRESQL
 import static DbType.SQLSERVER
-import static datadog.environment.OperatingSystem.architecture
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
@@ -117,7 +116,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     // MS SQL Server has no arm64 images.
     return !(db == SQLSERVER
       && OperatingSystem.isLinux()
-      && architecture().isArm64())
+      && OperatingSystem.architecture().isArm64())
   }
 
   def peerConnectionProps(DbType db){

--- a/dd-java-agent/instrumentation/restlet-2.2/src/latestDepTest/groovy/RestletTest.groovy
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/latestDepTest/groovy/RestletTest.groovy
@@ -1,5 +1,3 @@
-import static datadog.environment.OperatingSystem.architecture
-
 import datadog.environment.OperatingSystem
 import org.restlet.Request
 import org.restlet.Response
@@ -12,7 +10,7 @@ class RestletTest extends RestletTestBase {
   @Override
   boolean testParallelRequest() {
     // TODO: Parallel processing is failing on Linux arm64.
-    return !(OperatingSystem.isLinux() && architecture().isArm64())
+    return !(OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64())
   }
 
   @Override

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProcessBuilderHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProcessBuilderHelper.java
@@ -1,7 +1,5 @@
 package datadog.smoketest;
 
-import static datadog.environment.OperatingSystem.architecture;
-
 import datadog.environment.OperatingSystem;
 import java.io.File;
 import java.nio.file.Path;
@@ -59,7 +57,7 @@ class ProcessBuilderHelper {
 
     List<String> command = new ArrayList<>();
     command.addAll(baseCommand);
-    if (OperatingSystem.isLinux() && architecture().isArm64()) {
+    if (OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64()) {
       // Disable CDS to avoid SIGSEGVs on Linux arm64.
       command.add(1, "-Xshare:off");
     }

--- a/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
+++ b/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
@@ -1,6 +1,5 @@
 package datadog.smoketest
 
-import static datadog.environment.OperatingSystem.architecture
 import static java.util.concurrent.TimeUnit.SECONDS
 
 import datadog.environment.JavaVirtualMachine
@@ -9,7 +8,7 @@ import spock.lang.IgnoreIf
 
 // TODO: OpenJ9 (Semeru) on Linux arm64 fails on this test.
 @IgnoreIf({
-  OperatingSystem.isLinux() && architecture().isArm64() && JavaVirtualMachine.isJ9()
+  OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64() && JavaVirtualMachine.isJ9()
 })
 class Java9ModulesSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation plus some extra

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -1,6 +1,5 @@
 package datadog.smoketest
 
-import static datadog.environment.OperatingSystem.architecture
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.api.ProtocolVersion.V0_4
 import static datadog.trace.api.ProtocolVersion.V0_5
@@ -255,7 +254,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     }
 
     // Disable CDS to avoid SIGSEGVs on Linux arm64.
-    if (OperatingSystem.isLinux() && architecture().isArm64()) {
+    if (OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64()) {
       ret += "-Xshare:off"
     }
     ret as String[]

--- a/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
+++ b/dd-smoke-tests/websphere-jmx/src/test/groovy/datadog/smoketest/WebSphereJmxSmokeTest.groovy
@@ -1,7 +1,5 @@
 package datadog.smoketest
 
-import static datadog.environment.OperatingSystem.architecture
-
 import datadog.environment.OperatingSystem
 import java.time.Duration
 import java.util.concurrent.ArrayBlockingQueue
@@ -27,7 +25,7 @@ import spock.lang.Shared
  */
 //  There is no arm64 docker image for IBM icr.io/appcafe/websphere-traditional.
 @IgnoreIf({
-  OperatingSystem.isLinux() && architecture().isArm64()
+  OperatingSystem.isLinux() && OperatingSystem.architecture().isArm64()
 })
 class WebSphereJmxSmokeTest extends AbstractSmokeTest {
 


### PR DESCRIPTION
# What Does This Do

Unifies all call sites to use `OperatingSystem.architecture()` instead of the statically-imported `architecture()`, removing the `import static datadog.environment.OperatingSystem.architecture` imports across the codebase.

# Motivation

Addresses PR #11364 review feedback to keep usage of the `OperatingSystem` utility consistent. Qualifying calls with `OperatingSystem.architecture()` makes it explicit where the architecture check comes from and avoids ambiguity at the call site.

# Additional Notes

- Pure refactor — no behavioral change.

