### PR TITLE
Use TagExtractor for JDBC connection-info tags (canary) (phase 3 - span api adoption)

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInfoExtractor.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInfoExtractor.java
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_POOL_NAME;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_SCHEMA;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_WAREHOUSE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
+
+/**
+ * Named singleton {@link TagExtractor} for the pure JDBC connection tags (warehouse / schema /
+ * pool) — no derivation, no side-effects.
+ *
+ * <p>Promoted from an inline lambda in {@link JDBCDecorator} to a named class so it can be
+ * referenced by name at call sites ({@code span.setTags(dbInfo, ConnectionInfoExtractor.INSTANCE)})
+ * and composed with other extractors. Non-capturing and stateless — the single {@link #INSTANCE} is
+ * effectively a static function object, so a monomorphic call site inlines it away.
+ * Behavior-identical to the previous inline {@code setTagIfPresent} block. ({@code db.type} /
+ * instance / hostname stay in the decorator for now: their values feed service-name/naming
+ * derivation, a later declarative step.)
+ */
+public final class ConnectionInfoExtractor implements TagExtractor<DBInfo> {
+  public static final ConnectionInfoExtractor INSTANCE = new ConnectionInfoExtractor();
+
+  private ConnectionInfoExtractor() {}
+
+  @Override
+  public void extract(final DBInfo info, final AgentSpan span) {
+    setTagIfPresent(span, DB_WAREHOUSE, info.getWarehouse());
+    setTagIfPresent(span, DB_SCHEMA, info.getSchema());
+    setTagIfPresent(span, DB_POOL_NAME, info.getPoolName());
+  }
+
+  private static void setTagIfPresent(final AgentSpan span, final String key, final String value) {
+    if (value != null && !value.isEmpty()) {
+      span.setTag(key, value);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -19,7 +19,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
@@ -74,19 +73,6 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
       Config.get().isDbMetadataFetchingOnConnectEnabled();
   private static final boolean FETCH_DB_METADATA_ON_QUERY =
       Config.get().isDbMetadataFetchingOnQueryEnabled();
-
-  // Canary for the TagExtractor mechanism: the JDBC-specific, pure field->tag connection tags
-  // (warehouse / schema / pool — no derivation). A static-final non-capturing lambda applied via
-  // span.setTags(...) at the single onConnection site — a monomorphic call site the JIT inlines
-  // (the span.setTags indirection folds away). Behavior-identical to the previous inline
-  // setTagIfPresent block. (DB_TYPE / instance / hostname stay in the decorator for now: their
-  // values feed service-name/naming derivation — bucket (c), a later declarative step.)
-  private static final TagExtractor<DBInfo> CONNECTION_INFO_EXTRACTOR =
-      (info, span) -> {
-        setTagIfPresent(span, DB_WAREHOUSE, info.getWarehouse());
-        setTagIfPresent(span, DB_SCHEMA, info.getSchema());
-        setTagIfPresent(span, DB_POOL_NAME, info.getPoolName());
-      };
 
   private volatile boolean warnedAboutDBMPropagationMode = false; // to log a warning only once
   private volatile boolean loggedInjectionError = false;
@@ -161,17 +147,11 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     return info.getHost();
   }
 
-  private static void setTagIfPresent(final AgentSpan span, final String key, final String value) {
-    if (value != null && !value.isEmpty()) {
-      span.setTag(key, value);
-    }
-  }
-
   public AgentSpan onConnection(final AgentSpan span, DBInfo dbInfo) {
     if (dbInfo != null) {
       processDatabaseType(span, dbInfo.getType());
 
-      span.setTags(dbInfo, CONNECTION_INFO_EXTRACTOR);
+      span.setTags(dbInfo, ConnectionInfoExtractor.INSTANCE);
     }
     return super.onConnection(span, dbInfo);
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -19,6 +19,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
@@ -73,6 +74,19 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
       Config.get().isDbMetadataFetchingOnConnectEnabled();
   private static final boolean FETCH_DB_METADATA_ON_QUERY =
       Config.get().isDbMetadataFetchingOnQueryEnabled();
+
+  // Canary for the TagExtractor mechanism: the JDBC-specific, pure field->tag connection tags
+  // (warehouse / schema / pool — no derivation). A static-final non-capturing lambda applied via
+  // span.setTags(...) at the single onConnection site — a monomorphic call site the JIT inlines
+  // (the span.setTags indirection folds away). Behavior-identical to the previous inline
+  // setTagIfPresent block. (DB_TYPE / instance / hostname stay in the decorator for now: their
+  // values feed service-name/naming derivation — bucket (c), a later declarative step.)
+  private static final TagExtractor<DBInfo> CONNECTION_INFO_EXTRACTOR =
+      (info, span) -> {
+        setTagIfPresent(span, DB_WAREHOUSE, info.getWarehouse());
+        setTagIfPresent(span, DB_SCHEMA, info.getSchema());
+        setTagIfPresent(span, DB_POOL_NAME, info.getPoolName());
+      };
 
   private volatile boolean warnedAboutDBMPropagationMode = false; // to log a warning only once
   private volatile boolean loggedInjectionError = false;
@@ -147,7 +161,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     return info.getHost();
   }
 
-  private void setTagIfPresent(final AgentSpan span, final String key, final String value) {
+  private static void setTagIfPresent(final AgentSpan span, final String key, final String value) {
     if (value != null && !value.isEmpty()) {
       span.setTag(key, value);
     }
@@ -157,9 +171,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     if (dbInfo != null) {
       processDatabaseType(span, dbInfo.getType());
 
-      setTagIfPresent(span, DB_WAREHOUSE, dbInfo.getWarehouse());
-      setTagIfPresent(span, DB_SCHEMA, dbInfo.getSchema());
-      setTagIfPresent(span, DB_POOL_NAME, dbInfo.getPoolName());
+      span.setTags(dbInfo, CONNECTION_INFO_EXTRACTOR);
     }
     return super.onConnection(span, dbInfo);
   }


### PR DESCRIPTION
**Draft — stacked on #11817 (the `TagContributor`/`TagExtractor` API). First real use of the API; the canary for dissolving the decorators.**

Lifts `JDBCDecorator`'s JDBC-specific pure field→tag connection tags (`db.warehouse` / `db.schema` / `db.pool.name` — the `setTagIfPresent` block in `onConnection`) into **`ConnectionInfoExtractor`**, a named singleton `TagExtractor<DBInfo>`, applied via the span-first `span.setTags(dbInfo, ConnectionInfoExtractor.INSTANCE)` at the single `onConnection` site (monomorphic → the JIT inlines it). Behavior-identical: the extractor makes the same three `setTagIfPresent` calls via the same helper (now on the extractor class).

### Scope (deliberately minimal)
Bucket-(b) pure extraction only, JDBC-only, **no shared-base change**. `DB_TYPE` / user / instance / hostname stay in the decorator — `db.user` moves in #11823; instance/hostname feed service-name **derivation**, which awaits the declarative-derivation step.

### Perf
**Perf-neutral by construction** — the tags moved here were already *direct* `setTagIfPresent` calls (not the megamorphic template-method dispatches), and the extractor is monomorphic → inlines → same code as before. The dispatch-reduction win (N→1) lives in the *template methods* (`dbUser`/`dbInstance`/`dbHostname`), addressed in the stacked peels. See the synthetic `TagProjectionBenchmark` in #11817 for the mechanism.

### Validation
`JDBCInstrumentationV0Test` green (**87/87**, incl. the `db.warehouse`/`db.schema`/`db.pool.name` assertions). Notably, `ConnectionInfoExtractor` — a **separate top-level helper class** (the old lambda used to compile *into* `JDBCDecorator`) — is auto-injected via transitive helper collection with **no `helperClassNames()` edit**. (`RemoteJDBC*` tests are postgres/mysql/sqlserver testcontainers — env-gated, CI-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)