### PR TITLE
Peel dbUser out of DatabaseClientDecorator into a param-injected TagExtractor (phase 3 - span api adoption)

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/jmh/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientConnectionBenchmark.java
+++ b/dd-java-agent/agent-bootstrap/src/jmh/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientConnectionBenchmark.java
@@ -1,0 +1,209 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_USER;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.common.writer.Writer;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDSpan;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Acceptance test for the {@code dbUser} peel: measures the param-injected connection-tags {@link
+ * TagExtractor} form of {@link DatabaseClientDecorator#onConnection(AgentSpan, Object,
+ * TagExtractor)} — the shape that replaced the sparsely-overridden {@code dbUser} template method.
+ *
+ * <p>One decorator type is used throughout (so the receiver and the {@code dbInstance}/{@code
+ * dbHostname} template calls stay monomorphic); only the injected extractor varies, to isolate the
+ * question raised in review: does passing the extractor as a caller-side constant devirtualize and
+ * inline?
+ *
+ * <p>{@code mode}:
+ *
+ * <ul>
+ *   <li><b>mono</b> — a single {@code static final} extractor at the call site (the production
+ *       shape: each integration's advice passes its own constant). Expect {@code extract()} to
+ *       devirtualize and inline when {@code onConnection} inlines.
+ *   <li><b>mega</b> — {@link #TYPES} distinct extractor types cycled through the one site (the
+ *       worst case: a single shared site that never sees a stable type). Characterizes the downside
+ *       if the call is <em>not</em> inlined.
+ * </ul>
+ *
+ * <p>Run with {@code -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining} to confirm the mechanism
+ * (the tree, not just the number) — look for {@code DatabaseClientDecorator::onConnection} and the
+ * extractor {@code extract} bodies.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(SECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
+@Threads(8)
+public class DatabaseClientConnectionBenchmark {
+
+  private static final int TYPES = 8;
+  private static final String CONN = "bench-user";
+
+  /** The mono call site: a single static-final constant extractor. */
+  private static final TagExtractor<String> MONO = new E0();
+
+  @Param({"mono", "mega"})
+  String mode;
+
+  private boolean mega;
+  private BenchDbDecorator decorator;
+  private AgentSpan span;
+  private TagExtractor<String>[] extractors;
+  private int idx;
+
+  @SuppressWarnings("unchecked")
+  @Setup(Level.Trial)
+  public void setUp() {
+    CoreTracer tracer =
+        CoreTracer.builder().strictTraceWrites(true).writer(new NoOpWriter()).build();
+    GlobalTracer.forceRegister(tracer);
+    decorator = new BenchDbDecorator();
+    span = tracer.startSpan("benchmark", "db.query");
+    extractors =
+        new TagExtractor[] {
+          new E0(), new E1(), new E2(), new E3(), new E4(), new E5(), new E6(), new E7()
+        };
+    mega = "mega".equals(mode);
+  }
+
+  @Benchmark
+  public AgentSpan onConnection() {
+    if (mega) {
+      int i = idx;
+      idx = (i + 1 == TYPES) ? 0 : i + 1;
+      return decorator.onConnection(span, CONN, extractors[i]);
+    }
+    return decorator.onConnection(span, CONN, MONO);
+  }
+
+  // Eight structurally-identical but distinct extractor types (so the mega site sees a rotating
+  // type).
+  static final class E0 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E1 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E2 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E3 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E4 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E5 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E6 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class E7 implements TagExtractor<String> {
+    public void extract(String c, AgentSpan s) {
+      s.setTag(DB_USER, c);
+    }
+  }
+
+  static final class BenchDbDecorator extends DatabaseClientDecorator<String> {
+    private static final CharSequence COMPONENT = UTF8BytesString.create("benchmark");
+
+    @Override
+    protected String[] instrumentationNames() {
+      return new String[] {"benchmark"};
+    }
+
+    @Override
+    protected String service() {
+      return "benchmark-db";
+    }
+
+    @Override
+    protected CharSequence component() {
+      return COMPONENT;
+    }
+
+    @Override
+    protected CharSequence spanType() {
+      return "sql";
+    }
+
+    @Override
+    protected String dbType() {
+      return "benchdb";
+    }
+
+    @Override
+    protected String dbInstance(String connection) {
+      return connection;
+    }
+
+    @Override
+    protected CharSequence dbHostname(String connection) {
+      return null;
+    }
+  }
+
+  private static class NoOpWriter implements Writer {
+    @Override
+    public void write(final List<DDSpan> trace) {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public boolean flush() {
+      return false;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void incrementDropCounts(final int spanCount) {}
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -16,6 +16,7 @@ import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.function.BiConsumer;
@@ -55,11 +56,14 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbType();
 
-  protected abstract String dbUser(CONNECTION connection);
-
   protected abstract String dbInstance(CONNECTION connection);
 
   protected abstract CharSequence dbHostname(CONNECTION connection);
+
+  /**
+   * No-op connection-tag extractor: the default for stores that contribute no pure connection tags.
+   */
+  private static final TagExtractor<Object> NO_CONNECTION_TAGS = (connection, span) -> {};
 
   /**
    * This should be called when the connection is being used, not when it's created.
@@ -69,8 +73,26 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    * @return
    */
   public AgentSpan onConnection(final AgentSpan span, final CONNECTION connection) {
+    return onConnection(span, connection, noConnectionTags());
+  }
+
+  /**
+   * As {@link #onConnection(AgentSpan, Object)}, but with a {@link TagExtractor} for the store's
+   * pure connection tags (e.g. {@code db.user} for SQL) injected as a parameter.
+   *
+   * <p>Passing the extractor as a caller-side argument — rather than fetching it from a virtual
+   * method — is what preserves inlining: at a monomorphic advice site the extractor is a {@code
+   * static final} constant, so when this (small) method inlines, {@code extractor.extract(...)}
+   * devirtualizes and inlines too. It replaces the previous per-store template methods (the
+   * sparsely overridden {@code dbUser}, which most NoSQL stores could only answer with {@code
+   * null}) and is the seam for disentangling pure tag extraction from the derivation below.
+   */
+  public AgentSpan onConnection(
+      final AgentSpan span,
+      final CONNECTION connection,
+      final TagExtractor<CONNECTION> connectionTags) {
     if (connection != null) {
-      span.setTag(Tags.DB_USER, dbUser(connection));
+      connectionTags.extract(connection, span);
       onInstance(span, dbInstance(connection));
       CharSequence hostName = dbHostname(connection);
       if (hostName != null) {
@@ -82,6 +104,11 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       }
     }
     return span;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected static <CONNECTION> TagExtractor<CONNECTION> noConnectionTags() {
+    return (TagExtractor<CONNECTION>) NO_CONNECTION_TAGS;
   }
 
   protected AgentSpan onInstance(final AgentSpan span, final String dbInstance) {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
@@ -68,11 +68,6 @@ class DBTypeProcessingDatabaseClientDecoratorTest extends ClientDecoratorTest {
         }
 
         @Override
-        protected String dbUser(Map map) {
-          return map.user
-        }
-
-        @Override
         protected String dbInstance(Map map) {
           return map.instance
         }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -51,7 +51,8 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (session) {
-      1 * span.setTag(Tags.DB_USER, session.user)
+      // db.user is no longer set by the 2-arg onConnection (it used to come from the dbUser template
+      // method); it now arrives via the connection-tags extractor of the 3-arg form (see below).
       if (session.instance != null) {
         1 * span.setTag(Tags.DB_INSTANCE, session.instance)
       }
@@ -86,6 +87,32 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     true             | true               | true          | [user: "test-user", hostname: "test-hostname"]
     false            | true               | true          | [instance: "test-instance", hostname: "test-hostname"]
     true             | true               | true          | [user: "test-user", instance: "test-instance"]
+  }
+
+  def "test onConnection applies the connection-tags extractor"() {
+    setup:
+    def decorator = newDecorator()
+    def session = [user: "test-user"]
+
+    when:
+    decorator.onConnection(span, session, { Map m, AgentSpan s -> s.setTag(Tags.DB_USER, m.user) })
+
+    then:
+    1 * span.setTag(Tags.DB_USER, "test-user")
+    0 * _
+  }
+
+  def "test onConnection with a null connection skips the extractor"() {
+    setup:
+    def decorator = newDecorator()
+    def extractor = Mock(datadog.trace.bootstrap.instrumentation.api.TagExtractor)
+
+    when:
+    decorator.onConnection(span, null, extractor)
+
+    then:
+    0 * extractor.extract(_, _)
+    0 * _
   }
 
   def "test onStatement"() {
@@ -132,11 +159,6 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
         @Override
         protected String dbType() {
           return "test-db"
-        }
-
-        @Override
-        protected String dbUser(Map map) {
-          return map.user
         }
 
         @Override

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
@@ -36,11 +36,6 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
         }
 
         @Override
-        protected String dbUser(Object o) {
-          return "test-user"
-        }
-
-        @Override
         protected String dbInstance(Object o) {
           return "test-user"
         }

--- a/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4.0/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -51,11 +51,6 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   @Override
-  protected String dbUser(final Node node) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Node node) {
     return null;
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
@@ -43,11 +43,6 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
@@ -52,11 +52,6 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
@@ -52,11 +52,6 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/DatanucleusDecorator.java
+++ b/dd-java-agent/instrumentation/datanucleus-4.0.5/src/main/java/datadog/trace/instrumentation/datanucleus/DatanucleusDecorator.java
@@ -69,11 +69,6 @@ public class DatanucleusDecorator extends OrmClientDecorator {
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-3.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -63,11 +63,6 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   @Override
-  protected String dbUser(final Session session) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Session session) {
     return session.getLoggedKeyspace();
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
@@ -68,11 +68,6 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   @Override
-  protected String dbUser(final Session session) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Session session) {
     return session.getKeyspace().map(Objects::toString).orElse(null);
   }

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-common/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-common/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -58,11 +58,6 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-common/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-common/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -46,11 +46,6 @@ public class ElasticsearchTransportClientDecorator extends DBTypeProcessingDatab
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -41,11 +41,6 @@ public class HibernateDecorator extends OrmClientDecorator {
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
@@ -57,11 +57,6 @@ public class IgniteCacheDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(IgniteCache igniteCache) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(IgniteCache igniteCache) {
     return null;
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInfoExtractor.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInfoExtractor.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_POOL_NAME;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_SCHEMA;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_USER;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_WAREHOUSE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -27,6 +28,9 @@ public final class ConnectionInfoExtractor implements TagExtractor<DBInfo> {
 
   @Override
   public void extract(final DBInfo info, final AgentSpan span) {
+    // DB_USER is set unconditionally to preserve the prior DatabaseClientDecorator behavior (it set
+    // db.user from dbUser(info) without a present-check); the rest skip null/empty.
+    span.setTag(DB_USER, info.getUser());
     setTagIfPresent(span, DB_WAREHOUSE, info.getWarehouse());
     setTagIfPresent(span, DB_SCHEMA, info.getSchema());
     setTagIfPresent(span, DB_POOL_NAME, info.getPoolName());

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -129,11 +129,6 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   @Override
-  protected String dbUser(final DBInfo info) {
-    return info.getUser();
-  }
-
-  @Override
   protected String dbInstance(final DBInfo info) {
     if (info.getInstance() != null) {
       return info.getInstance();
@@ -150,10 +145,10 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   public AgentSpan onConnection(final AgentSpan span, DBInfo dbInfo) {
     if (dbInfo != null) {
       processDatabaseType(span, dbInfo.getType());
-
-      span.setTags(dbInfo, ConnectionInfoExtractor.INSTANCE);
     }
-    return super.onConnection(span, dbInfo);
+    // Pure connection tags (db.user / warehouse / schema / pool) are injected via the param form;
+    // the base applies them under its own null-check alongside instance/hostname derivation.
+    return super.onConnection(span, dbInfo, ConnectionInfoExtractor.INSTANCE);
   }
 
   public static DBInfo parseDBInfo(

--- a/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
@@ -41,11 +41,6 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(final Connection connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Connection connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
@@ -42,11 +42,6 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(final Connection connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Connection connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
@@ -41,11 +41,6 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(final Connection connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Connection connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-4.0/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -46,11 +46,6 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   }
 
   @Override
-  protected String dbUser(final RedisURI connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final RedisURI connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -42,11 +42,6 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   }
 
   @Override
-  protected String dbUser(final RedisURI connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final RedisURI connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/mongo-common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
@@ -53,11 +53,6 @@ public abstract class MongoDecorator
   }
 
   @Override
-  protected final String dbUser(final CommandStartedEvent event) {
-    return null;
-  }
-
-  @Override
   protected final String dbHostname(CommandStartedEvent event) {
     final ConnectionDescription connectionDescription = event.getConnectionDescription();
     if (connectionDescription != null) {

--- a/dd-java-agent/instrumentation/opensearch/opensearch-common/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-common/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
@@ -56,11 +56,6 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/opensearch/opensearch-common/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/opensearch-common/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientDecorator.java
@@ -45,11 +45,6 @@ public class OpensearchTransportClientDecorator extends DBTypeProcessingDatabase
   }
 
   @Override
-  protected String dbUser(final Object o) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Object o) {
     return null;
   }

--- a/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
@@ -44,11 +44,6 @@ public class RediscalaClientDecorator
   }
 
   @Override
-  protected String dbUser(final RedisConnectionInfo redisConnectionInfo) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final RedisConnectionInfo redisConnectionInfo) {
     return null;
   }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
@@ -43,11 +43,6 @@ public class RedissonClientDecorator
   }
 
   @Override
-  protected String dbUser(CommandData<?, ?> commandData) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(CommandData<?, ?> commandData) {
     return null;
   }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
@@ -43,11 +43,6 @@ public class RedissonClientDecorator
   }
 
   @Override
-  protected String dbUser(CommandData<?, ?> commandData) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(CommandData<?, ?> commandData) {
     return null;
   }

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
@@ -43,11 +43,6 @@ public class RedissonClientDecorator
   }
 
   @Override
-  protected String dbUser(CommandData<?, ?> commandData) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(CommandData<?, ?> commandData) {
     return null;
   }

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -45,11 +45,6 @@ public class MemcacheClientDecorator
   }
 
   @Override
-  protected String dbUser(final MemcachedConnection session) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final MemcachedConnection connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/valkey-java-5.3/src/main/java/io/valkey/ValkeyClientDecorator.java
+++ b/dd-java-agent/instrumentation/valkey-java-5.3/src/main/java/io/valkey/ValkeyClientDecorator.java
@@ -41,11 +41,6 @@ public class ValkeyClientDecorator extends DBTypeProcessingDatabaseClientDecorat
   }
 
   @Override
-  protected String dbUser(final Connection connection) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final Connection connection) {
     return null;
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-redis-client/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -55,11 +55,6 @@ public class VertxRedisClientDecorator
   }
 
   @Override
-  protected String dbUser(final SocketAddress socketAddress) {
-    return null;
-  }
-
-  @Override
   protected String dbInstance(final SocketAddress socketAddress) {
     return null;
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlClientDecorator.java
@@ -54,11 +54,6 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   @Override
-  protected String dbUser(final DBInfo info) {
-    return info.getUser();
-  }
-
-  @Override
   protected String dbInstance(final DBInfo info) {
     if (info.getInstance() != null) {
       return info.getInstance();
@@ -92,7 +87,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
     if (dbInfo != null) {
       processDatabaseType(span, dbInfo.getType());
     }
-    super.onConnection(span, dbInfo);
+    super.onConnection(span, dbInfo, VertxSqlConnectionExtractor.INSTANCE);
     if (null != dbQueryInfo) {
       span.setResourceName(dbQueryInfo.getSql());
       span.setTag(DB_OPERATION, dbQueryInfo.getOperation());

--- a/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlConnectionExtractor.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-sql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client_39/VertxSqlConnectionExtractor.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.vertx_sql_client_39;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_USER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.TagExtractor;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
+
+/**
+ * Named singleton {@link TagExtractor} for Vertx-SQL's pure connection tags ({@code db.user}). The
+ * SQL-family counterpart to the NoSQL stores that contribute none — injected via the param form of
+ * {@code DatabaseClientDecorator.onConnection} rather than the removed {@code dbUser} template
+ * method.
+ */
+public final class VertxSqlConnectionExtractor implements TagExtractor<DBInfo> {
+  public static final VertxSqlConnectionExtractor INSTANCE = new VertxSqlConnectionExtractor();
+
+  private VertxSqlConnectionExtractor() {}
+
+  @Override
+  public void extract(final DBInfo info, final AgentSpan span) {
+    // Unconditional to preserve the prior DatabaseClientDecorator behavior (db.user was set from
+    // dbUser(info) with no present-check).
+    span.setTag(DB_USER, info.getUser());
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -96,7 +96,9 @@ public interface AgentSpan
    * an implementer may override to do so.
    */
   default <T> AgentSpan setTags(final T source, final TagExtractor<T> extractor) {
-    extractor.extract(source, this);
+    if (source != null) {
+      extractor.extract(source, this);
+    }
     return this;
   }
 


### PR DESCRIPTION
## What

First real dissolution of the DB decorator hierarchy: removes the `dbUser` template method from `DatabaseClientDecorator` and replaces it with a **param-injected connection-tags `TagExtractor`**. Stacked on #11820.

## Why dbUser

A null-ratio scan of the DB template methods flagged it as the sparsest: **28/30 leaves returned `null`** — only JDBC and Vertx-SQL provide a real user. That sparsity is the **SQL/NoSQL false-generalization** showing through: `db.user` is a SQL-auth concept the NoSQL/cache stores (Redis, Mongo, Cassandra, …) can only answer with `null`, yet every DB span paid a virtual `dbUser()` call to set `DB_USER = null`. (`dbInstance` 0.65 / `dbHostname` 0.52 are next, but they're DERIVED — they feed service-name split — so they wait on the declarative-derivation layer.)

## The pattern (param-injected extractor)

`DatabaseClientDecorator` gains `onConnection(span, conn, TagExtractor<CONNECTION>)`; the 2-arg overload delegates with a shared no-op extractor. The extractor is passed as a **caller-side `static final` constant**, so at a monomorphic advice site it devirtualizes + inlines when `onConnection` inlines — the key advantage over a virtual `connectionExtractor()` provider (which would re-megamorphize). This is also the seam for disentangling pure extraction from side-effects in the harder decorators later.

## Changes
- **Base**: param-form `onConnection` + no-op default; remove `abstract dbUser` and the `setTag(DB_USER, …)` line.
- **JDBC**: fold `db.user` into `ConnectionInfoExtractor`, apply via `super.onConnection(..., INSTANCE)`.
- **Vertx-SQL**: new `VertxSqlConnectionExtractor`, applied via the param form at its `super.onConnection` call (the provider-with-no-override case the param form is *for*).
- **26 NoSQL/cache decorators**: drop the dead `dbUser` → `null` override.
- **`DatabaseClientConnectionBenchmark`** (jmh): the inlining acceptance harness (below).

Net **−71 lines**. `db.user` is set **unconditionally** by the two providers to preserve the prior (present-check-free) behavior exactly.

## Inlining verification (the acceptance test — done)

`DatabaseClientConnectionBenchmark` exercises the real param-form `onConnection` at a **mono** site (one `static final` extractor — the production shape) vs **mega** (8 rotating extractor types — worst case). `-XX:+PrintInlining`:

- **mono**: `DatabaseClientDecorator::onConnection — inline (hot)` and the concrete extractor's `extract() — inline (hot)` (the abstract `TagExtractor::extract` slot is bypassed). Full devirt + inline. **79.0M ops/s**.
- **mega**: **67.6M ops/s, only −14%** — the JIT polymorphically inlined all 8 tiny bodies. (Honest caveat: mega is *optimistic* — trivial 11-byte bodies fit HotSpot's polymorphic-inline ceiling; fuller real bodies would fall to a virtual call sooner. Production is mono.)

So the devirt claim holds at a monomorphic site.

## Testing
- `agent-bootstrap` decorator tests updated + green (incl. new param-form coverage). These are mock interaction-asserts for the old mechanism — flagged as Spock→JUnit migration candidates, not migrated here to keep the PR focused.
- `JDBCInstrumentationV0Test`: **87/87**; `ConnectionInfoExtractor` (now incl. `db.user`) auto-injected as a transitive helper — no `helperClassNames()` edit.
- Vertx-SQL / NoSQL integration tests are container-gated (CI); `VertxSqlConnectionExtractor` rides the same transitive-helper collection (`VertxSqlClientDecorator` is an explicit helper).

## Follow-ups
- `dbInstance`/`dbHostname` peel — gated on the declarative-derivation layer (their values feed `setServiceName`, a computed side-effect, not just a tag). Until that lands, `onConnection` (and its 2-arg overload) stays as the wrapper around that derivation.
- Spock→JUnit migration of the `DatabaseClientDecoratorTest` cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)