### PR TITLE
Fix multicast context propagation race in reactor/reactive-streams

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/reactivestreams/HandoffContext.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/reactivestreams/HandoffContext.java
@@ -1,0 +1,41 @@
+package datadog.trace.bootstrap.instrumentation.reactivestreams;
+
+import datadog.context.Context;
+
+/**
+ * Value of the {@code (Publisher, HandoffContext)} store used to hand a context from a publisher's
+ * subscribe to that publisher's own subscriber (or a blocking call).
+ *
+ * <p>{@link #threadConfined} deposits are only adopted on the producing thread. The reactor-core
+ * bridge uses them because a shared publisher — a multicast/replay {@code Sinks.Many} with several
+ * consumers — is subscribed concurrently, and keying by publisher identity alone would let one
+ * consumer adopt another's context. This is safe because a subscribe chain runs synchronously on
+ * one thread. {@link #anyThread} deposits are adopted anywhere, for producers (resilience4j,
+ * spring-webflux, spring-messaging) that attach to a unique publisher subscribed later, possibly on
+ * another thread.
+ */
+public final class HandoffContext {
+
+  private static final long ANY_THREAD = 0L;
+
+  private final long threadId;
+  private final Context context;
+
+  private HandoffContext(final Context context, final long threadId) {
+    this.context = context;
+    this.threadId = threadId;
+  }
+
+  public static HandoffContext anyThread(final Context context) {
+    return new HandoffContext(context, ANY_THREAD);
+  }
+
+  public static HandoffContext threadConfined(final Context context) {
+    return new HandoffContext(context, Thread.currentThread().getId());
+  }
+
+  /** The context, or {@code null} if this is a thread-confined deposit read on another thread. */
+  public Context contextForCurrentThread() {
+    return threadId == ANY_THREAD || threadId == Thread.currentThread().getId() ? context : null;
+  }
+}

--- a/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/PublisherInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -55,7 +56,7 @@ public class PublisherInstrumentation
       return ReactiveStreamsContextPropagation.captureOnSubscribe(
           self,
           s,
-          InstrumentationContext.get(Publisher.class, Context.class),
+          InstrumentationContext.get(Publisher.class, HandoffContext.class),
           InstrumentationContext.get(Subscriber.class, Context.class));
     }
 

--- a/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagation.java
+++ b/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.reactivestreams;
 import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -13,7 +14,7 @@ public final class ReactiveStreamsContextPropagation {
   public static ContextScope captureOnSubscribe(
       final Publisher<?> publisher,
       final Subscriber<?> subscriber,
-      final ContextStore<Publisher, Context> publisherContexts,
+      final ContextStore<Publisher, HandoffContext> publisherContexts,
       final ContextStore<Subscriber, Context> subscriberContexts) {
     // Don't consume the publisher context until we've verified the subscriber is non-null. For
     // subscribe(null), Reactive Streams mandates an NPE after this advice returns. Consuming the
@@ -22,7 +23,8 @@ public final class ReactiveStreamsContextPropagation {
       return null;
     }
 
-    final Context contextFromPublisher = publisherContexts.remove(publisher);
+    final HandoffContext handoff = publisherContexts.remove(publisher);
+    final Context contextFromPublisher = handoff == null ? null : handoff.contextForCurrentThread();
     final Context activeContext = Context.current();
     final Context context = contextFromPublisher != null ? contextFromPublisher : activeContext;
     if (context == Context.root()) {

--- a/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsModule.java
+++ b/dd-java-agent/instrumentation/reactive-streams-1.0/src/main/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsModule.java
@@ -6,6 +6,7 @@ import com.google.auto.service.AutoService;
 import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ public final class ReactiveStreamsModule extends InstrumenterModule.ContextTrack
   public Map<String, String> contextStore() {
     final Map<String, String> store = new HashMap<>();
     store.put("org.reactivestreams.Subscriber", Context.class.getName());
-    store.put("org.reactivestreams.Publisher", Context.class.getName());
+    store.put("org.reactivestreams.Publisher", HandoffContext.class.getName());
     return store;
   }
 

--- a/dd-java-agent/instrumentation/reactive-streams-1.0/src/test/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagationTest.java
+++ b/dd-java-agent/instrumentation/reactive-streams-1.0/src/test/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagationTest.java
@@ -8,6 +8,7 @@ import datadog.context.Context;
 import datadog.context.ContextKey;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -23,12 +24,12 @@ class ReactiveStreamsContextPropagationTest {
   void publisherCapturedContextOverridesActiveContext() {
     final Publisher<Object> publisher = subscriber -> {};
     final Subscriber<Object> subscriber = new NoopSubscriber();
-    final ContextStore<Publisher, Context> publisherContexts = new MapContextStore<>();
+    final ContextStore<Publisher, HandoffContext> publisherContexts = new MapContextStore<>();
     final ContextStore<Subscriber, Context> subscriberContexts = new MapContextStore<>();
 
-    // A context was captured on the publisher (e.g. at assembly / cross-thread subscribe).
+    // A context was handed off on the publisher, confined to this (the producing) thread.
     final Context captured = Context.root().with(KEY, "captured");
-    publisherContexts.put(publisher, captured);
+    publisherContexts.put(publisher, HandoffContext.threadConfined(captured));
 
     // The current thread already carries a different, non-root active context.
     final Context active = Context.root().with(KEY, "active");
@@ -52,9 +53,64 @@ class ReactiveStreamsContextPropagationTest {
       assertSame(active, Context.current());
     }
 
-    // The captured context is remembered for the subscriber, and removed from the publisher store.
+    // The captured context is remembered for the subscriber, and consumed from the publisher store.
     assertSame(captured, subscriberContexts.get(subscriber));
     assertNull(publisherContexts.get(publisher));
+  }
+
+  @Test
+  void publisherContextFromAnotherThreadIsIgnored() throws InterruptedException {
+    // A thread-confined deposit from another thread (concurrent multicast subscribe) must be
+    // ignored.
+    final Publisher<Object> publisher = subscriber -> {};
+    final Subscriber<Object> subscriber = new NoopSubscriber();
+    final ContextStore<Publisher, HandoffContext> publisherContexts = new MapContextStore<>();
+    final ContextStore<Subscriber, Context> subscriberContexts = new MapContextStore<>();
+
+    final Context foreign = Context.root().with(KEY, "foreign");
+    final Thread producer =
+        new Thread(() -> publisherContexts.put(publisher, HandoffContext.threadConfined(foreign)));
+    producer.start();
+    producer.join();
+
+    final Context active = Context.root().with(KEY, "active");
+    try (ContextScope activeScope = active.attach()) {
+      final ContextScope scope =
+          ReactiveStreamsContextPropagation.captureOnSubscribe(
+              publisher, subscriber, publisherContexts, subscriberContexts);
+      if (scope != null) {
+        scope.close();
+      }
+    }
+
+    // The foreign deposit is ignored; the subscriber keeps this thread's active context.
+    assertSame(active, subscriberContexts.get(subscriber));
+  }
+
+  @Test
+  void anyThreadPublisherContextIsAdoptedAcrossThreads() throws InterruptedException {
+    // An any-thread deposit (resilience4j/spring-messaging: attached early, subscribed later) is
+    // adopted even when the subscribe runs on a different thread.
+    final Publisher<Object> publisher = subscriber -> {};
+    final Subscriber<Object> subscriber = new NoopSubscriber();
+    final ContextStore<Publisher, HandoffContext> publisherContexts = new MapContextStore<>();
+    final ContextStore<Subscriber, Context> subscriberContexts = new MapContextStore<>();
+
+    final Context captured = Context.root().with(KEY, "captured");
+    final Thread producer =
+        new Thread(() -> publisherContexts.put(publisher, HandoffContext.anyThread(captured)));
+    producer.start();
+    producer.join();
+
+    final ContextScope scope =
+        ReactiveStreamsContextPropagation.captureOnSubscribe(
+            publisher, subscriber, publisherContexts, subscriberContexts);
+    if (scope != null) {
+      scope.close();
+    }
+
+    // The any-thread deposit is adopted despite the cross-thread subscribe.
+    assertSame(captured, subscriberContexts.get(subscriber));
   }
 
   @Test

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -383,6 +383,50 @@ class ReactorCoreTest extends InstrumentationSpecification {
     "immediate"   | Schedulers.immediate()
   }
 
+  def "subscribe-time context propagates across threads with #name"() {
+    // Guards that the thread-confined publisher hand-off (HandoffContext) does not break cross-thread
+    // propagation: the @Trace "addOne" spans run in map's onNext on scheduler threads and must still
+    // be children of the subscribe-time parent.
+    when:
+    runUnderTrace("parent") {
+      pipeline.call().collectList().block()
+    }
+
+    then:
+    assertTraces(1) {
+      trace(3) {
+        sortSpansByStart()
+        span {
+          operationName "parent"
+          parent()
+        }
+        span {
+          operationName "addOne"
+          childOf span(0)
+        }
+        span {
+          operationName "addOne"
+          childOf span(0)
+        }
+      }
+    }
+
+    where:
+    name                    | pipeline
+    "publishOn"             | {
+      Flux.just(1, 2).publishOn(Schedulers.parallel()).map(addOne)
+    }
+    "subscribeOn"           | {
+      Flux.just(1, 2).subscribeOn(Schedulers.single()).map(addOne)
+    }
+    "subscribeOn+publishOn" | {
+      Flux.just(1, 2)
+      .subscribeOn(Schedulers.single())
+      .publishOn(Schedulers.parallel())
+      .map(addOne)
+    }
+  }
+
   def "Context propagation through reactor context with span #spanType"() {
     when:
     runUnderTrace("parent", {

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/BlockingPublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/BlockingPublisherInstrumentation.java
@@ -5,10 +5,10 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameSta
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
-import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -42,7 +42,7 @@ public class BlockingPublisherInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope before(@Advice.This final Publisher self) {
       return ReactorContextBridge.activateForBlocking(
-          self, InstrumentationContext.get(Publisher.class, Context.class));
+          self, InstrumentationContext.get(Publisher.class, HandoffContext.class));
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/CorePublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/CorePublisherInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -58,7 +59,7 @@ public class CorePublisherInstrumentation
       return ReactorContextBridge.captureOnSubscribe(
           self,
           subscriber,
-          InstrumentationContext.get(Publisher.class, Context.class),
+          InstrumentationContext.get(Publisher.class, HandoffContext.class),
           InstrumentationContext.get(Subscriber.class, Context.class));
     }
 

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/OptimizableOperatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/OptimizableOperatorInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -54,7 +55,7 @@ public class OptimizableOperatorInstrumentation
           self,
           arg,
           s,
-          InstrumentationContext.get(Publisher.class, Context.class),
+          InstrumentationContext.get(Publisher.class, HandoffContext.class),
           InstrumentationContext.get(Subscriber.class, Context.class));
     }
   }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorContextBridge.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorContextBridge.java
@@ -4,6 +4,7 @@ import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.WithAgentSpan;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.CoreSubscriber;
@@ -48,38 +49,43 @@ public final class ReactorContextBridge {
   /**
    * On subscribe, hands the explicit context recorded for {@code subscriber} (a context-writing
    * subscriber) to the publisher store so the reactive-streams layer can propagate it, and attaches
-   * it.
+   * it. The deposit is {@linkplain HandoffContext#threadConfined thread-confined} since the
+   * subscribed publisher may be a concurrently-subscribed shared sink.
    */
   public static ContextScope captureOnSubscribe(
       final Publisher<?> publisher,
       final Subscriber<?> subscriber,
-      final ContextStore<Publisher, Context> publisherContexts,
+      final ContextStore<Publisher, HandoffContext> publisherContexts,
       final ContextStore<Subscriber, Context> subscriberContexts) {
     final Context context = subscriberContexts.get(subscriber);
     if (context == null) {
       return null;
     }
 
-    publisherContexts.put(publisher, context);
+    publisherContexts.put(publisher, HandoffContext.threadConfined(context));
     return attachIfRequired(context, Context.current());
   }
 
   public static ContextScope activateForBlocking(
-      final Publisher<?> publisher, final ContextStore<Publisher, Context> publisherContexts) {
-    return attachIfRequired(publisherContexts.get(publisher), Context.current());
+      final Publisher<?> publisher,
+      final ContextStore<Publisher, HandoffContext> publisherContexts) {
+    final HandoffContext handoff = publisherContexts.get(publisher);
+    return attachIfRequired(
+        handoff == null ? null : handoff.contextForCurrentThread(), Context.current());
   }
 
   public static void transferToOptimizedSubscriber(
       final Publisher<?> publisher,
       final Subscriber<?> source,
       final Subscriber<?> target,
-      final ContextStore<Publisher, Context> publisherContexts,
+      final ContextStore<Publisher, HandoffContext> publisherContexts,
       final ContextStore<Subscriber, Context> subscriberContexts) {
     if (source == null || target == null) {
       return;
     }
 
-    Context context = publisherContexts.get(publisher);
+    final HandoffContext handoff = publisherContexts.get(publisher);
+    Context context = handoff == null ? null : handoff.contextForCurrentThread();
     if (context == null) {
       context = subscriberContexts.get(source);
     }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorCoreModule.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorCoreModule.java
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +34,7 @@ public final class ReactorCoreModule extends InstrumenterModule.ContextTracking
   public Map<String, String> contextStore() {
     final Map<String, String> store = new HashMap<>();
     store.put("org.reactivestreams.Subscriber", Context.class.getName());
-    store.put("org.reactivestreams.Publisher", Context.class.getName());
+    store.put("org.reactivestreams.Publisher", HandoffContext.class.getName());
     return store;
   }
 

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -383,6 +383,50 @@ class ReactorCoreTest extends InstrumentationSpecification {
     "immediate"   | Schedulers.immediate()
   }
 
+  def "subscribe-time context propagates across threads with #name"() {
+    // Guards that the thread-confined publisher hand-off (HandoffContext) does not break cross-thread
+    // propagation: the @Trace "addOne" spans run in map's onNext on scheduler threads and must still
+    // be children of the subscribe-time parent.
+    when:
+    runUnderTrace("parent") {
+      pipeline.call().collectList().block()
+    }
+
+    then:
+    assertTraces(1) {
+      trace(3) {
+        sortSpansByStart()
+        span {
+          operationName "parent"
+          parent()
+        }
+        span {
+          operationName "addOne"
+          childOf span(0)
+        }
+        span {
+          operationName "addOne"
+          childOf span(0)
+        }
+      }
+    }
+
+    where:
+    name                    | pipeline
+    "publishOn"             | {
+      Flux.just(1, 2).publishOn(Schedulers.parallel()).map(addOne)
+    }
+    "subscribeOn"           | {
+      Flux.just(1, 2).subscribeOn(Schedulers.single()).map(addOne)
+    }
+    "subscribeOn+publishOn" | {
+      Flux.just(1, 2)
+      .subscribeOn(Schedulers.single())
+      .publishOn(Schedulers.parallel())
+      .map(addOne)
+    }
+  }
+
   def "Context propagation through reactor context with span #spanType"() {
     when:
     runUnderTrace("parent", {

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/CircuitBreakerOperatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/CircuitBreakerOperatorInstrumentation.java
@@ -4,9 +4,9 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Publisher;
@@ -40,7 +40,8 @@ public class CircuitBreakerOperatorInstrumentation
               result,
               CircuitBreakerDecorator.DECORATE,
               circuitBreaker,
-              InstrumentationContext.get(Publisher.class, Context.class)::put);
+              ReactorHelper.putInto(
+                  InstrumentationContext.get(Publisher.class, HandoffContext.class)));
     }
   }
 }

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/FallbackOperatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/FallbackOperatorInstrumentation.java
@@ -5,9 +5,9 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import java.util.function.Function;
 import net.bytebuddy.asm.Advice;
@@ -40,7 +40,9 @@ public class FallbackOperatorInstrumentation
 
       result =
           ReactorHelper.wrapFunction(
-              result, InstrumentationContext.get(Publisher.class, Context.class)::putIfAbsent);
+              result,
+              ReactorHelper.putIfAbsentInto(
+                  InstrumentationContext.get(Publisher.class, HandoffContext.class)));
     }
 
     // 2.0.0+

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/ReactorHelper.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/ReactorHelper.java
@@ -3,7 +3,9 @@ package datadog.trace.instrumentation.resilience4j;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
 import datadog.context.ContextScope;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -18,6 +20,20 @@ import reactor.core.publisher.SignalType;
 public class ReactorHelper {
 
   private static final Logger log = LoggerFactory.getLogger(ReactorHelper.class);
+
+  // These build the hand-off BiConsumer here rather than in @Advice code on purpose: a lambda
+  // defined in advice desugars to an invokedynamic that cannot be linked once the advice is inlined
+  // into the (third-party) operator, and fails silently. anyThread: the span is attached at
+  // assembly and the publisher may be subscribed later on another thread.
+  public static BiConsumer<Publisher<?>, AgentSpan> putInto(
+      final ContextStore<Publisher, HandoffContext> store) {
+    return (publisher, span) -> store.put(publisher, HandoffContext.anyThread(span));
+  }
+
+  public static BiConsumer<Publisher<?>, AgentSpan> putIfAbsentInto(
+      final ContextStore<Publisher, HandoffContext> store) {
+    return (publisher, span) -> store.putIfAbsent(publisher, HandoffContext.anyThread(span));
+  }
 
   public static Function<Publisher<?>, Publisher<?>> wrapFunction(
       Function<Publisher<?>, Publisher<?>> operator,

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jReactorModule.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jReactorModule.java
@@ -1,9 +1,9 @@
 package datadog.trace.instrumentation.resilience4j;
 
 import com.google.auto.service.AutoService;
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +33,8 @@ public class Resilience4jReactorModule extends InstrumenterModule.Tracing {
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("org.reactivestreams.Publisher", Context.class.getName());
+    return Collections.singletonMap(
+        "org.reactivestreams.Publisher", HandoffContext.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/RetryOperatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-reactor-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/RetryOperatorInstrumentation.java
@@ -4,9 +4,9 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import io.github.resilience4j.retry.Retry;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Publisher;
@@ -39,7 +39,8 @@ public class RetryOperatorInstrumentation
               result,
               RetryDecorator.DECORATE,
               retry,
-              InstrumentationContext.get(Publisher.class, Context.class)::put);
+              ReactorHelper.putInto(
+                  InstrumentationContext.get(Publisher.class, HandoffContext.class)));
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/KotlinAwareHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-messaging-4.0/src/main/java/datadog/trace/instrumentation/springmessaging/KotlinAwareHandlerInstrumentation.java
@@ -8,6 +8,7 @@ import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -38,7 +39,8 @@ public class KotlinAwareHandlerInstrumentation extends InstrumenterModule.Tracin
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("org.reactivestreams.Publisher", Context.class.getName());
+    return Collections.singletonMap(
+        "org.reactivestreams.Publisher", HandoffContext.class.getName());
   }
 
   @Override
@@ -58,8 +60,8 @@ public class KotlinAwareHandlerInstrumentation extends InstrumenterModule.Tracin
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Return Object result) {
       if (result instanceof Publisher) {
-        InstrumentationContext.get(Publisher.class, Context.class)
-            .put((Publisher<?>) result, Context.current());
+        InstrumentationContext.get(Publisher.class, HandoffContext.class)
+            .put((Publisher<?>) result, HandoffContext.anyThread(Context.current()));
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -6,10 +6,10 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DISPATCHER_HANDLE_HANDLER;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.function.Consumer;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Publisher;
@@ -51,7 +51,8 @@ public class DispatcherHandlerAdvice {
       final AgentSpan span = scope.span();
       final Consumer finisher = new AdviceUtils.MonoSpanFinisher(span);
       mono = mono.doOnError(finisher).doFinally(finisher);
-      InstrumentationContext.get(Publisher.class, Context.class).put(mono, span);
+      InstrumentationContext.get(Publisher.class, HandoffContext.class)
+          .put(mono, HandoffContext.anyThread(span));
     }
     scope.close();
     // span finished in MonoSpanFinisher

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerInstrumentation.java
@@ -7,9 +7,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.Collections;
 import java.util.Map;
 
@@ -24,7 +24,8 @@ public final class DispatcherHandlerInstrumentation extends AbstractWebfluxInstr
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("org.reactivestreams.Publisher", Context.class.getName());
+    return Collections.singletonMap(
+        "org.reactivestreams.Publisher", HandoffContext.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandleResultAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandleResultAdvice.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Publisher;
 import org.springframework.web.server.ServerWebExchange;
@@ -15,7 +15,8 @@ public class HandleResultAdvice {
       @Advice.Return(readOnly = false) Mono<Void> mono) {
     final AgentSpan span = exchange.getAttribute(AdviceUtils.SPAN_ATTRIBUTE);
     if (span != null && mono != null) {
-      InstrumentationContext.get(Publisher.class, Context.class).put(mono, span);
+      InstrumentationContext.get(Publisher.class, HandoffContext.class)
+          .put(mono, HandoffContext.anyThread(span));
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -5,10 +5,10 @@ import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourc
 import static datadog.trace.instrumentation.springwebflux.server.AdviceUtils.constructOperationName;
 import static datadog.trace.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 
-import datadog.context.Context;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Publisher;
 import org.springframework.http.HttpMethod;
@@ -72,7 +72,8 @@ public class HandlerAdapterAdvice {
       if (throwable != null) {
         DECORATE.onError(scope, throwable);
       } else if (mono != null) {
-        InstrumentationContext.get(Publisher.class, Context.class).put(mono, scope.span());
+        InstrumentationContext.get(Publisher.class, HandoffContext.class)
+            .put(mono, HandoffContext.anyThread(scope.span()));
       }
       scope.close();
       // span finished in SpanFinishingSubscriber

--- a/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-webflux/spring-webflux-5.0/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
@@ -9,9 +9,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import datadog.context.Context;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.description.type.TypeDescription;
@@ -33,7 +33,8 @@ public final class HandlerAdapterInstrumentation extends AbstractWebfluxInstrume
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("org.reactivestreams.Publisher", Context.class.getName());
+    return Collections.singletonMap(
+        "org.reactivestreams.Publisher", HandoffContext.class.getName());
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

This change fixes a race in Reactor context propagation when multiple threads concurrently subscribe to the same shared publisher, such as a multicast sink returned by connection.asFlux().

Previously, the Reactor subscribe-time handoff used a shared (Publisher, Context) slot. Since the publisher instance can be shared across concurrent subscribers, one subscribing thread could accidentally consume a context deposited by another thread. When that happened, the affected subscriber stored the wrong parent context, and later onNext restored that incorrect context, causing spans to be attached to the wrong context.

The fix changes the Reactor bridge handoff to use a HandoffContext that is stamped with the producing thread. Consumers now only adopt the publisher handoff when it was produced on the same thread. If the handoff came from a different thread, it is treated as foreign and ignored, and the subscriber falls back to its currently active context.

Ignoring a foreign-thread handoff is safe for this Reactor bridge because the handoff is only intended to bridge context within a single synchronous subscribe flow. In that flow, the producer and the legitimate consumer run on the same thread.


Note: this confinement is intentionally applied only to the Reactor bridge. Other producers, such as resilience4j, Spring WebFlux, or Spring Messaging, may create context during assembly and subscribe later on another thread. For those integrations, cross-thread handoff can be legitimate, so they continue to use anyThread.

# Motivation

# Additional Notes

A good way to choose between anyThread and threadConfined is to ask: `Can this same publisher be subscribed to by multiple threads at the same time?`

If yes, use threadConfined.

That means the publisher is shared. Since several subscribers may use the same publisher slot concurrently, we must make sure a subscriber only uses context created by its own thread. This prevents one subscriber from accidentally picking up another subscriber’s context.

If no, use anyThread.

That means the publisher is specific to one operation. There is no competing subscriber that could steal the context. However, the subscription may still happen later on a different thread, so the context must remain usable across threads.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
