### PR TITLE
Disallow manual triggers of `populate_dep_cache`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,6 @@ default:
         - .gradle/notifications
         - .mvn/caches
       policy: $DEPENDENCY_CACHE_POLICY
-      unprotect: true
       fallback_keys: # Use fallback keys because all cache types are not populated. See note under: populate_dep_cache
         - 'dependency-base'
         - 'dependency-lib'
@@ -771,7 +770,6 @@ muzzle-dep-report:
       fallback_keys:
         - dependency-base
         - dependency-lib
-      unprotect: true
   before_script:
     - git config --global --add safe.directory "$CI_PROJECT_DIR"
     # Akka token added to SSM from https://account.akka.io/token

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,6 +219,7 @@ default:
         - .gradle/notifications
         - .mvn/caches
       policy: $DEPENDENCY_CACHE_POLICY
+      unprotect: true
       fallback_keys: # Use fallback keys because all cache types are not populated. See note under: populate_dep_cache
         - 'dependency-base'
         - 'dependency-lib'
@@ -770,6 +771,7 @@ muzzle-dep-report:
       fallback_keys:
         - dependency-base
         - dependency-lib
+      unprotect: true
   before_script:
     - git config --global --add safe.directory "$CI_PROJECT_DIR"
     # Akka token added to SSM from https://account.akka.io/token

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,8 +388,6 @@ populate_dep_cache:
   rules:
     - if: '$POPULATE_CACHE'
       when: on_success
-    - when: manual
-      allow_failure: true
   parallel:
     matrix:
       - GRADLE_TARGET: ":dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar"


### PR DESCRIPTION
# What Does This Do

Remove manual trigger from `populate_dep_cache` job. `populate_dep_cache` can still be triggered from GitLab: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipeline_schedules

# Motivation

If a corrupted PR runs the `populate_dep_cache` job, all dep caches including for protected refs such as `master` and release tags will read in the corrupted cache. This could lead to security compromises, so disallow manual triggers of the `populate_dep_cache` job. The cache is otherwise populated from `master` either daily or when the GitLab workflow is manually triggered.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
