### PR TITLE
Remove unused SpotBugs suppressions from dd-smoke-tests

### DIFF
--- a/dd-smoke-tests/apm-tracing-disabled/application/build.gradle
+++ b/dd-smoke-tests/apm-tracing-disabled/application/build.gradle
@@ -34,7 +34,6 @@ if (hasProperty('apiJar')) {
 }
 
 dependencies {
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:4.9.8'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   // OpenTracing 0.32.0 is the last release and is intentionally pinned: this smoke test
   // exercises the legacy OpenTracing bridge in dd-trace-ot. Do not "upgrade" — there is

--- a/dd-smoke-tests/apm-tracing-disabled/application/src/main/java/datadog/smoketest/apmtracingdisabled/Controller.java
+++ b/dd-smoke-tests/apm-tracing-disabled/application/src/main/java/datadog/smoketest/apmtracingdisabled/Controller.java
@@ -1,6 +1,5 @@
 package datadog.smoketest.apmtracingdisabled;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
@@ -51,7 +50,6 @@ public class Controller {
   }
 
   @GetMapping("/iast")
-  @SuppressFBWarnings
   public void write(
       @RequestParam(name = "injection", required = false) String injection,
       @RequestParam(name = "url", required = false) String url,

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -6,7 +6,6 @@ import datadog.communication.util.IOUtils;
 import datadog.smoketest.springboot.TestBean;
 import datadog.smoketest.springboot.controller.mock.JakartaMockTransport;
 import ddtest.client.sources.Hasher;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -186,14 +185,12 @@ public class IastWebController {
     return "Command Injection page";
   }
 
-  @SuppressFBWarnings("PT_ABSOLUTE_PATH_TRAVERSAL")
   @GetMapping("/path_traversal/file")
   public String pathTraversalFile(final HttpServletRequest request) {
     new File(request.getParameter("path"));
     return "Path Traversal page";
   }
 
-  @SuppressFBWarnings("PT_ABSOLUTE_PATH_TRAVERSAL")
   @GetMapping("/path_traversal/paths")
   public String pathTraversalPaths(final HttpServletRequest request) {
     Paths.get(request.getParameter("path"));

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/XssController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/XssController.java
@@ -2,7 +2,6 @@ package datadog.smoketest.springboot.controller;
 
 import ddtest.securitycontrols.InputValidator;
 import ddtest.securitycontrols.Sanitizer;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class XssController {
 
   @GetMapping("/write")
-  @SuppressFBWarnings
   public void write(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().write(request.getParameter("string"));
@@ -28,7 +26,6 @@ public class XssController {
   }
 
   @GetMapping("/write2")
-  @SuppressFBWarnings
   public void write2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().write(request.getParameter("string").toCharArray());
@@ -38,7 +35,6 @@ public class XssController {
   }
 
   @GetMapping("/write3")
-  @SuppressFBWarnings
   public void write3(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String insecure = request.getParameter("string");
@@ -49,7 +45,6 @@ public class XssController {
   }
 
   @GetMapping("/write4")
-  @SuppressFBWarnings
   public void write4(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       char[] buf = request.getParameter("string").toCharArray();
@@ -60,7 +55,6 @@ public class XssController {
   }
 
   @GetMapping("/print")
-  @SuppressFBWarnings
   public void print(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().print(request.getParameter("string"));
@@ -70,7 +64,6 @@ public class XssController {
   }
 
   @GetMapping("/print2")
-  @SuppressFBWarnings
   public void print2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().print(request.getParameter("string").toCharArray());
@@ -80,7 +73,6 @@ public class XssController {
   }
 
   @GetMapping("/println")
-  @SuppressFBWarnings
   public void println(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().println(request.getParameter("string"));
@@ -90,7 +82,6 @@ public class XssController {
   }
 
   @GetMapping("/println2")
-  @SuppressFBWarnings
   public void println2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().println(request.getParameter("string").toCharArray());
@@ -100,7 +91,6 @@ public class XssController {
   }
 
   @GetMapping("/printf")
-  @SuppressFBWarnings
   public void printf(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = request.getParameter("string");
@@ -111,7 +101,6 @@ public class XssController {
   }
 
   @GetMapping("/printf2")
-  @SuppressFBWarnings
   public void printf2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = "Formatted like: %1$s and %2$s.";
@@ -122,7 +111,6 @@ public class XssController {
   }
 
   @GetMapping("/printf3")
-  @SuppressFBWarnings
   public void printf3(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = request.getParameter("string");
@@ -133,7 +121,6 @@ public class XssController {
   }
 
   @GetMapping("/printf4")
-  @SuppressFBWarnings
   public void printf4(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = "Formatted like: %1$s and %2$s.";
@@ -144,7 +131,6 @@ public class XssController {
   }
 
   @GetMapping("/format")
-  @SuppressFBWarnings
   public void format(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = request.getParameter("string");
@@ -155,7 +141,6 @@ public class XssController {
   }
 
   @GetMapping("/format2")
-  @SuppressFBWarnings
   public void format2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = "Formatted like: %1$s and %2$s.";
@@ -166,7 +151,6 @@ public class XssController {
   }
 
   @GetMapping("/format3")
-  @SuppressFBWarnings
   public void format3(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = request.getParameter("string");
@@ -177,7 +161,6 @@ public class XssController {
   }
 
   @GetMapping("/format4")
-  @SuppressFBWarnings
   public void format4(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String format = "Formatted like: %1$s and %2$s.";
@@ -194,7 +177,6 @@ public class XssController {
   }
 
   @GetMapping("/sanitize")
-  @SuppressFBWarnings
   public void sanitize(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       response.getWriter().write(Sanitizer.sanitize(request.getParameter("string")));
@@ -204,7 +186,6 @@ public class XssController {
   }
 
   @GetMapping("/validateAll")
-  @SuppressFBWarnings
   public void validateAll(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String s = request.getParameter("string");
@@ -216,7 +197,6 @@ public class XssController {
   }
 
   @GetMapping("/validateAll2")
-  @SuppressFBWarnings
   public void validate2(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String string1 = request.getParameter("string");
@@ -229,7 +209,6 @@ public class XssController {
   }
 
   @GetMapping("/validate")
-  @SuppressFBWarnings
   public void validate(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String string1 = request.getParameter("string");

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Trace;
 import datadog.trace.api.profiling.Profiling;
 import datadog.trace.api.profiling.ProfilingContextAttribute;
 import datadog.trace.api.profiling.ProfilingScope;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.List;
@@ -54,7 +53,6 @@ public class ProfilingTestApplication {
   }
 
   @Trace
-  @SuppressFBWarnings("DM_GC")
   private static void tracedMethod() throws InterruptedException {
     System.out.println("Tracing");
     tracedBusyMethod();
@@ -68,7 +66,6 @@ public class ProfilingTestApplication {
   }
 
   @Trace
-  @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
   private static void tracedBusyMethod() {
     long startTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
     Random random = new Random();


### PR DESCRIPTION
# What Does This Do

Removes now-dead SpotBugs artifacts from `dd-smoke-tests`:
- Drops all `@SuppressFBWarnings` annotations and their `edu.umd.cs.findbugs.annotations.SuppressFBWarnings` imports across the IAST, XSS, APM-tracing-disabled and profiling smoke-test apps.
- Removes the redundant `compileOnly 'com.github.spotbugs:spotbugs-annotations'` dependency from `apm-tracing-disabled/application/build.gradle`.

# Motivation

SpotBugs is disabled for the entire `:dd-smoke-tests` subtree in `gradle/spotbugs.gradle`:

```groovy
if (project.path.startsWith(":dd-smoke-tests")
  || !(name.endsWith("Main") || name.endsWith("Main_java11"))) {
  it.enabled = false
  return
}
```

Since the analysis never runs on these fixtures, the `@SuppressFBWarnings` annotations and the `spotbugs-annotations` dependency are pure dead weight.

# Additional Notes

- `com.google.code.findbugs:jsr305` is intentionally kept — it provides `@Nonnull`/`@Nullable` used by the Spring Boot fixtures, unrelated to SpotBugs analysis.
- `jboss-modules` still carries an `exclude module: 'spotbugs-annotations'` on its custom configurations; left as-is since it's a harmless transitive-exclude, not an analysis config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)