### PR TITLE
Run arm64 tests on merge queue and master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -756,14 +756,10 @@ muzzle-dep-report:
     # `ibm8`/`oracle8` have no arm64 images published upstream — never run them on arm64.
     - if: '$testJvm == "ibm8" || $testJvm == "oracle8"'
       when: never
-    # On the merge queue, run the full matrix (both default and non-default JVMs) on arm64.
-    # (`gh-readonly-queue` needs no handling — the `workflow:` rules skip its pipeline entirely.)
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success
-    # On master, run the default JVMs automatically (gating).
-    - if: '$CI_COMMIT_BRANCH == "master" && $testJvm =~ $DEFAULT_TEST_JVMS'
+    - if: '$CI_COMMIT_BRANCH == "master"
       when: on_success
-    # On merge requests, allow the default JVMs to be triggered manually (non-blocking).
     - if: $testJvm =~ $DEFAULT_TEST_JVMS
       when: manual
       allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -758,9 +758,9 @@ muzzle-dep-report:
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success
-    - if: '$CI_COMMIT_BRANCH == "master"
+    - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
-    - if: $testJvm =~ $DEFAULT_TEST_JVMS
+    - if: '$testJvm =~ $DEFAULT_TEST_JVMS'
       when: manual
       allow_failure: true
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -753,11 +753,18 @@ muzzle-dep-report:
     GIT_SUBMODULE_STRATEGY: normal
     GIT_SUBMODULE_DEPTH: 1
   rules:
+    # `ibm8`/`oracle8` have no arm64 images published upstream — never run them on arm64.
+    - if: '$testJvm == "ibm8" || $testJvm == "oracle8"'
+      when: never
+    # On the merge queue, run the full matrix (both default and non-default JVMs) on arm64.
+    # (`gh-readonly-queue` needs no handling — the `workflow:` rules skip its pipeline entirely.)
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+      when: on_success
+    # On master, run the default JVMs automatically (gating).
+    - if: '$CI_COMMIT_BRANCH == "master" && $testJvm =~ $DEFAULT_TEST_JVMS'
+      when: on_success
+    # On merge requests, allow the default JVMs to be triggered manually (non-blocking).
     - if: $testJvm =~ $DEFAULT_TEST_JVMS
-      when: manual
-      allow_failure: true
-      # Note: `ibm8` and `oracle8` omitted — no arm64 images published upstream.
-    - if: '$NON_DEFAULT_JVMS == "true" && $testJvm != "ibm8" && $testJvm != "oracle8"'
       when: manual
       allow_failure: true
   cache:


### PR DESCRIPTION
# What Does This Do

Reworks the `rules` in the shared `.test_job_arm64` template (inherited by all arm64 test jobs) so they trigger in three contexts:

- **MergeQueue** (`mq-working-branch-*`): full matrix — both default and non-default JVMs — running `on_success` (gating).
- **master**: default JVMs (`8, 11, 17, 21, 25, tip`) running `on_success` (gating).
- **Merge requests**: default JVMs available as `manual`, `allow_failure: true` (non-blocking).

`ibm8`/`oracle8` are excluded across all variants via a single top guard rule (`when: never`) since no arm64 images are published upstream.

# Motivation

Previously arm64 jobs were `manual` + `allow_failure` only, so arm64 was never exercised automatically. This gives real coverage: the full JVM matrix runs in the merge queue, default JVMs gate `master`, and developers can still trigger default-JVM runs manually on MRs.

# Additional Notes
`arm64` tested on GitLab manually for ~1 month, no issues so far, let's give a shot.
