### PR TITLE
Thread SpanPrototype through span construction (parked until dense store)

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -72,6 +72,7 @@ import datadog.trace.bootstrap.instrumentation.api.BlackHoleSpan;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.interceptor.CiVisibilityApmProtocolInterceptor;
@@ -1583,6 +1584,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     // Builder attributes
     // Make sure any fields added here are also reset properly in ReusableSingleSpanBuilder.reset
     protected TagMap.Ledger tagLedger;
+    protected SpanPrototype spanPrototype = SpanPrototype.NONE;
     protected long timestampMicro;
     protected AgentSpanContext parent;
     protected String serviceName;
@@ -1621,6 +1623,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
         boolean errorFlag,
         CharSequence spanType,
         TagMap.Ledger tagLedger,
+        SpanPrototype spanPrototype,
         List<AgentSpanLink> links,
         Object builderRequestContextDataAppSec,
         Object builderRequestContextDataIast,
@@ -1640,6 +1643,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
               errorFlag,
               spanType,
               tagLedger,
+              spanPrototype,
               links,
               builderRequestContextDataAppSec,
               builderRequestContextDataIast,
@@ -1725,6 +1729,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
           this.errorFlag,
           this.spanType,
           this.tagLedger,
+          this.spanPrototype,
           this.links,
           this.builderRequestContextDataAppSec,
           this.builderRequestContextDataIast,
@@ -1751,6 +1756,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
           false /* errorFlag */,
           null /* spanType */,
           null /* tagLedger */,
+          SpanPrototype.NONE /* spanPrototype */,
           null /* links */,
           null /* appSec */,
           null /* iast */,
@@ -1770,6 +1776,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
         boolean errorFlag,
         CharSequence spanType,
         TagMap.Ledger tagLedger,
+        SpanPrototype spanPrototype,
         List<AgentSpanLink> links,
         Object builderRequestContextDataAppSec,
         Object builderRequestContextDataIast,
@@ -1820,6 +1827,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
           errorFlag,
           spanType,
           tagLedger,
+          spanPrototype,
           links,
           builderRequestContextDataAppSec,
           builderRequestContextDataIast,
@@ -1908,6 +1916,11 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
       return this;
     }
 
+    public final CoreSpanBuilder withSpanPrototype(final SpanPrototype spanPrototype) {
+      this.spanPrototype = (spanPrototype == null) ? SpanPrototype.NONE : spanPrototype;
+      return this;
+    }
+
     @Override
     public final <T> AgentTracer.SpanBuilder withRequestContextData(
         RequestContextSlot slot, T data) {
@@ -1958,6 +1971,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
         boolean errorFlag,
         CharSequence spanType,
         TagMap.Ledger tagLedger,
+        SpanPrototype spanPrototype,
         List<AgentSpanLink> links,
         Object builderRequestContextDataAppSec,
         Object builderRequestContextDataIast,
@@ -2196,6 +2210,9 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
       // the builder. This is the order that the tags were added previously, but maybe the `tags`
       // set in the builder should come last, so that they override other tags.
       context.setAllTags(mergedTracerTags, mergedTracerTagsNeedsIntercept);
+      if (spanPrototype != SpanPrototype.NONE) {
+        context.setAllTags(spanPrototype.tags());
+      }
       context.setAllTags(tagLedger);
       context.setAllTags(coreTags, coreTagsNeedsIntercept);
       context.setAllTags(rootSpanTags, rootSpanTagsNeedsIntercept);
@@ -2276,6 +2293,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
       this.operationName = operationName;
 
       if (this.tagLedger != null) this.tagLedger.reset();
+      this.spanPrototype = SpanPrototype.NONE;
       this.timestampMicro = 0L;
       this.parent = null;
       this.serviceName = null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1039,6 +1039,24 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     return createMultiSpanBuilder(instrumentationName, operationName);
   }
 
+  /**
+   * Seeds identity (instrumentation name, operation, span type) and tags from a prototype.
+   *
+   * <p>TODO(follow-up): eager-sets identity from the proto today, which is fine while
+   * {@code buildSpan(proto)} is the only proto entry point. When a builder value and a proto value
+   * can coexist, resolve via helpers (builder-explicit wins, proto is the fallback) in the build
+   * path and make this carry-only — no reach-in to {@code builder.spanType}/{@code spanPrototype}.
+   */
+  public CoreSpanBuilder buildSpan(final SpanPrototype prototype) {
+    CoreSpanBuilder builder =
+        createMultiSpanBuilder(prototype.instrumentationName(), prototype.operationName());
+    builder.spanPrototype = prototype;
+    if (prototype.spanType() != null) {
+      builder.spanType = prototype.spanType();
+    }
+    return builder;
+  }
+
   MultiSpanBuilder createMultiSpanBuilder(
       final String instrumentationName, final CharSequence operationName) {
     return new MultiSpanBuilder(this, instrumentationName, operationName);
@@ -1913,11 +1931,6 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
       } else {
         tagLedger.set(tag, value);
       }
-      return this;
-    }
-
-    public final CoreSpanBuilder withSpanPrototype(final SpanPrototype spanPrototype) {
-      this.spanPrototype = (spanPrototype == null) ? SpanPrototype.NONE : spanPrototype;
       return this;
     }
 


### PR DESCRIPTION
> ⚠️ **Retired — superseded by #11894.** The clean SpanPrototype API (single-commit, frozen-`TagMap` builder) lives in **#11894**. This construction lineage diverged from it and predates the frozen-copy / plan-based apply design; the span-construction wiring will be rebuilt fresh on top of #11894.

---

**Draft — PARKED. Stacked on #11828. Do not merge before the dense store.**

Increment 2a of the SpanPrototype work: threads a `spanPrototype` through `CoreSpanBuilder` (mirroring `tagLedger` — field, `startImpl`, both `startSpan` overloads, `buildSpan`, `buildSpanContext`, `reset`) and applies it at `buildSpanContext` right after `defaultSpanTags` (before the per-span ledger, so per-span tags override the prototype's constants). Adds `CoreSpanBuilder.withSpanPrototype(...)`.

## Why parked
The construction-seed's payoff is a **copy-down**, which only beats per-span N-`set` when the copy is cheap. On today's bucketed `OptimizedTagMap` it isn't — the per-mechanism micro (on #11828) showed `copy()` of a 4-entry map *losing* to 4 `set(cachedEntry)` (≈295M/243M vs 417M ops/s), with **identical 104 B/op** across all arms. The win is dense-store-gated: a contiguous positional layout makes copy-down an `arraycopy`, and drops the alloc.

So this lands **with/after the dense store**, where touching the critical span-creation path arrives with a demonstrable win rather than a flat change. Because SpanPrototype rides the existing `TagMap.copy`/`setAllTags` API (not dense internals), the wiring **auto-cashes-in** when the dense store lands — no surface change, no penalty to holding.

## Safety
Additive: `SpanPrototype.NONE` default at every threaded site → the applied branch is skipped and every existing span-creation path is byte-for-byte unchanged. `CoreSpanBuilderTest` (25) + `CoreTracerTest2` (15) green.

## Remaining (when unparked)
- Public `startSpan`/`buildSpan(SpanPrototype, …)` entry points (additive overloads, delegate existing → `NONE`).
- The 4-arm `SpanStartBenchmark` (`{startSpan, buildSpan}` × `{old afterStart, new prototype}`) to characterize the dispatch-level delta on the dense store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)