### PR TITLE
Relax arm64 CI jobs and align coverage with amd64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -754,10 +754,16 @@ muzzle-dep-report:
     # `ibm8`/`oracle8` have no arm64 images published upstream — never run them on arm64.
     - if: '$testJvm == "ibm8" || $testJvm == "oracle8"'
       when: never
+    # arm64 tests are newly introduced to the merge queue and master. Keep them
+    # non-blocking (allow_failure) for now so we can collect stability stats and
+    # fix flaky/failing jobs without blocking the whole team. Remove allow_failure
+    # once the arm64 suite is proven stable.
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: on_success
+      allow_failure: true
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
+      allow_failure: true
     - if: '$testJvm =~ $DEFAULT_TEST_JVMS'
       when: manual
       allow_failure: true
@@ -924,6 +930,10 @@ test_base_arm64:
     CACHE_TYPE: "base"
   parallel:
     matrix: *test_matrix_4
+  # run coverage only on JVM 8, mirroring the amd64 test_base job
+  script:
+    - if [ "$testJvm" == "8" ]; then export GRADLE_PARAMS="$GRADLE_PARAMS -PcheckCoverage"; fi
+    - !reference [.test_job_arm64, script]
 
 test_inst:
   extends: .test_job_with_test_agent
@@ -1057,10 +1067,14 @@ test_debugger_arm64:
   extends: .test_job_arm64
   variables:
     GRADLE_TARGET: ":debuggerTest"
-    GRADLE_PARAMS: "-PcheckCoverage"
     CACHE_TYPE: "base"
   parallel:
     matrix: *test_matrix
+  # avoid running coverage for semeru8, semeru11 and semeru17 as some tests are disabled and therefore cannot reach the
+  # expected coverage (ibm8/oracle8 never run on arm64)
+  script:
+    - if [[ "$testJvm" != "semeru8" && "$testJvm" != "semeru11" && "$testJvm" != "semeru17" ]]; then export GRADLE_PARAMS="$GRADLE_PARAMS -PcheckCoverage"; fi
+    - !reference [.test_job_arm64, script]
 
 test_smoke:
   extends: .test_job

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -764,6 +764,13 @@ muzzle-dep-report:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
       allow_failure: true
+    # Enable non-default JVMs on demand.
+    - if: '$NON_DEFAULT_JVMS == "true"'
+      when: on_success
+      allow_failure: true
+    - if: '$CI_COMMIT_MESSAGE =~ /\[ci: NON_DEFAULT_JVMS\]/'
+      when: on_success
+      allow_failure: true
     - if: '$testJvm =~ $DEFAULT_TEST_JVMS'
       when: manual
       allow_failure: true


### PR DESCRIPTION
# What Does This Do

- Marks all `*_arm64` test jobs as `allow_failure: true` on **merge queue** (`mq-working-branch-*`) and **master** by adding `allow_failure` to the shared `.test_job_arm64` rules.
- Fixes `-PcheckCoverage` on arm64 to match the amd64 jobs:
  - `test_debugger_arm64`: skip coverage on `semeru8`/`semeru11`/`semeru17` (those disable some tests and can't reach the expected coverage).
  - `test_base_arm64`: run coverage only on JVM `8`, mirroring `test_base`.

# Motivation

arm64 tests were just introduced to the merge queue and master. Keeping them **non-blocking** lets us collect stability stats and fix flaky/failing jobs in a relaxed way without blocking the whole team. It also unbreaks the arm64 debugger job, which was failing coverage verification on Semeru JVMs (same root cause fixed for amd64 in #11807).

# Additional Notes

- `ibm8`/`oracle8` never run on arm64 (excluded by `.test_job_arm64` rules), so they're intentionally omitted from the debugger coverage condition.
- `allow_failure` is temporary — remove it once the arm64 suite is proven stable.