### PR TITLE
Context tests improvement proposals

### DIFF
--- a/components/context/src/test/java/datadog/context/ContextContinuationTest.java
+++ b/components/context/src/test/java/datadog/context/ContextContinuationTest.java
@@ -2,14 +2,14 @@ package datadog.context;
 
 import static datadog.context.Context.current;
 import static datadog.context.Context.root;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.synchronizedList;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -46,16 +46,16 @@ class ContextContinuationTest extends ContextTestBase {
 
   @Test
   void testCaptureFiresOnCaptureEvent() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     try (ContextScope scope = context.attach()) {
       ContextContinuation continuation =
           context.capture(); // capture while active (recommended pattern)
-      assertEquals(asList("attach", "capture"), events);
+      listener.assertNewEvents("attach", "capture");
       continuation.release();
     }
-    assertEquals(asList("attach", "capture", "release", "detach"), events);
+    listener.assertNewEvents("release", "detach");
   }
 
   @Test
@@ -75,25 +75,25 @@ class ContextContinuationTest extends ContextTestBase {
 
   @Test
   void testResumeAndScopeCloseFiresLifecycleEvents() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
       continuation = context.capture(); // capture while active
     }
-    assertEquals(asList("attach", "capture", "detach"), events);
+    listener.assertNewEvents("attach", "capture", "detach");
     try (ContextScope scope = continuation.resume()) {
-      assertEquals(asList("attach", "capture", "detach", "attach"), events);
+      listener.assertNewEvents("attach");
     }
     // release fires before detach (continuation is released first inside ContextScopeImpl.close)
-    assertEquals(asList("attach", "capture", "detach", "attach", "release", "detach"), events);
+    listener.assertNewEvents("release", "detach");
   }
 
   @Test
   void testHoldPreventsAutoReleaseOnScopeClose() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
@@ -104,26 +104,24 @@ class ContextContinuationTest extends ContextTestBase {
       assertEquals(context, current());
     }
     assertEquals(root(), current());
-    assertEquals(
-        asList("attach", "capture", "detach", "attach", "detach"),
-        events,
-        "release should not fire while hold is active");
+    // release should not fire while hold is active
+    listener.assertNewEvents("attach", "capture", "detach", "attach", "detach");
     continuation.release();
-    assertEquals(asList("attach", "capture", "detach", "attach", "detach", "release"), events);
+    listener.assertNewEvents("release");
   }
 
   @Test
   void testExplicitReleaseWithoutResumeFiresReleaseEvent() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
       continuation = context.capture(); // capture while active
     }
-    assertEquals(asList("attach", "capture", "detach"), events);
+    listener.assertNewEvents("attach", "capture", "detach");
     continuation.release();
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNewEvents("release");
   }
 
   @Test
@@ -168,7 +166,7 @@ class ContextContinuationTest extends ContextTestBase {
 
   @Test
   void testMultipleResumesReleaseAfterLastScopeCloses() throws InterruptedException {
-    List<String> events = Collections.synchronizedList(new ArrayList<>());
+    List<String> events = synchronizedList(new ArrayList<>());
     ContextManager.register(
         new ContextListener() {
           @Override
@@ -217,7 +215,7 @@ class ContextContinuationTest extends ContextTestBase {
       closeSecond.countDown();
       assertDoesNotThrow(() -> f1.get());
       assertDoesNotThrow(() -> f2.get());
-      assertEquals(asList("release"), events);
+      assertEquals(singletonList("release"), events);
     } finally {
       executor.shutdown();
     }
@@ -225,19 +223,19 @@ class ContextContinuationTest extends ContextTestBase {
 
   @Test
   void testSameContextResumeReleasesImmediately() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     try (ContextScope outer = context.attach()) {
       // Context is already current; resume is a noop and continuation is released immediately
       ContextContinuation continuation = context.capture();
       try (ContextScope noop = continuation.resume()) {
         assertEquals(context, current());
-        assertEquals(asList("attach", "capture", "release"), events); // released synchronously
+        listener.assertNewEvents("attach", "capture", "release"); // released synchronously
       }
       assertEquals(context, current()); // outer scope still holds context
     }
-    assertEquals(asList("attach", "capture", "release", "detach"), events);
+    listener.assertNewEvents("detach");
   }
 
   @Test
@@ -249,8 +247,8 @@ class ContextContinuationTest extends ContextTestBase {
       continuation = contextC.capture();
     }
 
-    List<String> events = new ArrayList<>();
-    ContextManager.register(keyedTrackingListener(events, CONTINUATION_KEY));
+    TrackingListener listener = keyedTrackingListener(CONTINUATION_KEY);
+    ContextManager.register(listener);
 
     Context contextD = root().with(CONTINUATION_KEY, "D");
     try (ContextScope scopeR = continuation.resume()) {
@@ -261,17 +259,14 @@ class ContextContinuationTest extends ContextTestBase {
         // close the resume scope out-of-order while D is still nested on top;
         // release fires immediately, but detach:C does not (C is not current)
         scopeR.close();
-        assertEquals(asList("attach:C", "detach:C", "attach:D", "release:C"), events);
+        listener.assertNewEvents("attach:C", "detach:C", "attach:D", "release:C");
         assertEquals(contextD, current()); // D is still current
       } // scopeD closes here: unwind D normally, restores C
-      assertEquals(
-          asList("attach:C", "detach:C", "attach:D", "release:C", "detach:D", "attach:C"), events);
+      listener.assertNewEvents("detach:D", "attach:C");
     } // try-with-resources closes scopeR again; no second release, C unwinds to root
 
     assertEquals(root(), current());
-    assertEquals(
-        asList("attach:C", "detach:C", "attach:D", "release:C", "detach:D", "attach:C", "detach:C"),
-        events);
+    listener.assertNewEvents("detach:C");
   }
 
   @Test
@@ -285,8 +280,8 @@ class ContextContinuationTest extends ContextTestBase {
       continuation.hold();
     }
 
-    List<String> events = new ArrayList<>();
-    ContextManager.register(keyedTrackingListener(events, CONTINUATION_KEY));
+    TrackingListener listener = keyedTrackingListener(CONTINUATION_KEY);
+    ContextManager.register(listener);
 
     Context contextD = root().with(CONTINUATION_KEY, "D");
     try (ContextScope scopeR = continuation.resume()) {
@@ -295,26 +290,23 @@ class ContextContinuationTest extends ContextTestBase {
         assertEquals(contextD, current());
 
         scopeR.close(); // out-of-order close while D is still on top; hold prevents auto-release
-        assertEquals(asList("attach:C", "detach:C", "attach:D"), events);
+        listener.assertNewEvents("attach:C", "detach:C", "attach:D");
         assertEquals(contextD, current());
       } // scopeD closes here: unwind D, restores C
     } // TWR closes scopeR again (now in-order); detach:C, no release yet (hold is active)
 
     assertEquals(root(), current());
-    assertEquals(
-        asList("attach:C", "detach:C", "attach:D", "detach:D", "attach:C", "detach:C"), events);
+    listener.assertNewEvents("detach:D", "attach:C", "detach:C");
 
     continuation.release(); // explicit release must fire release:C
-    assertEquals(
-        asList("attach:C", "detach:C", "attach:D", "detach:D", "attach:C", "detach:C", "release:C"),
-        events);
+    listener.assertNewEvents("release:C");
   }
 
   @Test
   void testMultipleHoldCallsAreIdempotent() {
     // Calling hold() more than once should not require more than one explicit release().
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
@@ -324,36 +316,36 @@ class ContextContinuationTest extends ContextTestBase {
     }
     // One explicit release() is enough — no extra releases needed for the second hold().
     continuation.release();
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNewEvents("attach", "capture", "detach", "release");
     continuation.release(); // still idempotent after the final release
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNoNewEvents();
   }
 
   @Test
   void testHoldAfterReleaseIsIgnored() {
     // hold() on an already-released continuation must not resurrect it.
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
       continuation = context.capture();
     }
     continuation.release();
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNewEvents("attach", "capture", "detach", "release");
     continuation.hold(); // must be silently ignored
     // resume() after release is already a noop, even with the spurious hold()
     try (ContextScope scope = continuation.resume()) {
       assertEquals(root(), current());
     }
     continuation.release(); // must not fire a second release event
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNoNewEvents();
   }
 
   @Test
   void testHoldAllowsMultipleReleaseCalls() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(CONTINUATION_KEY, "value");
     ContextContinuation continuation;
     try (ContextScope scope = context.attach()) {
@@ -361,8 +353,8 @@ class ContextContinuationTest extends ContextTestBase {
       continuation.hold();
     }
     continuation.release();
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNewEvents("attach", "capture", "detach", "release");
     continuation.release(); // second release is a no-op
-    assertEquals(asList("attach", "capture", "detach", "release"), events);
+    listener.assertNoNewEvents();
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextListenerEventTest.java
+++ b/components/context/src/test/java/datadog/context/ContextListenerEventTest.java
@@ -3,102 +3,97 @@ package datadog.context;
 import static datadog.context.Context.current;
 import static datadog.context.Context.root;
 import static datadog.context.ContextTest.STRING_KEY;
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ContextListenerEventTest extends ContextTestBase {
   @Test
   void testListenersNotifiedOnAttachAndDetach() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(keyedTrackingListener(events, STRING_KEY));
+    TrackingListener listener = keyedTrackingListener(STRING_KEY);
+    ContextManager.register(listener);
     Context context = root().with(STRING_KEY, "value");
     try (ContextScope scope = context.attach()) {
-      assertEquals(asList("attach:value"), events);
+      listener.assertNewEvents("attach:value");
     }
-    assertEquals(asList("attach:value", "detach:value"), events);
+    listener.assertNewEvents("detach:value");
   }
 
   @Test
   void testListenersNotNotifiedForRootContext() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     root().attach(); // current is already root, no events
-    assertTrue(events.isEmpty(), "root attach should not trigger listeners");
+    listener.assertNoEvents(); // root attach should not trigger listeners
     root().swap(); // current is already root, no events
-    assertTrue(events.isEmpty(), "root swap should not trigger listeners");
+    listener.assertNoEvents(); // root swap should not trigger listeners
     Context context = root().with(STRING_KEY, "value");
     try (ContextScope scope = context.attach()) {
-      assertEquals(1, events.size()); // attach:non-root only
+      listener.assertNewEvents("attach"); // attach:non-root only
     }
-    assertEquals(2, events.size()); // detach:non-root but not attach:root
+    listener.assertNewEvents("detach"); // detach:non-root but not attach:root
   }
 
   @Test
   void testListenersNotNotifiedOnSameContextAttach() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(STRING_KEY, "same");
     try (ContextScope outer = context.attach()) {
-      assertEquals(asList("attach"), events);
+      listener.assertNewEvents("attach");
       try (ContextScope noop = context.attach()) {
         assertEquals(context, current());
-        assertEquals(asList("attach"), events); // no new events on same-context attach
+        listener.assertNoNewEvents(); // no new events on same-context attach
       }
-      assertEquals(asList("attach"), events); // noop close fires no events either
+      listener.assertNoNewEvents(); // noop close fires no events either
     }
-    assertEquals(asList("attach", "detach"), events);
+    listener.assertNewEvents("detach");
   }
 
   @Test
   void testListenersNotNotifiedOnSameContextSwap() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
     Context context = root().with(STRING_KEY, "same");
     context.swap();
-    assertEquals(asList("attach"), events);
+    listener.assertNewEvents("attach");
     context.swap(); // same context again, no events
-    assertEquals(asList("attach"), events);
+    listener.assertNoNewEvents();
     root().swap();
-    assertEquals(asList("attach", "detach"), events);
+    listener.assertNewEvents("detach");
   }
 
   @Test
   void testDuplicateListenerIgnored() {
-    List<String> events = new ArrayList<>();
-    ContextListener listener = trackingListener(events);
+    TrackingListener listener = trackingListener();
     ContextManager.register(listener);
     ContextManager.register(listener); // should be ignored
     try (ContextScope scope = root().with(STRING_KEY, "value").attach()) {}
-    assertEquals(asList("attach", "detach"), events);
+    listener.assertEvents("attach", "detach");
   }
 
   @Test
   void testMultipleListenersAllNotified() {
-    List<String> events1 = new ArrayList<>();
-    List<String> events2 = new ArrayList<>();
-    ContextManager.register(trackingListener(events1));
-    ContextManager.register(trackingListener(events2));
+    TrackingListener listener1 = trackingListener();
+    TrackingListener listener2 = trackingListener();
+    ContextManager.register(listener1);
+    ContextManager.register(listener2);
     try (ContextScope scope = root().with(STRING_KEY, "value").attach()) {}
-    assertEquals(asList("attach", "detach"), events1);
-    assertEquals(asList("attach", "detach"), events2);
+    listener1.assertEvents("attach", "detach");
+    listener2.assertEvents("attach", "detach");
   }
 
   @Test
   void testSwapNotifiesListeners() {
-    List<String> events = new ArrayList<>();
-    ContextManager.register(keyedTrackingListener(events, STRING_KEY));
+    TrackingListener listener = keyedTrackingListener(STRING_KEY);
+    ContextManager.register(listener);
     Context context = root().with(STRING_KEY, "value");
     Context previous = context.swap();
     assertSame(root(), previous);
-    assertEquals(asList("attach:value"), events);
+    listener.assertNewEvents("attach:value");
     previous = root().swap();
     assertSame(context, previous);
-    assertEquals(asList("attach:value", "detach:value"), events);
+    listener.assertNewEvents("detach:value");
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextProvidersForkedTest.java
+++ b/components/context/src/test/java/datadog/context/ContextProvidersForkedTest.java
@@ -7,8 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
@@ -85,26 +83,26 @@ class ContextProvidersForkedTest {
           }
 
           @Override
-          public ContextScope attach(Context context) {
+          public ContextScope attach(@Nonnull Context context) {
             return new NoopContextScope(root());
           }
 
           @Override
-          public Context swap(Context context) {
+          public Context swap(@Nonnull Context context) {
             return root();
           }
 
           @Override
-          public ContextContinuation capture(Context context) {
+          public ContextContinuation capture(@Nonnull Context context) {
             return new NoopContextContinuation(root());
           }
 
           @Override
-          public void addListener(ContextListener listener) {}
+          public void addListener(@Nonnull ContextListener listener) {}
         });
 
-    List<String> events = new ArrayList<>();
-    ContextManager.register(trackingListener(events));
+    ContextTestBase.TrackingListener listener = trackingListener();
+    ContextManager.register(listener);
 
     // NOOP manager, context will always be root
     try (ContextScope scope = context.attach()) {
@@ -123,6 +121,6 @@ class ContextProvidersForkedTest {
     assertSame(root(), Context.current());
 
     // NOOP manager, no events emitted
-    assertTrue(events.isEmpty());
+    listener.assertNoEvents();
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextTestBase.java
+++ b/components/context/src/test/java/datadog/context/ContextTestBase.java
@@ -2,9 +2,12 @@ package datadog.context;
 
 import static datadog.context.Context.current;
 import static datadog.context.Context.root;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,51 +25,81 @@ abstract class ContextTestBase {
     assertEquals(root(), current());
   }
 
-  static ContextListener trackingListener(List<String> events) {
-    return new ContextListener() {
-      @Override
-      public void onAttach(Context c) {
-        events.add("attach");
-      }
-
-      @Override
-      public void onDetach(Context c) {
-        events.add("detach");
-      }
-
-      @Override
-      public void onCapture(Context c) {
-        events.add("capture");
-      }
-
-      @Override
-      public void onRelease(Context c) {
-        events.add("release");
-      }
-    };
+  static TrackingListener trackingListener() {
+    return new TrackingListener(null);
   }
 
-  static ContextListener keyedTrackingListener(List<String> events, ContextKey<String> key) {
-    return new ContextListener() {
-      @Override
-      public void onAttach(Context c) {
-        events.add("attach:" + c.get(key));
-      }
+  static TrackingListener keyedTrackingListener(ContextKey<String> key) {
+    return new TrackingListener(key);
+  }
 
-      @Override
-      public void onDetach(Context c) {
-        events.add("detach:" + c.get(key));
-      }
+  /**
+   * A {@link ContextListener} that records the events it receives so tests can assert on them.
+   *
+   * <p>With a {@link ContextKey}, each event is suffixed with that key's context value; otherwise
+   * only the event name is recorded (e.g. {@code "attach"}).
+   */
+  static final class TrackingListener implements ContextListener {
+    private final List<String> events;
+    @Nullable private final ContextKey<String> key;
+    private int checkpoint;
 
-      @Override
-      public void onCapture(Context c) {
-        events.add("capture:" + c.get(key));
-      }
+    private TrackingListener(@Nullable ContextKey<String> key) {
+      this.events = new ArrayList<>();
+      this.key = key;
+    }
 
-      @Override
-      public void onRelease(Context c) {
-        events.add("release:" + c.get(key));
-      }
-    };
+    @Override
+    public void onAttach(Context context) {
+      record("attach", context);
+    }
+
+    @Override
+    public void onDetach(Context context) {
+      record("detach", context);
+    }
+
+    @Override
+    public void onCapture(Context context) {
+      record("capture", context);
+    }
+
+    @Override
+    public void onRelease(Context context) {
+      record("release", context);
+    }
+
+    private void record(String event, Context context) {
+      this.events.add(this.key == null ? event : event + ":" + context.get(this.key));
+    }
+
+    /** Asserts the full sequence of recorded events equals {@code expected}. */
+    void assertEvents(String... expected) {
+      assertEquals(asList(expected), new ArrayList<>(this.events));
+    }
+
+    /** Asserts that no events have been recorded at all. */
+    void assertNoEvents() {
+      assertEvents();
+    }
+
+    /**
+     * Asserts the events recorded since the previous {@link #assertNewEvents} call equal {@code
+     * expected}, then advances the checkpoint past them.
+     */
+    void assertNewEvents(String... expected) {
+      List<String> snapshot = new ArrayList<>(this.events);
+      List<String> newEvents = new ArrayList<>(snapshot.subList(this.checkpoint, snapshot.size()));
+      assertEquals(asList(expected), newEvents);
+      this.checkpoint = snapshot.size();
+    }
+
+    /**
+     * Asserts that no events have been recorded since the previous {@link #assertNewEvents} or
+     * {@link #assertNoNewEvents} call.
+     */
+    void assertNoNewEvents() {
+      assertNewEvents();
+    }
   }
 }

--- a/dd-java-agent/instrumentation/junit/junit-5/junit-5.8/src/main/java/datadog/trace/instrumentation/junit5/BeforeAfterOperationsTracer.java
+++ b/dd-java-agent/instrumentation/junit/junit-5/junit-5.8/src/main/java/datadog/trace/instrumentation/junit5/BeforeAfterOperationsTracer.java
@@ -51,7 +51,7 @@ public class BeforeAfterOperationsTracer implements InvocationInterceptor {
       Invocation<Void> invocation, Method executable, String operationName) throws Throwable {
     AgentSpan agentSpan = AgentTracer.startSpan("junit", executable.getName());
     agentSpan.setTag(Tags.TEST_CALLBACK, operationName);
-    try (ContextScope agentScope = AgentTracer.activateSpan(agentSpan)) {
+    try (ContextScope scope = AgentTracer.activateSpan(agentSpan)) {
       invocation.proceed();
     } catch (Throwable t) {
       agentSpan.addThrowable(t);

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -30,6 +30,7 @@ import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.util.AgentTaskScheduler;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -376,12 +377,12 @@ public final class ContinuableScopeManager implements ContextManager {
   }
 
   @Override
-  public ContextScope attach(Context context) {
+  public ContextScope attach(@NonNull Context context) {
     return activate(context);
   }
 
   @Override
-  public Context swap(Context context) {
+  public Context swap(@NonNull Context context) {
     ScopeStack oldStack = tlsScopeStack.get();
     ContinuableScope oldScope = oldStack.top;
 
@@ -412,7 +413,7 @@ public final class ContinuableScopeManager implements ContextManager {
   }
 
   @Override
-  public ContextContinuation capture(Context context) {
+  public ContextContinuation capture(@NonNull Context context) {
     // respect async propagation flag for Context.current().capture()
     ContinuableScope activeScope = scopeStack().active();
     if (activeScope != null
@@ -431,7 +432,7 @@ public final class ContinuableScopeManager implements ContextManager {
   }
 
   @Override
-  public void addListener(ContextListener unused) {
+  public void addListener(@NonNull ContextListener unused) {
     // this new API is not expected to be used in legacy mode...
     log.warn("Unexpected call to ContextManager.addListener(...)");
   }


### PR DESCRIPTION
# What Does This Do

This PR is a proposal of few refactoring changes:
* [Dedicated context listener assert methods](https://github.com/DataDog/dd-trace-java/commit/884c1a4b0477b31fd39f1d73a0e4dc2d6e5798b0): 
  * The goal is to have a (small) dedicated API to evaluate context events, and without having to give back the previously asserted event.
  * It allows to tests more nicely and finely the events as we can now easily test for the next event right after a context method call.
  * I did not change the test logic by introducing finer event tests, I only deduplicated events that are previous tests from the past list element check.
  * This should also help when we will refine product / feature integration with the new context API to write more granular tests.
* [Add null annotations for context manager implementation](https://github.com/DataDog/dd-trace-java/commit/11080378ba42ee765befba6a47c9d6155c67f4e2)
  * Minor change adding `@NonNull` annotation on ContextManager implementation in core
* [Fix variable name following 11763](https://github.com/DataDog/dd-trace-java/pull/11837/changes/726b66e373c9b0bf4f98ddfd1a6e25b0cf4c7469)
  * Minor nitpick about variable name following type change

# Motivation

Those are proposals. Let me know which one you agree with and want to get merged, and which one should I drop from this branch.

# Additional Notes

This is a trimmed down version of #11837

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
