### PR TITLE
Bound MSSQL testcontainer startup and retry on transient crashes

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -192,6 +192,10 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     sqlserver = new MSSQLServerContainer(MSSQLServerContainer.IMAGE)
       .acceptLicense()
       .withPassword(jdbcPasswords.get(SQLSERVER))
+      // Bound startup and retry once to survive transient container crashes on CI.
+      .withStartupTimeoutSeconds(120)
+      .withConnectTimeoutSeconds(120)
+      .withStartupAttempts(2)
     sqlserver.start()
     PortUtils.waitForPortToOpen(sqlserver.getHost(), sqlserver.getMappedPort(MS_SQL_SERVER_PORT), 5, SECONDS)
     jdbcUrls.put(SQLSERVER, "${sqlserver.getJdbcUrl()};DatabaseName=${dbName.get(SQLSERVER)}")


### PR DESCRIPTION
# What Does This Do

Adds `.withStartupTimeoutSeconds(120)`, `.withConnectTimeoutSeconds(120)` and `.withStartupAttempts(2)` to the `MSSQLServerContainer` in `RemoteJDBCInstrumentationTest`.

# Motivation

The SQL Server container occasionally crashes on startup in CI (`exited with code 139` / SIGSEGV). `JdbcDatabaseContainer` defaults to a single 240s connection wait, so one bad container burned ~4-5 min per case and blew the `:jdbc:forkedTest` 20-min timeout. Splitting the same 240s budget into two 120s attempts retries with a fresh container, so a transient crash recovers instead of failing the whole run.

