### PR TITLE
Add RxJava 3 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -157,6 +157,7 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.instrumentation.reactivestreams.ReactiveStreamsAsyncResultExtension:build_time,"
               + "datadog.trace.instrumentation.reactor.core.ReactorAsyncResultExtension:build_time,"
               + "datadog.trace.instrumentation.rxjava2.RxJavaAsyncResultExtension:build_time,"
+              + "datadog.trace.instrumentation.rxjava3.RxJavaAsyncResultExtension:build_time,"
               + "datadog.trace.logging.ddlogger.DDLogger:build_time,"
               + "datadog.trace.logging.ddlogger.DDLoggerFactory:build_time,"
               + "datadog.trace.logging.ddlogger.DDLoggerFactory$HelperWrapper:build_time,"

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -50,10 +50,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
 
   /**
    * RxJava 3's AbstractDirectTask creates FINISHED/DISPOSED sentinel FutureTask instances in its
-   * static initializer. If that initializer runs while a trace is active (e.g. the first scheduled
-   * delay/timeout under a span), the executor instrumentation captures a continuation on those
-   * static singletons that is never cancelled, leaking the pending trace. Disable async propagation
-   * while the type initializer runs.
+   * static initializer.
    */
   private static final ElementMatcher<TypeDescription> RXJAVA3_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask");

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -47,6 +47,15 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       namedOneOf("reactor.core.scheduler.SchedulerTask", "reactor.core.scheduler.WorkerTask");
   private static final ElementMatcher<TypeDescription> RXJAVA2_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
+  /**
+   * RxJava 3's AbstractDirectTask creates FINISHED/DISPOSED sentinel FutureTask instances in its
+   * static initializer. If that initializer runs while a trace is active (e.g. the first scheduled
+   * delay/timeout under a span), the executor instrumentation captures a continuation on those
+   * static singletons that is never cancelled, leaking the pending trace. Disable async propagation
+   * while the type initializer runs.
+   */
+  private static final ElementMatcher<TypeDescription> RXJAVA3_DISABLED_TYPE_INITIALIZERS =
+      named("io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask");
   private static final ElementMatcher<TypeDescription> NETTY_GLOBAL_EVENT_EXECUTOR =
       namedOneOf(
           "io.netty.util.concurrent.GlobalEventExecutor",
@@ -90,6 +99,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "org.apache.activemq.broker.TransactionBroker",
       "com.mongodb.internal.connection.DefaultConnectionPool$AsyncWorkManager",
       "io.reactivex.internal.schedulers.AbstractDirectTask",
+      "io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask",
       "jdk.internal.net.http.HttpClientImpl",
       LETTUCE_HANDSHAKE_HANDLER,
       "io.netty.util.concurrent.GlobalEventExecutor",
@@ -110,6 +120,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS)
         .or(RXJAVA2_DISABLED_TYPE_INITIALIZERS)
+        .or(RXJAVA3_DISABLED_TYPE_INITIALIZERS)
         .or(JAVA_HTTP_CLIENT);
   }
 
@@ -196,6 +207,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(RXJAVA2_DISABLED_TYPE_INITIALIZERS)), advice);
+    transformer.applyAdvice(
+        isTypeInitializer().and(isDeclaredBy(RXJAVA3_DISABLED_TYPE_INITIALIZERS)), advice);
     transformer.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(NETTY_GLOBAL_EVENT_EXECUTOR)), advice);
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -47,6 +47,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       namedOneOf("reactor.core.scheduler.SchedulerTask", "reactor.core.scheduler.WorkerTask");
   private static final ElementMatcher<TypeDescription> RXJAVA2_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.internal.schedulers.AbstractDirectTask");
+
   /**
    * RxJava 3's AbstractDirectTask creates FINISHED/DISPOSED sentinel FutureTask instances in its
    * static initializer. If that initializer runs while a trace is active (e.g. the first scheduled
@@ -56,6 +57,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
    */
   private static final ElementMatcher<TypeDescription> RXJAVA3_DISABLED_TYPE_INITIALIZERS =
       named("io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask");
+
   private static final ElementMatcher<TypeDescription> NETTY_GLOBAL_EVENT_EXECUTOR =
       namedOneOf(
           "io.netty.util.concurrent.GlobalEventExecutor",

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/build.gradle
@@ -1,0 +1,36 @@
+muzzle {
+  pass {
+    group = "io.reactivex.rxjava3"
+    module = "rxjava"
+    versions = "[3.0.0,)"
+  }
+  // Assert the rxjava3 advice never resolves against rxjava2 — the two namespaces
+  // must not overlap. rxjava3 references io.reactivex.rxjava3.core.*, absent from the
+  // rxjava2 artifact, so muzzle must fail to match it.
+  fail {
+    name = "rxjava2-must-not-match"
+    group = "io.reactivex.rxjava2"
+    module = "rxjava"
+    versions = "[2.0.0,)"
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.3'
+  compileOnly group: 'io.reactivex.rxjava3', name: 'rxjava', version: '3.0.0'
+
+  testImplementation project(':dd-java-agent:instrumentation:datadog:tracing:trace-annotation')
+  testImplementation project(':dd-java-agent:instrumentation:opentelemetry:opentelemetry-annotations-1.20')
+  testImplementation group: 'io.reactivex.rxjava3', name: 'rxjava', version: '3.0.0'
+  testImplementation group: 'io.opentelemetry.instrumentation', name: 'opentelemetry-instrumentation-annotations', version: '1.28.0'
+
+  // Load the rxjava2 instrumenter at test runtime to prove the two versions coexist on
+  // the agent without interference (it stays dormant with only rxjava3 on the classpath).
+  testRuntimeOnly project(':dd-java-agent:instrumentation:rxjava:rxjava-2.0')
+
+  latestDepTestImplementation group: 'io.reactivex.rxjava3', name: 'rxjava', version: '+'
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
@@ -38,7 +38,7 @@ public final class CompletableInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Completable completable) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+      if (parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Completable.class, Context.class)
             .put(completable, parentContext);
       }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
@@ -54,7 +54,6 @@ public final class CompletableInstrumentation
         Context parentContext =
             InstrumentationContext.get(Completable.class, Context.class).get(completable);
         if (parentContext != null) {
-          // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingCompletableObserver(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe
           return parentContext.attach();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/CompletableInstrumentation.java
@@ -1,0 +1,73 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.CompletableObserver;
+import net.bytebuddy.asm.Advice;
+
+public final class CompletableInstrumentation
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.rxjava3.core.Completable";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("subscribe"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("io.reactivex.rxjava3.core.CompletableObserver"))),
+        getClass().getName() + "$PropagateParentSpanAdvice");
+  }
+
+  public static class CaptureParentSpanAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onConstruct(@Advice.This final Completable completable) {
+      Context parentContext = Java8BytecodeBridge.getCurrentContext();
+      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+        InstrumentationContext.get(Completable.class, Context.class)
+            .put(completable, parentContext);
+      }
+    }
+  }
+
+  public static class PropagateParentSpanAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static ContextScope onSubscribe(
+        @Advice.This final Completable completable,
+        @Advice.Argument(value = 0, readOnly = false) CompletableObserver observer) {
+      if (observer != null) {
+        Context parentContext =
+            InstrumentationContext.get(Completable.class, Context.class).get(completable);
+        if (parentContext != null) {
+          // wrap the observer so spans from its events treat the captured span as their parent
+          observer = new TracingCompletableObserver(observer, parentContext);
+          // attach the context here in case additional observers are created during subscribe
+          return parentContext.attach();
+        }
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void closeScope(@Advice.Enter final ContextScope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
@@ -38,7 +38,7 @@ public final class FlowableInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Flowable<?> flowable) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+      if (parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Flowable.class, Context.class).put(flowable, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
@@ -53,7 +53,6 @@ public final class FlowableInstrumentation
         Context parentContext =
             InstrumentationContext.get(Flowable.class, Context.class).get(flowable);
         if (parentContext != null) {
-          // wrap the subscriber so spans from its events treat the captured span as their parent
           subscriber = new TracingSubscriber<>(subscriber, parentContext);
           // attach the context here in case additional subscribers are created during subscribe
           return parentContext.attach();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
@@ -12,8 +12,8 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableSubscriber;
 import net.bytebuddy.asm.Advice;
-import org.reactivestreams.Subscriber;
 
 public final class FlowableInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
@@ -30,7 +30,7 @@ public final class FlowableInstrumentation
         isMethod()
             .and(named("subscribe"))
             .and(takesArguments(1))
-            .and(takesArgument(0, named("org.reactivestreams.Subscriber"))),
+            .and(takesArgument(0, named("io.reactivex.rxjava3.core.FlowableSubscriber"))),
         getClass().getName() + "$PropagateParentSpanAdvice");
   }
 
@@ -48,7 +48,7 @@ public final class FlowableInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope onSubscribe(
         @Advice.This final Flowable<?> flowable,
-        @Advice.Argument(value = 0, readOnly = false) Subscriber<?> subscriber) {
+        @Advice.Argument(value = 0, readOnly = false) FlowableSubscriber<?> subscriber) {
       if (subscriber != null) {
         Context parentContext =
             InstrumentationContext.get(Flowable.class, Context.class).get(flowable);

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/FlowableInstrumentation.java
@@ -1,0 +1,72 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
+import io.reactivex.rxjava3.core.Flowable;
+import net.bytebuddy.asm.Advice;
+import org.reactivestreams.Subscriber;
+
+public final class FlowableInstrumentation
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.rxjava3.core.Flowable";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("subscribe"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.reactivestreams.Subscriber"))),
+        getClass().getName() + "$PropagateParentSpanAdvice");
+  }
+
+  public static class CaptureParentSpanAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onConstruct(@Advice.This final Flowable<?> flowable) {
+      Context parentContext = Java8BytecodeBridge.getCurrentContext();
+      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+        InstrumentationContext.get(Flowable.class, Context.class).put(flowable, parentContext);
+      }
+    }
+  }
+
+  public static class PropagateParentSpanAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static ContextScope onSubscribe(
+        @Advice.This final Flowable<?> flowable,
+        @Advice.Argument(value = 0, readOnly = false) Subscriber<?> subscriber) {
+      if (subscriber != null) {
+        Context parentContext =
+            InstrumentationContext.get(Flowable.class, Context.class).get(flowable);
+        if (parentContext != null) {
+          // wrap the subscriber so spans from its events treat the captured span as their parent
+          subscriber = new TracingSubscriber<>(subscriber, parentContext);
+          // attach the context here in case additional subscribers are created during subscribe
+          return parentContext.attach();
+        }
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void closeScope(@Advice.Enter final ContextScope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.MaybeObserver;
+import net.bytebuddy.asm.Advice;
+
+public final class MaybeInstrumentation
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.rxjava3.core.Maybe";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("subscribe"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("io.reactivex.rxjava3.core.MaybeObserver"))),
+        getClass().getName() + "$PropagateParentSpanAdvice");
+  }
+
+  public static class CaptureParentSpanAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onConstruct(@Advice.This final Maybe<?> maybe) {
+      Context parentContext = Java8BytecodeBridge.getCurrentContext();
+      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+        InstrumentationContext.get(Maybe.class, Context.class).put(maybe, parentContext);
+      }
+    }
+  }
+
+  public static class PropagateParentSpanAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static ContextScope onSubscribe(
+        @Advice.This final Maybe<?> maybe,
+        @Advice.Argument(value = 0, readOnly = false) MaybeObserver<?> observer) {
+      if (observer != null) {
+        Context parentContext = InstrumentationContext.get(Maybe.class, Context.class).get(maybe);
+        if (parentContext != null) {
+          // wrap the observer so spans from its events treat the captured span as their parent
+          observer = new TracingMaybeObserver<>(observer, parentContext);
+          // attach the context here in case additional observers are created during subscribe
+          return parentContext.attach();
+        }
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void closeScope(@Advice.Enter final ContextScope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
@@ -51,7 +51,6 @@ public final class MaybeInstrumentation
       if (observer != null) {
         Context parentContext = InstrumentationContext.get(Maybe.class, Context.class).get(maybe);
         if (parentContext != null) {
-          // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingMaybeObserver<>(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe
           return parentContext.attach();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/MaybeInstrumentation.java
@@ -37,7 +37,7 @@ public final class MaybeInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Maybe<?> maybe) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+      if (parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Maybe.class, Context.class).put(maybe, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
@@ -1,0 +1,71 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import net.bytebuddy.asm.Advice;
+
+public final class ObservableInstrumentation
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.rxjava3.core.Observable";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("subscribe"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("io.reactivex.rxjava3.core.Observer"))),
+        getClass().getName() + "$PropagateParentSpanAdvice");
+  }
+
+  public static class CaptureParentSpanAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onConstruct(@Advice.This final Observable<?> observable) {
+      Context parentContext = Java8BytecodeBridge.getCurrentContext();
+      if (parentContext != null) {
+        InstrumentationContext.get(Observable.class, Context.class).put(observable, parentContext);
+      }
+    }
+  }
+
+  public static class PropagateParentSpanAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static ContextScope onSubscribe(
+        @Advice.This final Observable<?> observable,
+        @Advice.Argument(value = 0, readOnly = false) Observer<?> observer) {
+      if (observer != null) {
+        Context parentContext =
+            InstrumentationContext.get(Observable.class, Context.class).get(observable);
+        if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+          // wrap the observer so spans from its events treat the captured span as their parent
+          observer = new TracingObserver<>(observer, parentContext);
+          // attach the context here in case additional observers are created during subscribe
+          return parentContext.attach();
+        }
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void closeScope(@Advice.Enter final ContextScope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
@@ -52,7 +52,6 @@ public final class ObservableInstrumentation
         Context parentContext =
             InstrumentationContext.get(Observable.class, Context.class).get(observable);
         if (parentContext != null) {
-          // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingObserver<>(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe
           return parentContext.attach();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
@@ -51,7 +51,7 @@ public final class ObservableInstrumentation
       if (observer != null) {
         Context parentContext =
             InstrumentationContext.get(Observable.class, Context.class).get(observable);
-        if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+        if (parentContext != null) {
           // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingObserver<>(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
@@ -37,7 +37,7 @@ public final class ObservableInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Observable<?> observable) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null) {
+      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Observable.class, Context.class).put(observable, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/ObservableInstrumentation.java
@@ -37,7 +37,7 @@ public final class ObservableInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Observable<?> observable) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+      if (parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Observable.class, Context.class).put(observable, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaAsyncResultExtension.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaAsyncResultExtension.java
@@ -1,0 +1,68 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.EagerHelper;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AsyncResultExtension;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AsyncResultExtensions;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+
+public class RxJavaAsyncResultExtension implements AsyncResultExtension, EagerHelper {
+  static {
+    AsyncResultExtensions.register(new RxJavaAsyncResultExtension());
+  }
+
+  /**
+   * Register the extension as an {@link AsyncResultExtension} using static class initialization.
+   * <br>
+   * It uses an empty static method call to ensure the class loading and the one-time-only static
+   * class initialization. This will ensure this extension will only be registered once under {@link
+   * AsyncResultExtensions}.
+   */
+  public static void init() {}
+
+  @Override
+  public boolean supports(Class<?> result) {
+    return Completable.class.isAssignableFrom(result)
+        || Maybe.class.isAssignableFrom(result)
+        || Single.class.isAssignableFrom(result)
+        || Observable.class.isAssignableFrom(result)
+        || Flowable.class.isAssignableFrom(result);
+  }
+
+  @Override
+  public Object apply(Object result, AgentSpan span) {
+    if (result instanceof Completable) {
+      return ((Completable) result)
+          .doOnEvent(throwable -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Maybe) {
+      return ((Maybe<?>) result)
+          .doOnEvent((o, throwable) -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Single) {
+      return ((Single<?>) result)
+          .doOnEvent((o, throwable) -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Observable) {
+      return ((Observable<?>) result)
+          .doOnComplete(span::finish)
+          .doOnError(throwable -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Flowable) {
+      return ((Flowable<?>) result)
+          .doOnComplete(span::finish)
+          .doOnError(throwable -> onError(span, throwable))
+          .doOnCancel(span::finish);
+    }
+    return null;
+  }
+
+  private static void onError(AgentSpan span, Throwable throwable) {
+    span.addThrowable(throwable);
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static java.util.Arrays.asList;
+
+import com.google.auto.service.AutoService;
+import datadog.context.Context;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoService(InstrumenterModule.class)
+public final class RxJavaModule extends InstrumenterModule.ContextTracking {
+  public RxJavaModule() {
+    super("rxjava");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TracingCompletableObserver",
+      packageName + ".TracingSubscriber",
+      packageName + ".TracingMaybeObserver",
+      packageName + ".TracingObserver",
+      packageName + ".RxJavaAsyncResultExtension",
+      packageName + ".TracingSingleObserver",
+    };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    final Map<String, String> store = new HashMap<>();
+    store.put("io.reactivex.rxjava3.core.Flowable", Context.class.getName());
+    store.put("io.reactivex.rxjava3.core.Completable", Context.class.getName());
+    store.put("io.reactivex.rxjava3.core.Maybe", Context.class.getName());
+    store.put("io.reactivex.rxjava3.core.Observable", Context.class.getName());
+    store.put("io.reactivex.rxjava3.core.Single", Context.class.getName());
+    return store;
+  }
+
+  @Override
+  public List<Instrumenter> typeInstrumentations() {
+    return asList(
+        new CompletableInstrumentation(),
+        new FlowableInstrumentation(),
+        new MaybeInstrumentation(),
+        new ObservableInstrumentation(),
+        new SingleInstrumentation());
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @AutoService(InstrumenterModule.class)
 public final class RxJavaModule extends InstrumenterModule.ContextTracking {
   public RxJavaModule() {
-    super("rxjava");
+    super("rxjava", "rxjava-3");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/RxJavaModule.java
@@ -30,12 +30,13 @@ public final class RxJavaModule extends InstrumenterModule.ContextTracking {
 
   @Override
   public Map<String, String> contextStore() {
+    String contextClass = Context.class.getName();
     final Map<String, String> store = new HashMap<>();
-    store.put("io.reactivex.rxjava3.core.Flowable", Context.class.getName());
-    store.put("io.reactivex.rxjava3.core.Completable", Context.class.getName());
-    store.put("io.reactivex.rxjava3.core.Maybe", Context.class.getName());
-    store.put("io.reactivex.rxjava3.core.Observable", Context.class.getName());
-    store.put("io.reactivex.rxjava3.core.Single", Context.class.getName());
+    store.put("io.reactivex.rxjava3.core.Flowable", contextClass);
+    store.put("io.reactivex.rxjava3.core.Completable", contextClass);
+    store.put("io.reactivex.rxjava3.core.Maybe", contextClass);
+    store.put("io.reactivex.rxjava3.core.Observable", contextClass);
+    store.put("io.reactivex.rxjava3.core.Single", contextClass);
     return store;
   }
 

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
@@ -38,7 +38,7 @@ public final class SingleInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Single<?> single) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+      if (parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Single.class, Context.class).put(single, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
@@ -38,7 +38,7 @@ public final class SingleInstrumentation
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onConstruct(@Advice.This final Single<?> single) {
       Context parentContext = Java8BytecodeBridge.getCurrentContext();
-      if (parentContext != null) {
+      if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
         InstrumentationContext.get(Single.class, Context.class).put(single, parentContext);
       }
     }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
@@ -51,7 +51,7 @@ public final class SingleInstrumentation
         @Advice.Argument(value = 0, readOnly = false) SingleObserver<?> observer) {
       if (observer != null) {
         Context parentContext = InstrumentationContext.get(Single.class, Context.class).get(single);
-        if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+        if (parentContext != null) {
           // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingSingleObserver<>(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
@@ -52,7 +52,6 @@ public final class SingleInstrumentation
       if (observer != null) {
         Context parentContext = InstrumentationContext.get(Single.class, Context.class).get(single);
         if (parentContext != null) {
-          // wrap the observer so spans from its events treat the captured span as their parent
           observer = new TracingSingleObserver<>(observer, parentContext);
           // attach the context here in case additional observers are created during subscribe
           return parentContext.attach();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/SingleInstrumentation.java
@@ -1,0 +1,71 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleObserver;
+import net.bytebuddy.asm.Advice;
+
+public final class SingleInstrumentation
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.rxjava3.core.Single";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("subscribe"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("io.reactivex.rxjava3.core.SingleObserver"))),
+        getClass().getName() + "$PropagateParentSpanAdvice");
+  }
+
+  public static class CaptureParentSpanAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onConstruct(@Advice.This final Single<?> single) {
+      Context parentContext = Java8BytecodeBridge.getCurrentContext();
+      if (parentContext != null) {
+        InstrumentationContext.get(Single.class, Context.class).put(single, parentContext);
+      }
+    }
+  }
+
+  public static class PropagateParentSpanAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static ContextScope onSubscribe(
+        @Advice.This final Single<?> single,
+        @Advice.Argument(value = 0, readOnly = false) SingleObserver<?> observer) {
+      if (observer != null) {
+        Context parentContext = InstrumentationContext.get(Single.class, Context.class).get(single);
+        if (parentContext != null && parentContext != Java8BytecodeBridge.getRootContext()) {
+          // wrap the observer so spans from its events treat the captured span as their parent
+          observer = new TracingSingleObserver<>(observer, parentContext);
+          // attach the context here in case additional observers are created during subscribe
+          return parentContext.attach();
+        }
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void closeScope(@Advice.Enter final ContextScope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingCompletableObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingCompletableObserver.java
@@ -1,0 +1,38 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import io.reactivex.rxjava3.core.CompletableObserver;
+import io.reactivex.rxjava3.disposables.Disposable;
+import javax.annotation.Nonnull;
+
+/** Wrapper that makes sure spans from observer events treat the captured span as their parent. */
+public final class TracingCompletableObserver implements CompletableObserver {
+  private final CompletableObserver observer;
+  private final Context parentContext;
+
+  public TracingCompletableObserver(
+      @Nonnull final CompletableObserver observer, @Nonnull final Context parentContext) {
+    this.observer = observer;
+    this.parentContext = parentContext;
+  }
+
+  @Override
+  public void onSubscribe(final Disposable d) {
+    observer.onSubscribe(d);
+  }
+
+  @Override
+  public void onError(final Throwable e) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onError(e);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onComplete();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingMaybeObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingMaybeObserver.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import io.reactivex.rxjava3.core.MaybeObserver;
+import io.reactivex.rxjava3.disposables.Disposable;
+import javax.annotation.Nonnull;
+
+/** Wrapper that makes sure spans from observer events treat the captured span as their parent. */
+public final class TracingMaybeObserver<T> implements MaybeObserver<T> {
+  private final MaybeObserver<T> observer;
+  private final Context parentContext;
+
+  public TracingMaybeObserver(
+      @Nonnull final MaybeObserver<T> observer, @Nonnull final Context parentContext) {
+    this.observer = observer;
+    this.parentContext = parentContext;
+  }
+
+  @Override
+  public void onSubscribe(final Disposable d) {
+    observer.onSubscribe(d);
+  }
+
+  @Override
+  public void onSuccess(final T value) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onSuccess(value);
+    }
+  }
+
+  @Override
+  public void onError(final Throwable e) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onError(e);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onComplete();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
@@ -4,13 +4,14 @@ import datadog.context.Context;
 import datadog.context.ContextScope;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
+import javax.annotation.Nonnull;
 
 /** Wrapper that makes sure spans from observer events treat the captured span as their parent. */
 public final class TracingObserver<T> implements Observer<T> {
   private final Observer<T> observer;
   private final Context parentContext;
 
-  public TracingObserver(final Observer<T> observer, final Context parentContext) {
+  public TracingObserver(@Nonnull final Observer<T> observer, @Nonnull final Context parentContext) {
     this.observer = observer;
     this.parentContext = parentContext;
   }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
@@ -11,7 +11,8 @@ public final class TracingObserver<T> implements Observer<T> {
   private final Observer<T> observer;
   private final Context parentContext;
 
-  public TracingObserver(@Nonnull final Observer<T> observer, @Nonnull final Context parentContext) {
+  public TracingObserver(
+      @Nonnull final Observer<T> observer, @Nonnull final Context parentContext) {
     this.observer = observer;
     this.parentContext = parentContext;
   }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingObserver.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+
+/** Wrapper that makes sure spans from observer events treat the captured span as their parent. */
+public final class TracingObserver<T> implements Observer<T> {
+  private final Observer<T> observer;
+  private final Context parentContext;
+
+  public TracingObserver(final Observer<T> observer, final Context parentContext) {
+    this.observer = observer;
+    this.parentContext = parentContext;
+  }
+
+  @Override
+  public void onSubscribe(final Disposable d) {
+    observer.onSubscribe(d);
+  }
+
+  @Override
+  public void onNext(final T value) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onNext(value);
+    }
+  }
+
+  @Override
+  public void onError(final Throwable e) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onError(e);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onComplete();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSingleObserver.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSingleObserver.java
@@ -1,0 +1,38 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import io.reactivex.rxjava3.core.SingleObserver;
+import io.reactivex.rxjava3.disposables.Disposable;
+import javax.annotation.Nonnull;
+
+/** Wrapper that makes sure spans from observer events treat the captured span as their parent. */
+public final class TracingSingleObserver<T> implements SingleObserver<T> {
+  private final SingleObserver<T> observer;
+  private final Context parentContext;
+
+  public TracingSingleObserver(
+      @Nonnull final SingleObserver<T> observer, @Nonnull final Context parentContext) {
+    this.observer = observer;
+    this.parentContext = parentContext;
+  }
+
+  @Override
+  public void onSubscribe(final Disposable d) {
+    observer.onSubscribe(d);
+  }
+
+  @Override
+  public void onSuccess(final T value) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onSuccess(value);
+    }
+  }
+
+  @Override
+  public void onError(final Throwable e) {
+    try (final ContextScope scope = parentContext.attach()) {
+      observer.onError(e);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSubscriber.java
@@ -2,17 +2,17 @@ package datadog.trace.instrumentation.rxjava3;
 
 import datadog.context.Context;
 import datadog.context.ContextScope;
+import io.reactivex.rxjava3.core.FlowableSubscriber;
 import javax.annotation.Nonnull;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 /** Wrapper that makes sure spans from subscriber events treat the captured span as their parent. */
-public final class TracingSubscriber<T> implements Subscriber<T> {
-  private final Subscriber<T> subscriber;
+public final class TracingSubscriber<T> implements FlowableSubscriber<T> {
+  private final FlowableSubscriber<T> subscriber;
   private final Context parentContext;
 
   public TracingSubscriber(
-      @Nonnull final Subscriber<T> subscriber, @Nonnull final Context parentContext) {
+      @Nonnull final FlowableSubscriber<T> subscriber, @Nonnull final Context parentContext) {
     this.subscriber = subscriber;
     this.parentContext = parentContext;
   }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/main/java/datadog/trace/instrumentation/rxjava3/TracingSubscriber.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import javax.annotation.Nonnull;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/** Wrapper that makes sure spans from subscriber events treat the captured span as their parent. */
+public final class TracingSubscriber<T> implements Subscriber<T> {
+  private final Subscriber<T> subscriber;
+  private final Context parentContext;
+
+  public TracingSubscriber(
+      @Nonnull final Subscriber<T> subscriber, @Nonnull final Context parentContext) {
+    this.subscriber = subscriber;
+    this.parentContext = parentContext;
+  }
+
+  @Override
+  public void onSubscribe(final Subscription subscription) {
+    subscriber.onSubscribe(subscription);
+  }
+
+  @Override
+  public void onNext(final T value) {
+    try (final ContextScope scope = parentContext.attach()) {
+      subscriber.onNext(value);
+    }
+  }
+
+  @Override
+  public void onError(final Throwable e) {
+    try (final ContextScope scope = parentContext.attach()) {
+      subscriber.onError(e);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (final ContextScope scope = parentContext.attach()) {
+      subscriber.onComplete();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/annotatedsample/RxJava3TracedMethods.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/annotatedsample/RxJava3TracedMethods.java
@@ -100,6 +100,31 @@ public class RxJava3TracedMethods {
         });
   }
 
+  @WithSpan
+  public static Completable traceAsyncNeverCompletable() {
+    return Completable.never();
+  }
+
+  @WithSpan
+  public static Maybe<String> traceAsyncNeverMaybe() {
+    return Maybe.never();
+  }
+
+  @WithSpan
+  public static Single<String> traceAsyncNeverSingle() {
+    return Single.never();
+  }
+
+  @WithSpan
+  public static Observable<String> traceAsyncNeverObservable() {
+    return Observable.never();
+  }
+
+  @WithSpan
+  public static Flowable<String> traceAsyncNeverFlowable() {
+    return Flowable.never();
+  }
+
   private static void await(CountDownLatch latch) {
     try {
       if (!latch.await(5, SECONDS)) {

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/annotatedsample/RxJava3TracedMethods.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/annotatedsample/RxJava3TracedMethods.java
@@ -1,0 +1,112 @@
+package annotatedsample;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.CountDownLatch;
+
+public class RxJava3TracedMethods {
+  @WithSpan
+  public static Completable traceAsyncCompletable(CountDownLatch latch) {
+    return Completable.fromRunnable(() -> await(latch));
+  }
+
+  @WithSpan
+  public static Completable traceAsyncFailingCompletable(
+      CountDownLatch latch, Exception exception) {
+    return Completable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Maybe<String> traceAsyncMaybe(CountDownLatch latch) {
+    return Maybe.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Maybe<String> traceAsyncFailingMaybe(CountDownLatch latch, Exception exception) {
+    return Maybe.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Single<String> traceAsyncSingle(CountDownLatch latch) {
+    return Single.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Single<String> traceAsyncFailingSingle(CountDownLatch latch, Exception exception) {
+    return Single.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Observable<String> traceAsyncObservable(CountDownLatch latch) {
+    return Observable.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Observable<String> traceAsyncFailingObservable(
+      CountDownLatch latch, Exception exception) {
+    return Observable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Flowable<String> traceAsyncFlowable(CountDownLatch latch) {
+    return Flowable.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Flowable<String> traceAsyncFailingFlowable(
+      CountDownLatch latch, Exception exception) {
+    return Flowable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, SECONDS)) {
+        throw new IllegalStateException("Latch still locked");
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/datadog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/datadog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
@@ -1,0 +1,209 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.test.assertions.Matchers.validates;
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.error;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import annotatedsample.RxJava3TracedMethods;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.SpanMatcher;
+import datadog.trace.agent.test.assertions.TagsMatcher;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.junit.utils.config.WithConfig;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@WithConfig(key = "trace.otel.enabled", value = "true")
+@WithConfig(key = "integration.opentelemetry-annotations-1.20.enabled", value = "true")
+class RxJava3ResultExtensionTest extends AbstractInstrumentationTest {
+
+  static final String EXCEPTION_MESSAGE = "Test exception";
+
+  // The COMPONENT and SPAN_KIND tags are stored as UTF8BytesString, so we compare by string content
+  // rather than using is("...") which would fail the asymmetric String#equals(UTF8BytesString)
+  // check.
+  static TagsMatcher otelComponent() {
+    return tag(Tags.COMPONENT, validates(o -> "opentelemetry".equals(String.valueOf(o))));
+  }
+
+  static TagsMatcher internalSpanKind() {
+    return tag(Tags.SPAN_KIND, validates(o -> Tags.SPAN_KIND_INTERNAL.equals(String.valueOf(o))));
+  }
+
+  // The operation and resource names are stored as UTF8BytesString, so we compare by string content
+  // (CharSequence equality is asymmetric: String#equals(UTF8BytesString) is false).
+  static SpanMatcher otelSpan(String name) {
+    return span()
+        .operationName(java.util.regex.Pattern.compile(java.util.regex.Pattern.quote(name)))
+        .resourceName((CharSequence cs) -> name.contentEquals(cs));
+  }
+
+  /**
+   * The five reactive types exercised by the test, with their type-specific terminal operations.
+   */
+  enum ReactiveType {
+    COMPLETABLE("Completable"),
+    MAYBE("Maybe"),
+    SINGLE("Single"),
+    OBSERVABLE("Observable"),
+    FLOWABLE("Flowable");
+
+    final String type;
+
+    ReactiveType(String type) {
+      this.type = type;
+    }
+
+    /** Runs the blocking terminal operation that drives the async result to completion. */
+    void runTerminal(Object asyncType) {
+      switch (this) {
+        case COMPLETABLE:
+          ((Completable) asyncType).blockingAwait();
+          break;
+        case MAYBE:
+          ((Maybe<?>) asyncType).blockingGet();
+          break;
+        case SINGLE:
+          ((Single<?>) asyncType).blockingGet();
+          break;
+        case OBSERVABLE:
+          ((Observable<?>) asyncType).blockingLast();
+          break;
+        case FLOWABLE:
+          ((Flowable<?>) asyncType).blockingLast();
+          break;
+        default:
+          throw new IllegalStateException("Unknown type: " + this);
+      }
+    }
+
+    /** Subscribes and immediately disposes (cancels) the async result. */
+    void subscribeAndDispose(Object asyncType) {
+      switch (this) {
+        case COMPLETABLE:
+          ((Completable) asyncType).subscribe().dispose();
+          break;
+        case MAYBE:
+          ((Maybe<?>) asyncType).subscribe().dispose();
+          break;
+        case SINGLE:
+          ((Single<?>) asyncType).subscribe().dispose();
+          break;
+        case OBSERVABLE:
+          ((Observable<?>) asyncType).subscribe().dispose();
+          break;
+        case FLOWABLE:
+          ((Flowable<?>) asyncType).subscribe().dispose();
+          break;
+        default:
+          throw new IllegalStateException("Unknown type: " + this);
+      }
+    }
+
+    Object traceAsync(CountDownLatch latch) {
+      switch (this) {
+        case COMPLETABLE:
+          return RxJava3TracedMethods.traceAsyncCompletable(latch);
+        case MAYBE:
+          return RxJava3TracedMethods.traceAsyncMaybe(latch);
+        case SINGLE:
+          return RxJava3TracedMethods.traceAsyncSingle(latch);
+        case OBSERVABLE:
+          return RxJava3TracedMethods.traceAsyncObservable(latch);
+        case FLOWABLE:
+          return RxJava3TracedMethods.traceAsyncFlowable(latch);
+        default:
+          throw new IllegalStateException("Unknown type: " + this);
+      }
+    }
+
+    Object traceAsyncFailing(CountDownLatch latch, Exception exception) {
+      switch (this) {
+        case COMPLETABLE:
+          return RxJava3TracedMethods.traceAsyncFailingCompletable(latch, exception);
+        case MAYBE:
+          return RxJava3TracedMethods.traceAsyncFailingMaybe(latch, exception);
+        case SINGLE:
+          return RxJava3TracedMethods.traceAsyncFailingSingle(latch, exception);
+        case OBSERVABLE:
+          return RxJava3TracedMethods.traceAsyncFailingObservable(latch, exception);
+        case FLOWABLE:
+          return RxJava3TracedMethods.traceAsyncFailingFlowable(latch, exception);
+        default:
+          throw new IllegalStateException("Unknown type: " + this);
+      }
+    }
+  }
+
+  @ParameterizedTest(name = "test WithSpan annotated async method {0}")
+  @EnumSource(ReactiveType.class)
+  void success(ReactiveType type) {
+    CountDownLatch latch = new CountDownLatch(1);
+    Object asyncType = type.traceAsync(latch);
+
+    // The span must not be finished before the async result completes.
+    assertEquals(0, writer.size());
+
+    latch.countDown();
+    type.runTerminal(asyncType);
+
+    String method = "traceAsync" + type.type;
+    assertTraces(
+        trace(
+            otelSpan("RxJava3TracedMethods." + method)
+                .tags(defaultTags(), otelComponent(), internalSpanKind())));
+  }
+
+  @ParameterizedTest(name = "test WithSpan annotated async method failing {0}")
+  @EnumSource(ReactiveType.class)
+  void failing(ReactiveType type) {
+    CountDownLatch latch = new CountDownLatch(1);
+    IllegalStateException expectedException = new IllegalStateException(EXCEPTION_MESSAGE);
+    Object asyncType = type.traceAsyncFailing(latch, expectedException);
+
+    assertEquals(0, writer.size());
+
+    latch.countDown();
+    assertThrows(IllegalStateException.class, () -> type.runTerminal(asyncType));
+
+    String method = "traceAsyncFailing" + type.type;
+    assertTraces(
+        trace(
+            otelSpan("RxJava3TracedMethods." + method)
+                .error()
+                .tags(
+                    defaultTags(),
+                    otelComponent(),
+                    internalSpanKind(),
+                    error(IllegalStateException.class, EXCEPTION_MESSAGE))));
+  }
+
+  @ParameterizedTest(name = "test WithSpan annotated async method cancelled {0}")
+  @EnumSource(ReactiveType.class)
+  void cancelled(ReactiveType type) {
+    CountDownLatch latch = new CountDownLatch(1);
+    Object asyncType = type.traceAsync(latch);
+
+    assertEquals(0, writer.size());
+
+    latch.countDown();
+    type.subscribeAndDispose(asyncType);
+
+    String method = "traceAsync" + type.type;
+    assertTraces(
+        trace(
+            otelSpan("RxJava3TracedMethods." + method)
+                .tags(defaultTags(), otelComponent(), internalSpanKind())));
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/datadog/trace/instrumentation/rxjava3/SubscriptionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/datadog/trace/instrumentation/rxjava3/SubscriptionTest.java
@@ -1,0 +1,50 @@
+package datadog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionTest extends AbstractInstrumentationTest {
+
+  @Test
+  void subscriptionPropagatesParentSpan() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    AgentSpan parent = startSpan("test", "parent");
+    try (AgentScope scope = activateSpan(parent)) {
+      Maybe<Connection> connection = Maybe.create(emitter -> emitter.onSuccess(new Connection()));
+      connection.subscribe(
+          c -> {
+            c.query();
+            latch.countDown();
+          });
+    } finally {
+      parent.finish();
+    }
+    latch.await();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("parent"),
+            span().childOfPrevious().operationName("Connection.query")));
+  }
+
+  static class Connection {
+    int query() {
+      AgentSpan span = startSpan("test", "Connection.query");
+      span.finish();
+      return new Random().nextInt();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
@@ -6,7 +6,6 @@ import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
 import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
 import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
 import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import datadog.trace.agent.test.AbstractInstrumentationTest;
@@ -31,8 +30,6 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
   }
 
   static class Worker {
-    static long parentId;
-
     static int child(int i) {
       return childTraced(i);
     }
@@ -44,7 +41,6 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
 
     @Trace(operationName = "interop-parent", resourceName = "interop-parent")
     static <T> T runUnderParent(Supplier<T> work) {
-      parentId = activeSpan().getSpanId();
       return work.get();
     }
   }
@@ -64,7 +60,7 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
             SORT_BY_START_TIME,
             span().root().operationName("interop-parent").resourceName("interop-parent"),
             span()
-                .childOf(Worker.parentId)
+                .childOfIndex(0)
                 .operationName("child")
                 .resourceName("child")
                 .tags(componentTrace(), defaultTags())));
@@ -85,7 +81,7 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
             SORT_BY_START_TIME,
             span().root().operationName("interop-parent").resourceName("interop-parent"),
             span()
-                .childOf(Worker.parentId)
+                .childOfIndex(0)
                 .operationName("child")
                 .resourceName("child")
                 .tags(componentTrace(), defaultTags())));
@@ -103,7 +99,7 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
             SORT_BY_START_TIME,
             span().root().operationName("interop-parent").resourceName("interop-parent"),
             span()
-                .childOf(Worker.parentId)
+                .childOfIndex(0)
                 .operationName("child")
                 .resourceName("child")
                 .tags(componentTrace(), defaultTags())));
@@ -123,12 +119,12 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
             SORT_BY_START_TIME,
             span().root().operationName("interop-parent").resourceName("interop-parent"),
             span()
-                .childOf(Worker.parentId)
+                .childOfIndex(0)
                 .operationName("child")
                 .resourceName("child")
                 .tags(componentTrace(), defaultTags()),
             span()
-                .childOf(Worker.parentId)
+                .childOfIndex(0)
                 .operationName("child")
                 .resourceName("child")
                 .tags(componentTrace(), defaultTags())));

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
@@ -23,9 +23,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-// NOTE: This test lives in the `testdog` package (not `datadog`) on purpose: the agent ignores
-// `datadog.*` classes for instrumentation, so `@Trace`-annotated methods declared under `datadog.*`
-// would never be instrumented. See RxJava3Test for the same convention.
 class RxJava3InteropTest extends AbstractInstrumentationTest {
 
   // The component tag is stored as a UTF8BytesString, so compare by string content.

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
@@ -1,0 +1,158 @@
+package testdog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.test.assertions.Matchers.validates;
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.TagsMatcher;
+import datadog.trace.api.Trace;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+// NOTE: This test lives in the `testdog` package (not `datadog`) on purpose: the agent ignores
+// `datadog.*` classes for instrumentation, so `@Trace`-annotated methods declared under `datadog.*`
+// would never be instrumented. See RxJava3Test for the same convention.
+//
+// PURPOSE: investigate whether a Datadog trace context propagates through RxJava 3's Java 8 interop
+// factory methods (fromCompletionStage / fromOptional / fromStream). There is no dedicated reactive
+// instrumentation for these bridges; any propagation must come from the agent's
+// concurrent/executor instrumentation. Each test asserts the ACTUAL observed behavior.
+class RxJava3InteropTest extends AbstractInstrumentationTest {
+
+  static {
+    // Async completion / scheduler hops can finish child spans after the local root is written,
+    // tripping strict trace write ordering checks. Mirror RxJava3Test.
+    testConfig.strictTraceWrites(false);
+  }
+
+  // The component tag is stored as a UTF8BytesString, so compare by string content.
+  static TagsMatcher componentTrace() {
+    return tag(Tags.COMPONENT, validates(o -> "trace".equals(String.valueOf(o))));
+  }
+
+  static class Worker {
+    static long parentId;
+
+    static int child(int i) {
+      return childTraced(i);
+    }
+
+    @Trace(operationName = "child", resourceName = "child")
+    static int childTraced(int i) {
+      return i + 1;
+    }
+
+    @Trace(operationName = "interop-parent", resourceName = "interop-parent")
+    static <T> T runUnderParent(Supplier<T> work) {
+      parentId = activeSpan().getSpanId();
+      return work.get();
+    }
+  }
+
+  @Test
+  void fromCompletionStageSync() {
+    Integer result =
+        Worker.runUnderParent(
+            () ->
+                Single.fromCompletionStage(CompletableFuture.completedFuture(1))
+                    .map(Worker::child)
+                    .blockingGet());
+    assertEquals(2, result);
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("interop-parent").resourceName("interop-parent"),
+            span()
+                .childOf(Worker.parentId)
+                .operationName("child")
+                .resourceName("child")
+                .tags(componentTrace(), defaultTags())));
+  }
+
+  // FINDING: context propagates even when the CompletableFuture is completed on another thread.
+  // There is no rxjava3 instrumentation for fromCompletionStage; propagation comes from the agent's
+  // concurrent/executor instrumentation, which carries the active context across the ForkJoinPool
+  // used by supplyAsync. blockingGet() runs the map() on the calling thread, where the
+  // interop-parent scope is still active, so the child span is a direct child of interop-parent.
+  @Test
+  void fromCompletionStageAsync() {
+    Integer result =
+        Worker.runUnderParent(
+            () ->
+                Single.fromCompletionStage(CompletableFuture.supplyAsync(() -> 1))
+                    .map(Worker::child)
+                    .blockingGet());
+    assertEquals(2, result);
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("interop-parent").resourceName("interop-parent"),
+            span()
+                .childOf(Worker.parentId)
+                .operationName("child")
+                .resourceName("child")
+                .tags(componentTrace(), defaultTags())));
+  }
+
+  @Test
+  void fromOptional() {
+    Integer result =
+        Worker.runUnderParent(
+            () -> Maybe.fromOptional(Optional.of(1)).map(Worker::child).blockingGet());
+    assertEquals(2, result);
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("interop-parent").resourceName("interop-parent"),
+            span()
+                .childOf(Worker.parentId)
+                .operationName("child")
+                .resourceName("child")
+                .tags(componentTrace(), defaultTags())));
+  }
+
+  // FINDING: fromStream(2 elements) emits one child span per element (2 spans here), each a direct
+  // child of interop-parent. The map() runs synchronously on the subscribing thread under the
+  // active interop-parent scope, so no async/concurrent instrumentation is involved.
+  @Test
+  void fromStream() {
+    List<Integer> result =
+        Worker.runUnderParent(
+            () -> Flowable.fromStream(Stream.of(1, 2)).map(Worker::child).toList().blockingGet());
+    assertEquals(2, result.size());
+    assertEquals(2, result.get(0));
+    assertEquals(3, result.get(1));
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("interop-parent").resourceName("interop-parent"),
+            span()
+                .childOf(Worker.parentId)
+                .operationName("child")
+                .resourceName("child")
+                .tags(componentTrace(), defaultTags()),
+            span()
+                .childOf(Worker.parentId)
+                .operationName("child")
+                .resourceName("child")
+                .tags(componentTrace(), defaultTags())));
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
@@ -26,18 +26,7 @@ import org.junit.jupiter.api.Test;
 // NOTE: This test lives in the `testdog` package (not `datadog`) on purpose: the agent ignores
 // `datadog.*` classes for instrumentation, so `@Trace`-annotated methods declared under `datadog.*`
 // would never be instrumented. See RxJava3Test for the same convention.
-//
-// PURPOSE: investigate whether a Datadog trace context propagates through RxJava 3's Java 8 interop
-// factory methods (fromCompletionStage / fromOptional / fromStream). There is no dedicated reactive
-// instrumentation for these bridges; any propagation must come from the agent's
-// concurrent/executor instrumentation. Each test asserts the ACTUAL observed behavior.
 class RxJava3InteropTest extends AbstractInstrumentationTest {
-
-  static {
-    // Async completion / scheduler hops can finish child spans after the local root is written,
-    // tripping strict trace write ordering checks. Mirror RxJava3Test.
-    testConfig.strictTraceWrites(false);
-  }
 
   // The component tag is stored as a UTF8BytesString, so compare by string content.
   static TagsMatcher componentTrace() {
@@ -84,13 +73,6 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
                 .tags(componentTrace(), defaultTags())));
   }
 
-  /**
-   * FINDING: context propagates even when the CompletableFuture is completed on another thread.
-   * There is no rxjava3 instrumentation for fromCompletionStage; propagation comes from the agent's
-   * concurrent/executor instrumentation, which carries the active context across the ForkJoinPool
-   * used by supplyAsync. blockingGet() runs the map() on the calling thread, where the
-   * interop-parent scope is still active, so the child span is a direct child of interop-parent.
-   */
   @Test
   void fromCompletionStageAsync() {
     Integer result =
@@ -130,11 +112,6 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
                 .tags(componentTrace(), defaultTags())));
   }
 
-  /**
-   * FINDING: fromStream(2 elements) emits one child span per element (2 spans here), each a direct
-   * child of interop-parent. The map() runs synchronously on the subscribing thread under the
-   * active interop-parent scope, so no async/concurrent instrumentation is involved.
-   */
   @Test
   void fromStream() {
     List<Integer> result =

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3InteropTest.java
@@ -84,11 +84,13 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
                 .tags(componentTrace(), defaultTags())));
   }
 
-  // FINDING: context propagates even when the CompletableFuture is completed on another thread.
-  // There is no rxjava3 instrumentation for fromCompletionStage; propagation comes from the agent's
-  // concurrent/executor instrumentation, which carries the active context across the ForkJoinPool
-  // used by supplyAsync. blockingGet() runs the map() on the calling thread, where the
-  // interop-parent scope is still active, so the child span is a direct child of interop-parent.
+  /**
+   * FINDING: context propagates even when the CompletableFuture is completed on another thread.
+   * There is no rxjava3 instrumentation for fromCompletionStage; propagation comes from the agent's
+   * concurrent/executor instrumentation, which carries the active context across the ForkJoinPool
+   * used by supplyAsync. blockingGet() runs the map() on the calling thread, where the
+   * interop-parent scope is still active, so the child span is a direct child of interop-parent.
+   */
   @Test
   void fromCompletionStageAsync() {
     Integer result =
@@ -128,9 +130,11 @@ class RxJava3InteropTest extends AbstractInstrumentationTest {
                 .tags(componentTrace(), defaultTags())));
   }
 
-  // FINDING: fromStream(2 elements) emits one child span per element (2 spans here), each a direct
-  // child of interop-parent. The map() runs synchronously on the subscribing thread under the
-  // active interop-parent scope, so no async/concurrent instrumentation is involved.
+  /**
+   * FINDING: fromStream(2 elements) emits one child span per element (2 spans here), each a direct
+   * child of interop-parent. The map() runs synchronously on the subscribing thread under the
+   * active interop-parent scope, so no async/concurrent instrumentation is involved.
+   */
   @Test
   void fromStream() {
     List<Integer> result =

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
@@ -128,6 +128,23 @@ class RxJava3ResultExtensionTest extends AbstractInstrumentationTest {
       }
     }
 
+    Object traceAsyncNever() {
+      switch (this) {
+        case COMPLETABLE:
+          return RxJava3TracedMethods.traceAsyncNeverCompletable();
+        case MAYBE:
+          return RxJava3TracedMethods.traceAsyncNeverMaybe();
+        case SINGLE:
+          return RxJava3TracedMethods.traceAsyncNeverSingle();
+        case OBSERVABLE:
+          return RxJava3TracedMethods.traceAsyncNeverObservable();
+        case FLOWABLE:
+          return RxJava3TracedMethods.traceAsyncNeverFlowable();
+        default:
+          throw new IllegalStateException("Unknown type: " + this);
+      }
+    }
+
     Object traceAsyncFailing(CountDownLatch latch, Exception exception) {
       switch (this) {
         case COMPLETABLE:
@@ -201,6 +218,22 @@ class RxJava3ResultExtensionTest extends AbstractInstrumentationTest {
     type.subscribeAndDispose(asyncType);
 
     String method = "traceAsync" + type.type;
+    assertTraces(
+        trace(
+            otelSpan("RxJava3TracedMethods." + method)
+                .tags(defaultTags(), otelComponent(), internalSpanKind())));
+  }
+
+  @ParameterizedTest(name = "test WithSpan annotated never async method cancelled {0}")
+  @EnumSource(ReactiveType.class)
+  void cancelledNever(ReactiveType type) {
+    Object asyncType = type.traceAsyncNever();
+
+    assertEquals(0, writer.size());
+
+    type.subscribeAndDispose(asyncType);
+
+    String method = "traceAsyncNever" + type.type;
     assertTraces(
         trace(
             otelSpan("RxJava3TracedMethods." + method)

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.rxjava3;
+package testdog.trace.instrumentation.rxjava3;
 
 import static datadog.trace.agent.test.assertions.Matchers.validates;
 import static datadog.trace.agent.test.assertions.SpanMatcher.span;

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3ResultExtensionTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 @WithConfig(key = "trace.otel.enabled", value = "true")
-@WithConfig(key = "integration.opentelemetry-annotations-1.20.enabled", value = "true")
 class RxJava3ResultExtensionTest extends AbstractInstrumentationTest {
 
   static final String EXCEPTION_MESSAGE = "Test exception";

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -50,11 +50,6 @@ class RxJava3Test extends AbstractInstrumentationTest {
     return tag(Tags.COMPONENT, validates(o -> "trace".equals(String.valueOf(o))));
   }
 
-  /**
-   * Holds the {@code @Trace}-annotated methods used by the scenarios. The captured span ids are
-   * stored in static fields and read back by the asserting test methods to express cross-span
-   * parent relationships.
-   */
   static class Worker {
     static long traceParentId;
     static long publisherParentId;
@@ -88,12 +83,10 @@ class RxJava3Test extends AbstractInstrumentationTest {
       traceParentId = activeSpan().getSpanId();
       AgentSpan span = startSpan("test", "publisher-parent");
       publisherParentId = span.getSpanId();
-      // After this activation, the operations below should be children of this span
       AgentScope scope = activateSpan(span);
 
       Object publisher = publisherSupplier.get();
       try {
-        // Read all data from publisher
         if (publisher instanceof Maybe) {
           return ((Maybe<Object>) publisher).blockingGet();
         } else if (publisher instanceof Flowable) {

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -24,7 +24,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Arrays;
 import java.util.List;
@@ -574,5 +576,81 @@ class RxJava3Test extends AbstractInstrumentationTest {
             .blockingGet();
 
     assertEquals(4, values.size());
+
+    // No trace-parent span is active while the chain is assembled, so the instrumentation must be
+    // non-intrusive: parallel scheduler hops must not synthesize any trace. Flushing makes sure
+    // any span that the instrumentation might have wrongly created on the scheduler threads is
+    // reported before we assert the writer is empty.
+    tracer.flush();
+    assertEquals(
+        0,
+        writer.getTraceCount(),
+        () -> "Unexpected traces emitted without active trace: " + writer);
+  }
+
+  @ParameterizedTest(name = "Flowable propagates context on ''{0}'' scheduler")
+  @MethodSource("schedulerArgs")
+  void flowableParallelContextPropagation(String schedulerName, Scheduler scheduler) {
+    Worker.assemblePublisherUnderTrace(
+        () ->
+            Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
+                .parallel()
+                .runOn(scheduler)
+                .flatMap(num -> Maybe.just(num).map(Worker::addOne).toFlowable())
+                .sequential());
+
+    SpanMatcher[] matchers = new SpanMatcher[6];
+    matchers[0] =
+        span()
+            .root()
+            .operationName("trace-parent")
+            .resourceName("trace-parent")
+            .tags(componentTrace(), defaultTags());
+    matchers[1] =
+        span()
+            .id(Worker.publisherParentId)
+            .childOf(Worker.traceParentId)
+            .operationName("publisher-parent")
+            .resourceName("publisher-parent")
+            .tags(defaultTags());
+    for (int i = 0; i < 4; i++) {
+      matchers[2 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addOne")
+              .resourceName("addOne")
+              .tags(componentTrace(), defaultTags());
+    }
+
+    assertTraces(trace(SORT_BY_START_TIME, matchers));
+  }
+
+  // --- No spurious traces outside active trace --------------------------------
+
+  // Verifies that CaptureParentSpanAdvice and PropagateParentSpanAdvice are no-ops when there is
+  // no active trace: the instrumentation must not synthesize any spans of its own.
+  static List<Arguments> noSpuriousTracesArgs() {
+    return Arrays.asList(
+        Arguments.of(
+            "observable",
+            (Supplier<Object>)
+                () ->
+                    Observable.fromIterable(Arrays.asList(1, 2, 3, 4))
+                        .map(i -> i + 1)
+                        .toList()
+                        .blockingGet()),
+        Arguments.of(
+            "single", (Supplier<Object>) () -> Single.just(1).map(i -> i + 1).blockingGet()));
+  }
+
+  @ParameterizedTest(name = "No spurious traces for ''{0}'' assembled outside active trace")
+  @MethodSource("noSpuriousTracesArgs")
+  void noSpuriousTracesWhenAssembledOutsideTrace(String name, Supplier<Object> supplier) {
+    supplier.get();
+    tracer.flush();
+    assertEquals(
+        0,
+        writer.getTraceCount(),
+        () -> "Unexpected traces emitted without active trace: " + writer);
   }
 }

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -40,9 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-// NOTE: This test lives in the `testdog` package (not `datadog`) on purpose: the agent ignores
-// `datadog.*` classes for instrumentation, so `@Trace`-annotated methods declared under `datadog.*`
-// would never be instrumented. See the java-lang-21 tests for the same convention.
 class RxJava3Test extends AbstractInstrumentationTest {
 
   static final String EXCEPTION_MESSAGE = "test exception";

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -45,13 +45,6 @@ import org.reactivestreams.Subscription;
 // would never be instrumented. See the java-lang-21 tests for the same convention.
 class RxJava3Test extends AbstractInstrumentationTest {
 
-  static {
-    // The reactive chains in these scenarios can finish child spans after the local root has been
-    // written (e.g. delayed/scheduled work), which trips strict trace write ordering checks. This
-    // mirrors the Groovy RxJava2Test which also disables strict trace writes for the same reason.
-    testConfig.strictTraceWrites(false);
-  }
-
   static final String EXCEPTION_MESSAGE = "test exception";
 
   // The component tag is stored as a UTF8BytesString, so we compare by string content rather than

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -170,16 +170,23 @@ class RxJava3Test extends AbstractInstrumentationTest {
             new Object[] {4},
             2,
             (Supplier<Object>) () -> Maybe.just(2).map(Worker::addOne).map(Worker::addOne)),
-        // NOTE: the RxJava2 test also exercises delayed Maybe chains
-        // (`Maybe.just(n).delay(100, MILLISECONDS).map(addOne)` and the twice-delayed variant).
-        // With the rxjava-3.0 instrumentation a `Maybe.delay(...)` chain leaks a pending trace
-        // reference: the trace is never reported (it stays pending even after an explicit
-        // `tracer.flush()`), so `assertTraces` times out. The single-delay case fails
-        // deterministically; the twice-delayed case is flaky for the same reason. The
-        // byte-for-byte-equivalent rxjava-2.0 instrumentation handles these chains correctly, so
-        // this is a genuine rxjava-3.0 propagation gap rather than a test artifact. The delayed
-        // Maybe rows are therefore omitted until the instrumentation is fixed (the delayed Flowable
-        // rows below, which use a different operator path, complete reliably).
+        Arguments.of(
+            "delayed maybe",
+            new Object[] {4},
+            1,
+            (Supplier<Object>)
+                () -> Maybe.just(3).delay(100, MILLISECONDS).map(Worker::addOne)),
+        Arguments.of(
+            "delayed twice maybe",
+            new Object[] {6},
+            2,
+            (Supplier<Object>)
+                () ->
+                    Maybe.just(4)
+                        .delay(100, MILLISECONDS)
+                        .map(Worker::addOne)
+                        .delay(100, MILLISECONDS)
+                        .map(Worker::addOne)),
         Arguments.of(
             "basic flowable",
             new Object[] {6, 7},

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -22,6 +22,8 @@ import datadog.trace.api.Trace;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
@@ -122,10 +124,18 @@ class RxJava3Test extends AbstractInstrumentationTest {
       publisherParentId = span.getSpanId();
       AgentScope scope = activateSpan(span);
 
+      // Normalize every reactive type to a Flowable so a single Subscriber can cancel the
+      // subscription right away, exercising the cancellation path of each instrumentation.
       Object publisher = publisherSupplier.get();
       Flowable<?> flowable;
       if (publisher instanceof Maybe) {
         flowable = ((Maybe<?>) publisher).toFlowable();
+      } else if (publisher instanceof Single) {
+        flowable = ((Single<?>) publisher).toFlowable();
+      } else if (publisher instanceof Observable) {
+        flowable = ((Observable<?>) publisher).toFlowable(BackpressureStrategy.BUFFER);
+      } else if (publisher instanceof Completable) {
+        flowable = ((Completable) publisher).toFlowable();
       } else {
         flowable = (Flowable<?>) publisher;
       }
@@ -368,7 +378,12 @@ class RxJava3Test extends AbstractInstrumentationTest {
     return Arrays.asList(
         Arguments.of("basic maybe", (Supplier<Object>) () -> Maybe.just(1)),
         Arguments.of(
-            "basic flowable", (Supplier<Object>) () -> Flowable.fromIterable(Arrays.asList(5, 6))));
+            "basic flowable", (Supplier<Object>) () -> Flowable.fromIterable(Arrays.asList(5, 6))),
+        Arguments.of("basic single", (Supplier<Object>) () -> Single.just(1)),
+        Arguments.of(
+            "basic observable",
+            (Supplier<Object>) () -> Observable.fromIterable(Arrays.asList(5, 6))),
+        Arguments.of("basic completable", (Supplier<Object>) Completable::complete));
   }
 
   @ParameterizedTest(name = "Publisher ''{0}'' cancel")

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -140,25 +140,27 @@ class RxJava3Test extends AbstractInstrumentationTest {
         flowable = (Flowable<?>) publisher;
       }
 
-      flowable.subscribe(
-          new Subscriber<Object>() {
-            @Override
-            public void onSubscribe(Subscription subscription) {
-              subscription.cancel();
-            }
+      try {
+        flowable.subscribe(
+            new Subscriber<Object>() {
+              @Override
+              public void onSubscribe(Subscription subscription) {
+                subscription.cancel();
+              }
 
-            @Override
-            public void onNext(Object t) {}
+              @Override
+              public void onNext(Object t) {}
 
-            @Override
-            public void onError(Throwable error) {}
+              @Override
+              public void onError(Throwable error) {}
 
-            @Override
-            public void onComplete() {}
-          });
-
-      scope.close();
-      span.finish();
+              @Override
+              public void onComplete() {}
+            });
+      } finally {
+        scope.close();
+        span.finish();
+      }
     }
 
     @Trace(operationName = "trace-parent", resourceName = "trace-parent")

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -492,9 +492,10 @@ class RxJava3Test extends AbstractInstrumentationTest {
   void correctParentsFromSubscriptionTime(String name, int workItems, Supplier<Object> supplier) {
     Worker.assemblePublisherUnderTrace(
         () -> {
-          // The "add one" operations in the publisher created here should be children of the
-          // publisher-parent, while the "add two" operations should be children of the
-          // intermediate.
+          // The "add one" operations are assembled under publisher-parent and stay its children.
+          // The "add two" operations are assembled under intermediate, but intermediate is finished
+          // before subscription, so re-activating its context at delivery time is a no-op and
+          // addTwo falls back to the still-active publisher-parent as well.
           Object publisher = supplier.get();
 
           AgentSpan intermediate = startSpan("test", "intermediate");

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -174,8 +174,7 @@ class RxJava3Test extends AbstractInstrumentationTest {
             "delayed maybe",
             new Object[] {4},
             1,
-            (Supplier<Object>)
-                () -> Maybe.just(3).delay(100, MILLISECONDS).map(Worker::addOne)),
+            (Supplier<Object>) () -> Maybe.just(3).delay(100, MILLISECONDS).map(Worker::addOne)),
         Arguments.of(
             "delayed twice maybe",
             new Object[] {6},

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/RxJava3Test.java
@@ -1,0 +1,572 @@
+package testdog.trace.instrumentation.rxjava3;
+
+import static datadog.trace.agent.test.assertions.Matchers.validates;
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.error;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.SpanMatcher;
+import datadog.trace.agent.test.assertions.TagsMatcher;
+import datadog.trace.api.Trace;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+// NOTE: This test lives in the `testdog` package (not `datadog`) on purpose: the agent ignores
+// `datadog.*` classes for instrumentation, so `@Trace`-annotated methods declared under `datadog.*`
+// would never be instrumented. See the java-lang-21 tests for the same convention.
+class RxJava3Test extends AbstractInstrumentationTest {
+
+  static {
+    // The reactive chains in these scenarios can finish child spans after the local root has been
+    // written (e.g. delayed/scheduled work), which trips strict trace write ordering checks. This
+    // mirrors the Groovy RxJava2Test which also disables strict trace writes for the same reason.
+    testConfig.strictTraceWrites(false);
+  }
+
+  static final String EXCEPTION_MESSAGE = "test exception";
+
+  // The component tag is stored as a UTF8BytesString, so we compare by string content rather than
+  // using is("trace") which would fail the asymmetric String#equals(UTF8BytesString) check.
+  static TagsMatcher componentTrace() {
+    return tag(Tags.COMPONENT, validates(o -> "trace".equals(String.valueOf(o))));
+  }
+
+  /**
+   * Holds the {@code @Trace}-annotated methods used by the scenarios. The captured span ids are
+   * stored in static fields and read back by the asserting test methods to express cross-span
+   * parent relationships.
+   */
+  static class Worker {
+    static long traceParentId;
+    static long publisherParentId;
+    static long intermediateId;
+
+    static int addOne(int i) {
+      return addOneTraced(i);
+    }
+
+    @Trace(operationName = "addOne", resourceName = "addOne")
+    static int addOneTraced(int i) {
+      return i + 1;
+    }
+
+    static int addTwo(int i) {
+      return addTwoTraced(i);
+    }
+
+    @Trace(operationName = "addTwo", resourceName = "addTwo")
+    static int addTwoTraced(int i) {
+      return i + 2;
+    }
+
+    static Object throwException() {
+      throw new RuntimeException(EXCEPTION_MESSAGE);
+    }
+
+    @Trace(operationName = "trace-parent", resourceName = "trace-parent")
+    @SuppressWarnings("unchecked")
+    static Object assemblePublisherUnderTrace(Supplier<Object> publisherSupplier) {
+      traceParentId = activeSpan().getSpanId();
+      AgentSpan span = startSpan("test", "publisher-parent");
+      publisherParentId = span.getSpanId();
+      // After this activation, the operations below should be children of this span
+      AgentScope scope = activateSpan(span);
+
+      Object publisher = publisherSupplier.get();
+      try {
+        // Read all data from publisher
+        if (publisher instanceof Maybe) {
+          return ((Maybe<Object>) publisher).blockingGet();
+        } else if (publisher instanceof Flowable) {
+          List<Object> list = ((Flowable<Object>) publisher).toList().blockingGet();
+          return list.toArray(new Object[0]);
+        }
+        throw new RuntimeException("Unknown publisher: " + publisher);
+      } finally {
+        span.finish();
+        scope.close();
+      }
+    }
+
+    @Trace(operationName = "trace-parent", resourceName = "trace-parent")
+    static void cancelUnderTrace(Supplier<Object> publisherSupplier) {
+      traceParentId = activeSpan().getSpanId();
+      AgentSpan span = startSpan("test", "publisher-parent");
+      publisherParentId = span.getSpanId();
+      AgentScope scope = activateSpan(span);
+
+      Object publisher = publisherSupplier.get();
+      Flowable<?> flowable;
+      if (publisher instanceof Maybe) {
+        flowable = ((Maybe<?>) publisher).toFlowable();
+      } else {
+        flowable = (Flowable<?>) publisher;
+      }
+
+      flowable.subscribe(
+          new Subscriber<Object>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+              subscription.cancel();
+            }
+
+            @Override
+            public void onNext(Object t) {}
+
+            @Override
+            public void onError(Throwable error) {}
+
+            @Override
+            public void onComplete() {}
+          });
+
+      scope.close();
+      span.finish();
+    }
+
+    @Trace(operationName = "trace-parent", resourceName = "trace-parent")
+    static Object runUnderTraceParent(Supplier<Object> work) {
+      traceParentId = activeSpan().getSpanId();
+      return work.get();
+    }
+  }
+
+  // --- Publisher success ---------------------------------------------------
+
+  static List<Arguments> publisherSuccessArgs() {
+    return Arrays.asList(
+        Arguments.of(
+            "basic maybe",
+            new Object[] {2},
+            1,
+            (Supplier<Object>) () -> Maybe.just(1).map(Worker::addOne)),
+        Arguments.of(
+            "two operations maybe",
+            new Object[] {4},
+            2,
+            (Supplier<Object>) () -> Maybe.just(2).map(Worker::addOne).map(Worker::addOne)),
+        // NOTE: the RxJava2 test also exercises delayed Maybe chains
+        // (`Maybe.just(n).delay(100, MILLISECONDS).map(addOne)` and the twice-delayed variant).
+        // With the rxjava-3.0 instrumentation a `Maybe.delay(...)` chain leaks a pending trace
+        // reference: the trace is never reported (it stays pending even after an explicit
+        // `tracer.flush()`), so `assertTraces` times out. The single-delay case fails
+        // deterministically; the twice-delayed case is flaky for the same reason. The
+        // byte-for-byte-equivalent rxjava-2.0 instrumentation handles these chains correctly, so
+        // this is a genuine rxjava-3.0 propagation gap rather than a test artifact. The delayed
+        // Maybe rows are therefore omitted until the instrumentation is fixed (the delayed Flowable
+        // rows below, which use a different operator path, complete reliably).
+        Arguments.of(
+            "basic flowable",
+            new Object[] {6, 7},
+            2,
+            (Supplier<Object>)
+                () -> Flowable.fromIterable(Arrays.asList(5, 6)).map(Worker::addOne)),
+        Arguments.of(
+            "two operations flowable",
+            new Object[] {8, 9},
+            4,
+            (Supplier<Object>)
+                () ->
+                    Flowable.fromIterable(Arrays.asList(6, 7))
+                        .map(Worker::addOne)
+                        .map(Worker::addOne)),
+        Arguments.of(
+            "delayed flowable",
+            new Object[] {8, 9},
+            2,
+            (Supplier<Object>)
+                () ->
+                    Flowable.fromIterable(Arrays.asList(7, 8))
+                        .delay(100, MILLISECONDS)
+                        .map(Worker::addOne)),
+        Arguments.of(
+            "delayed twice flowable",
+            new Object[] {10, 11},
+            4,
+            (Supplier<Object>)
+                () ->
+                    Flowable.fromIterable(Arrays.asList(8, 9))
+                        .delay(100, MILLISECONDS)
+                        .map(Worker::addOne)
+                        .delay(100, MILLISECONDS)
+                        .map(Worker::addOne)),
+        Arguments.of(
+            "maybe from callable",
+            new Object[] {12},
+            2,
+            (Supplier<Object>)
+                () -> Maybe.fromCallable(() -> Worker.addOne(10)).map(Worker::addOne)));
+  }
+
+  @ParameterizedTest(name = "Publisher ''{0}'' test")
+  @MethodSource("publisherSuccessArgs")
+  void publisherSuccess(String name, Object[] expected, int workSpans, Supplier<Object> supplier) {
+    Object result = Worker.assemblePublisherUnderTrace(supplier);
+
+    if (expected.length == 1) {
+      assertEquals(expected[0], result);
+    } else {
+      assertArrayEquals(expected, (Object[]) result);
+    }
+
+    SpanMatcher[] matchers = new SpanMatcher[workSpans + 2];
+    matchers[0] =
+        span()
+            .root()
+            .operationName("trace-parent")
+            .resourceName("trace-parent")
+            .tags(componentTrace(), defaultTags());
+    matchers[1] =
+        span()
+            .id(Worker.publisherParentId)
+            .childOf(Worker.traceParentId)
+            .operationName("publisher-parent")
+            .resourceName("publisher-parent")
+            .tags(defaultTags());
+    for (int i = 0; i < workSpans; i++) {
+      matchers[2 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addOne")
+              .resourceName("addOne")
+              .tags(componentTrace(), defaultTags());
+    }
+
+    assertTraces(trace(SORT_BY_START_TIME, matchers));
+  }
+
+  // --- Publisher error -----------------------------------------------------
+
+  static List<Arguments> publisherErrorArgs() {
+    return Arrays.asList(
+        Arguments.of(
+            "maybe", (Supplier<Object>) () -> Maybe.error(new RuntimeException(EXCEPTION_MESSAGE))),
+        Arguments.of(
+            "flowable",
+            (Supplier<Object>) () -> Flowable.error(new RuntimeException(EXCEPTION_MESSAGE))));
+  }
+
+  @ParameterizedTest(name = "Publisher error ''{0}'' test")
+  @MethodSource("publisherErrorArgs")
+  void publisherError(String name, Supplier<Object> supplier) {
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> Worker.assemblePublisherUnderTrace(supplier));
+    assertEquals(EXCEPTION_MESSAGE, exception.getMessage());
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span()
+                .root()
+                .operationName("trace-parent")
+                .resourceName("trace-parent")
+                .error()
+                .tags(
+                    componentTrace(),
+                    error(RuntimeException.class, EXCEPTION_MESSAGE),
+                    defaultTags()),
+            // It's important that we don't attach errors at the reactive level so that we don't
+            // impact the spans on reactive integrations such as netty and lettuce.
+            span()
+                .id(Worker.publisherParentId)
+                .childOf(Worker.traceParentId)
+                .operationName("publisher-parent")
+                .resourceName("publisher-parent")
+                .tags(defaultTags())));
+  }
+
+  // --- Publisher step error ------------------------------------------------
+
+  static List<Arguments> publisherStepErrorArgs() {
+    return Arrays.asList(
+        Arguments.of(
+            "basic maybe failure",
+            1,
+            (Supplier<Object>)
+                () -> Maybe.just(1).map(Worker::addOne).map(i -> Worker.throwException())),
+        Arguments.of(
+            "basic flowable failure",
+            1,
+            (Supplier<Object>)
+                () ->
+                    Flowable.fromIterable(Arrays.asList(5, 6))
+                        .map(Worker::addOne)
+                        .map(i -> Worker.throwException())));
+  }
+
+  @ParameterizedTest(name = "Publisher step ''{0}'' test")
+  @MethodSource("publisherStepErrorArgs")
+  void publisherStepError(String name, int workSpans, Supplier<Object> supplier) {
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> Worker.assemblePublisherUnderTrace(supplier));
+    assertEquals(EXCEPTION_MESSAGE, exception.getMessage());
+
+    SpanMatcher[] matchers = new SpanMatcher[workSpans + 2];
+    matchers[0] =
+        span()
+            .root()
+            .operationName("trace-parent")
+            .resourceName("trace-parent")
+            .error()
+            .tags(
+                componentTrace(), error(RuntimeException.class, EXCEPTION_MESSAGE), defaultTags());
+    matchers[1] =
+        span()
+            .id(Worker.publisherParentId)
+            .childOf(Worker.traceParentId)
+            .operationName("publisher-parent")
+            .resourceName("publisher-parent")
+            .tags(defaultTags());
+    for (int i = 0; i < workSpans; i++) {
+      matchers[2 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addOne")
+              .resourceName("addOne")
+              .tags(componentTrace(), defaultTags());
+    }
+
+    assertTraces(trace(SORT_BY_START_TIME, matchers));
+  }
+
+  // --- Cancel --------------------------------------------------------------
+
+  static List<Arguments> cancelArgs() {
+    return Arrays.asList(
+        Arguments.of("basic maybe", (Supplier<Object>) () -> Maybe.just(1)),
+        Arguments.of(
+            "basic flowable", (Supplier<Object>) () -> Flowable.fromIterable(Arrays.asList(5, 6))));
+  }
+
+  @ParameterizedTest(name = "Publisher ''{0}'' cancel")
+  @MethodSource("cancelArgs")
+  void cancel(String name, Supplier<Object> supplier) {
+    Worker.cancelUnderTrace(supplier);
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span()
+                .root()
+                .operationName("trace-parent")
+                .resourceName("trace-parent")
+                .tags(componentTrace(), defaultTags()),
+            span()
+                .id(Worker.publisherParentId)
+                .childOf(Worker.traceParentId)
+                .operationName("publisher-parent")
+                .resourceName("publisher-parent")
+                .tags(defaultTags())));
+  }
+
+  // --- Chain spans correct parent ------------------------------------------
+
+  static List<Arguments> chainParentArgs() {
+    return Arrays.asList(
+        Arguments.of(
+            "basic maybe",
+            3,
+            (Supplier<Object>)
+                () ->
+                    Maybe.just(1)
+                        .map(Worker::addOne)
+                        .map(Worker::addOne)
+                        .concatWith(Maybe.just(1).map(Worker::addOne))),
+        Arguments.of(
+            "basic flowable",
+            5,
+            (Supplier<Object>)
+                () ->
+                    Flowable.fromIterable(Arrays.asList(5, 6))
+                        .map(Worker::addOne)
+                        .map(Worker::addOne)
+                        .concatWith(Maybe.just(1).map(Worker::addOne).toFlowable())));
+  }
+
+  @ParameterizedTest(name = "Publisher chain spans have the correct parent for ''{0}''")
+  @MethodSource("chainParentArgs")
+  void chainParent(String name, int workSpans, Supplier<Object> supplier) {
+    Worker.assemblePublisherUnderTrace(supplier);
+
+    SpanMatcher[] matchers = new SpanMatcher[workSpans + 2];
+    matchers[0] =
+        span()
+            .root()
+            .operationName("trace-parent")
+            .resourceName("trace-parent")
+            .tags(componentTrace(), defaultTags());
+    matchers[1] =
+        span()
+            .id(Worker.publisherParentId)
+            .childOf(Worker.traceParentId)
+            .operationName("publisher-parent")
+            .resourceName("publisher-parent")
+            .tags(defaultTags());
+    for (int i = 0; i < workSpans; i++) {
+      matchers[2 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addOne")
+              .resourceName("addOne")
+              .tags(componentTrace(), defaultTags());
+    }
+
+    assertTraces(trace(SORT_BY_START_TIME, matchers));
+  }
+
+  // --- Correct parents from subscription time (blockingGet) ----------------
+
+  @Test
+  void correctParentsFromSubscriptionTimeBlockingGet() {
+    Maybe<Integer> maybe = Maybe.just(42).map(Worker::addOne).map(Worker::addTwo);
+
+    Worker.runUnderTraceParent(
+        () -> {
+          maybe.blockingGet();
+          return null;
+        });
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("trace-parent").resourceName("trace-parent"),
+            span()
+                .childOf(Worker.traceParentId)
+                .operationName("addOne")
+                .tags(componentTrace(), defaultTags()),
+            span()
+                .childOf(Worker.traceParentId)
+                .operationName("addTwo")
+                .tags(componentTrace(), defaultTags())));
+  }
+
+  // --- Correct parents from subscription time (intermediate span) ----------
+
+  static List<Arguments> subscriptionTimeIntermediateArgs() {
+    return Arrays.asList(
+        Arguments.of("basic maybe", 1, (Supplier<Object>) () -> Maybe.just(1).map(Worker::addOne)),
+        Arguments.of(
+            "basic flowable",
+            2,
+            (Supplier<Object>)
+                () -> Flowable.fromIterable(Arrays.asList(1, 2)).map(Worker::addOne)));
+  }
+
+  @ParameterizedTest(
+      name = "Publisher chain spans have the correct parents from subscription time ''{0}''")
+  @MethodSource("subscriptionTimeIntermediateArgs")
+  @SuppressWarnings("unchecked")
+  void correctParentsFromSubscriptionTime(String name, int workItems, Supplier<Object> supplier) {
+    Worker.assemblePublisherUnderTrace(
+        () -> {
+          // The "add one" operations in the publisher created here should be children of the
+          // publisher-parent, while the "add two" operations should be children of the
+          // intermediate.
+          Object publisher = supplier.get();
+
+          AgentSpan intermediate = startSpan("test", "intermediate");
+          Worker.intermediateId = intermediate.getSpanId();
+          AgentScope scope = activateSpan(intermediate);
+          try {
+            if (publisher instanceof Maybe) {
+              return ((Maybe<Integer>) publisher).map(Worker::addTwo);
+            } else if (publisher instanceof Flowable) {
+              return ((Flowable<Integer>) publisher).map(Worker::addTwo);
+            }
+            throw new IllegalStateException("Unknown publisher type");
+          } finally {
+            intermediate.finish();
+            scope.close();
+          }
+        });
+
+    SpanMatcher[] matchers = new SpanMatcher[3 + 2 * workItems];
+    matchers[0] =
+        span()
+            .root()
+            .operationName("trace-parent")
+            .resourceName("trace-parent")
+            .tags(componentTrace(), defaultTags());
+    matchers[1] =
+        span()
+            .id(Worker.publisherParentId)
+            .childOf(Worker.traceParentId)
+            .operationName("publisher-parent")
+            .resourceName("publisher-parent")
+            .tags(defaultTags());
+    matchers[2] =
+        span()
+            .id(Worker.intermediateId)
+            .childOf(Worker.publisherParentId)
+            .operationName("intermediate")
+            .resourceName("intermediate")
+            .tags(defaultTags());
+    for (int i = 0; i < 2 * workItems; i += 2) {
+      matchers[3 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addOne")
+              .tags(componentTrace(), defaultTags());
+      matchers[4 + i] =
+          span()
+              .childOf(Worker.publisherParentId)
+              .operationName("addTwo")
+              .tags(componentTrace(), defaultTags());
+    }
+
+    assertTraces(trace(SORT_BY_START_TIME, matchers));
+  }
+
+  // --- Schedulers ----------------------------------------------------------
+
+  static List<Arguments> schedulerArgs() {
+    return Arrays.asList(
+        Arguments.of("new-thread", Schedulers.newThread()),
+        Arguments.of("computation", Schedulers.computation()),
+        Arguments.of("single", Schedulers.single()),
+        Arguments.of("trampoline", Schedulers.trampoline()));
+  }
+
+  @ParameterizedTest(name = "Flowables produce the right number of results on ''{0}'' scheduler")
+  @MethodSource("schedulerArgs")
+  void schedulers(String schedulerName, Scheduler scheduler) {
+    List<String> values =
+        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
+            .parallel()
+            .runOn(scheduler)
+            .flatMap(
+                num ->
+                    Maybe.just(num.toString() + " on " + Thread.currentThread().getName())
+                        .toFlowable())
+            .sequential()
+            .toList()
+            .blockingGet();
+
+    assertEquals(4, values.size());
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/SubscriptionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/SubscriptionTest.java
@@ -9,7 +9,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import datadog.trace.agent.test.AbstractInstrumentationTest;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Test;
@@ -17,12 +22,119 @@ import org.junit.jupiter.api.Test;
 class SubscriptionTest extends AbstractInstrumentationTest {
 
   @Test
-  void subscriptionPropagatesParentSpan() throws InterruptedException {
+  void maybeSubscriptionPropagatesParentSpan() throws InterruptedException {
     CountDownLatch latch = new CountDownLatch(1);
 
     AgentSpan parent = startSpan("test", "parent");
     try (AgentScope scope = activateSpan(parent)) {
       Maybe<Connection> connection = Maybe.create(emitter -> emitter.onSuccess(new Connection()));
+      connection.subscribe(
+          c -> {
+            c.query();
+            latch.countDown();
+          });
+    } finally {
+      parent.finish();
+    }
+    latch.await();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("parent"),
+            span().childOfPrevious().operationName("Connection.query")));
+  }
+
+  @Test
+  void singleSubscriptionPropagatesParentSpan() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    AgentSpan parent = startSpan("test", "parent");
+    try (AgentScope scope = activateSpan(parent)) {
+      Single<Connection> connection = Single.create(emitter -> emitter.onSuccess(new Connection()));
+      connection.subscribe(
+          c -> {
+            c.query();
+            latch.countDown();
+          });
+    } finally {
+      parent.finish();
+    }
+    latch.await();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("parent"),
+            span().childOfPrevious().operationName("Connection.query")));
+  }
+
+  @Test
+  void completableSubscriptionPropagatesParentSpan() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    AgentSpan parent = startSpan("test", "parent");
+    try (AgentScope scope = activateSpan(parent)) {
+      Completable action = Completable.create(emitter -> emitter.onComplete());
+      action.subscribe(
+          () -> {
+            new Connection().query();
+            latch.countDown();
+          });
+    } finally {
+      parent.finish();
+    }
+    latch.await();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("parent"),
+            span().childOfPrevious().operationName("Connection.query")));
+  }
+
+  @Test
+  void observableSubscriptionPropagatesParentSpan() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    AgentSpan parent = startSpan("test", "parent");
+    try (AgentScope scope = activateSpan(parent)) {
+      Observable<Connection> connection =
+          Observable.create(
+              emitter -> {
+                emitter.onNext(new Connection());
+                emitter.onComplete();
+              });
+      connection.subscribe(
+          c -> {
+            c.query();
+            latch.countDown();
+          });
+    } finally {
+      parent.finish();
+    }
+    latch.await();
+
+    assertTraces(
+        trace(
+            SORT_BY_START_TIME,
+            span().root().operationName("parent"),
+            span().childOfPrevious().operationName("Connection.query")));
+  }
+
+  @Test
+  void flowableSubscriptionPropagatesParentSpan() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    AgentSpan parent = startSpan("test", "parent");
+    try (AgentScope scope = activateSpan(parent)) {
+      Flowable<Connection> connection =
+          Flowable.create(
+              emitter -> {
+                emitter.onNext(new Connection());
+                emitter.onComplete();
+              },
+              BackpressureStrategy.BUFFER);
       connection.subscribe(
           c -> {
             c.query();

--- a/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/SubscriptionTest.java
+++ b/dd-java-agent/instrumentation/rxjava/rxjava-3.0/src/test/java/testdog/trace/instrumentation/rxjava3/SubscriptionTest.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.rxjava3;
+package testdog.trace.instrumentation.rxjava3;
 
 import static datadog.trace.agent.test.assertions.SpanMatcher.span;
 import static datadog.trace.agent.test.assertions.TraceMatcher.SORT_BY_START_TIME;

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -9601,6 +9601,14 @@
         "aliases": ["DD_TRACE_INTEGRATION_RXJAVA_ENABLED", "DD_INTEGRATION_RXJAVA_ENABLED"]
       }
     ],
+    "DD_TRACE_RXJAVA_3_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": ["DD_TRACE_INTEGRATION_RXJAVA_3_ENABLED", "DD_INTEGRATION_RXJAVA_3_ENABLED"]
+      }
+    ],
     "DD_TRACE_S3_ENABLED": [
       {
         "version": "A",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -559,6 +559,7 @@ include(
   ":dd-java-agent:instrumentation:rs:jax-rs:jax-rs-client:jax-rs-client-2.0",
   ":dd-java-agent:instrumentation:rxjava:rxjava-1.0",
   ":dd-java-agent:instrumentation:rxjava:rxjava-2.0",
+  ":dd-java-agent:instrumentation:rxjava:rxjava-3.0",
   ":dd-java-agent:instrumentation:scala:scala-concurrent-2.8",
   ":dd-java-agent:instrumentation:scala:scala-promise:scala-promise-2.10",
   ":dd-java-agent:instrumentation:scala:scala-promise:scala-promise-2.13",


### PR DESCRIPTION
# What Does This Do

We already trace RxJava 1 and 2 but not 3. RxJava 3 moved its types to the `io.reactivex.rxjava3.core.*` namespace, so the existing rxjava-2.0 instrumentation never matches it. This adds a new `rxjava-3.0` module that brings RxJava 3 to parity.

What's in it:

* New `dd-java-agent/instrumentation/rxjava/rxjava-3.0` module. It ports the rxjava-2.0 logic to the RxJava 3 namespace: context capture on the five reactive types (Flowable, Observable, Single, Maybe, Completable) and re-attachment around subscriber callbacks, plus the async result extension that finishes `@WithSpan` / `@Trace` spans when the stream completes, errors, or is cancelled.
* Muzzle has a `pass` for rxjava3 `[3.0.0,)` and a `fail` block that asserts the advice can never match the rxjava2 artifact, so the two versions stay isolated. The module also pulls in rxjava-2.0 as a test runtime dependency to confirm both instrumenters coexist.
* Registered in the GraalVM native image build time list next to the rxjava2 entry.
* Tests are JUnit 5 (44 cases): subscription propagation, the core propagation suite, the `@WithSpan` result extension across all five types, and a Java 8 interop check (`fromCompletionStage`, `fromStream`, `fromOptional`). latestDepTest runs the same suite against the newest published rxjava3.

One thing reviewers should look at closely: this also touches the shared `java-concurrent` module. While testing delayed chains I found that RxJava 3 added `io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask`, whose static initializer builds two sentinel `FutureTask` instances. When that initializer first runs under an active trace (the first `delay` or `timeout` hop inside a span), the executor instrumentation captures a continuation on those static singletons that never gets cancelled, so the trace stays pending and is never reported. ~RxJava 2 has no equivalent class, which is why the byte for byte equivalent rxjava-2.0 code never hit this~(correction: 2.0.9+ seem to have it). The fix disables async propagation while that type initializer runs, following the same pattern already used for Reactor's `SchedulerTask` and `WorkerTask`. The matcher is an exact class name, so it stays inert unless RxJava 3 is on the classpath.

The Java 8 interop check found no propagation gaps once that fix was in place.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
