### PR TITLE
Fix serialization error in spotless `test-published-artifacts`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -447,6 +447,7 @@ spotless:
     CACHE_TYPE: "spotless"
   script:
     - ./gradlew --version
+    # test-published-dependencies's build file needs main version file
     - ./gradlew spotlessCheck writeMainVersionFile $GRADLE_ARGS
     - cd test-published-dependencies && ./gradlew spotlessCheck $GRADLE_ARGS
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -447,7 +447,8 @@ spotless:
     CACHE_TYPE: "spotless"
   script:
     - ./gradlew --version
-    - ./gradlew spotlessCheck $GRADLE_ARGS
+    - ./gradlew spotlessCheck writeMainVersionFile $GRADLE_ARGS
+    - cd test-published-dependencies && ./gradlew spotlessCheck $GRADLE_ARGS
 
 check-instrumentation-naming:
   extends: .gradle_build

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -13,5 +13,22 @@ allprojects {
   version = versionFromFile
 
   apply(from = "$sharedConfigDirectory/repositories.gradle")
-  apply(from = "$sharedConfigDirectory/spotless.gradle")
+  apply(plugin = "com.diffplug.spotless")
+
+  spotless {
+    kotlinGradle {
+      target("*.gradle.kts")
+      ktlint("1.8.0").editorConfigOverride(
+        mapOf(
+          // Disable trailing comma rules to minimize diff.
+          "ktlint_standard_trailing-comma-on-call-site" to "disabled",
+          "ktlint_standard_trailing-comma-on-declaration-site" to "disabled",
+        ),
+      )
+    }
+    java {
+      target("src/**/*.java")
+      googleJavaFormat("1.35.0")
+    }
+  }
 }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -15,6 +15,9 @@ allprojects {
   apply(from = "$sharedConfigDirectory/repositories.gradle")
   apply(plugin = "com.diffplug.spotless")
 
+  // Apply a simple spotless config here.
+  // Using the dd-trace-java's plugin scripts, adds a step with grecplipse that
+  // has a concurrency bug surfacing with gradle 9.6 when there's no matching file.
   spotless {
     kotlinGradle {
       target("*.gradle.kts")


### PR DESCRIPTION
# What Does This Do

This PR updates the CI configuration to address a serialization bug in the Spotless plugin when no files match the defined extension target. It introduces a dedicated Spotless configuration specifically for the `test-published-artifacts` verification process.

Check `test_published_artifacts`'s spotless early on in `spotless` job.

Relates to https://github.com/diffplug/spotless/pull/2994

# Motivation

The previous shared Spotless configuration triggered a build failure due to an obscure error involving the Greclipse formatter's serialization, which impacted build stability. This change ensures the setup remains robust and avoids such errors.

# Additional Notes

This issue is specific to the `Greclipse` formatter and arises under certain conditions where no matching files exist. The dedicated configuration provides a clear and isolated solution for this scenario.

More precisely, the failure appears o be a thread-safety bug in Spotless. During Gradle's parallel input fingerprinting, `ConfigurationCacheHackList.hashCode()` serializes each formatter step. `FormatterStepSerializationRoundtrip$HackClone.writeObject` does a _non-atomic_ check, then populate on its `cleaned` field, i.e. it publishes `cleaned` field before assigning the internal state of `FormatterStepSerializationRoundtrip`. In our case this led to a second thread that can serialize the half-built "clone", this why we see a 

```
Caused by: java.lang.IllegalStateException: If the initializer was null, then one of roundtripStateInternal or equalityStateInternal should be non-null, and neither was
        at com.diffplug.spotless.FormatterStepSerializationRoundtrip.writeObject(FormatterStepSerializationRoundtrip.java:74)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.base/java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1072)
```

The issue was probably never trigger before, because Gradle 9.6 improved the speed in that area (fingerprinting).

Given that `test_published_artifacts` no longer needs a groovy formatter, I chose to avoid applyin the plugin script of dd-trace-java, and applied a tailored (and simple) spotless configuration.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]