### PR TITLE
Allow profiling of workers with async-profiler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,24 @@ allprojects {
     }
   }
 
+  System.getProperty("datadog.forkedAsyncProfiler")?.let { raw ->
+    val options = if (raw.isBlank() || raw == "true") "all" else raw.removePrefix("start,")
+    val lib =
+      System.getProperty("datadog.forkedAsyncProfilerLib", "/opt/homebrew/lib/libasyncProfiler.dylib")
+    val libFile = file(lib)
+    if (!libFile.exists()) {
+      logger.warn("async-profiler library not found at: $lib")
+      logger.warn("To install async-profiler on macOS, run: 'brew install async-profiler'")
+      logger.warn("Skipping async-profiler configuration for tests")
+    } else {
+      val outDir = System.getProperty("datadog.forkedAsyncProfilerDir", "/tmp")
+      tasks.withType<Test>().configureEach {
+        // %p keeps one recording per worker JVM (maxParallelForks / forkEvery may spawn several).
+        jvmArgs("-agentpath:$lib=start,$options,file=$outDir/async-${project.name}-%p.jfr")
+      }
+    }
+  }
+
   // Disable CDS to avoid SIGSEGVs on Linux arm64.
   if (isLinuxArm64) {
     tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
# What Does This Do
Adds support for profiling worker threads using the async-profiler, enabling better performance analysis and diagnostics.

This code depends on having `brew install async-profiler` (https://github.com/Homebrew/homebrew-core/pull/267881).

# Motivation

gradle-profiler profiles the daemon only

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]