### PR TITLE
Add AGP usage visibility for Gradle projects

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestModule.java
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.execution.TestStatus;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.EventType;
+import datadog.trace.api.civisibility.telemetry.tag.IsAndroid;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -114,6 +115,10 @@ public abstract class AbstractTestModule {
       span.finish();
     }
 
-    metricCollector.add(CiVisibilityCountMetric.EVENT_FINISHED, 1, EventType.MODULE);
+    metricCollector.add(
+        CiVisibilityCountMetric.EVENT_FINISHED,
+        1,
+        EventType.MODULE,
+        span.getTag(Tags.TEST_IS_ANDROID) != null ? IsAndroid.TRUE : null);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/AbstractTestSession.java
@@ -19,6 +19,7 @@ import datadog.trace.api.civisibility.telemetry.tag.EventType;
 import datadog.trace.api.civisibility.telemetry.tag.FailFastTestOrderEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.FailedTestReplayEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.HasCodeowner;
+import datadog.trace.api.civisibility.telemetry.tag.IsAndroid;
 import datadog.trace.api.civisibility.telemetry.tag.IsHeadless;
 import datadog.trace.api.civisibility.telemetry.tag.IsUnsupportedCI;
 import datadog.trace.api.civisibility.telemetry.tag.Provider;
@@ -199,6 +200,9 @@ public abstract class AbstractTestSession {
     }
     if (span.getTag(DDTags.TEST_HAS_FAILED_TEST_REPLAY) != null) {
       tags.add(FailedTestReplayEnabled.SessionMetric.TRUE);
+    }
+    if (span.getTag(Tags.TEST_IS_ANDROID) != null) {
+      tags.add(IsAndroid.TRUE);
     }
     return tags;
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -194,6 +194,7 @@ public class BuildSystemSessionImpl<T extends CoverageProcessor> extends Abstrac
         TagMergeSpec.of(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, Long::sum),
         TagMergeSpec.of(DDTags.CI_ITR_TESTS_SKIPPED, Boolean::logicalOr),
         TagMergeSpec.of(Tags.TEST_TEST_MANAGEMENT_ENABLED, Boolean::logicalOr),
+        TagMergeSpec.of(Tags.TEST_IS_ANDROID, Boolean::logicalOr),
         TagMergeSpec.of(DDTags.TEST_HAS_FAILED_TEST_REPLAY, Boolean::logicalOr),
         TagMergeSpec.of(DDTags.CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS, Boolean::logicalOr),
         TagMergeSpec.of(DDTags.CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS, Boolean::logicalOr),

--- a/dd-java-agent/instrumentation/gradle/gradle-3.0/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleBuildListener.java
+++ b/dd-java-agent/instrumentation/gradle/gradle-3.0/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleBuildListener.java
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.domain.BuildModuleSettings;
 import datadog.trace.api.civisibility.domain.BuildSessionSettings;
 import datadog.trace.api.civisibility.domain.JavaAgent;
 import datadog.trace.api.civisibility.events.BuildEventsHandler;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -111,9 +112,22 @@ public class GradleBuildListener extends BuildAdapter {
       List<Path> classpath = GradleUtils.getClasspath(task);
       JavaAgent jacocoAgent = GradleUtils.getJacocoAgent(task);
 
+      // "com.android.base" is applied transitively by every Android Gradle Plugin, so it is a
+      // reliable single marker for an Android project regardless of how its tests are executed.
+      Map<String, Object> additionalTags =
+          project.getPluginManager().hasPlugin("com.android.base")
+              ? Collections.singletonMap(Tags.TEST_IS_ANDROID, true)
+              : Collections.emptyMap();
+
       BuildModuleSettings moduleSettings =
           buildEventsHandler.onTestModuleStart(
-              gradle, taskPath, moduleLayout, jvmExecutable, classpath, jacocoAgent, null);
+              gradle,
+              taskPath,
+              moduleLayout,
+              jvmExecutable,
+              classpath,
+              jacocoAgent,
+              additionalTags);
       Map<String, String> systemProperties = moduleSettings.getSystemProperties();
       GradleProjectConfigurator.INSTANCE.configureTracer(task, systemProperties);
     }

--- a/dd-java-agent/instrumentation/gradle/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListener.java
+++ b/dd-java-agent/instrumentation/gradle/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListener.java
@@ -183,6 +183,14 @@ public class CiVisibilityGradleListener extends BuildAdapter
     Project project = gradle.getRootProject().project(projectPath);
     Test task = (Test) project.getTasks().getByName(taskIdentity.name);
 
+    // "com.android.base" is applied transitively by the application/library/dynamic-feature/test
+    // Android Gradle Plugins. The Android KMP library plugin (AGP 8.8+) is a separate entry point
+    // that does NOT apply com.android.base, so it must be checked explicitly.
+    PluginManager pluginManager = project.getPluginManager();
+    boolean isAndroid =
+        pluginManager.hasPlugin("com.android.base")
+            || pluginManager.hasPlugin("com.android.kotlin.multiplatform.library");
+
     Map<String, Object> inputProperties = task.getInputs().getProperties();
     BuildModuleLayout moduleLayout =
         (BuildModuleLayout) inputProperties.get(CiVisibilityPluginExtension.MODULE_LAYOUT_PROPERTY);
@@ -197,7 +205,7 @@ public class CiVisibilityGradleListener extends BuildAdapter
     List<Path> taskClasspath = CiVisibilityPluginExtension.getClasspath(task);
 
     ciVisibilityService.onModuleStart(
-        taskPath, moduleLayout, jvmExecutable, taskClasspath, jacocoAgent);
+        taskPath, isAndroid, moduleLayout, jvmExecutable, taskClasspath, jacocoAgent);
   }
 
   private JavaAgent getJacocoAgent(Test task) {

--- a/dd-java-agent/instrumentation/gradle/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityService.java
+++ b/dd-java-agent/instrumentation/gradle/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityService.java
@@ -123,12 +123,21 @@ public abstract class CiVisibilityService
 
   public void onModuleStart(
       String taskPath,
+      boolean isAndroid,
       BuildModuleLayout moduleLayout,
       Path jvmExecutable,
       Collection<Path> taskClasspath,
       JavaAgent jacocoAgent) {
+    Map<String, Object> additionalTags =
+        isAndroid ? Collections.singletonMap(Tags.TEST_IS_ANDROID, true) : Collections.emptyMap();
     buildEventsHandler.onTestModuleStart(
-        SESSION_KEY, taskPath, moduleLayout, jvmExecutable, taskClasspath, jacocoAgent, null);
+        SESSION_KEY,
+        taskPath,
+        moduleLayout,
+        jvmExecutable,
+        taskClasspath,
+        jacocoAgent,
+        additionalTags);
   }
 
   public void onModuleFinish(

--- a/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
+++ b/dd-smoke-tests/gradle/src/test/java/datadog/smoketest/GradleDaemonSmokeTest.java
@@ -131,7 +131,7 @@ class GradleDaemonSmokeTest extends AbstractGradleTest {
 
   @TableTest({
     "scenario           | gradleVersion | projectName              | expectedTraces",
-    "robolectric-latest | latest        | test-succeed-robolectric | 6             "
+    "robolectric-latest | latest        | test-succeed-robolectric | 7             "
   })
   @ParameterizedTest
   void testRobolectric(String gradleVersion, String projectName, int expectedTraces)

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/build.gradleTest
@@ -8,6 +8,10 @@ import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.LibraryElements
 
 apply plugin: 'java'
+// Inert stand-in for the Android Gradle Plugin (see buildSrc/): real AGP needs the Android SDK,
+// which is absent in the smoke-test environment. Our build-level Android detection only checks for
+// the 'com.android.base' plugin id, so applying an id-only stand-in exercises it.
+apply plugin: 'com.android.base'
 
 repositories {
   mavenLocal()

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/build.gradleTest
@@ -1,0 +1,21 @@
+apply plugin: 'java'
+
+repositories {
+  mavenLocal()
+
+  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+  if (proxyUrl) {
+    maven {
+      url = proxyUrl
+      allowInsecureProtocol = true
+    }
+  }
+
+  mavenCentral()
+}
+
+dependencies {
+  // Plugin<Project> lives in the Gradle API; the CI Visibility javac plugin is auto-injected into
+  // this compile task too, so the repositories above must be able to resolve it.
+  implementation gradleApi()
+}

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/src/main/java/datadog/smoke/gradle/AndroidBaseStandInPlugin.java
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/src/main/java/datadog/smoke/gradle/AndroidBaseStandInPlugin.java
@@ -1,0 +1,22 @@
+package datadog.smoke.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * No-op stand-in for the Android Gradle Plugin's {@code com.android.base} plugin.
+ *
+ * <p>Real AGP requires the Android SDK to be installed, which is not available in the smoke-test
+ * environment. The CI Visibility build-level Android detection only checks whether a plugin
+ * registered under the {@code com.android.base} id has been applied (see {@code
+ * CiVisibilityGradleListener}); every AGP variant applies {@code com.android.base} transitively.
+ * Registering an inert plugin under that exact id therefore exercises the detection, the
+ * module→session tag propagation and the {@code is_android} telemetry faithfully, without pulling
+ * in AGP or the SDK.
+ */
+public class AndroidBaseStandInPlugin implements Plugin<Project> {
+  @Override
+  public void apply(Project project) {
+    // intentionally empty: only the plugin id matters for detection
+  }
+}

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/src/main/resources/META-INF/gradle-plugins/com.android.base.properties
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/buildSrc/src/main/resources/META-INF/gradle-plugins/com.android.base.properties
@@ -1,0 +1,1 @@
+implementation-class=datadog.smoke.gradle.AndroidBaseStandInPlugin

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/events.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/events.ftl
@@ -23,6 +23,7 @@
       "test.command" : "gradle test",
       "test.framework" : "junit4",
       "test.framework_version" : "4.13.2",
+      "test.is_android" : "true",
       "test.itr.tests_skipping.enabled" : "true",
       "test.itr.tests_skipping.type" : "test",
       "test.status" : "pass",
@@ -52,6 +53,48 @@
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_2},
       "_dd.test.is_user_provided_service" : "true",
+      "_dd.tracer_host" : ${content_meta__dd_tracer_host},
+      "ci.workspace_path" : ${content_meta_ci_workspace_path},
+      "component" : "gradle",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version},
+      "span.kind" : "test_session_end",
+      "test.command" : "gradle :buildSrc",
+      "test.gradle.nested_build" : "true",
+      "test.status" : "skip",
+      "test.toolchain" : ${content_meta_test_toolchain},
+      "test.type" : "test",
+      "test_session.name" : "gradle :buildSrc"
+    },
+    "metrics" : {
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0,
+      "process_id" : ${content_metrics_process_id}
+    },
+    "name" : "gradle.test_session",
+    "resource" : ":buildSrc",
+    "service" : "test-gradle-service",
+    "start" : ${content_start_2},
+    "test_session_id" : ${content_test_session_id_2}
+  },
+  "type" : "test_session_end",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
+      "_dd.test.is_user_provided_service" : "true",
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
       "component" : "gradle",
       "env" : "integration-test",
@@ -69,6 +112,7 @@
       "test.command" : "gradle test",
       "test.framework" : "junit4",
       "test.framework_version" : "4.13.2",
+      "test.is_android" : "true",
       "test.itr.tests_skipping.enabled" : "true",
       "test.itr.tests_skipping.type" : "test",
       "test.module" : ":test",
@@ -77,46 +121,17 @@
       "test_session.name" : "gradle test"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_2},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
       "test.itr.tests_skipping.count" : 0
     },
     "name" : "gradle.test_module",
     "resource" : ":test",
     "service" : "test-gradle-service",
-    "start" : ${content_start_2},
+    "start" : ${content_start_3},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id}
   },
   "type" : "test_module_end",
-  "version" : 1
-}, {
-  "content" : {
-    "duration" : ${content_duration_3},
-    "error" : 0,
-    "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_3},
-      "_dd.test.is_user_provided_service" : "true",
-      "env" : "integration-test",
-      "language" : "jvm",
-      "library_version" : ${content_meta_library_version},
-      "os.architecture" : ${content_meta_os_architecture},
-      "os.platform" : ${content_meta_os_platform},
-      "os.version" : ${content_meta_os_version},
-      "runtime-id" : ${content_meta_runtime_id},
-      "runtime.name" : ${content_meta_runtime_name},
-      "runtime.vendor" : ${content_meta_runtime_vendor},
-      "runtime.version" : ${content_meta_runtime_version}
-    },
-    "metrics" : { },
-    "name" : "classes",
-    "parent_id" : ${content_test_session_id},
-    "resource" : "classes",
-    "service" : "test-gradle-service",
-    "span_id" : ${content_span_id},
-    "start" : ${content_start_3},
-    "trace_id" : ${content_test_session_id}
-  },
-  "type" : "span",
   "version" : 1
 }, {
   "content" : {
@@ -137,13 +152,13 @@
       "runtime.version" : ${content_meta_runtime_version}
     },
     "metrics" : { },
-    "name" : "compileJava",
-    "parent_id" : ${content_test_session_id},
-    "resource" : "compileJava",
+    "name" : "classes",
+    "parent_id" : ${content_test_session_id_2},
+    "resource" : "classes",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_2},
+    "span_id" : ${content_span_id},
     "start" : ${content_start_4},
-    "trace_id" : ${content_test_session_id}
+    "trace_id" : ${content_test_session_id_2}
   },
   "type" : "span",
   "version" : 1
@@ -166,11 +181,11 @@
       "runtime.version" : ${content_meta_runtime_version}
     },
     "metrics" : { },
-    "name" : "compileTestJava",
+    "name" : "classes",
     "parent_id" : ${content_test_session_id},
-    "resource" : "compileTestJava",
+    "resource" : "classes",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_3},
+    "span_id" : ${content_span_id_2},
     "start" : ${content_start_5},
     "trace_id" : ${content_test_session_id}
   },
@@ -182,6 +197,122 @@
     "error" : 0,
     "meta" : {
       "_dd.p.tid" : ${content_meta__dd_p_tid_6},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "compileGroovy",
+    "parent_id" : ${content_test_session_id_2},
+    "resource" : "compileGroovy",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_3},
+    "start" : ${content_start_6},
+    "trace_id" : ${content_test_session_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_7},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_7},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "compileJava",
+    "parent_id" : ${content_test_session_id_2},
+    "resource" : "compileJava",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_4},
+    "start" : ${content_start_7},
+    "trace_id" : ${content_test_session_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_8},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_8},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "compileJava",
+    "parent_id" : ${content_test_session_id},
+    "resource" : "compileJava",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_5},
+    "start" : ${content_start_8},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_9},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_9},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "compileTestJava",
+    "parent_id" : ${content_test_session_id},
+    "resource" : "compileTestJava",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_6},
+    "start" : ${content_start_9},
+    "trace_id" : ${content_test_session_id}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_10},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_10},
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -208,7 +339,7 @@
       "test_session.name" : "gradle test"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_3},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
@@ -218,7 +349,7 @@
     "name" : "junit4.test_suite",
     "resource" : "datadog.smoke.AndroidJUnit4RunnerTest",
     "service" : "test-gradle-service",
-    "start" : ${content_start_6},
+    "start" : ${content_start_10},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id}
@@ -227,7 +358,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_7},
+    "duration" : ${content_duration_11},
     "error" : 0,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
@@ -240,7 +371,7 @@
       "_dd.library_capabilities.test_management.attempt_to_fix" : "5",
       "_dd.library_capabilities.test_management.disable" : "1",
       "_dd.library_capabilities.test_management.quarantine" : "1",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_7},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_11},
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -273,7 +404,7 @@
       "test_session.name" : "gradle test"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_4},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
@@ -285,8 +416,8 @@
     "parent_id" : ${content_parent_id},
     "resource" : "datadog.smoke.AndroidJUnit4RunnerTest.test_androidjunit4_runner",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_4},
-    "start" : ${content_start_7},
+    "span_id" : ${content_span_id_7},
+    "start" : ${content_start_11},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id},
@@ -296,10 +427,10 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_8},
+    "duration" : ${content_duration_12},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_8},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_12},
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -326,7 +457,7 @@
       "test_session.name" : "gradle test"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_5},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
@@ -336,7 +467,7 @@
     "name" : "junit4.test_suite",
     "resource" : "datadog.smoke.RobolectricRunnerTest",
     "service" : "test-gradle-service",
-    "start" : ${content_start_8},
+    "start" : ${content_start_12},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id_2}
@@ -345,7 +476,7 @@
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_9},
+    "duration" : ${content_duration_13},
     "error" : 0,
     "meta" : {
       "_dd.library_capabilities.auto_test_retries" : "1",
@@ -358,7 +489,7 @@
       "_dd.library_capabilities.test_management.attempt_to_fix" : "5",
       "_dd.library_capabilities.test_management.disable" : "1",
       "_dd.library_capabilities.test_management.quarantine" : "1",
-      "_dd.p.tid" : ${content_meta__dd_p_tid_9},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_13},
       "_dd.test.is_user_provided_service" : "true",
       "_dd.tracer_host" : ${content_meta__dd_tracer_host},
       "ci.workspace_path" : ${content_meta_ci_workspace_path},
@@ -391,7 +522,7 @@
       "test_session.name" : "gradle test"
     },
     "metrics" : {
-      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_6},
+      "_dd.host.vcpu_count" : ${content_metrics__dd_host_vcpu_count_7},
       "_dd.profiling.enabled" : 0,
       "_dd.trace_span_attribute_schema" : 0,
       "process_id" : ${content_metrics_process_id_2},
@@ -403,8 +534,8 @@
     "parent_id" : ${content_parent_id},
     "resource" : "datadog.smoke.RobolectricRunnerTest.test_robolectric_runner",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_5},
-    "start" : ${content_start_9},
+    "span_id" : ${content_span_id_8},
+    "start" : ${content_start_13},
     "test_module_id" : ${content_test_module_id},
     "test_session_id" : ${content_test_session_id},
     "test_suite_id" : ${content_test_suite_id_2},
@@ -414,10 +545,68 @@
   "version" : 2
 }, {
   "content" : {
-    "duration" : ${content_duration_10},
+    "duration" : ${content_duration_14},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_10},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_14},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "jar",
+    "parent_id" : ${content_test_session_id_2},
+    "resource" : "jar",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_9},
+    "start" : ${content_start_14},
+    "trace_id" : ${content_test_session_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_15},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_15},
+      "_dd.test.is_user_provided_service" : "true",
+      "env" : "integration-test",
+      "language" : "jvm",
+      "library_version" : ${content_meta_library_version},
+      "os.architecture" : ${content_meta_os_architecture},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "runtime.version" : ${content_meta_runtime_version}
+    },
+    "metrics" : { },
+    "name" : "processResources",
+    "parent_id" : ${content_test_session_id_2},
+    "resource" : "processResources",
+    "service" : "test-gradle-service",
+    "span_id" : ${content_span_id_10},
+    "start" : ${content_start_15},
+    "trace_id" : ${content_test_session_id_2}
+  },
+  "type" : "span",
+  "version" : 1
+}, {
+  "content" : {
+    "duration" : ${content_duration_16},
+    "error" : 0,
+    "meta" : {
+      "_dd.p.tid" : ${content_meta__dd_p_tid_16},
       "_dd.test.is_user_provided_service" : "true",
       "env" : "integration-test",
       "language" : "jvm",
@@ -435,18 +624,18 @@
     "parent_id" : ${content_test_session_id},
     "resource" : "processResources",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_6},
-    "start" : ${content_start_10},
+    "span_id" : ${content_span_id_11},
+    "start" : ${content_start_16},
     "trace_id" : ${content_test_session_id}
   },
   "type" : "span",
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_11},
+    "duration" : ${content_duration_17},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_11},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_17},
       "_dd.test.is_user_provided_service" : "true",
       "env" : "integration-test",
       "language" : "jvm",
@@ -464,18 +653,18 @@
     "parent_id" : ${content_test_session_id},
     "resource" : "processTestResources",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_7},
-    "start" : ${content_start_11},
+    "span_id" : ${content_span_id_12},
+    "start" : ${content_start_17},
     "trace_id" : ${content_test_session_id}
   },
   "type" : "span",
   "version" : 1
 }, {
   "content" : {
-    "duration" : ${content_duration_12},
+    "duration" : ${content_duration_18},
     "error" : 0,
     "meta" : {
-      "_dd.p.tid" : ${content_meta__dd_p_tid_12},
+      "_dd.p.tid" : ${content_meta__dd_p_tid_18},
       "_dd.test.is_user_provided_service" : "true",
       "env" : "integration-test",
       "language" : "jvm",
@@ -493,8 +682,8 @@
     "parent_id" : ${content_test_session_id},
     "resource" : "testClasses",
     "service" : "test-gradle-service",
-    "span_id" : ${content_span_id_8},
-    "start" : ${content_start_12},
+    "span_id" : ${content_span_id_13},
+    "start" : ${content_start_18},
     "trace_id" : ${content_test_session_id}
   },
   "type" : "span",

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -22,6 +22,7 @@ import datadog.trace.api.civisibility.telemetry.tag.GitShaMatch;
 import datadog.trace.api.civisibility.telemetry.tag.HasCodeowner;
 import datadog.trace.api.civisibility.telemetry.tag.HasFailedAllRetries;
 import datadog.trace.api.civisibility.telemetry.tag.ImpactedTestsDetectionEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.IsAndroid;
 import datadog.trace.api.civisibility.telemetry.tag.IsAndroidEmulated;
 import datadog.trace.api.civisibility.telemetry.tag.IsAttemptToFix;
 import datadog.trace.api.civisibility.telemetry.tag.IsDisabled;
@@ -73,7 +74,8 @@ public enum CiVisibilityCountMetric {
       HasCodeowner.class,
       IsUnsupportedCI.class,
       EarlyFlakeDetectionAbortReason.class,
-      FailedTestReplayEnabled.SessionMetric.class),
+      FailedTestReplayEnabled.SessionMetric.class,
+      IsAndroid.class),
   /** The number of test events finished */
   TEST_EVENT_FINISHED(
       "event_finished",

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsAndroid.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsAndroid.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether a test module/session belongs to an Android project. */
+public enum IsAndroid implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "is_android:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -90,6 +90,8 @@ public class Tags {
   public static final String TEST_ANDROID_CODENAME = "test.android.codename";
   public static final String TEST_ANDROID_ROBOLECTRIC_VERSION = "test.android.robolectric.version";
 
+  public static final String TEST_IS_ANDROID = "test.is_android";
+
   public static final String TEST_SESSION_ID = "test_session_id";
   public static final String TEST_MODULE_ID = "test_module_id";
   public static final String TEST_SUITE_ID = "test_suite_id";


### PR DESCRIPTION
# What Does This Do

- Implements additional visibility for session and module spans in Gradle projects making use of the Android Gradle Plugin. Our Gradle instrumentation will consider "Android Projects" those containing the `com.android.base` plugin in their used plugins.
	- New `test.is_android` tag is added to module spans and propagated to session spans with an `OR` operation.
	- New `is_android` boolean field on the `event_finished` telemetry metric.

# Motivation

Together with https://github.com/DataDog/dd-trace-java/pull/11852, the changes aim to provide better visibility for Android users using Test Optimization. In this case, it provides visibility on the overall Android user base, even if they don't use Robolectric emulation for unit tests.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [SDTEST-3887]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-3887]: https://datadoghq.atlassian.net/browse/SDTEST-3887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ