### PR TITLE
Update CI to new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: "Bug Report (Low Priority)"
 description: "Create a public Bug Report. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult."
-labels: "type: bug"
+labels: "type: bug fix"
 body:
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: "Bug Report (Low Priority)"
-description: "Create a public Bug Report. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult."
-labels: "type: bug fix"
+description: "Create a public Bug Report. Note that these may not be addressed, as it depends on capacity and that looking up account information may be difficult."
+labels: "type: bug report"
 body:
   - type: input
     attributes:

--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -103,9 +103,9 @@ jobs:
               'tag: diagnostics': ':mag:',
               'tag: performance': ':zap:',
               'tag: security': ':closed_lock_with_key:',
-              'type: bug': ':bug:',
+              'type: bug fix': ':bug:',
               'type: documentation': ':book:',
-              'type: enhancement': ':sparkles:',
+              'type: feature': ':sparkles:',
               'type: feature request': ':bulb:',
               'type: refactoring': ':broom:'
             }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
@@ -7,7 +7,7 @@
                 "name": "inst: java"
             },
             {
-                "name": "type: bug"
+                "name": "type: bug fix"
             }
         ],
         "title": "Adding some new features",

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-linking-issue.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-linking-issue.json
@@ -7,7 +7,7 @@
                 "name": "comp: api"
             },
             {
-                "name": "type: enhancement"
+                "name": "type: feature"
             }
         ],
         "title": "Adding some new features",

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-title-tag.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-title-tag.json
@@ -7,7 +7,7 @@
                 "name": "comp: api"
             },
             {
-                "name": "type: enhancement"
+                "name": "type: feature"
             }
         ],
         "title": "[API] Adding some new features",

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request.json
@@ -7,7 +7,7 @@
                 "name": "comp: api"
             },
             {
-                "name": "type: enhancement"
+                "name": "type: feature"
             }
         ],
         "title": "Adding some new features",

--- a/.github/workflows/update-jmxfetch-submodule.yaml
+++ b/.github/workflows/update-jmxfetch-submodule.yaml
@@ -64,6 +64,6 @@ jobs:
             --base master \
             --head ${{ steps.define-branch.outputs.branch }} \
             --label "comp: tooling" \
-            --label "type: enhancement" \
+            --label "type: feature" \
             --label "tag: no release notes" \
             --body "This PR updates the agent-jmxfetch submodule."


### PR DESCRIPTION
# What Does This Do

This PR updates the CI, template and automations to the new GitHub labels from:
* `type: enhancement` to `type: feature` for PR -- there is still `type: feature request` for issue
* `type: bug` to `type: bug fix` for PR and `type: bug report` for issue.

`type: bug fix` will qualify for limited development fixing small bugs that could go in patch releases while `type: feature` will fit for bigger changes that adds or changes a feature behavior.

# Additional Notes

Add clarity among the existing labels. In particular being able to distinguish between bug reports and fixes, feature requests and development

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
