### PR TITLE
Fix flaky PayloadDispatcherImplTest by stubbing getRootSpan

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
@@ -171,6 +171,9 @@ class PayloadDispatcherImplTest extends DDSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return new DDSpan("test", 0, context, null)
+    def span = new DDSpan("test", 0, context, null)
+    // Stub explicitly to avoid Spock fabricating a dummy DDSpan per call (slow reflection fallback).
+    trace.getRootSpan() >> span
+    return span
   }
 }


### PR DESCRIPTION
# What Does This Do

Stubs `getRootSpan()` on the `PendingTrace` stub in `PayloadDispatcherImplTest.realSpan()` so it returns the real span instead of letting Spock fabricate a dummy on every call.

# Motivation

The test `flush automatically when data limit is breached` was flaky on CI with `SpockTimeoutError: Method timed out after 10.00 seconds`.

`getRootSpan()` returns `DDSpan` (a concrete class with no no-arg constructor). Since it was left unstubbed, every serialization pass in the tight `while (!flushed.get())` loop hit Spock's `EmptyOrDummyResponse`, which tried `Class.newInstance()` (→ `InstantiationException`) and fell back to expensive reflection/ByteBuddy. Accumulated across all iterations, this intermittently blew the 10s `@Timeout` on loaded CI runners.

# Additional Notes

Behavior is unchanged: the span is a single-span trace, so it is its own root — `getRootSpanContextIfDifferent()` still resolves to `this`. The fix just removes the per-call reflection cost, making the loop fast and deterministic.

Test failed on CI with the following stack trace:
```
org.spockframework.runtime.SpockTimeoutError: Method timed out after 10.00 seconds

Method timed out after 10.00 seconds
	at java.base@11.0.31/java.lang.Throwable.fillInStackTrace(Throwable.java:787)
	at java.base@11.0.31/java.lang.Throwable.<init>(Throwable.java:270)
	at java.base@11.0.31/java.lang.Exception.<init>(Exception.java:66)
	at java.base@11.0.31/java.lang.ReflectiveOperationException.<init>(ReflectiveOperationException.java:56)
	at java.base@11.0.31/java.lang.InstantiationException.<init>(InstantiationException.java:63)
	at java.base@11.0.31/java.lang.Class.newInstance(Class.java:571)
	at app//org.spockframework.mock.EmptyOrDummyResponse.createEmptyObject(EmptyOrDummyResponse.java:141)
	at app//org.spockframework.mock.EmptyOrDummyResponse.respond(EmptyOrDummyResponse.java:117)
	at app//org.spockframework.mock.IResponseGenerator.lambda$getResponseSupplier$0(IResponseGenerator.java:67)
	at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:60)
	at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:83)
	at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at app//datadog.trace.core.DDSpanContext.getRootSpanContextIfDifferent(DDSpanContext.java:584)
	at app//datadog.trace.core.DDSpanContext.getRootSpanContextOrThis(DDSpanContext.java:578)
	at app//datadog.trace.core.DDSpanContext.getSamplingPriority(DDSpanContext.java:644)
	at app//datadog.trace.core.DDSpanContext.processTagsAndBaggage(DDSpanContext.java:1243)
	at app//datadog.trace.core.DDSpanContext.processTagsAndBaggage(DDSpanContext.java:1198)
	at app//datadog.trace.core.DDSpan.processTagsAndBaggage(DDSpan.java:780)
	at app//datadog.trace.common.writer.ddagent.TraceMapperV0_5.map(TraceMapperV0_5.java:82)
	at app//datadog.trace.common.writer.ddagent.TraceMapperV0_5.map(TraceMapperV0_5.java:29)
	at app//datadog.communication.serialization.msgpack.MsgPackWriter.format(MsgPackWriter.java:84)
	at app//datadog.trace.common.writer.PayloadDispatcherImpl.addTrace(PayloadDispatcherImpl.java:71)
	at datadog.trace.common.writer.PayloadDispatcherImplTest.flush automatically when data limit is breached(PayloadDispatcherImplTest.groovy:46)
```
