### PR TITLE
chore: consolidate data-jobs-monitoring team into data-observability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,8 +133,8 @@
 /internal-api/src/main/java/datadog/trace/api/debugger/         @DataDog/debugger-java
 
 
-# @DataDog/data-jobs-monitoring
-/dd-java-agent/instrumentation/spark/           @DataDog/data-jobs-monitoring
+# @DataDog/data-observability
+/dd-java-agent/instrumentation/spark/           @DataDog/data-observability
 
 # @DataDog/data-streams-monitoring
 /dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/datastreams @DataDog/data-streams-monitoring


### PR DESCRIPTION
## Summary
- DJM (`@DataDog/data-jobs-monitoring`) and DO frontend GitHub teams were merged into a single team, `@DataDog/data-observability`. Old team-specific slugs are being deprecated org-wide.
- Replaces `@DataDog/data-jobs-monitoring` with `@DataDog/data-observability` in `.github/CODEOWNERS` (section header comment + the one active rule for `/dd-java-agent/instrumentation/spark/`).
- Swept the repo for `data-jobs-monitoring` (slug) and "data jobs monitoring" (natural language) — the only remaining hits are two log messages in `Agent.java` referring to the product by name, left unchanged (out of scope for this ownership consolidation).

## Test plan
- [x] CODEOWNERS change only, no code/build impact
- [ ] CI green