### PR TITLE
Fix unbounded multipart form-field buffering in Jetty 8 PartHelper

### DIFF
--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jetty8;
 import static datadog.trace.api.gateway.Events.EVENTS;
 
 import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
@@ -259,12 +260,20 @@ public class PartHelper {
 
   private static String readPartContent(Part part) {
     Charset charset = charsetFromContentType(part.getContentType());
+    // Bound the buffered form-field text by the file-content byte cap. There is no dedicated
+    // "max form-field bytes" config, so we intentionally reuse getAppSecMaxFileContentBytes():
+    // this is the only framework that must manually buffer form-field text (Servlet 3.0 has no
+    // container-side bound), and without a cap a single huge text field could exhaust the heap.
+    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
     try (InputStream is = part.getInputStream()) {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       byte[] buf = new byte[4096];
+      int total = 0;
       int read;
-      while ((read = is.read(buf)) != -1) {
+      while (total < maxBytes
+          && (read = is.read(buf, 0, Math.min(buf.length, maxBytes - total))) != -1) {
         baos.write(buf, 0, read);
+        total += read;
       }
       return new String(baos.toByteArray(), charset);
     } catch (IOException e) {

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/PartHelper.java
@@ -108,14 +108,23 @@ public class PartHelper {
 
   /**
    * Returns a name→values map of form-field parts (those without a {@code filename=} parameter).
-   * File-upload parts are skipped to avoid reading potentially large content.
+   * File-upload parts are skipped to avoid reading potentially large content. Reads up to {@link
+   * Config#getAppSecMaxFileContentBytes()} bytes per field, up to {@link
+   * Config#getAppSecMaxFileContentCount()} fields total — same knobs and cap pattern as {@code
+   * MultipartHelper#extractContents()} uses for file content (PR #11706), reused here since there
+   * is no dedicated "max form fields" config.
    */
   public static Map<String, List<String>> extractFormFields(Collection<?> parts) {
     if (parts == null || parts.isEmpty()) {
       return Collections.emptyMap();
     }
+    int maxFields = Config.get().getAppSecMaxFileContentCount();
     Map<String, List<String>> result = new LinkedHashMap<>();
+    int count = 0;
     for (Object obj : parts) {
+      if (count >= maxFields) {
+        break;
+      }
       try {
         Part part = (Part) obj;
         if (filenameFromPart(part) != null) {
@@ -130,6 +139,7 @@ public class PartHelper {
           continue;
         }
         result.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+        count++;
       } catch (Exception e) {
         log.debug("extractFormFields: skipping malformed part", e);
       }

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty8;
 
 import static java.util.Arrays.asList;
+import static java.util.Arrays.fill;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import datadog.trace.api.Config;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -234,6 +236,20 @@ class PartHelperTest {
             fieldWithContentType("drink", iso88591Bytes, "text/plain; charset=ISO-8859-1"));
     Map<String, List<String>> result = PartHelper.extractFormFields(parts);
     assertEquals(singletonList("café"), result.get("drink"));
+  }
+
+  @Test
+  void extractFormFieldsTruncatesFieldExceedingMaxContentBytes() throws IOException {
+    int maxBytes = Config.get().getAppSecMaxFileContentBytes();
+    // ASCII value larger than the cap so byte length == char length and truncation is exact.
+    char[] chars = new char[maxBytes * 2 + 123];
+    fill(chars, 'a');
+    String oversized = new String(chars);
+    List<Part> parts = singletonList(field("big", oversized));
+    Map<String, List<String>> result = PartHelper.extractFormFields(parts);
+    List<String> values = result.get("big");
+    assertEquals(1, values.size());
+    assertEquals(maxBytes, values.get(0).length());
   }
 
   // ── getAllParts ─────────────────────────────────────────────────────────────

--- a/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
+++ b/dd-java-agent/instrumentation/jetty/jetty-appsec/jetty-appsec-8.1.3/src/test/java/datadog/trace/instrumentation/jetty8/PartHelperTest.java
@@ -252,6 +252,18 @@ class PartHelperTest {
     assertEquals(maxBytes, values.get(0).length());
   }
 
+  @Test
+  void extractFormFieldsCapsAtMaxFileContentCount() throws IOException {
+    int maxFields = Config.get().getAppSecMaxFileContentCount();
+    int count = maxFields + 1;
+    Part[] parts = new Part[count];
+    for (int i = 0; i < count; i++) {
+      parts[i] = field("field" + i, "value" + i);
+    }
+    Map<String, List<String>> result = PartHelper.extractFormFields(asList(parts));
+    assertEquals(maxFields, result.size());
+  }
+
   // ── getAllParts ─────────────────────────────────────────────────────────────
 
   @Test


### PR DESCRIPTION
# What Does This Do

- Bounds `PartHelper.readPartContent()` (jetty-appsec-8.1.3) so it no longer buffers a multipart form-field's `InputStream` into an unbounded `ByteArrayOutputStream`.
- Caps the read at `Config.get().getAppSecMaxFileContentBytes()` (`appsec.max.file-content.bytes`, default 4096 bytes). There is no dedicated "max form-field bytes" config, so this intentionally reuses the existing file-content knob — documented with a code comment at the call site.
- Caps the number of form-field parts processed in `PartHelper.extractFormFields()` via `Config.get().getAppSecMaxFileContentCount()`, mirroring the `MAX_FILES_TO_INSPECT` pattern used by `MultipartHelper#extractContents()` (PR #11706) for file content. Bounding only the per-field byte read left the total allocation unbounded as `O(fields × byteCap)` — an attacker could still exhaust memory with many small fields instead of one large one.
- Leaves `charsetFromContentType()` and its explicit UTF-8 fallback untouched; the fix does not switch to `MultipartContentDecoder` (used for file content elsewhere), since that decoder falls back to `Charset.defaultCharset()`, which would make WAF pattern-matching non-deterministic across hosts.
- Adds `extractFormFieldsTruncatesFieldExceedingMaxContentBytes` and `extractFormFieldsCapsAtMaxFileContentCount` to `PartHelperTest.java`, asserting the byte truncation and the field-count cap land exactly at their respective configured limits.

# Motivation

Jetty 8 (Servlet 3.0) has no `getParameterMap()`-equivalent for multipart requests, so `PartHelper` must manually read each form-field `Part`'s stream to extract its text value. Before this fix, that read had no upper bound — either per field or across all fields — so a remote attacker could exhaust heap / cause severe GC pressure with a single oversized text field, or with a large number of small fields. Found via automated security scan (APMSP-3580).

# Additional Notes

- PR #11706 (pending merge, same file) adds `MultipartContentDecoder`/`MAX_CONTENT_BYTES`/`MAX_FILES_TO_INSPECT` to this same class for an unrelated `files_content` feature, and explicitly leaves `readPartContent()`/`extractFormFields()` untouched. Expect a small, easily-resolvable merge conflict on imports/constants depending on merge order — this fix does not depend on #11706 landing first, since both `Config.get().getAppSecMaxFileContentBytes()` and `Config.get().getAppSecMaxFileContentCount()` already exist independently in `internal-api`.
- Release-blocking assessment (for team confirmation): not release-blocking. This is a DoS/memory-pressure issue only (no RCE or data exfiltration), requires a legacy Jetty 8.1.3 deployment with a multipart endpoint, and the fix itself is small and low-risk.
- Reusing the file-content byte and count caps for form-field text is a deliberate tradeoff (avoids introducing a new AppSec config surface for a bug fix); see the code comments in `readPartContent()` and `extractFormFields()`.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [APMSP-3580](https://datadoghq.atlassian.net/browse/APMSP-3580)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).


[APMSP-3580]: https://datadoghq.atlassian.net/browse/APMSP-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ