### PR TITLE
Improve cacheability of agent shadowJar task

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.github.jengelman.gradle.plugins.shadow.transformers.ApacheLicenseResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ApacheNoticeResourceTransformer
+import org.gradle.api.file.DuplicatesStrategy.INCLUDE
+
 plugins {
   java
   id("com.diffplug.spotless") version "8.4.0"
@@ -69,11 +73,11 @@ tasks {
   }
 
   shadowJar {
-    duplicatesStrategy = DuplicatesStrategy.FAIL
-    // Let's skip license/notice since this jar's only use is during build
-    filesMatching(listOf("META-INF/LICENSE*", "META-INF/NOTICE*")) {
-      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    }
+    duplicatesStrategy = INCLUDE
+    transform<ApacheLicenseResourceTransformer>()
+    transform<ApacheNoticeResourceTransformer>()
+    failOnDuplicateEntries = true
+
     manifest {
       attributes(mapOf("Main-Class" to "datadog.trace.plugin.csi.PluginApplication"))
     }

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -1,4 +1,7 @@
+import static org.gradle.api.file.DuplicatesStrategy.INCLUDE
+
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.jar.JarFile
 
@@ -83,21 +86,19 @@ def generalShadowJarConfig(ShadowJar shadowJarTask) {
     mergeServiceFiles()
     addMultiReleaseAttribute = false
 
-    duplicatesStrategy = DuplicatesStrategy.FAIL
-    // Service descriptors are intentionally merged by mergeServiceFiles(); let
-    // duplicate service entries reach that transformer instead of failing first.
-    filesMatching('META-INF/services/**') {
-      duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    }
-    // Vendored dependencies often repeat license/notice metadata. Keep one copy
-    // while still failing on unexpected duplicate runtime resources and classes.
-    filesMatching([
-      'META-INF/LICENSE*',
-      'META-INF/NOTICE*',
-      'META-INF/AL2.0',
-      'META-INF/LGPL2.1',
-    ]) {
-      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    // Allow duplicate to merge service files
+    duplicatesStrategy = INCLUDE
+    // Ensure there is no duplicate in the final jar after resource transformer applied
+    failOnDuplicateEntries.set(true)
+
+    // Vendored dependencies repeat license/notice metadata; keep a single copy
+    transform(PreserveFirstFoundResourceTransformer) {
+      it.resources.addAll(
+        'META-INF/LICENSE*',
+        'META-INF/NOTICE*',
+        'META-INF/AL2.0',
+        'META-INF/LGPL2.1',
+        )
     }
 
     // Remove some cruft from the final jar.

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -89,11 +89,11 @@ def generalShadowJarConfig(ShadowJar shadowJarTask) {
     // Allow duplicate to merge service files
     duplicatesStrategy = INCLUDE
     // Ensure there is no duplicate in the final jar after resource transformer applied
-    failOnDuplicateEntries.set(true)
+    failOnDuplicateEntries = true
 
     // Vendored dependencies repeat license/notice metadata; keep a single copy
     transform(PreserveFirstFoundResourceTransformer) {
-      it.resources.addAll(
+      it.include(
         'META-INF/LICENSE*',
         'META-INF/NOTICE*',
         'META-INF/AL2.0',


### PR DESCRIPTION
# What Does This Do

This PR removes the custom actions (`filesMatching` with closures) that prevent the task to be cached by Gradle.
It uses the default shadow jar mechanisms instead: 

* resource transformers to merge service files and keep only a single copy of duplicate license files
* `failOnDuplicateEntries` that ensure the zip file do not have duplicate entry

This is needed as resource duplication is needed for the transformer to merge them but the `failOnDuplicateEntries` is the safety check that there won’t be duplicate after resource transformation.

# Motivation

The goal is to help with build cache and avoiding recreating the JARs when publishing them to maven central - so it’s effectively the same artefact that will be tested and published.

# Additional Notes

I have additional ideas for the index generation too I need to review first before making a PR with.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
