### PR TITLE
Make agent index generation stable irrespective of filesystem iteration order

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -114,7 +114,7 @@ public final class AgentJarIndex {
         paths
             .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
             .map(resourcesDir::relativize)
-            .sorted(Comparator.comparing(IndexGenerator::normalizedPath))
+            .sorted()
             .filter(entry -> entry.getNameCount() >= 2)
             .forEach(
                 entry -> {
@@ -199,10 +199,6 @@ public final class AgentJarIndex {
         }
       }
       return entryKey.replace('/', '.');
-    }
-
-    private static String normalizedPath(Path path) {
-      return path.toString().replace(File.separatorChar, '/');
     }
 
     public static void main(String[] args) throws IOException {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -7,18 +7,19 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,7 @@ public final class AgentJarIndex {
    * Generates an index from the contents of the 'build/resources' directory that makes up the agent
    * jar.
    */
-  static class IndexGenerator extends SimpleFileVisitor<Path> {
+  static class IndexGenerator {
     private static final Set<String> ignoredFileNames =
         new HashSet<>(Arrays.asList("MANIFEST.MF", "NOTICE", "LICENSE.renamed"));
 
@@ -102,9 +103,6 @@ public final class AgentJarIndex {
     private final List<String> collectedEntryKeys = new ArrayList<>();
     private final List<Integer> collectedPrefixIds = new ArrayList<>();
 
-    private Path prefixRoot;
-    private int prefixId;
-
     IndexGenerator(Path resourcesDir) {
       this.resourcesDir = resourcesDir;
 
@@ -112,7 +110,29 @@ public final class AgentJarIndex {
     }
 
     void buildIndex() throws IOException {
-      Files.walkFileTree(resourcesDir, this);
+      try (Stream<Path> paths = Files.walk(resourcesDir)) {
+        List<Path> entries =
+            paths
+                .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                .map(resourcesDir::relativize)
+                .sorted(Comparator.comparing(IndexGenerator::normalizedPath))
+                .collect(Collectors.toList());
+
+        Set<String> seen = new HashSet<>();
+        for (Path entry : entries) {
+          if (entry.getNameCount() < 2) {
+            continue;
+          }
+
+          String prefix = entry.getName(0) + "/";
+          int prefixId = prefixIdFor(prefix);
+          String entryKey = computeEntryKey(entry.subpath(1, entry.getNameCount()));
+          if (null != entryKey && seen.add(prefixId + "\0" + entryKey)) {
+            collectedEntryKeys.add(entryKey);
+            collectedPrefixIds.add(prefixId);
+          }
+        }
+      }
 
       for (int i = 0; i < collectedEntryKeys.size(); i++) {
         prefixTrie.put(collectedEntryKeys.get(i), collectedPrefixIds.get(i));
@@ -152,42 +172,13 @@ public final class AgentJarIndex {
       return prefixes.get(prefixId - 1);
     }
 
-    @Override
-    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-      if (dir.getParent().equals(resourcesDir)) {
-        String prefix = dir.getFileName() + "/";
-        prefixRoot = dir;
-        prefixId = 1 + prefixes.indexOf(prefix);
-        if (prefixId < 1) {
-          prefixes.add(prefix);
-          prefixId = prefixes.size();
-        }
+    private int prefixIdFor(String prefix) {
+      int prefixId = 1 + prefixes.indexOf(prefix);
+      if (prefixId < 1) {
+        prefixes.add(prefix);
+        prefixId = prefixes.size();
       }
-      return FileVisitResult.CONTINUE;
-    }
-
-    @Override
-    public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
-      if (dir.equals(prefixRoot)) {
-        prefixRoot = null;
-      }
-      return FileVisitResult.CONTINUE;
-    }
-
-    @Override
-    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-      if (null != prefixRoot) {
-        String entryKey = computeEntryKey(prefixRoot.relativize(file));
-        if (null != entryKey) {
-          collectedEntryKeys.add(entryKey);
-          collectedPrefixIds.add(prefixId);
-          if (entryKey.endsWith("*")) {
-            // optimization: wildcard will match everything under here so can skip
-            return FileVisitResult.SKIP_SIBLINGS;
-          }
-        }
-      }
-      return FileVisitResult.CONTINUE;
+      return prefixId;
     }
 
     static String computeEntryKey(Path path) {
@@ -214,6 +205,10 @@ public final class AgentJarIndex {
         }
       }
       return entryKey.replace('/', '.');
+    }
+
+    private static String normalizedPath(Path path) {
+      return path.toString().replace(File.separatorChar, '/');
     }
 
     public static void main(String[] args) throws IOException {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarFile;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import org.slf4j.Logger;
@@ -110,28 +109,23 @@ public final class AgentJarIndex {
     }
 
     void buildIndex() throws IOException {
+      Set<String> seen = new HashSet<>();
       try (Stream<Path> paths = Files.walk(resourcesDir)) {
-        List<Path> entries =
-            paths
-                .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
-                .map(resourcesDir::relativize)
-                .sorted(Comparator.comparing(IndexGenerator::normalizedPath))
-                .collect(Collectors.toList());
-
-        Set<String> seen = new HashSet<>();
-        for (Path entry : entries) {
-          if (entry.getNameCount() < 2) {
-            continue;
-          }
-
-          String prefix = entry.getName(0) + "/";
-          int prefixId = prefixIdFor(prefix);
-          String entryKey = computeEntryKey(entry.subpath(1, entry.getNameCount()));
-          if (null != entryKey && seen.add(prefixId + "\0" + entryKey)) {
-            collectedEntryKeys.add(entryKey);
-            collectedPrefixIds.add(prefixId);
-          }
-        }
+        paths
+            .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+            .map(resourcesDir::relativize)
+            .sorted(Comparator.comparing(IndexGenerator::normalizedPath))
+            .filter(entry -> entry.getNameCount() >= 2)
+            .forEach(
+                entry -> {
+                  String prefix = entry.getName(0) + "/";
+                  int prefixId = prefixIdFor(prefix);
+                  String entryKey = computeEntryKey(entry.subpath(1, entry.getNameCount()));
+                  if (null != entryKey && seen.add(prefixId + "\0" + entryKey)) {
+                    collectedEntryKeys.add(entryKey);
+                    collectedPrefixIds.add(prefixId);
+                  }
+                });
       }
 
       for (int i = 0; i < collectedEntryKeys.size(); i++) {

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
@@ -236,6 +236,18 @@ class AgentJarIndexTest {
   }
 
   @Test
+  void buildIndexIgnoresTopLevelFilesWhenCollectingPrefixes(@TempDir Path tempDir)
+      throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "root-resource.properties");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    Path indexFile = writeIndex(resources, tempDir.resolve("dd-java-agent.index"));
+
+    assertEquals(Arrays.asList("inst/"), readPrefixes(indexFile));
+  }
+
+  @Test
   void buildIndexIsIndependentOfDirectoryCreationOrder(@TempDir Path tempDir) throws Exception {
     Path buildResources = tempDir.resolve("build-resources");
     createFile(buildResources, "appsec/com/datadog/appsec/Event.classdata");

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentJarIndexTest.java
@@ -1,13 +1,18 @@
 package datadog.trace.bootstrap;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -101,6 +106,25 @@ class AgentJarIndexTest {
     Path file = root.resolve(relativePath.replace('/', java.io.File.separatorChar));
     Files.createDirectories(file.getParent());
     Files.createFile(file);
+  }
+
+  private static Path writeIndex(Path resourcesDir, Path indexFile) throws IOException {
+    AgentJarIndex.IndexGenerator generator = new AgentJarIndex.IndexGenerator(resourcesDir);
+    generator.buildIndex();
+    generator.writeIndex(indexFile);
+    return indexFile;
+  }
+
+  private static List<String> readPrefixes(Path indexFile) throws IOException {
+    try (DataInputStream in =
+        new DataInputStream(new BufferedInputStream(Files.newInputStream(indexFile)))) {
+      int prefixCount = in.readInt();
+      String[] prefixes = new String[prefixCount];
+      for (int i = 0; i < prefixCount; i++) {
+        prefixes[i] = in.readUTF();
+      }
+      return Arrays.asList(prefixes);
+    }
   }
 
   @Test
@@ -197,6 +221,40 @@ class AgentJarIndexTest {
     assertEquals(
         "metrics/com/datadoghq/stats/StatsClient.classdata",
         index.classEntryName("com.datadoghq.stats.StatsClient"));
+  }
+
+  @Test
+  void buildIndexWritesPrefixesInSortedOrder(@TempDir Path tempDir) throws Exception {
+    Path resources = tempDir.resolve("resources");
+    createFile(resources, "metrics/com/datadoghq/stats/StatsClient.classdata");
+    createFile(resources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+    createFile(resources, "appsec/com/datadog/appsec/Event.classdata");
+
+    Path indexFile = writeIndex(resources, tempDir.resolve("dd-java-agent.index"));
+
+    assertEquals(Arrays.asList("appsec/", "inst/", "metrics/"), readPrefixes(indexFile));
+  }
+
+  @Test
+  void buildIndexIsIndependentOfDirectoryCreationOrder(@TempDir Path tempDir) throws Exception {
+    Path buildResources = tempDir.resolve("build-resources");
+    createFile(buildResources, "appsec/com/datadog/appsec/Event.classdata");
+    createFile(buildResources, "ci-visibility/com/datadog/ci/Visibility.classdata");
+    createFile(buildResources, "cws-tls/com/datadog/cws/Tls.classdata");
+    createFile(
+        buildResources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    Path deployResources = tempDir.resolve("deploy-resources");
+    createFile(deployResources, "cws-tls/com/datadog/cws/Tls.classdata");
+    createFile(deployResources, "ci-visibility/com/datadog/ci/Visibility.classdata");
+    createFile(deployResources, "appsec/com/datadog/appsec/Event.classdata");
+    createFile(
+        deployResources, "inst/datadog/trace/instrumentation/servlet/ServletAdvice.classdata");
+
+    Path buildIndex = writeIndex(buildResources, tempDir.resolve("build-dd-java-agent.index"));
+    Path deployIndex = writeIndex(deployResources, tempDir.resolve("deploy-dd-java-agent.index"));
+
+    assertArrayEquals(Files.readAllBytes(buildIndex), Files.readAllBytes(deployIndex));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Refactors `AgentJarIndex.IndexGenerator` to ensure the index file generation is immune to the unspecified order of filesystem traversal. This resolves inconsistencies in the index file created due to the dependency on traversal order of `Files.walkFileTree`.

# Motivation

The previous implementation relied on the order in which files were traversed by `Files.walkFileTree`, which is inherently unstable (order-wsie) and filesystem-dependent. This led to varying index files, especially in CI environments with parallel Gradle tasks. Although the generated index was correct, the varying prefix IDs impacted reproducibility and the downstream `shadowJar`.

# Additional Notes

This happens because `Files.walkFileTree` rely under the hood on `UnixFileSystemProvider.newDirectoryStream` which uses `readdir(3)` std lib C api which asks the file system via syscall, in particular we can read (bold are mine):

> The order in which filenames are read by successive calls to
> readdir() depends on the filesystem implementation; it is **unlikely**
> that the names will be sorted in any fashion.

https://www.man7.org/linux/man-pages/man3/readdir.3.html
https://man7.org/linux/man-pages/man2/getdents.2.html

> [!NOTE]
> `generateAgentJarIndex` is still re-executed because it relies on included jars from `it.inputs.files(includedJarFileTree)`, the actual folder being:
> `workspace/dd-java-agent/build/generated/included`
>
> https://github.com/DataDog/dd-trace-java/blob/fc7d48cb93183767a6815e4694218f16ff3fefe4/dd-java-agent/build.gradle#L342-L365
> 
> However, the rehydrated pipeline cache from gitlab only capture folders in the `.gradle` folder (unerstandably) 
> 
> ```yaml
> - key: $CI_PIPELINE_ID-$CACHE_TYPE
>     paths:
>     - .gradle/caches/$GRADLE_VERSION
>     - .gradle/$GRADLE_VERSION/executionHistory
>     - workspace
> ```
> 
> The `expandAgentShadowJar*` tasks filling up `includedAgentDir` are Copy like tasks and as such are not cached as well, which made the task not up-to-date.
> ~~So tHere is another update coming to that task on the build file, PR not yet opened.~~ See #11896
> 
> See Gradle build cache points ([1](https://docs.gradle.org/current/userguide/build_cache.html#:~:text=%3AprocessResources%20and%20%3Ajar%20being%20Copy%2Dlike%20tasks%20which%20are%20not%20cacheable%20since%20it%20is%20generally%20faster%20to%20execute%20them.), [2](https://docs.gradle.org/current/userguide/build_cache.html#:~:text=Some%20tasks%2C%20like%20Copy%20or%20Jar%2C%20usually%20do%20not%20make%20sense%20to%20make%20cacheable%20because%20Gradle%20is%20only%20copying%20files%20from%20one%20location%20to%20another.%20It%20also%20doesn%E2%80%99t%20make%20sense%20to%20make%20tasks%20cacheable%20that%20do%20not%20produce%20outputs%20or%20have%20no%20task%20actions.))
> 
> > :processResources and :jar being Copy-like tasks which are not cacheable since it is generally faster to execute them.
>
> > Some tasks, like [Copy](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Copy.html) or [Jar](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html), usually do not make sense to make cacheable because Gradle is only copying files from one location to another. It also doesn’t make sense to make tasks cacheable that do not produce outputs or have no task actions.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]