### PR TITLE
Fix instrumenting metric probes for Kotlin

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
@@ -58,6 +59,8 @@ import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -265,7 +268,8 @@ public class CapturedContextInstrumenter extends Instrumenter {
   }
 
   @Override
-  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+  protected InsnList getBeforeReturnInsnList(
+      AbstractInsnNode node, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     InsnList insnList = new InsnList();
     // stack [ret_value]
     insnList.add(new VarInsnNode(Opcodes.ALOAD, entryContextVar));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
@@ -3,8 +3,11 @@ package com.datadog.debugger.instrumentation;
 import com.datadog.debugger.probe.ProbeDefinition;
 import datadog.trace.bootstrap.debugger.Limits;
 import java.util.List;
+import java.util.Map;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 
 public class ExceptionInstrumenter extends CapturedContextInstrumenter {
 
@@ -25,7 +28,8 @@ public class ExceptionInstrumenter extends CapturedContextInstrumenter {
   }
 
   @Override
-  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+  protected InsnList getBeforeReturnInsnList(
+      AbstractInsnNode node, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     return null;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -13,6 +13,7 @@ import com.datadog.debugger.util.JvmLanguage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import org.objectweb.asm.Opcodes;
@@ -28,9 +29,17 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Common class for generating instrumentation */
 public abstract class Instrumenter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Instrumenter.class);
   protected static final String CONSTRUCTOR_NAME = "<init>";
   protected static final String PROBEID_TAG_NAME = "debugger.probeid";
 
@@ -151,12 +160,14 @@ public abstract class Instrumenter {
   }
 
   protected void processInstructions() {
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
+    computeFrames(classNode.name, methodNode, frames);
     AbstractInsnNode node = methodNode.instructions.getFirst();
     LabelNode sentinelNode = new LabelNode();
     methodNode.instructions.add(sentinelNode);
     while (node != null && !node.equals(sentinelNode)) {
       if (node.getType() != AbstractInsnNode.LINE) {
-        node = processInstruction(node);
+        node = processInstruction(node, frames);
       }
       node = node.getNext();
     }
@@ -168,7 +179,40 @@ public abstract class Instrumenter {
     }
   }
 
-  protected AbstractInsnNode processInstruction(AbstractInsnNode node) {
+  // returns the extra values sitting *below* `valuesToKeep` values already
+  // accounted for at the top of the stack (e.g. the return value), as POP/POP2 insns
+  protected InsnList stackCleanupInsnList(
+      AbstractInsnNode node, int valuesToKeep, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
+    InsnList result = new InsnList();
+    Frame<BasicValue> frame = frames.get(node);
+    if (frame == null) {
+      return result;
+    }
+    for (int i = frame.getStackSize() - valuesToKeep - 1; i >= 0; i--) {
+      BasicValue value = frame.getStack(i);
+      result.add(new InsnNode(value.getSize() == 2 ? Opcodes.POP2 : Opcodes.POP));
+    }
+    return result;
+  }
+
+  private static void computeFrames(
+      String owner, MethodNode methodNode, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
+    try {
+      Frame<BasicValue>[] frameArray =
+          new Analyzer<>(new BasicInterpreter()).analyze(owner, methodNode);
+      AbstractInsnNode current = methodNode.instructions.getFirst();
+      int idx = 0;
+      while (current != null) {
+        frames.put(current, frameArray[idx++]);
+        current = current.getNext();
+      }
+    } catch (AnalyzerException ex) {
+      LOGGER.debug("Failed to analyze method[%s::%s] instructions", owner, methodNode.name, ex);
+    }
+  }
+
+  protected AbstractInsnNode processInstruction(
+      AbstractInsnNode node, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     switch (node.getOpcode()) {
       case Opcodes.RET:
       case Opcodes.RETURN:
@@ -179,7 +223,7 @@ public abstract class Instrumenter {
       case Opcodes.ARETURN:
         {
           // stack [ret_value]
-          InsnList beforeReturnInsnList = getBeforeReturnInsnList(node);
+          InsnList beforeReturnInsnList = getBeforeReturnInsnList(node, frames);
           if (beforeReturnInsnList != null) {
             methodNode.instructions.insertBefore(node, beforeReturnInsnList);
           }
@@ -193,7 +237,8 @@ public abstract class Instrumenter {
     return node;
   }
 
-  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+  protected InsnList getBeforeReturnInsnList(
+      AbstractInsnNode node, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     return null;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
@@ -56,6 +56,7 @@ import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -71,6 +72,8 @@ import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +161,8 @@ public class MetricInstrumenter extends Instrumenter {
   }
 
   @Override
-  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+  protected InsnList getBeforeReturnInsnList(
+      AbstractInsnNode node, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     int size = 1;
     int storeOpCode = 0;
     int loadOpCode = 0;
@@ -166,7 +170,9 @@ public class MetricInstrumenter extends Instrumenter {
     switch (node.getOpcode()) {
       case Opcodes.RET:
       case Opcodes.RETURN:
-        return wrapTryCatch(callMetric(metricProbe, node));
+        InsnList insnList = wrapTryCatch(callMetric(metricProbe, node));
+        insnList.insert(stackCleanupInsnList(node, 0, frames)); // void return: nothing to keep
+        return insnList;
       case Opcodes.LRETURN:
         storeOpCode = Opcodes.LSTORE;
         loadOpCode = Opcodes.LLOAD;
@@ -202,7 +208,10 @@ public class MetricInstrumenter extends Instrumenter {
         wrapTryCatch(
             callMetric(metricProbe, node, new ReturnContext(tmpIdx, loadOpCode, returnType)));
     // store return value from the stack to local before wrapped call
-    insnList.insert(new VarInsnNode(storeOpCode, tmpIdx));
+    InsnList prefixInsns = new InsnList();
+    prefixInsns.add(new VarInsnNode(storeOpCode, tmpIdx));
+    prefixInsns.add(stackCleanupInsnList(node, 1, frames)); // keep 1 value (the one we just stored)
+    insnList.insert(prefixInsns);
     // restore return value to the stack after wrapped call
     insnList.add(new VarInsnNode(loadOpCode, tmpIdx));
     return insnList;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -31,10 +31,12 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -454,6 +456,33 @@ public class MetricProbesInstrumentationTest {
     assertTrue(listener.doubleGauges.containsKey(METRIC_NAME));
     assertTrue(listener.doubleGauges.get(METRIC_NAME).doubleValue() > 0);
     assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+  }
+
+  @Test
+  public void methodSyntheticDurationKotlinDist() {
+    final String CLASS_NAME = "CapturedSnapshot302";
+    String METRIC_NAME = "syn_dist";
+    MetricProbe metricProbe =
+        createMetricBuilder(METRIC_ID, METRIC_NAME, DISTRIBUTION)
+            .where(CLASS_NAME, "download", null)
+            .valueScript(new ValueScript(DSL.ref("@duration"), "@duration"))
+            .evaluateAt(MethodLocation.EXIT)
+            .build();
+    MetricForwarderListener listener = installMetricProbes(metricProbe);
+    URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
+    List<File> filesToDelete = new ArrayList<>();
+    try {
+      Class<?> testClass =
+          KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
+      Object companion = Reflect.onClass(testClass).get("Companion");
+      int result = Reflect.on(companion).call("main", "1").get();
+      assertEquals(1, result);
+      assertTrue(listener.doubleDistributions.containsKey(METRIC_NAME));
+      assertTrue(listener.doubleDistributions.get(METRIC_NAME).doubleValue() > 0);
+      assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    } finally {
+      filesToDelete.forEach(File::delete);
+    }
   }
 
   @Test
@@ -1348,7 +1377,7 @@ public class MetricProbesInstrumentationTest {
     Config config = mock(Config.class);
     when(config.isDynamicInstrumentationEnabled()).thenReturn(true);
     when(config.isDynamicInstrumentationClassFileDumpEnabled()).thenReturn(true);
-    when(config.isDynamicInstrumentationVerifyByteCode()).thenReturn(true);
+    // when(config.isDynamicInstrumentationVerifyByteCode()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -1377,7 +1377,7 @@ public class MetricProbesInstrumentationTest {
     Config config = mock(Config.class);
     when(config.isDynamicInstrumentationEnabled()).thenReturn(true);
     when(config.isDynamicInstrumentationClassFileDumpEnabled()).thenReturn(true);
-    // when(config.isDynamicInstrumentationVerifyByteCode()).thenReturn(true);
+    when(config.isDynamicInstrumentationVerifyByteCode()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -356,7 +356,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
     LogProbe probe =
         LogProbe.builder()
             .probeId(LINE_PROBE_ID1)
-            .where("DebuggerTestApplication.java", 88)
+            .where("DebuggerTestApplication.java", 95)
             .captureSnapshot(true)
             .build();
     setCurrentConfiguration(createConfig(probe));
@@ -365,7 +365,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
     registerSnapshotListener(
         snapshot -> {
           assertEquals(LINE_PROBE_ID1.getId(), snapshot.getProbe().getId());
-          CapturedContext capturedContext = snapshot.getCaptures().getLines().get(88);
+          CapturedContext capturedContext = snapshot.getCaptures().getLines().get(95);
           assertFullMethodCaptureArgs(capturedContext);
           assertNull(capturedContext.getLocals());
           assertNull(capturedContext.getCapturedThrowable());

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -210,7 +210,7 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
         MetricProbe.builder()
             .probeId(PROBE_ID)
             // on line: System.out.println("fullMethod");
-            .where("DebuggerTestApplication.java", 88)
+            .where("DebuggerTestApplication.java", 95)
             .kind(kind)
             .metricName(metricName)
             .valueScript(script)


### PR DESCRIPTION
# What Does This Do
track objects on the stack with frame for each instruction using ASM analyzer. based on this generate POP/POP2 bytecode instruction to leave the stack clean before inserting metric calls.

# Motivation
Kotlin compiler can, especially for suspend functions, generates a state machine with duplicate values on the stack while a return instruction will clear them (dropping the frame).

we are previously relying on the fact that the number of values on the stack are precise even before a return instruction which leads to introduce jump to a same location but without the same number of values on the stack, triggering the verifier.


# Additional Notes
Claude analysis:
```
 Look at the original, uninstrumented download() bytecode right before the first areturn (the orig.txt dump, bci 160–192):                                                     
                                                                                                                                                                                
  160: invokestatic  DelayKt.delay(...)   // stack: [R]           R = delay() result                                                                                            
  163: dup                                // stack: [R, R]                                                                                                                      
  164: aload         7                    // stack: [R, R, S]     S = COROUTINE_SUSPENDED sentinel (var7)                                                                       
  166: if_acmpeq     178                  // pops R,S; if equal -> stack: [R]   (one dup of R survives)                                                                         
  ...                                                                                                                                                                           
  178: aload         4  ...  183: bastore // jacoco bookkeeping, stack-neutral -> still [R]                                                                                     
  184: aload         7                    // stack: [R, S]        pushes the sentinel AGAIN                                                                                     
  186: aload         4  ...  191: bastore // jacoco bookkeeping, stack-neutral -> still [R, S]                                                                                  
  192: areturn                            // returns S (top of stack); R is silently discarded                                                                                  
                                                                                                                                                                                
  This is completely legal, ordinary bytecode: kotlinc's suspend-dispatch pattern leaves a redundant duplicate value (R) underneath the actual return value (S), relying on the 
  fact that areturn is a terminal instruction — the JVM only cares about the top-of-stack value at return time and simply throws away everything else below it. There's no      
  verification problem in the original class because nothing executes after that areturn that would need a merged stack-map frame.                                              
                                                                                                                                                                                
  Now look at what MetricInstrumenter.getBeforeReturnInsnList (MetricInstrumenter.java:192-208) does to this exact ARETURN:                                                     
                                                                                                                                                                                
  int tmpIdx = newVar(size);                                                                                                                                                    
  InsnList insnList = wrapTryCatch(callMetric(metricProbe, node, new ReturnContext(tmpIdx, loadOpCode, returnType)));                                                           
  insnList.insert(new VarInsnNode(storeOpCode, tmpIdx));  // ASTORE tmpIdx  — prepended                                                                                         
  insnList.add(new VarInsnNode(loadOpCode, tmpIdx));      // ALOAD  tmpIdx  — appended                                                                                          

  It assumes the stack at an ARETURN site contains exactly one value — the thing being returned — and replaces the bare areturn with ASTORE tmp → [try{ metric-emission code    
  }catch] → ALOAD tmp → GOTO sharedReturn. That assumption is false for this call site: it pops only the top value (S, into var 9), but the redundant R sitting underneath is   
  not consumed by anything anymore, because the code that follows the store is no longer a terminal areturn — it's non-terminal metric-emission code (ldc/getstatic/invokestatic
  DebuggerContext.metric) that pushes and pops its own operands from scratch, oblivious to the stale R still sitting beneath it.                                                

   So in the instrumented class, at the point corresponding to bci 230 (aload 9, right after the invokestatic metric(...) call returns):                                         
  - Via normal fall-through (227 → 230): the real stack is [R] — one leftover item, never cleaned up.                                                                           
  - Via the inner exception handler (bci 320 pop; 321 goto 230): when an exception is thrown out of the metric-emission code, the JVM's exception-dispatch semantics clear the  
  entire operand stack down to just the thrown exception before entering the handler (per the JVM spec — this is mandatory, not optional). So after pop removes the exception,  
  the real stack there is genuinely [] — the leftover R is gone, wiped out by the exception dispatch, not by any instruction in the instrumentation's own code.                 
                                                                                                                                                                                
  Two different real stack depths (1 vs. 0) converge on the same label (bci 230) — that is exactly what "Inconsistent stackmap frames at branch target 230" is reporting. It's  
  not really a "bad/stale StackMapTable entry" bug so much as the instrumentation genuinely producing divergent stack depths on the two converging paths.                       
```


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [DEBUG-5816]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5816]: https://datadoghq.atlassian.net/browse/DEBUG-5816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ