### PR TITLE
Make GitInfo a TagContributor (addTags -> addTo) (phase 3 - span api adoption)

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/GitMetadataTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/GitMetadataTraceInterceptor.java
@@ -29,7 +29,7 @@ public class GitMetadataTraceInterceptor extends AbstractTraceInterceptor {
     String ciWorkspacePath = (String) firstSpan.getTag(Tags.CI_WORKSPACE_PATH);
 
     GitInfo gitInfo = GitInfoProvider.INSTANCE.getGitInfo(ciWorkspacePath);
-    gitInfo.addTags(firstSpan);
+    gitInfo.addTo(firstSpan);
 
     return trace;
   }

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfo.java
@@ -3,9 +3,10 @@ package datadog.trace.api.git;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.TagContributor;
 import java.util.Objects;
 
-public final class GitInfo {
+public final class GitInfo implements TagContributor {
   public static final GitInfo NOOP = new GitInfo(null, null, null, CommitInfo.NOOP);
 
   private final String repositoryURL;
@@ -22,7 +23,7 @@ public final class GitInfo {
     this.tag = tag;
     this.commit = commit;
 
-    // GitInfo is reused across many traces, so create entries once and reuse them (see addTags)
+    // GitInfo is reused across many traces, so create entries once and reuse them (see addTo)
     // null & empty values result in null entries which nop when added to a span
     this.repositoryEntry = TagMap.Entry.create(DDTags.INTERNAL_GIT_REPOSITORY_URL, repositoryURL);
     this.commitEntry =
@@ -47,7 +48,8 @@ public final class GitInfo {
     return commit;
   }
 
-  public void addTags(AgentSpan span) {
+  @Override
+  public void addTo(AgentSpan span) {
     span.setTag(this.repositoryEntry);
     span.setTag(this.commitEntry);
   }


### PR DESCRIPTION
`GitInfo` already projected its own state onto a span via `addTags`. This formalizes it as a `TagContributor` and renames `addTags` -> `addTo` to match the interface (`void addTo(AgentSpan)`). The sole caller (`GitMetadataTraceInterceptor`) is updated.

Stacked on the `TagContributor` API PR (base: `dougqh/tag-extractor-api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
