### PR TITLE
Demonstrate SpanPrototype: bake constant span tags in decorators (phase 1b)

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -12,6 +12,7 @@ import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.lang.reflect.Method;
 import java.net.Inet4Address;
@@ -47,6 +48,10 @@ public abstract class BaseDecorator {
 
   // Deliberately not volatile, reading null and repeating the calculation is safe
   private TagMap.Entry cachedComponentEntry = null;
+
+  // Deliberately not volatile, same benign-race reasoning as cachedComponentEntry: baking twice is
+  // safe because the constant tags are identical.
+  private SpanPrototype cachedPrototype = null;
 
   protected BaseDecorator() {
     final Config config = Config.get();
@@ -88,6 +93,36 @@ public abstract class BaseDecorator {
 
   protected boolean traceAnalyticsDefault() {
     return false;
+  }
+
+  /**
+   * The baked-once {@link SpanPrototype} for this decorator: the constant identity + tags {@link
+   * #afterStart} would otherwise stamp one at a time. Composed across the hierarchy via {@link
+   * #prototypeBuilder()} and cached (lazily, to respect the same static-init ordering caution as
+   * {@link #componentEntry()}).
+   *
+   * <p>Not yet wired into span creation — this is the provider surface; the seed hook comes next.
+   */
+  public final SpanPrototype prototype() {
+    SpanPrototype prototype = cachedPrototype;
+    if (prototype == null) {
+      cachedPrototype = prototype = prototypeBuilder().build();
+    }
+    return prototype;
+  }
+
+  /**
+   * Contributes this decorator's constant identity + tags to the prototype under construction.
+   * Overrides must call {@code super.prototypeBuilder()} first, then add their own — mirroring the
+   * {@link #afterStart} super-chain, but run once at bake time rather than per span. Authors
+   * compose via the typed builder and never see {@link TagMap}.
+   */
+  protected SpanPrototype.Builder prototypeBuilder() {
+    return SpanPrototype.builder()
+        .instrumentationName(instrumentationNames())
+        .spanType(spanType())
+        .initComponent(component())
+        .initTag(traceAnalyticsEntry);
   }
 
   public void afterStart(final AgentSpan span) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 
 public abstract class ClientDecorator extends BaseDecorator {
@@ -42,5 +43,10 @@ public abstract class ClientDecorator extends BaseDecorator {
     // Generate metrics for all client spans.
     span.setMeasured(true);
     super.afterStart(span);
+  }
+
+  @Override
+  protected SpanPrototype.Builder prototypeBuilder() {
+    return super.prototypeBuilder().initKind(spanKind());
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 
 public abstract class ServerDecorator extends BaseDecorator {
@@ -17,5 +18,12 @@ public abstract class ServerDecorator extends BaseDecorator {
     span.setTag(LANG_ENTRY);
 
     super.afterStart(span);
+  }
+
+  @Override
+  protected SpanPrototype.Builder prototypeBuilder() {
+    return super.prototypeBuilder()
+        .initKind(Tags.SPAN_KIND_SERVER)
+        .initTag(DDTags.LANGUAGE_TAG_KEY, DDTags.LANGUAGE_TAG_VALUE);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/decorator/SpanPrototypeTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/instrumentation/decorator/SpanPrototypeTest.java
@@ -1,0 +1,81 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import org.junit.jupiter.api.Test;
+
+class SpanPrototypeTest {
+
+  @Test
+  void serverPrototypeComposesBaseAndServerConstants() {
+    final SpanPrototype prototype = new TestServerDecorator().prototype();
+    final TagMap tags = prototype.tags();
+
+    // Identity (BaseDecorator)
+    assertEquals("test", prototype.instrumentationName());
+    assertEquals("test-type", prototype.spanType());
+    // BaseDecorator contribution
+    assertEquals("test-component", tags.getString(Tags.COMPONENT));
+    // ServerDecorator contribution
+    assertEquals(Tags.SPAN_KIND_SERVER, tags.getString(Tags.SPAN_KIND));
+    assertEquals(DDTags.LANGUAGE_TAG_VALUE, tags.getString(DDTags.LANGUAGE_TAG_KEY));
+  }
+
+  @Test
+  void clientPrototypeComposesBaseAndClientConstants() {
+    final TagMap tags = new TestClientDecorator().prototype().tags();
+
+    assertEquals("test-component", tags.getString(Tags.COMPONENT));
+    assertEquals(Tags.SPAN_KIND_CLIENT, tags.getString(Tags.SPAN_KIND));
+  }
+
+  @Test
+  void prototypeIsBakedOnce() {
+    final TestServerDecorator decorator = new TestServerDecorator();
+    assertSame(decorator.prototype(), decorator.prototype());
+  }
+
+  static final class TestServerDecorator extends ServerDecorator {
+    @Override
+    protected String[] instrumentationNames() {
+      return new String[] {"test"};
+    }
+
+    @Override
+    protected CharSequence spanType() {
+      return "test-type";
+    }
+
+    @Override
+    protected CharSequence component() {
+      return "test-component";
+    }
+  }
+
+  static final class TestClientDecorator extends ClientDecorator {
+    @Override
+    protected String[] instrumentationNames() {
+      return new String[] {"test"};
+    }
+
+    @Override
+    protected CharSequence spanType() {
+      return "test-type";
+    }
+
+    @Override
+    protected CharSequence component() {
+      return "test-component";
+    }
+
+    @Override
+    protected String service() {
+      return "test-service";
+    }
+  }
+}

--- a/internal-api/src/jmh/java/datadog/trace/api/SpanPrototypeBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/api/SpanPrototypeBenchmark.java
@@ -1,0 +1,91 @@
+package datadog.trace.api;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.bootstrap.instrumentation.api.SpanPrototype;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Per-mechanism benchmark for {@link SpanPrototype}: the constant-tag application a span pays at
+ * start. Compares the three phases of the mechanism, holding the resulting tag set identical:
+ *
+ * <ul>
+ *   <li><b>oldPerSpanStamps</b> — a fresh {@code TagMap} filled by N individual {@code set(entry)}
+ *       calls, as {@code BaseDecorator.afterStart} does today (once per span).
+ *   <li><b>newBulkApply</b> — a fresh map + one {@code putAll} of the baked-once prototype (the
+ *       afterStart-consolidation on-ramp).
+ *   <li><b>newConstructionSeed</b> — the span's map is <em>born</em> as a {@code copy()} of the
+ *       frozen prototype (clone-at-birth; what increment 2's construction wiring unlocks).
+ * </ul>
+ *
+ * <p>Isolates the constant-application only (not span creation or the {@code afterStart} virtual
+ * chain), so the delta is purely N-stamps vs. bulk-copy. Run with {@code -prof gc} — the
+ * interesting axes are ops/s and B/op.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(SECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(3)
+@Threads(8)
+public class SpanPrototypeBenchmark {
+
+  // The constant set a typical server span carries, as cached entries (the shared-Entry
+  // hand-optimization the decorators use today).
+  private static final TagMap.Entry COMPONENT = TagMap.Entry.create(Tags.COMPONENT, "netty");
+  private static final TagMap.Entry KIND =
+      TagMap.Entry.create(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER);
+  private static final TagMap.Entry LANGUAGE =
+      TagMap.Entry.create(DDTags.LANGUAGE_TAG_KEY, DDTags.LANGUAGE_TAG_VALUE);
+  private static final TagMap.Entry ANALYTICS =
+      TagMap.Entry.create(DDTags.ANALYTICS_SAMPLE_RATE, 1.0d);
+
+  private SpanPrototype prototype;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    // Baked once — the same constants, composed through the builder.
+    prototype =
+        SpanPrototype.builder()
+            .initComponent("netty")
+            .initKind(Tags.SPAN_KIND_SERVER)
+            .initTag(DDTags.LANGUAGE_TAG_KEY, DDTags.LANGUAGE_TAG_VALUE)
+            .initTag(ANALYTICS)
+            .build();
+  }
+
+  @Benchmark
+  public TagMap oldPerSpanStamps() {
+    TagMap tags = TagMap.create();
+    tags.set(COMPONENT);
+    tags.set(KIND);
+    tags.set(LANGUAGE);
+    tags.set(ANALYTICS);
+    return tags;
+  }
+
+  @Benchmark
+  public TagMap newBulkApply() {
+    TagMap tags = TagMap.create();
+    tags.putAll(prototype.tags());
+    return tags;
+  }
+
+  @Benchmark
+  public TagMap newConstructionSeed() {
+    return prototype.tags().copy();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanPrototype.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanPrototype.java
@@ -1,0 +1,145 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.trace.api.TagMap;
+
+/**
+ * A baked-once, frozen descriptor of a span's constant initial state — the per-decorator constants
+ * (instrumentation name, span type, {@code span.kind}, component, …) that {@code
+ * BaseDecorator.afterStart} otherwise stamps one entry at a time, per span.
+ *
+ * <p>Composed through {@link #builder()}: authors set identity and constant tags via typed methods
+ * and never touch {@link TagMap} directly. {@link Builder#extends_(SpanPrototype)} inherits a base
+ * prototype (e.g. a SpanType base like {@code HttpServer}) so an integration adds only what's
+ * specific to it. Rides the existing {@code TagMap} API, so it's independent of any deeper TagMap
+ * rework — the internal seed can get faster without changing this surface.
+ *
+ * <p>v1 carries identity + constant tags. Derivation / canonicalization / lifecycle hooks are
+ * deliberately out — grown when the work that needs each arrives, not pre-slotted.
+ */
+public final class SpanPrototype {
+  /** The empty prototype — for spans created without a decorator-provided prototype. */
+  public static final SpanPrototype NONE = builder().build();
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final String instrumentationName;
+  private final CharSequence operationName;
+  private final CharSequence spanType;
+  private final TagMap tags; // frozen
+
+  private SpanPrototype(final Builder builder) {
+    this.instrumentationName = builder.instrumentationName;
+    this.operationName = builder.operationName;
+    this.spanType = builder.spanType;
+    this.tags = builder.tags.immutableCopy();
+  }
+
+  public String instrumentationName() {
+    return instrumentationName;
+  }
+
+  public CharSequence operationName() {
+    return operationName;
+  }
+
+  public CharSequence spanType() {
+    return spanType;
+  }
+
+  /** The frozen constant tags — the internal seed applied at span construction. */
+  public TagMap tags() {
+    return tags;
+  }
+
+  public static final class Builder {
+    private String instrumentationName;
+    private CharSequence operationName;
+    private CharSequence spanType;
+    // Internal accumulator — never exposed; authors compose via the typed methods below.
+    private final TagMap tags = TagMap.create();
+
+    private Builder() {}
+
+    /**
+     * Inherit a base prototype's identity and constant tags (e.g. a SpanType base). Subsequent
+     * identity / {@code init*} calls on this builder override the inherited values.
+     */
+    public Builder extends_(final SpanPrototype base) {
+      if (base != null) {
+        if (base.instrumentationName != null) {
+          this.instrumentationName = base.instrumentationName;
+        }
+        if (base.operationName != null) {
+          this.operationName = base.operationName;
+        }
+        if (base.spanType != null) {
+          this.spanType = base.spanType;
+        }
+        this.tags.putAll(base.tags);
+      }
+      return this;
+    }
+
+    public Builder instrumentationName(final String[] instrumentationNames) {
+      return (instrumentationNames == null || instrumentationNames.length == 0)
+          ? this
+          : instrumentationName(instrumentationNames[0]);
+    }
+
+    public Builder instrumentationName(final String instrumentationName) {
+      this.instrumentationName = instrumentationName;
+      return this;
+    }
+
+    public Builder operationName(final CharSequence operationName) {
+      this.operationName = operationName;
+      return this;
+    }
+
+    public Builder spanType(final CharSequence spanType) {
+      this.spanType = spanType;
+      return this;
+    }
+
+    /** Sets {@code span.kind}. */
+    public Builder initKind(final CharSequence kind) {
+      return initTag(Tags.SPAN_KIND, kind);
+    }
+
+    /** Sets {@code component}. */
+    public Builder initComponent(final CharSequence component) {
+      return initTag(Tags.COMPONENT, component);
+    }
+
+    public Builder initTag(final String key, final CharSequence value) {
+      if (value != null) {
+        this.tags.set(key, value);
+      }
+      return this;
+    }
+
+    public Builder initTag(final String key, final Object value) {
+      if (value != null) {
+        this.tags.set(key, value);
+      }
+      return this;
+    }
+
+    /**
+     * Advanced/internal: reuse an already-built entry — a decorator's cached constant or a metric
+     * entry — rather than re-creating it. Authors should prefer the typed {@code init*} methods.
+     */
+    public Builder initTag(final TagMap.EntryReader entry) {
+      if (entry != null) {
+        this.tags.set(entry);
+      }
+      return this;
+    }
+
+    public SpanPrototype build() {
+      return new SpanPrototype(this);
+    }
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/bootstrap/instrumentation/api/SpanPrototypeTest.java
+++ b/internal-api/src/test/java/datadog/trace/bootstrap/instrumentation/api/SpanPrototypeTest.java
@@ -1,0 +1,25 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SpanPrototypeTest {
+
+  @Test
+  void extendsInheritsBaseIdentityAndTagsThenOverrides() {
+    final SpanPrototype base =
+        SpanPrototype.builder()
+            .instrumentationName("base")
+            .spanType("base-type")
+            .initKind("server")
+            .build();
+    final SpanPrototype derived =
+        SpanPrototype.builder().extends_(base).initComponent("netty").spanType("http").build();
+
+    assertEquals("base", derived.instrumentationName()); // inherited
+    assertEquals("http", derived.spanType()); // overridden
+    assertEquals("server", derived.tags().getString(Tags.SPAN_KIND)); // inherited tag
+    assertEquals("netty", derived.tags().getString(Tags.COMPONENT)); // added tag
+  }
+}


### PR DESCRIPTION
## What
Demonstrates `SpanPrototype` (#11894) by wiring `BaseDecorator` / `ClientDecorator` / `ServerDecorator` to bake a per-decorator prototype — the identity + constant tags each decorator contributes — the concrete usage behind the deck's slide examples.

## Why
Shows the API in action: a decorator bakes its constant tags once (`prototype()` / `prototypeBuilder()`), the shape a span would adopt by copy. Also carries the decorator-coupled tests (the pure-API test stays in #11894).

## Split of #11828
Part 2 of 2, **stacked on #11894**. Construction (`buildSpan(SpanPrototype)`) is #11834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
