### PR TITLE
Make index tasks cacheable and improve input fingerprinting

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -347,8 +347,11 @@ def generateAgentJarIndex = tasks.register('generateAgentJarIndex', JavaExec) {
   it.mainClass = 'datadog.trace.bootstrap.AgentJarIndex$IndexGenerator'
 
   it.inputs.files(includedJarFileTree)
-  it.inputs.files(it.classpath)
+    .withPropertyName("includedAgentFiles")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   it.outputs.dir(destinationDir)
+    .withPropertyName("agentJarIndex")
+  it.outputs.cacheIf { true }
   it.classpath = objects.fileCollection().tap {
     it.from(project.configurations.named("shadowInclude"))
     it.from(project.configurations.named('slf4j-simple'))

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -153,8 +153,9 @@ TaskProvider<JavaExec> registerIndexTask(String indexTaskName, String indexer, S
       it.from(project.configurations.named("runtimeClasspath"))
       it.from(project.configurations.named('slf4j-simple'))
     }
-    it.inputs.files(it.classpath)
     it.outputs.dir(destinationDir)
+      .withPropertyName("indexDirectory")
+    it.outputs.cacheIf { true }
     it.argumentProviders.add(new CommandLineArgumentProvider() {
         @Override
         Iterable<String> asArguments() {


### PR DESCRIPTION
# What Does This Do

This PR makes the `instrumentation index` and `agentJarIndex` build tasks cacheable. Additionally, it improves how Gradle fingerprints task inputs for consistency and better cache normalization.

# Motivation

Enabling task caching improves build performance by reusing outputs from previous executions. Adjusting input fingerprint normalization ensures accurate task caching behavior under different build environments.

> [!NOTE]
> [`JavaExec`](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/JavaExec.html) is disabled for caching by default because Gradle needs task-specific input/output information. These index generators are deterministic for the same inputs, so declaring the missing metadata and enabling [`TaskOutputs.cacheIf`](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)) lets Gradle restore their generated index files from the build cache instead of rerunning them.


# Additional Notes

- The `instrumentation index` task no longer declares redundant input for the class path, as it is already specified in the `JavaExec` specification.
- The `agentJarIndex` task now uses [`PathSensitivity.RELATIVE`](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/PathSensitivity.html#RELATIVE) for the expanded file tree.
  for input fingerprinting, focusing on relevant files below specific directories and improving CI build behavior.

Related to
* #11889

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]