### PR TITLE
Update groovy enforcement label and merge queue documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,11 +12,7 @@
   Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
 - Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
 - Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
-- Add your completed PR to the merge queue by commenting `/merge`. You can also:
-  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
-  - Remove your PR from the merge queue with `/merge -c`
-  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
-  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)
+- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR
 
 Jira ticket: [PROJ-IDENT]
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -124,7 +124,7 @@ _Actions:_
 
 * Fail the PR if it introduces any new `.groovy` file, including added, copied, or renamed files whose previous name was not already `.groovy`.
 
-_Recovery:_ Re-write the new Groovy files in Java / JUnit. To override this check entirely, add the `tag: override-groovy-enforcement` label to the PR. Remove the label to re-enable enforcement.
+_Recovery:_ Re-write the new Groovy files in Java / JUnit. To override this check entirely, add the `tag: override groovy enforcement` label to the PR. Remove the label to re-enable enforcement.
 
 _Notes:_ The override label skips the workflow entirely.
 

--- a/.github/workflows/enforce-groovy-migration.yaml
+++ b/.github/workflows/enforce-groovy-migration.yaml
@@ -54,9 +54,9 @@ jobs:
 
             // Check for override label — skip all checks if label present
             const labels = context.payload.pull_request.labels.map(l => l.name)
-            if (labels.includes('tag: override-groovy-enforcement')) {
+            if (labels.includes('tag: override groovy enforcement')) {
               await deleteManagedComment()
-              console.log('tag: override-groovy-enforcement label detected — skipping all checks.')
+              console.log('tag: override groovy enforcement label detected — skipping all checks.')
               return
             }
 
@@ -99,7 +99,7 @@ jobs:
                 `Please avoid introducing new \`.groovy\` files to this repository.\n\n` +
                 `${fileList}\n\n` +
                 `Instead, rewrite the new file(s) in Java / JUnit. See the [How to Test With JUnit Guide](https://github.com/DataDog/dd-trace-java/blob/master/docs/how_to_test_with_junit.md) for more details.\n\n` +
-                `If this PR needs an exception, add the \`tag: override-groovy-enforcement\` label to bypass this workflow.\n\n` +
+                `If this PR needs an exception, add the \`tag: override groovy enforcement\` label to bypass this workflow.\n\n` +
                 managedMarker
               if (existingComment) {
                 await github.rest.issues.updateComment({
@@ -125,5 +125,5 @@ jobs:
             }
 
             if (introducedGroovy.length > 0) {
-              core.setFailed(`${introducedGroovy.length} new Groovy file(s) detected. See PR comment for details. To bypass this workflow, add the 'tag: override-groovy-enforcement' label.`)
+              core.setFailed(`${introducedGroovy.length} new Groovy file(s) detected. See PR comment for details. To bypass this workflow, add the 'tag: override groovy enforcement' label.`)
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,21 @@ Labels are used to not only categorize but also alter the continuous integration
 > For reference, the [full list of all labels available](https://github.com/DataDog/dd-trace-java/labels).
 > If you feel one is missing, let [the maintainer team](https://github.com/orgs/DataDog/teams/apm-java) know!
 
+### Merge Queue
+
+Pull requests are merged into the protected branches using [the Datadog GitLab merge queue system](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).
+Once approved, pull requests can be added to merge queue using the `Merge when ready` button at the bottom of the page, or by commenting `/merge`.
+The merge queue will run more tests than the pull request checks, meaning having test failures on merge queue while having pull request checks passing is an expected behavior - the pull request checks are lighter to provide quick feedback during development iterations.
+
+By default, the merge commit message uses the pull request title as its subject and the squashed pull request commit messages as its body.
+A custom commit message can be specified by commenting `/merge --commit-message "custom message"`.
+
+Pull requests can be force-merged by commenting: `/merge -f --reason "reason"`.
+
+>[!WARNING]
+> By-passing merge queue will effectively merge pull request content without running all continuous integration tests and checks.
+> Only by-pass the merge queue to fix the build or help restore the continuous integration status.
+
 ## Pull request reviews
 
 ### Review expectations


### PR DESCRIPTION
# What Does This Do

This PR introduce minor changes to the repository:
* rename the groovy migration label for consistency
* move the merge queue documentation from the PR template to the contributing guidelines

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Add your completed PR to the merge queue by commenting `/merge`. You can also:
  - Customize the commit message associated with the merge with `/merge --commit-message "..."`
  - Remove your PR from the merge queue with `/merge -c`
  - Skip all merge queue checks with `/merge -f --reason "reason"`; please use this judiciously, as some checks do not run at the PR-level (note: the PR still needs to be mergeable, this will only skip the pre-merge build)
  - Get more information in [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
