### PR TITLE
Fix netty instrumentation requirement for JDK 27

### DIFF
--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -3,7 +3,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
-import datadog.environment.JavaVirtualMachine
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -23,7 +22,6 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.asynchttpclient.Response
 import org.asynchttpclient.proxy.ProxyServer
 import spock.lang.AutoCleanup
-import spock.lang.IgnoreIf
 import spock.lang.Timeout
 
 import java.util.concurrent.ExecutionException
@@ -97,9 +95,6 @@ abstract class Netty41ClientTest extends HttpClientTest {
     return false
   }
 
-  @IgnoreIf(reason = "JDK 27 TODO: address failing test", value = {
-    JavaVirtualMachine.isJavaVersion(27)
-  })
   def "connection error (unopened port)"() {
     given:
     def uri = new URI("http://127.0.0.1:$UNUSABLE_PORT/")
@@ -126,7 +121,9 @@ abstract class Netty41ClientTest extends HttpClientTest {
           errored true
           tags {
             "$Tags.COMPONENT" "netty"
-            errorTags AbstractChannel.AnnotatedConnectException, "Connection refused: /127.0.0.1:$UNUSABLE_PORT"
+            errorTags AbstractChannel.AnnotatedConnectException, {
+              it.startsWith("Connection refused") && it.endsWith("/127.0.0.1:$UNUSABLE_PORT")
+            }
             defaultTags()
           }
         }


### PR DESCRIPTION
# What Does This Do

Loosen netty instrumentation error check

# Motivation

JDK 27 changes the socket connection-refused message from:

```
Connection refused: /127.0.0.1:61
```

to:

```
Connection refused (connect failed): /127.0.0.1:61
```

# Additional Notes

Full GitLab pipeline that runs non-default JVMs, JDK 27 tests included: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/123869235

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
