### PR TITLE
Have a stable symbol to test ffm tracing

### DIFF
--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-22.0/src/test/groovy/FFMInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-22.0/src/test/groovy/FFMInstrumentationForkedTest.groovy
@@ -136,58 +136,32 @@ class FFMInstrumentationForkedTest extends InstrumentationSpecification {
 
   def "should trace ffm calls using libraryLookup by path for library loaded with System.load"() {
     setup:
-    injectSysConfig("trace.native.methods", "libjvm[*]")
-    final String libName = System.mapLibraryName("jvm")
-    final Path libPath = Path.of(System.getProperty("java.home"), "lib", "server", libName)
+    injectSysConfig("trace.native.methods", "libdt_socket[*]")
+    final String libName = System.mapLibraryName("dt_socket")
+    final Path libPath = Path.of(System.getProperty("java.home"), "lib", libName)
 
     when:
     LoaderUtil.loadLibrary(libPath)
-    try (final Arena arena = Arena.ofConfined()) {
-      final SymbolLookup libLookup = LoaderUtil.loaderLookup()
-      FunctionDescriptor fd = FunctionDescriptor.of(
-      ValueLayout.JAVA_INT,   // jint return
-      ValueLayout.ADDRESS,    // JavaVM**
-      ValueLayout.JAVA_INT,   // jsize bufLen
-      ValueLayout.ADDRESS     // jsize* nVMs
-      )
-
-      // this is a quite stable symbol (it's in the public API)
-      MemorySegment sym =
-      libLookup.find("JNI_GetCreatedJavaVMs")
-      .orElseThrow()
-
-      MethodHandle methodHandle = Linker.nativeLinker().downcallHandle(sym, fd)
-
-      // Allocate space for JavaVM* (we only expect 1 VM)
-      MemorySegment vmBuf = arena.allocate(ValueLayout.ADDRESS)
-
-      // Allocate space for jsize nVMs
-      MemorySegment nVMs = arena.allocate(ValueLayout.JAVA_INT)
-
-      int result = (int) methodHandle.invokeWithArguments(
-      vmBuf,
-      1,
-      nVMs
-      )
-
-      int count = nVMs.get(ValueLayout.JAVA_INT, 0)
-
-      System.out.println("Return code: " + result)
-      System.out.println("Number of VMs: " + count)
-
-      if (count > 0) {
-        MemorySegment vmPtr = vmBuf.get(ValueLayout.ADDRESS, 0)
-        System.out.println("JavaVM pointer: " + vmPtr)
-      }
-    }
-
+    final SymbolLookup libLookup = LoaderUtil.loaderLookup()
+    final MemorySegment onLoadAddr = libLookup.findOrThrow("jdwpTransport_OnLoad")
+    final MethodHandle onLoadHandle =
+    Linker.nativeLinker().downcallHandle(
+    onLoadAddr,
+    FunctionDescriptor.of(
+    ValueLayout.JAVA_INT,
+    ValueLayout.ADDRESS,
+    ValueLayout.ADDRESS,
+    ValueLayout.JAVA_INT,
+    ValueLayout.ADDRESS))
+    // version 0 is rejected before any argument is dereferenced
+    onLoadHandle.invokeWithArguments(MemorySegment.NULL, MemorySegment.NULL, 0, MemorySegment.NULL)
 
     then:
     assertTraces(1) {
       trace(1) {
         span {
           operationName "trace.native"
-          resourceName "libjvm.JNI_GetCreatedJavaVMs"
+          resourceName "libdt_socket.jdwpTransport_OnLoad"
           tags {
             "$Tags.COMPONENT" "trace-ffm"
             defaultTags()


### PR DESCRIPTION
# What Does This Do

This test was failing because it assumed that a symbol was loaded by `libjvm` while it appears in our arm64 linux pipeline that was also sometimes loaded by `libattach` so that the symbol did not get traced correctly.

This PR changes the test by making sure that the symbol is uniquely exported by one lib that exists across arch and jdk so that it won't flake. 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
