### PR TITLE
Add datadog.common.filesystem to list of bootstrap package prefixes

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
@@ -15,6 +15,7 @@ public final class Constants {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES = {
     "datadog.slf4j",
+    "datadog.common.filesystem",
     "datadog.context",
     "datadog.environment",
     "datadog.json",

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
@@ -62,6 +62,7 @@ public class BootstrapClasspathSetupListener implements LauncherSessionListener 
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES_COPY = {
     "datadog.slf4j",
+    "datadog.common.filesystem",
     "datadog.context",
     "datadog.environment",
     "datadog.json",


### PR DESCRIPTION
# Motivation

Hopefully fixes the following log-spam when running instrumentation tests on CI:
```
14:42:03.913 [Test worker] DEBUG datadog.trace.bootstrap.config.provider.StableConfigSource - Stable configuration file found at path: /etc/datadog-agent/application_monitoring.yaml
14:42:03.920 [Test worker] ERROR datadog.trace.bootstrap.config.provider.StableConfigSource - Unexpected error while reading stable configuration file: /etc/datadog-agent/application_monitoring.yaml
java.lang.NoClassDefFoundError: datadog/common/filesystem/Files
	at datadog.trace.bootstrap.config.provider.StableConfigSource.<init>(StableConfigSource.java:37)
	at datadog.trace.bootstrap.config.provider.StableConfigSource.<clinit>(StableConfigSource.java:22)
	at datadog.trace.bootstrap.config.provider.ConfigProvider.createDefault(ConfigProvider.java:523)
	at datadog.trace.bootstrap.config.provider.ConfigProvider$Singleton.<clinit>(ConfigProvider.java:34)
	at datadog.trace.bootstrap.config.provider.ConfigProvider.getInstance(ConfigProvider.java:504)
	at datadog.trace.api.InstrumenterConfig.<clinit>(InstrumenterConfig.java:749)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at datadog.trace.test.util.DDSpecification.makeConfigInstanceModifiable(DDSpecification.groovy:70)
	at datadog.trace.test.util.DDSpecification.<clinit>(DDSpecification.groovy:29)
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
