### PR TITLE
fix computeFrames call

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
@@ -99,9 +99,10 @@ public class CapturedContextInstrumenter extends Instrumenter {
       installFinallyBlocks();
       return InstrumentationResult.Status.INSTALLED;
     }
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
     instrumentMethodEnter();
     instrumentTryCatchHandlers();
-    processInstructions();
+    processInstructions(frames);
     addFinallyHandler(contextInitLabel, returnHandlerLabel);
     installFinallyBlocks();
     return InstrumentationResult.Status.INSTALLED;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
@@ -21,7 +21,8 @@ public class ExceptionInstrumenter extends CapturedContextInstrumenter {
 
   @Override
   public InstrumentationResult.Status instrument() {
-    processInstructions(); // fill returnHandlerLabel
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
+    processInstructions(frames); // fill returnHandlerLabel
     addFinallyHandler(methodEnterLabel, returnHandlerLabel);
     installFinallyBlocks();
     return InstrumentationResult.Status.INSTALLED;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -159,9 +159,7 @@ public abstract class Instrumenter {
     return lastInvokeSpecial;
   }
 
-  protected void processInstructions() {
-    Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
-    computeFrames(classNode.name, methodNode, frames);
+  protected void processInstructions(Map<AbstractInsnNode, Frame<BasicValue>> frames) {
     AbstractInsnNode node = methodNode.instructions.getFirst();
     LabelNode sentinelNode = new LabelNode();
     methodNode.instructions.add(sentinelNode);
@@ -195,8 +193,9 @@ public abstract class Instrumenter {
     return result;
   }
 
-  private static void computeFrames(
-      String owner, MethodNode methodNode, Map<AbstractInsnNode, Frame<BasicValue>> frames) {
+  protected static Map<AbstractInsnNode, Frame<BasicValue>> computeFrames(
+      String owner, MethodNode methodNode) {
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
     try {
       Frame<BasicValue>[] frameArray =
           new Analyzer<>(new BasicInterpreter()).analyze(owner, methodNode);
@@ -207,8 +206,14 @@ public abstract class Instrumenter {
         current = current.getNext();
       }
     } catch (AnalyzerException ex) {
-      LOGGER.debug("Failed to analyze method[{}::{}] instructions", owner, methodNode.name, ex);
+      LOGGER.debug(
+          "Failed to analyze method[{}::{}{}] instructions",
+          owner,
+          methodNode.name,
+          methodNode.desc,
+          ex);
     }
+    return frames;
   }
 
   protected AbstractInsnNode processInstruction(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
@@ -111,7 +111,9 @@ public class MetricInstrumenter extends Instrumenter {
         }
       case EXIT:
         {
-          processInstructions();
+          Map<AbstractInsnNode, Frame<BasicValue>> frames =
+              computeFrames(classNode.name, methodNode);
+          processInstructions(frames);
           addFinallyHandler(returnHandlerLabel);
           installFinallyBlocks();
           break;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
@@ -13,13 +13,17 @@ import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.util.ClassFileLines;
 import java.util.List;
+import java.util.Map;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 
 public class SpanInstrumenter extends Instrumenter {
   private int spanVar;
@@ -38,7 +42,8 @@ public class SpanInstrumenter extends Instrumenter {
       return addRangeSpan(classFileLines);
     }
     spanVar = newVar(DEBUGGER_SPAN_TYPE);
-    processInstructions();
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
+    processInstructions(frames);
     LabelNode initSpanLabel = new LabelNode();
     InsnList insnList = createSpan(initSpanLabel);
     LabelNode endLabel = new LabelNode();


### PR DESCRIPTION
# What Does This Do
make sure it is called before any instrumentation. for CaptureContextInstrumenter, processInstructions is called after some instrumentation at the beginning of the method. so extract computeFrames outside of processInstructions and return directly the frames Map.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [DEBUG-5816]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5816]: https://datadoghq.atlassian.net/browse/DEBUG-5816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ