### PR TITLE
Add pagination metrics for known tests fetch

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -222,6 +222,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
     Map<String, Map<String, List<String>>> aggregateTests = new HashMap<>();
     String pageState = null;
     int pageNumber = 0;
+    long startMs = System.currentTimeMillis();
+    int totalRequestMs = 0;
 
     do {
       pageNumber += 1;
@@ -233,6 +235,7 @@ public class ConfigurationApiImpl implements ConfigurationApi {
           new Envelope<>(new Data<>(uuid, "ci_app_libraries_tests_request", requestDto));
       String json = knownTestsRequestAdapter.toJson(request);
       RequestBody requestBody = RequestBody.create(JSON, json);
+      long pageStartMs = System.currentTimeMillis();
       KnownTestsResponse knownTests =
           backendApi.post(
               KNOWN_TESTS_URI,
@@ -243,6 +246,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
                       .attributes,
               telemetryListener,
               false);
+      long pageEndMs = System.currentTimeMillis();
+      totalRequestMs += (int) (pageEndMs - pageStartMs);
 
       mergeKnownTests(aggregateTests, knownTests.tests);
 
@@ -266,6 +271,12 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             : 0;
     LOGGER.debug("Received {} known tests in total", knownTestsCount);
     metricCollector.add(CiVisibilityDistributionMetric.KNOWN_TESTS_RESPONSE_TESTS, knownTestsCount);
+    long totalFetchMs = System.currentTimeMillis() - startMs;
+    metricCollector.add(CiVisibilityDistributionMetric.KNOWN_TESTS_PAGES_FETCHED, pageNumber);
+    metricCollector.add(
+        CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_FETCH_MS, (int) totalFetchMs);
+    metricCollector.add(
+        CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_REQUEST_MS, totalRequestMs);
     // returning null disables features that rely on known tests; this is intentional on the very
     // first execution for a repository, when we want to seed the backend with the initial set.
     return testsByModule;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -33,6 +33,8 @@ import datadog.trace.civisibility.config.api.dto.response.TestManagementTestsRes
 import datadog.trace.util.RandomUtils;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
+import okhttp3.Call;
+import okhttp3.Response;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -210,20 +212,15 @@ public class ConfigurationApiImpl implements ConfigurationApi {
   @Override
   public Map<String, Collection<TestFQN>> getKnownTestsByModule(TracerEnvironment tracerEnvironment)
       throws IOException {
-    OkHttpUtils.CustomListener telemetryListener =
-        new TelemetryListener.Builder(metricCollector)
-            .requestCount(CiVisibilityCountMetric.KNOWN_TESTS_REQUEST)
-            .requestErrors(CiVisibilityCountMetric.KNOWN_TESTS_REQUEST_ERRORS)
-            .requestDuration(CiVisibilityDistributionMetric.KNOWN_TESTS_REQUEST_MS)
-            .responseBytes(CiVisibilityDistributionMetric.KNOWN_TESTS_RESPONSE_BYTES)
-            .build();
+    // Listener that both emits per-request metrics and accumulates total request time
+    AccumulatingTelemetryListener accumulatingListener =
+        new AccumulatingTelemetryListener(metricCollector);
 
     // Aggregate tests map across all pages: module -> suite -> tests
     Map<String, Map<String, List<String>>> aggregateTests = new HashMap<>();
     String pageState = null;
     int pageNumber = 0;
     long startMs = System.currentTimeMillis();
-    int totalRequestMs = 0;
 
     do {
       pageNumber += 1;
@@ -235,7 +232,6 @@ public class ConfigurationApiImpl implements ConfigurationApi {
           new Envelope<>(new Data<>(uuid, "ci_app_libraries_tests_request", requestDto));
       String json = knownTestsRequestAdapter.toJson(request);
       RequestBody requestBody = RequestBody.create(JSON, json);
-      long pageStartMs = System.currentTimeMillis();
       KnownTestsResponse knownTests =
           backendApi.post(
               KNOWN_TESTS_URI,
@@ -244,10 +240,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
                   testFullNamesResponseAdapter.fromJson(Okio.buffer(Okio.source(is)))
                       .data
                       .attributes,
-              telemetryListener,
+              accumulatingListener,
               false);
-      long pageEndMs = System.currentTimeMillis();
-      totalRequestMs += (int) (pageEndMs - pageStartMs);
 
       mergeKnownTests(aggregateTests, knownTests.tests);
 
@@ -276,7 +270,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
     metricCollector.add(
         CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_FETCH_MS, (int) totalFetchMs);
     metricCollector.add(
-        CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_REQUEST_MS, totalRequestMs);
+        CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_REQUEST_MS,
+        accumulatingListener.getTotalRequestMs());
     // returning null disables features that rely on known tests; this is intentional on the very
     // first execution for a repository, when we want to seed the backend with the initial set.
     return testsByModule;
@@ -353,5 +348,64 @@ public class ConfigurationApiImpl implements ConfigurationApi {
         CiVisibilityDistributionMetric.TEST_MANAGEMENT_TESTS_RESPONSE_TESTS, testsCount);
 
     return response.toTestFQNsBySetting();
+  }
+
+  /**
+   * Listener that emits per-request telemetry metrics and accumulates total request duration
+   * across all retry attempts. By measuring each OkHttp call individually, this excludes retry
+   * backoff sleeps from total_request_ms, ensuring it represents the sum of actual request times.
+   */
+  private static class AccumulatingTelemetryListener extends OkHttpUtils.CustomListener {
+    private final TelemetryListener delegate;
+    private long callStartMs;
+    private int totalRequestMs;
+
+    public AccumulatingTelemetryListener(CiVisibilityMetricCollector metricCollector) {
+      this.delegate =
+          (TelemetryListener)
+              new TelemetryListener.Builder(metricCollector)
+                  .requestCount(CiVisibilityCountMetric.KNOWN_TESTS_REQUEST)
+                  .requestErrors(CiVisibilityCountMetric.KNOWN_TESTS_REQUEST_ERRORS)
+                  .requestDuration(CiVisibilityDistributionMetric.KNOWN_TESTS_REQUEST_MS)
+                  .responseBytes(CiVisibilityDistributionMetric.KNOWN_TESTS_RESPONSE_BYTES)
+                  .build();
+    }
+
+    @Override
+    public void callStart(Call call) {
+      callStartMs = System.currentTimeMillis();
+      delegate.callStart(call);
+    }
+
+    @Override
+    public void requestBodyEnd(Call call, long byteCount) {
+      delegate.requestBodyEnd(call, byteCount);
+    }
+
+    @Override
+    public void responseHeadersEnd(Call call, okhttp3.Response response) {
+      delegate.responseHeadersEnd(call, response);
+    }
+
+    @Override
+    public void responseBodyEnd(Call call, long byteCount) {
+      delegate.responseBodyEnd(call, byteCount);
+    }
+
+    @Override
+    public void callEnd(Call call) {
+      delegate.callEnd(call);
+      totalRequestMs += (int) (System.currentTimeMillis() - callStartMs);
+    }
+
+    @Override
+    public void callFailed(Call call, IOException ioe) {
+      delegate.callFailed(call, ioe);
+      totalRequestMs += (int) (System.currentTimeMillis() - callStartMs);
+    }
+
+    public int getTotalRequestMs() {
+      return totalRequestMs;
+    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -33,14 +33,13 @@ import datadog.trace.civisibility.config.api.dto.response.TestManagementTestsRes
 import datadog.trace.util.RandomUtils;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
-import okhttp3.Call;
-import okhttp3.Response;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.Okio;
@@ -351,9 +350,9 @@ public class ConfigurationApiImpl implements ConfigurationApi {
   }
 
   /**
-   * Listener that emits per-request telemetry metrics and accumulates total request duration
-   * across all retry attempts. By measuring each OkHttp call individually, this excludes retry
-   * backoff sleeps from total_request_ms, ensuring it represents the sum of actual request times.
+   * Listener that emits per-request telemetry metrics and accumulates total request duration across
+   * all retry attempts. By measuring each OkHttp call individually, this excludes retry backoff
+   * sleeps from total_request_ms, ensuring it represents the sum of actual request times.
    */
   private static class AccumulatingTelemetryListener extends OkHttpUtils.CustomListener {
     private final TelemetryListener delegate;

--- a/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/config/ConfigurationApiImplTest.java
+++ b/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/config/ConfigurationApiImplTest.java
@@ -3,7 +3,9 @@ package datadog.trace.civisibility.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import datadog.communication.BackendApi;
@@ -13,6 +15,8 @@ import datadog.communication.http.HttpRetryPolicy;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.agent.test.server.http.JavaTestHttpServer;
 import datadog.trace.api.civisibility.config.TestFQN;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.NoOpMetricCollector;
 import datadog.trace.api.intake.Intake;
 import datadog.trace.civisibility.config.api.dto.request.TracerEnvironment;
@@ -214,7 +218,9 @@ class ConfigurationApiImplTest extends AbstractConfigurationApiContractTest {
                               sendResponseBody(api, responses.get(current - 1).getBytes());
                             })));
     servers.add(intakeServer);
-    ConfigurationApi configurationApi = givenConfigurationApi(intakeServer, true, true);
+    CiVisibilityMetricCollector metricCollector = mock(CiVisibilityMetricCollector.class);
+    ConfigurationApi configurationApi =
+        givenConfigurationApi(intakeServer, true, true, metricCollector);
 
     Map<String, Collection<TestFQN>> knownTests =
         configurationApi.getKnownTestsByModule(tracerEnvironment);
@@ -233,15 +239,34 @@ class ConfigurationApiImplTest extends AbstractConfigurationApiContractTest {
         "module-c",
         Arrays.asList(new TestFQN("suite-c", "test-5"), new TestFQN("suite-c", "test-6")));
     assertEquals(expected, knownTests);
+
+    // Verify pagination metrics
+    verify(metricCollector)
+        .add(eq(CiVisibilityDistributionMetric.KNOWN_TESTS_RESPONSE_TESTS), eq(6));
+    verify(metricCollector)
+        .add(eq(CiVisibilityDistributionMetric.KNOWN_TESTS_PAGES_FETCHED), eq(3));
+    verify(metricCollector)
+        .add(eq(CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_FETCH_MS), any(Integer.class));
+    verify(metricCollector)
+        .add(eq(CiVisibilityDistributionMetric.KNOWN_TESTS_TOTAL_REQUEST_MS), any(Integer.class));
   }
 
   private ConfigurationApi givenConfigurationApi(
       JavaTestHttpServer intakeServer, boolean agentless, boolean compression) {
+    return givenConfigurationApi(
+        intakeServer, agentless, compression, NoOpMetricCollector.INSTANCE);
+  }
+
+  private ConfigurationApi givenConfigurationApi(
+      JavaTestHttpServer intakeServer,
+      boolean agentless,
+      boolean compression,
+      CiVisibilityMetricCollector metricCollector) {
     BackendApi api =
         agentless
             ? givenIntakeApi(intakeServer.getAddress(), compression)
             : givenEvpProxy(intakeServer.getAddress(), compression);
-    return new ConfigurationApiImpl(api, NoOpMetricCollector.INSTANCE, () -> REQUEST_UID);
+    return new ConfigurationApiImpl(api, metricCollector, () -> REQUEST_UID);
   }
 
   private JavaTestHttpServer givenBackendEndpoint(

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
@@ -45,6 +45,12 @@ public enum CiVisibilityDistributionMetric {
   KNOWN_TESTS_RESPONSE_BYTES("known_tests.response_bytes", ResponseCompressed.class),
   /** The number of tests received by the known tests endpoint */
   KNOWN_TESTS_RESPONSE_TESTS("known_tests.response_tests"),
+  /** The number of pages fetched during known tests pagination */
+  KNOWN_TESTS_PAGES_FETCHED("known_tests.pages_fetched"),
+  /** The total wall-clock time to fetch all pages of known tests in ms */
+  KNOWN_TESTS_TOTAL_FETCH_MS("known_tests.total_fetch_ms"),
+  /** The sum of individual per-page request durations in ms */
+  KNOWN_TESTS_TOTAL_REQUEST_MS("known_tests.total_request_ms"),
   /** The time it takes to get the response of the flaky tests endpoint request in ms */
   FLAKY_TESTS_REQUEST_MS("flaky_tests.request_ms"),
   /** The number of bytes received by the flaky tests endpoint */


### PR DESCRIPTION
## What does this PR do?

Adds three new distribution metrics to track known tests (Early Flake Detection) pagination behavior:

- `civisibility.known_tests.pages_fetched` - Number of pages fetched during pagination
- `civisibility.known_tests.total_fetch_ms` - Wall-clock time from first to last page request
- `civisibility.known_tests.total_request_ms` - Sum of individual per-page request durations

## Motivation

Currently, only per-request timing is tracked. These new metrics provide observability into:
- How often pagination occurs (single vs multi-page responses)
- Backend pagination performance (total wall-clock time)
- Network overhead vs local processing time (total_fetch_ms vs total_request_ms)

## Implementation Details

- Metrics are emitted **only on successful completion** after all pages are fetched
- If fetch fails midway (network error, invalid response), metrics are not emitted
- Per-request metrics remain unchanged (backward compatible)
- Added enum entries to `CiVisibilityDistributionMetric`
- Updated `ConfigurationApiImpl.getKnownTestsByModule()` to track timing

## Testing

- Tests pass
- Code formatted with spotless

## Checklist

- [x] Tests passing
- [x] Code formatted (spotless)
- [x] Backward compatible (no breaking changes)
- [x] Follows existing telemetry patterns