### PR TITLE
Fix flaky test with timeout

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
@@ -29,10 +29,12 @@ public class StringTemplateBuilder {
   private final List<LogProbe.Segment> segments;
 
   private final Limits limits;
+  private final Duration timeout;
 
-  public StringTemplateBuilder(List<LogProbe.Segment> segments, Limits limits) {
+  public StringTemplateBuilder(List<LogProbe.Segment> segments, Limits limits, Duration timeout) {
     this.segments = segments;
     this.limits = limits;
+    this.timeout = timeout;
   }
 
   public String evaluate(CapturedContext context, LogProbe.LogStatus status) {
@@ -41,7 +43,6 @@ public class StringTemplateBuilder {
     }
     StringBuilder sb = new StringBuilder();
     // Only one timeout for all expressions
-    Duration timeout = Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout());
     TimeoutChecker timeoutChecker = TimeoutChecker.create(Config.get(), timeout);
     for (LogProbe.Segment segment : segments) {
       ValueScript parsedExr = segment.getParsedExpr();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -12,12 +12,14 @@ import com.datadog.debugger.instrumentation.ExceptionInstrumenter;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
+import java.time.Duration;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +49,8 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
         new ProbeCondition(DSL.when(DSL.TRUE), "true"),
         capture,
         sampling,
-        null);
+        null,
+        Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout()));
     this.exceptionProbeManager = exceptionProbeManager;
     this.chainedExceptionIdx = chainedExceptionIdx;
     initSamplers();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -325,6 +325,7 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
       Collections.synchronizedMap(new WeakIdentityHashMap<>());
   protected transient Sampler sampler;
   protected transient Sampler errorSampler;
+  protected final transient Duration evalTimeout;
 
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
@@ -341,7 +342,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
         null,
         null,
         null,
-        null);
+        null,
+        Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout()));
   }
 
   public LogProbe(
@@ -356,7 +358,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling,
-      List<CaptureExpression> captureExpressions) {
+      List<CaptureExpression> captureExpressions,
+      Duration evalTimeout) {
     this(
         language,
         probeId,
@@ -369,7 +372,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
         probeCondition,
         capture,
         sampling,
-        captureExpressions);
+        captureExpressions,
+        evalTimeout);
   }
 
   private LogProbe(
@@ -384,7 +388,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling,
-      List<CaptureExpression> captureExpressions) {
+      List<CaptureExpression> captureExpressions,
+      Duration evalTimeout) {
     super(language, probeId, tags, where, evaluateAt);
     this.template = template;
     this.segments = segments;
@@ -393,6 +398,7 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
     this.capture = capture;
     this.sampling = sampling;
     this.captureExpressions = captureExpressions;
+    this.evalTimeout = evalTimeout;
   }
 
   public LogProbe(LogProbe.Builder builder) {
@@ -408,7 +414,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
         builder.probeCondition,
         builder.capture,
         builder.sampling,
-        builder.captureExpressions);
+        builder.captureExpressions,
+        builder.evalTimeout);
     this.snapshotProcessor = builder.snapshotProcessor;
     initSamplers();
   }
@@ -426,7 +433,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
         probeCondition,
         capture,
         sampling,
-        captureExpressions);
+        captureExpressions,
+        evalTimeout);
   }
 
   public String getTemplate() {
@@ -547,7 +555,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
     if (!logStatus.isSampled() || !logStatus.getCondition()) {
       return;
     }
-    StringTemplateBuilder logMessageBuilder = new StringTemplateBuilder(segments, LIMITS);
+    StringTemplateBuilder logMessageBuilder =
+        new StringTemplateBuilder(segments, LIMITS, evalTimeout);
     String msg = logMessageBuilder.evaluate(context, logStatus);
     if (msg != null && msg.length() > LOG_MSG_LIMIT) {
       StringBuilder sb = new StringBuilder(LOG_MSG_LIMIT + 3);
@@ -1123,6 +1132,8 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
     private Sampling sampling;
     private List<CaptureExpression> captureExpressions;
     private Consumer<Snapshot> snapshotProcessor;
+    private Duration evalTimeout =
+        Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout());
 
     public Builder snapshotProcessor(Consumer<Snapshot> processor) {
       this.snapshotProcessor = processor;
@@ -1166,6 +1177,11 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
 
     public Builder captureExpressions(List<CaptureExpression> captureExpressions) {
       this.captureExpressions = captureExpressions;
+      return this;
+    }
+
+    public Builder evalTimeout(Duration evalTimeout) {
+      this.evalTimeout = evalTimeout;
       return this;
     }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -162,11 +162,20 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
   private final TargetSpan targetSpan;
   private final List<Decoration> decorations;
   private transient Sampler errorSampler;
+  private final transient Duration evalTimeout;
 
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public SpanDecorationProbe() {
-    this(LANGUAGE, null, null, null, MethodLocation.DEFAULT, TargetSpan.ACTIVE, null);
+    this(
+        LANGUAGE,
+        null,
+        null,
+        null,
+        MethodLocation.DEFAULT,
+        TargetSpan.ACTIVE,
+        null,
+        Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout()));
   }
 
   public SpanDecorationProbe(
@@ -176,10 +185,12 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
       Where where,
       MethodLocation methodLocation,
       TargetSpan targetSpan,
-      List<Decoration> decorations) {
+      List<Decoration> decorations,
+      Duration evalTimeout) {
     super(language, probeId, tagStrs, where, methodLocation);
     this.targetSpan = targetSpan;
     this.decorations = decorations;
+    this.evalTimeout = evalTimeout;
   }
 
   public SpanDecorationProbe(SpanDecorationProbe.Builder builder) {
@@ -190,7 +201,8 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
         builder.where,
         builder.evaluateAt,
         builder.targetSpan,
-        builder.decorations);
+        builder.decorations,
+        builder.evalTimeout);
     initSamplers();
   }
 
@@ -210,8 +222,7 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
       MethodLocation methodLocation,
       boolean singleProbe) {
     // Only one timeout for all conditions
-    Duration timeout = Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout());
-    TimeoutChecker timeoutChecker = TimeoutChecker.create(Config.get(), timeout);
+    TimeoutChecker timeoutChecker = TimeoutChecker.create(Config.get(), evalTimeout);
     for (Decoration decoration : decorations) {
       if (decoration.when != null) {
         try {
@@ -234,7 +245,8 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
       SpanDecorationStatus spanStatus = (SpanDecorationStatus) status;
       for (Tag tag : decoration.tags) {
         String tagName = sanitize(tag.name);
-        StringTemplateBuilder builder = new StringTemplateBuilder(tag.value.getSegments(), LIMITS);
+        StringTemplateBuilder builder =
+            new StringTemplateBuilder(tag.value.getSegments(), LIMITS, evalTimeout);
         LogProbe.LogStatus logStatus = new LogProbe.LogStatus(this);
         String tagValue = builder.evaluate(context, logStatus);
         if (logStatus.hasLogTemplateErrors()) {
@@ -418,6 +430,8 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
   public static class Builder extends ProbeDefinition.Builder<SpanDecorationProbe.Builder> {
     private TargetSpan targetSpan;
     private List<Decoration> decorations;
+    private Duration evalTimeout =
+        Duration.ofMillis(Config.get().getDynamicInstrumentationEvalTimeout());
 
     public Builder targetSpan(TargetSpan targetSpan) {
       this.targetSpan = targetSpan;
@@ -431,6 +445,11 @@ public class SpanDecorationProbe extends ProbeDefinition implements CapturedCont
 
     public Builder decorations(Decoration decoration) {
       this.decorations = Collections.singletonList(decoration);
+      return this;
+    }
+
+    public Builder evalTimeout(Duration evalTimeout) {
+      this.evalTimeout = evalTimeout;
       return this;
     }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import net.bytebuddy.agent.ByteBuddyAgent;
@@ -550,12 +551,16 @@ public class LogProbesInstrumentationTest {
 
   private static LogProbe createMethodProbe(
       ProbeId id, String template, String typeName, String methodName, String signature) {
-    return createProbeBuilder(id, template, typeName, methodName, signature).build();
+    return createProbeBuilder(id, template, typeName, methodName, signature)
+        .evalTimeout(Duration.ofMillis(1000))
+        .build();
   }
 
   private static LogProbe createLineProbe(
       ProbeId id, String template, String sourceFile, int line) {
-    return createProbeBuilder(id, template, sourceFile, line).build();
+    return createProbeBuilder(id, template, sourceFile, line)
+        .evalTimeout(Duration.ofMillis(1000))
+        .build();
   }
 
   private TestSnapshotListener installProbes(Configuration configuration) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StringTemplateBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StringTemplateBuilderTest.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.bootstrap.debugger.Limits;
 import java.lang.management.ManagementFactory;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -26,11 +27,13 @@ import org.junit.jupiter.api.condition.JRE;
 
 class StringTemplateBuilderTest {
   private static final Limits LIMITS = new Limits(1, 3, 255, 5);
+  private static final Duration TIMEOUT = Duration.ofSeconds(1);
 
   @Test
   public void emptyProbe() {
     LogProbe probe = LogProbe.builder().build();
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     String message = summaryBuilder.evaluate(new CapturedContext(), new LogProbe.LogStatus(probe));
     assertNull(message);
   }
@@ -38,7 +41,8 @@ class StringTemplateBuilderTest {
   @Test
   public void emptyTemplate() {
     LogProbe probe = createLogProbe("");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     String message = summaryBuilder.evaluate(new CapturedContext(), new LogProbe.LogStatus(probe));
     assertEquals("", message);
   }
@@ -46,7 +50,8 @@ class StringTemplateBuilderTest {
   @Test
   public void onlyStringTemplate() {
     LogProbe probe = createLogProbe("this is a simple string");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     String message = summaryBuilder.evaluate(new CapturedContext(), new LogProbe.LogStatus(probe));
     assertEquals("this is a simple string", message);
   }
@@ -54,7 +59,8 @@ class StringTemplateBuilderTest {
   @Test
   public void undefinedArgTemplate() {
     LogProbe probe = createLogProbe("{arg}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     String message = summaryBuilder.evaluate(new CapturedContext(), new LogProbe.LogStatus(probe));
     assertEquals("{Cannot find symbol: arg}", message);
   }
@@ -62,7 +68,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argTemplate() {
     LogProbe probe = createLogProbe("{arg}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -80,7 +87,8 @@ class StringTemplateBuilderTest {
             new ValueScript(
                 DSL.bool(DSL.contains(DSL.ref("arg"), new StringValue("o"))), "{arg}")));
     LogProbe probe = LogProbe.builder().template("{contains(arg, 'o')}", segments).build();
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -93,14 +101,16 @@ class StringTemplateBuilderTest {
   @Test
   public void argMultipleInFlightTemplate() {
     LogProbe probe = createLogProbe("{arg}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
           CapturedContext.CapturedValue.of("arg", String.class.getTypeName(), "foo")
         });
     String message = summaryBuilder.evaluate(capturedContext, new LogProbe.LogStatus(probe));
-    StringTemplateBuilder summaryBuilder2 = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder2 =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext2 = new CapturedContext();
     capturedContext2.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -114,7 +124,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argNullTemplate() {
     LogProbe probe = createLogProbe("{nullObject}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -127,7 +138,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argArrayTemplate() {
     LogProbe probe = createLogProbe("{primArray} {strArray}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -147,7 +159,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argCollectionTemplate() {
     LogProbe probe = createLogProbe("{strList} {strSet}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -173,7 +186,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argMapTemplate() {
     LogProbe probe = createLogProbe("{strMap}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     Map<String, String> map = new LinkedHashMap<>();
     for (int i = 0; i < 10; i++) {
@@ -201,7 +215,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argComplexObjectTemplate() {
     LogProbe probe = createLogProbe("{obj}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -214,7 +229,8 @@ class StringTemplateBuilderTest {
   @Test
   public void argComplexObjectArrayTemplate() {
     LogProbe probe = createLogProbe("{array}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {
@@ -230,7 +246,8 @@ class StringTemplateBuilderTest {
   @DisabledIf("datadog.environment.JavaVirtualMachine#isJ9")
   public void argInaccessibleFieldTemplate() {
     LogProbe probe = createLogProbe("{obj}");
-    StringTemplateBuilder summaryBuilder = new StringTemplateBuilder(probe.getSegments(), LIMITS);
+    StringTemplateBuilder summaryBuilder =
+        new StringTemplateBuilder(probe.getSegments(), LIMITS, TIMEOUT);
     CapturedContext capturedContext = new CapturedContext();
     capturedContext.addArguments(
         new CapturedContext.CapturedValue[] {


### PR DESCRIPTION
# What Does This Do
Log template evaluation is now limited by a timeout. For tests this timeout maybe too short in some situation. Refactor StringTemplateBuilder timeout to store the default value in probes so we can build probe with a custom timeout for tests. Add custom eval timeout for LogPRobeInstrumentationTest

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
