### PR TITLE
Report failed flaky tests as skip

### DIFF
--- a/.gitlab/collect-result/CollectResults.java
+++ b/.gitlab/collect-result/CollectResults.java
@@ -3,12 +3,15 @@ import java.util.List;
 
 class CollectResults {
   public static void main(String[] args) throws Exception {
+    // Detect flaky jobs
+    var continueOnFailure = Boolean.parseBoolean(System.getenv("CONTINUE_ON_FAILURE"));
+    // Run collector
     var collector =
         new ResultCollector(
             Path.of("results"),
             Path.of("workspace"),
-            List.of(Path.of("workspace"), Path.of("buildSrc")));
-
+            List.of(Path.of("workspace"), Path.of("buildSrc")),
+            continueOnFailure);
     collector.collect();
   }
 }

--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -153,20 +153,23 @@ final class JUnitReport {
     }
   }
 
-  /// Downgrades failing testcases to `test.final_status=skip` for jobs that tolerate failures.
+  /// Marks every testcase as `test.final_status=skip` for jobs that tolerate failures.
   ///
   /// The flaky test jobs (`test_flaky`, `test_flaky_inst`) run with `CONTINUE_ON_FAILURE=true`, so
-  /// Gradle test failures are swallowed and a failing flaky test does not fail the job. Reporting
-  /// those failures to Test Optimization as `fail` produces false-positive failure notifications
-  /// and skews SLIs, so we record them as `skip` instead. Passing and skipped tests keep their 
-  /// natural status, so the tests stay visible in Test Optimization.
+  /// their result never gates the pipeline: it runs to completion regardless of pass or fail.
+  /// `test.final_status` records that CI impact rather than the raw outcome, so every test in these
+  /// jobs is `skip` — a failure is a non-blocking failure and a pass is a non-blocking pass. This
+  /// keeps flaky failures from creating false-positive notifications and skewing SLIs, while the
+  /// real per-test outcome stays available in `test.status` (derived from the `<failure>`,
+  /// `<error>`, and `<skipped>` children, which are left in place). Always-green tests that could
+  /// leave the flaky pipeline are then found with `@test.status:pass @test.final_status:skip`.
   ///
-  /// **Must run before {@link #tagFinalStatuses()}** so the natural `fail` status is never assigned
-  /// to these testcases. Testcases already tagged by {@link #tagRetriedAttempts()} or
-  /// {@link #tagSyntheticFailures()} are left untouched.
-  void tagFailuresAsSkipped() {
+  /// **Must run before {@link #tagFinalStatuses()}** so the natural pass/fail status is never
+  /// assigned. Testcases already tagged by {@link #tagRetriedAttempts()} or
+  /// {@link #tagSyntheticFailures()} are left untouched (already `skip`).
+  void tagAllAsSkipped() {
     for (var testcase : testcases()) {
-      if (hasFinalStatusProperty(testcase) || !isFailed(testcase)) {
+      if (hasFinalStatusProperty(testcase)) {
         continue;
       }
       addFinalStatusProperty(testcase, "skip", MissingPropertiesPlacement.FIRST_CHILD);
@@ -259,17 +262,13 @@ final class JUnitReport {
   }
 
   private static String finalStatus(Element testcase) {
-    if (isFailed(testcase)) {
+    if (hasChildElement(testcase, "failure") || hasChildElement(testcase, "error")) {
       return "fail";
     }
     if (hasChildElement(testcase, "skipped")) {
       return "skip";
     }
     return "pass";
-  }
-
-  private static boolean isFailed(Element testcase) {
-    return hasChildElement(testcase, "failure") || hasChildElement(testcase, "error");
   }
 
   private static Element firstChildElement(Element parent, String tagName) {

--- a/.gitlab/collect-result/JUnitReport.java
+++ b/.gitlab/collect-result/JUnitReport.java
@@ -153,6 +153,26 @@ final class JUnitReport {
     }
   }
 
+  /// Downgrades failing testcases to `test.final_status=skip` for jobs that tolerate failures.
+  ///
+  /// The flaky test jobs (`test_flaky`, `test_flaky_inst`) run with `CONTINUE_ON_FAILURE=true`, so
+  /// Gradle test failures are swallowed and a failing flaky test does not fail the job. Reporting
+  /// those failures to Test Optimization as `fail` produces false-positive failure notifications
+  /// and skews SLIs, so we record them as `skip` instead. Passing and skipped tests keep their 
+  /// natural status, so the tests stay visible in Test Optimization.
+  ///
+  /// **Must run before {@link #tagFinalStatuses()}** so the natural `fail` status is never assigned
+  /// to these testcases. Testcases already tagged by {@link #tagRetriedAttempts()} or
+  /// {@link #tagSyntheticFailures()} are left untouched.
+  void tagFailuresAsSkipped() {
+    for (var testcase : testcases()) {
+      if (hasFinalStatusProperty(testcase) || !isFailed(testcase)) {
+        continue;
+      }
+      addFinalStatusProperty(testcase, "skip", MissingPropertiesPlacement.FIRST_CHILD);
+    }
+  }
+
   void write(Path xmlFile) throws Exception {
     Files.createDirectories(xmlFile.getParent());
     var tmpFile = Files.createTempFile(xmlFile.getParent(), "collect-results-", ".xml");
@@ -239,13 +259,17 @@ final class JUnitReport {
   }
 
   private static String finalStatus(Element testcase) {
-    if (hasChildElement(testcase, "failure") || hasChildElement(testcase, "error")) {
+    if (isFailed(testcase)) {
       return "fail";
     }
     if (hasChildElement(testcase, "skipped")) {
       return "skip";
     }
     return "pass";
+  }
+
+  private static boolean isFailed(Element testcase) {
+    return hasChildElement(testcase, "failure") || hasChildElement(testcase, "error");
   }
 
   private static Element firstChildElement(Element parent, String tagName) {

--- a/.gitlab/collect-result/ResultCollector.java
+++ b/.gitlab/collect-result/ResultCollector.java
@@ -13,12 +13,15 @@ final class ResultCollector {
   private final Path resultsDir;
   private final Path workspaceDir;
   private final List<Path> searchDirs;
+  private final boolean continueOnFailure;
   private final SourceFileResolver sourceFileResolver;
 
-  ResultCollector(Path resultsDir, Path workspaceDir, List<Path> searchDirs) {
+  ResultCollector(
+      Path resultsDir, Path workspaceDir, List<Path> searchDirs, boolean continueOnFailure) {
     this.resultsDir = resultsDir;
     this.workspaceDir = workspaceDir;
     this.searchDirs = searchDirs;
+    this.continueOnFailure = continueOnFailure;
     this.sourceFileResolver = new SourceFileResolver(workspaceDir);
   }
 
@@ -30,6 +33,11 @@ final class ResultCollector {
     if (testResultDirs.isEmpty()) {
       System.out.println("No test results found");
       return;
+    }
+
+    if (continueOnFailure) {
+      System.out.println(
+          "CONTINUE_ON_FAILURE=true: reporting failed tests as skip");
     }
 
     System.out.println("Saving test results:");
@@ -51,6 +59,10 @@ final class ResultCollector {
     report.tagRetriedAttempts();
     reportChangedBeforeFinalStatus |= report.normalizeStableTestNames();
     report.tagSyntheticFailures();
+    // On flaky jobs, downgrade failures to skip before assigning natural statuses (APMLP-1267).
+    if (continueOnFailure) {
+      report.tagFailuresAsSkipped();
+    }
     report.tagFinalStatuses();
     report.write(targetXml);
 

--- a/.gitlab/collect-result/ResultCollector.java
+++ b/.gitlab/collect-result/ResultCollector.java
@@ -36,8 +36,7 @@ final class ResultCollector {
     }
 
     if (continueOnFailure) {
-      System.out.println(
-          "CONTINUE_ON_FAILURE=true: reporting failed tests as skip");
+      System.out.println("CONTINUE_ON_FAILURE=true: reporting all tests as skip");
     }
 
     System.out.println("Saving test results:");
@@ -59,9 +58,10 @@ final class ResultCollector {
     report.tagRetriedAttempts();
     reportChangedBeforeFinalStatus |= report.normalizeStableTestNames();
     report.tagSyntheticFailures();
-    // On flaky jobs, downgrade failures to skip before assigning natural statuses (APMLP-1267).
+    // Flaky jobs (CONTINUE_ON_FAILURE=true) never gate CI, so record every test as skip before
+    // assigning natural statuses (APMLP-1267).
     if (continueOnFailure) {
-      report.tagFailuresAsSkipped();
+      report.tagAllAsSkipped();
     }
     report.tagFinalStatuses();
     report.write(targetXml);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ docs/                     Developer documentation (see below)
 
 - Title: imperative verb sentence describing user-visible change (e.g. "Fix span sampling rule parsing")
 - Labels: always add `tag: ai generated` and at least one `comp:` or `inst:` label + one `type:` label
-- Use `tag: no release note` for internal/refactoring changes
+- Use `tag: no release notes` for internal/refactoring changes
 - Open as draft first, convert to ready when reviewable
 
 ## Bootstrap constraints (critical)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Both pull requests and issues should be labelled with at least a component or an
 
 Labels are used to not only categorize but also alter the continuous integration behavior:
 
-* `tag: no release note` to exclude a pull request from the next release changelog. Use it when changes are not relevant to the users like:
+* `tag: no release notes` to exclude a pull request from the next release changelog. Use it when changes are not relevant to the users like:
   * Internal features changes
   * Refactoring pull requests
   * CI and build tools improvements


### PR DESCRIPTION
# What Does This Do

This PR updates the test result collector to mark the failed flaky tests as skip.

# Motivation

Avoid reporting "failures" to the Test Optimization product.

# Additional Notes

It additionally fixes a typo for the release notes tag documentation.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [APMLP-1267]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1267]: https://datadoghq.atlassian.net/browse/APMLP-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ