### PR TITLE
Add offline Feature Flagging reference implementation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -528,6 +528,9 @@ public class Agent {
     if (flareEnabled) {
       stopFlarePoller();
     }
+    if (featureFlaggingEnabled) {
+      shutdownFeatureFlagging(AGENT_CLASSLOADER);
+    }
 
     if (agentlessLogSubmissionEnabled) {
       shutdownLogsIntake();
@@ -1176,6 +1179,20 @@ public class Agent {
       }
 
       StaticEventLogger.end("Feature Flagging");
+    }
+  }
+
+  static void shutdownFeatureFlagging(final ClassLoader agentClassLoader) {
+    if (agentClassLoader == null) {
+      return;
+    }
+    try {
+      final Class<?> ffSysClass =
+          agentClassLoader.loadClass("com.datadog.featureflag.FeatureFlaggingSystem");
+      final Method stopMethod = ffSysClass.getMethod("stop");
+      stopMethod.invoke(null);
+    } catch (final Throwable e) {
+      log.warn("Unable to stop Feature Flagging subsystem", e);
     }
   }
 

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentFeatureFlaggingLifecycleTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/AgentFeatureFlaggingLifecycleTest.java
@@ -1,0 +1,48 @@
+package datadog.trace.bootstrap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentFeatureFlaggingLifecycleTest {
+
+  @BeforeEach
+  void reset() {
+    FakeFeatureFlaggingSystem.stopCalls.set(0);
+  }
+
+  @Test
+  void shutdownInvokesFeatureFlaggingSystemStopThroughAgentClassLoader() {
+    final ClassLoader classLoader =
+        new ClassLoader(null) {
+          @Override
+          public Class<?> loadClass(final String name) throws ClassNotFoundException {
+            if ("com.datadog.featureflag.FeatureFlaggingSystem".equals(name)) {
+              return FakeFeatureFlaggingSystem.class;
+            }
+            return super.loadClass(name);
+          }
+        };
+
+    Agent.shutdownFeatureFlagging(classLoader);
+
+    assertEquals(1, FakeFeatureFlaggingSystem.stopCalls.get());
+  }
+
+  @Test
+  void shutdownIsNoopBeforeAgentClassLoaderExists() {
+    Agent.shutdownFeatureFlagging(null);
+
+    assertEquals(0, FakeFeatureFlaggingSystem.stopCalls.get());
+  }
+
+  public static final class FakeFeatureFlaggingSystem {
+    private static final AtomicInteger stopCalls = new AtomicInteger();
+
+    public static void stop() {
+      stopCalls.incrementAndGet();
+    }
+  }
+}

--- a/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
+++ b/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
@@ -42,6 +42,7 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
     command.addAll(['-jar', springBootShadowJar, "--server.port=${httpPort}".toString()])
     final builder = new ProcessBuilder(command).directory(new File(buildDirectory))
     builder.environment().put('DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED', 'true')
+    builder.environment().put('DD_FEATURE_FLAGS_CONFIGURATION_SOURCE', 'remote_config')
     return builder
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -49,6 +49,10 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_INJECT_DATADOG_ATTRIBUTE = true;
   static final String DEFAULT_SITE = "datadoghq.com";
 
+  public static final String DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE = "agentless";
+  public static final int DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS = 30;
+  public static final int DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS = 2;
+
   static final boolean DEFAULT_CODE_ORIGIN_FOR_SPANS_INTERFACE_SUPPORT = false;
   static final int DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES = 8;
   static final boolean DEFAULT_TRACE_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/FeatureFlaggingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/FeatureFlaggingConfig.java
@@ -3,4 +3,15 @@ package datadog.trace.api.config;
 public class FeatureFlaggingConfig {
 
   public static final String FLAGGING_PROVIDER_ENABLED = "experimental.flagging.provider.enabled";
+
+  public static final String FEATURE_FLAGS_CONFIGURATION_SOURCE =
+      "feature.flags.configuration.source";
+  public static final String FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL =
+      "feature.flags.configuration.source.agentless.base.url";
+  public static final String FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS =
+      "feature.flags.configuration.source.agentless.poll.interval.seconds";
+  public static final String FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS =
+      "feature.flags.configuration.source.agentless.request.timeout.seconds";
+
+  private FeatureFlaggingConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -86,6 +86,9 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_BODY_AND_PA
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_BODY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_PARAMS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_EXPERIMENTATAL_JEE_SPLIT_BY_DEPLOYMENT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
@@ -361,6 +364,10 @@ import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_DETECTION_INCL
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_EXCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_INCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.THIRD_PARTY_SHADING_IDENTIFIERS;
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE;
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL;
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS;
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE;
 import static datadog.trace.api.config.GeneralConfig.AGENTLESS_LOG_SUBMISSION_URL;
@@ -1212,6 +1219,11 @@ public class Config {
   private final String remoteConfigTargetsKey;
 
   private final int remoteConfigMaxExtraServices;
+
+  private final String featureFlaggingConfigurationSource;
+  private final String featureFlaggingConfigurationSourceAgentlessBaseUrl;
+  private final int featureFlaggingConfigurationSourcePollIntervalSeconds;
+  private final int featureFlaggingConfigurationSourceRequestTimeoutSeconds;
 
   private final boolean dbmInjectSqlBaseHash;
   private final String dbmPropagationMode;
@@ -2837,6 +2849,40 @@ public class Config {
         configProvider.getInteger(
             REMOTE_CONFIG_MAX_EXTRA_SERVICES, DEFAULT_REMOTE_CONFIG_MAX_EXTRA_SERVICES);
 
+    featureFlaggingConfigurationSource =
+        normalizeFeatureFlaggingConfigurationSource(
+            configProvider.getString(
+                FEATURE_FLAGS_CONFIGURATION_SOURCE, DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE));
+    featureFlaggingConfigurationSourceAgentlessBaseUrl =
+        configProvider.getStringNotEmpty(
+            FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL, null);
+    int configuredFeatureFlaggingPollIntervalSeconds =
+        configProvider.getInteger(
+            FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS,
+            DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS);
+    if (configuredFeatureFlaggingPollIntervalSeconds <= 0) {
+      log.warn(
+          "Invalid Feature Flagging agentless poll interval: {}. The value must be positive",
+          configuredFeatureFlaggingPollIntervalSeconds);
+      configuredFeatureFlaggingPollIntervalSeconds =
+          DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS;
+    }
+    featureFlaggingConfigurationSourcePollIntervalSeconds =
+        configuredFeatureFlaggingPollIntervalSeconds;
+    int configuredFeatureFlaggingRequestTimeoutSeconds =
+        configProvider.getInteger(
+            FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS,
+            DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS);
+    if (configuredFeatureFlaggingRequestTimeoutSeconds <= 0) {
+      log.warn(
+          "Invalid Feature Flagging agentless request timeout: {}. The value must be positive",
+          configuredFeatureFlaggingRequestTimeoutSeconds);
+      configuredFeatureFlaggingRequestTimeoutSeconds =
+          DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS;
+    }
+    featureFlaggingConfigurationSourceRequestTimeoutSeconds =
+        configuredFeatureFlaggingRequestTimeoutSeconds;
+
     dynamicInstrumentationEnabled =
         configProvider.getBoolean(
             DYNAMIC_INSTRUMENTATION_ENABLED, DEFAULT_DYNAMIC_INSTRUMENTATION_ENABLED);
@@ -3749,6 +3795,14 @@ public class Config {
     return traceInferredProxyEnabled;
   }
 
+  private static String normalizeFeatureFlaggingConfigurationSource(final String source) {
+    if (source == null) {
+      return DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE;
+    }
+    final String normalized = source.trim().toLowerCase(Locale.ROOT);
+    return normalized.isEmpty() ? DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE : normalized;
+  }
+
   public boolean isBaggageExtract() {
     return tracePropagationStylesToExtract.contains(TracePropagationStyle.BAGGAGE);
   }
@@ -4654,6 +4708,22 @@ public class Config {
 
   public int getRemoteConfigMaxExtraServices() {
     return remoteConfigMaxExtraServices;
+  }
+
+  public String getFeatureFlaggingConfigurationSource() {
+    return featureFlaggingConfigurationSource;
+  }
+
+  public String getFeatureFlaggingConfigurationSourceAgentlessBaseUrl() {
+    return featureFlaggingConfigurationSourceAgentlessBaseUrl;
+  }
+
+  public int getFeatureFlaggingConfigurationSourcePollIntervalSeconds() {
+    return featureFlaggingConfigurationSourcePollIntervalSeconds;
+  }
+
+  public int getFeatureFlaggingConfigurationSourceRequestTimeoutSeconds() {
+    return featureFlaggingConfigurationSourceRequestTimeoutSeconds;
   }
 
   public boolean isDynamicInstrumentationEnabled() {
@@ -6488,6 +6558,14 @@ public class Config {
         + remoteConfigMaxPayloadSize
         + ", remoteConfigIntegrityCheckEnabled="
         + remoteConfigIntegrityCheckEnabled
+        + ", featureFlaggingConfigurationSource="
+        + featureFlaggingConfigurationSource
+        + ", featureFlaggingConfigurationSourceAgentlessBaseUrl="
+        + featureFlaggingConfigurationSourceAgentlessBaseUrl
+        + ", featureFlaggingConfigurationSourcePollIntervalSeconds="
+        + featureFlaggingConfigurationSourcePollIntervalSeconds
+        + ", featureFlaggingConfigurationSourceRequestTimeoutSeconds="
+        + featureFlaggingConfigurationSourceRequestTimeoutSeconds
         + ", debuggerEnabled="
         + dynamicInstrumentationEnabled
         + ", debuggerUploadTimeout="

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -66,7 +66,8 @@ public final class AgentThreadFactory implements ThreadFactory {
 
     LLMOBS_EVALS_PROCESSOR("dd-llmobs-evals-processor"),
 
-    FEATURE_FLAG_EXPOSURE_PROCESSOR("dd-ffe-exposure-processor");
+    FEATURE_FLAG_EXPOSURE_PROCESSOR("dd-ffe-exposure-processor"),
+    FEATURE_FLAG_CONFIGURATION_POLLER("dd-feature-flagging-http-poller");
 
     public final String threadName;
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -2,6 +2,8 @@ package datadog.trace.api
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+import static datadog.trace.api.ConfigDefaults.DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS
+import static datadog.trace.api.ConfigDefaults.DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL
@@ -55,6 +57,8 @@ import static datadog.trace.api.config.GeneralConfig.TAGS
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES
 import static datadog.trace.api.config.GeneralConfig.TRACE_OTEL_SEMANTICS_ENABLED
 import static datadog.trace.api.config.GeneralConfig.VERSION
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_ENABLED
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS
@@ -3477,5 +3481,33 @@ class ConfigTest extends DDSpecification {
     "false" | false
     "1"     | true
     "0"     | false
+  }
+
+  def "agentless feature flag timing uses positive configured values"() {
+    setup:
+    Properties properties = new Properties()
+    properties.setProperty(FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS, "60")
+    properties.setProperty(FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS, "4")
+
+    when:
+    def config = new Config(ConfigProvider.withPropertiesOverride(properties))
+
+    then:
+    config.featureFlaggingConfigurationSourcePollIntervalSeconds == 60
+    config.featureFlaggingConfigurationSourceRequestTimeoutSeconds == 4
+  }
+
+  def "agentless feature flag timing falls back for non-positive values"() {
+    setup:
+    Properties properties = new Properties()
+    properties.setProperty(FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS, "0")
+    properties.setProperty(FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS, "-1")
+
+    when:
+    def config = new Config(ConfigProvider.withPropertiesOverride(properties))
+
+    then:
+    config.featureFlaggingConfigurationSourcePollIntervalSeconds == DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_POLL_INTERVAL_SECONDS
+    config.featureFlaggingConfigurationSourceRequestTimeoutSeconds == DEFAULT_FEATURE_FLAGGING_CONFIGURATION_SOURCE_REQUEST_TIMEOUT_SECONDS
   }
 }

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -1497,6 +1497,38 @@
         "aliases": []
       }
     ],
+    "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": "agentless",
+        "aliases": []
+      }
+    ],
+    "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
+    "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": [
+      {
+        "version": "A",
+        "type": "int",
+        "default": "30",
+        "aliases": []
+      }
+    ],
+    "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": [
+      {
+        "version": "A",
+        "type": "int",
+        "default": "2",
+        "aliases": []
+      }
+    ],
     "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED": [
       {
         "version": "A",

--- a/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
+++ b/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
@@ -14,31 +14,93 @@ public class FeatureFlaggingSystem {
 
   private FeatureFlaggingSystem() {}
 
-  public static void start(final SharedCommunicationObjects sco) {
+  public static synchronized void start(final SharedCommunicationObjects sco) {
+    if (CONFIG_SERVICE != null || EXPOSURE_WRITER != null) {
+      LOGGER.debug("Feature Flagging system already started");
+      return;
+    }
     LOGGER.debug("Feature Flagging system starting");
     final Config config = Config.get();
-
-    if (!config.isRemoteConfigEnabled()) {
-      throw new IllegalStateException("Feature Flagging system started without RC");
-    }
-    CONFIG_SERVICE = new RemoteConfigServiceImpl(sco, config);
-    CONFIG_SERVICE.init();
-
-    EXPOSURE_WRITER = new ExposureWriterImpl(sco, config);
-    EXPOSURE_WRITER.init();
+    final ConfigurationSourceService configService = createConfigurationSourceService(sco, config);
+    final ExposureWriter exposureWriter = new ExposureWriterImpl(sco, config);
+    initialize(configService, exposureWriter);
 
     LOGGER.debug("Feature Flagging system started");
   }
 
-  public static void stop() {
-    if (EXPOSURE_WRITER != null) {
-      EXPOSURE_WRITER.close();
-      EXPOSURE_WRITER = null;
+  static void initialize(
+      final ConfigurationSourceService configService, final ExposureWriter exposureWriter) {
+    try {
+      if (configService != null) {
+        configService.init();
+      }
+      exposureWriter.init();
+      CONFIG_SERVICE = configService;
+      EXPOSURE_WRITER = exposureWriter;
+    } catch (final RuntimeException | Error e) {
+      exposureWriter.close();
+      if (configService != null) {
+        configService.close();
+      }
+      throw e;
     }
-    if (CONFIG_SERVICE != null) {
-      CONFIG_SERVICE.close();
-      CONFIG_SERVICE = null;
+  }
+
+  static ConfigurationSourceService createConfigurationSourceService(
+      final SharedCommunicationObjects sco, final Config config) {
+    final ConfigurationSource configurationSource =
+        ConfigurationSource.from(config.getFeatureFlaggingConfigurationSource());
+
+    if (configurationSource == ConfigurationSource.REMOTE_CONFIG) {
+      if (!config.isRemoteConfigEnabled()) {
+        throw new IllegalStateException("Feature Flagging system started without RC");
+      }
+      return new RemoteConfigServiceImpl(sco, config);
+    }
+    if (configurationSource == ConfigurationSource.AGENTLESS) {
+      return new AgentlessConfigurationSource(config);
+    }
+    LOGGER.debug(
+        "Feature Flagging offline configuration source selected; no config service started");
+    return null;
+  }
+
+  public static synchronized void stop() {
+    final ExposureWriter exposureWriter = EXPOSURE_WRITER;
+    final ConfigurationSourceService configService = CONFIG_SERVICE;
+    EXPOSURE_WRITER = null;
+    CONFIG_SERVICE = null;
+    try {
+      if (exposureWriter != null) {
+        exposureWriter.close();
+      }
+    } finally {
+      if (configService != null) {
+        configService.close();
+      }
     }
     LOGGER.debug("Feature Flagging system stopped");
+  }
+
+  private enum ConfigurationSource {
+    AGENTLESS("agentless"),
+    REMOTE_CONFIG("remote_config"),
+    OFFLINE("offline");
+
+    private final String value;
+
+    ConfigurationSource(final String value) {
+      this.value = value;
+    }
+
+    private static ConfigurationSource from(final String value) {
+      for (final ConfigurationSource source : values()) {
+        if (source.value.equals(value)) {
+          return source;
+        }
+      }
+      throw new IllegalArgumentException(
+          "Unsupported Feature Flagging configuration source: " + value);
+    }
   }
 }

--- a/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
+++ b/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
@@ -60,9 +60,7 @@ public class FeatureFlaggingSystem {
     if (configurationSource == ConfigurationSource.AGENTLESS) {
       return new AgentlessConfigurationSource(config);
     }
-    LOGGER.debug(
-        "Feature Flagging offline configuration source selected; no config service started");
-    return null;
+    return new OfflineConfigurationSource();
   }
 
   public static synchronized void stop() {

--- a/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
+++ b/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
@@ -9,7 +9,7 @@ public class FeatureFlaggingSystem {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FeatureFlaggingSystem.class);
 
-  private static volatile RemoteConfigService CONFIG_SERVICE;
+  private static volatile ConfigurationSourceService CONFIG_SERVICE;
   private static volatile ExposureWriter EXPOSURE_WRITER;
 
   private FeatureFlaggingSystem() {}

--- a/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
+++ b/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
@@ -1,5 +1,6 @@
 package com.datadog.featureflag;
 
+import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.Test;
 class FeatureFlaggingSystemTest {
 
   @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "remote_config")
+  @WithConfig(key = REMOTE_CONFIGURATION_ENABLED, value = "true")
   void testFeatureFlagSystemInitialization() {
     ConfigurationPoller poller = mock(ConfigurationPoller.class);
     DDAgentFeaturesDiscovery discovery = mock(DDAgentFeaturesDiscovery.class);
@@ -48,6 +51,7 @@ class FeatureFlaggingSystemTest {
   }
 
   @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "remote_config")
   @WithConfig(key = REMOTE_CONFIGURATION_ENABLED, value = "false")
   void testThatRemoteConfigIsRequired() {
     SharedCommunicationObjects sharedCommunicationObjects = mock(SharedCommunicationObjects.class);

--- a/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
+++ b/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
@@ -4,7 +4,6 @@ import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFI
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -107,15 +106,16 @@ class FeatureFlaggingSystemTest {
 
   @Test
   @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "offline")
-  void offlineConfigurationSourceDoesNotStartNetworkSource() {
-    assertNull(
+  void offlineConfigurationSourceUsesStartupBytesService() {
+    assertInstanceOf(
+        OfflineConfigurationSource.class,
         FeatureFlaggingSystem.createConfigurationSourceService(
             sharedCommunicationObjects(), Config.get()));
   }
 
   @Test
   @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "offline")
-  void startWithOfflineConfigurationSourceSkipsConfigService() {
+  void startWithOfflineConfigurationSourceRegistersConfigService() {
     try {
       assertDoesNotThrow(() -> FeatureFlaggingSystem.start(sharedCommunicationObjects()));
     } finally {

--- a/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
+++ b/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
@@ -2,9 +2,13 @@ package com.datadog.featureflag;
 
 import static datadog.trace.api.config.FeatureFlaggingConfig.FEATURE_FLAGS_CONFIGURATION_SOURCE;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,11 +42,13 @@ class FeatureFlaggingSystemTest {
     sharedCommunicationObjects.agentHttpClient = new OkHttpClient.Builder().build();
 
     FeatureFlaggingSystem.start(sharedCommunicationObjects);
+    FeatureFlaggingSystem.start(sharedCommunicationObjects);
 
     verify(poller).addCapabilities(Capabilities.CAPABILITY_FFE_FLAG_CONFIGURATION_RULES);
     verify(poller).addListener(eq(Product.FFE_FLAGS), any(ConfigurationDeserializer.class), any());
     verify(poller).start();
 
+    FeatureFlaggingSystem.stop();
     FeatureFlaggingSystem.stop();
 
     verify(poller).removeCapabilities(Capabilities.CAPABILITY_FFE_FLAG_CONFIGURATION_RULES);
@@ -63,5 +69,94 @@ class FeatureFlaggingSystemTest {
     } finally {
       FeatureFlaggingSystem.stop();
     }
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "agentless")
+  @WithConfig(key = REMOTE_CONFIGURATION_ENABLED, value = "false")
+  void agentlessConfigurationSourceUsesHttpServiceWithoutRemoteConfig() {
+    assertInstanceOf(
+        AgentlessConfigurationSource.class,
+        FeatureFlaggingSystem.createConfigurationSourceService(
+            sharedCommunicationObjects(), Config.get()));
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "remote_config")
+  @WithConfig(key = REMOTE_CONFIGURATION_ENABLED, value = "true")
+  void explicitRemoteConfigUsesRemoteConfigService() {
+    SharedCommunicationObjects sharedCommunicationObjects = sharedCommunicationObjects();
+    when(sharedCommunicationObjects.configurationPoller(any(Config.class)))
+        .thenReturn(mock(ConfigurationPoller.class));
+
+    assertInstanceOf(
+        RemoteConfigServiceImpl.class,
+        FeatureFlaggingSystem.createConfigurationSourceService(
+            sharedCommunicationObjects, Config.get()));
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "invalid")
+  void invalidConfigurationSourceFailsBeforeStartingNetworkSource() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            FeatureFlaggingSystem.createConfigurationSourceService(
+                sharedCommunicationObjects(), Config.get()));
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "offline")
+  void offlineConfigurationSourceDoesNotStartNetworkSource() {
+    assertNull(
+        FeatureFlaggingSystem.createConfigurationSourceService(
+            sharedCommunicationObjects(), Config.get()));
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "offline")
+  void startWithOfflineConfigurationSourceSkipsConfigService() {
+    try {
+      assertDoesNotThrow(() -> FeatureFlaggingSystem.start(sharedCommunicationObjects()));
+    } finally {
+      FeatureFlaggingSystem.stop();
+    }
+  }
+
+  @Test
+  void initializationFailureClosesConfigurationSourceAndExposureWriter() {
+    ConfigurationSourceService configService = mock(ConfigurationSourceService.class);
+    ExposureWriter exposureWriter = mock(ExposureWriter.class);
+    doThrow(new IllegalStateException("exposure init failed")).when(exposureWriter).init();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> FeatureFlaggingSystem.initialize(configService, exposureWriter));
+
+    verify(configService).init();
+    verify(configService).close();
+    verify(exposureWriter).close();
+  }
+
+  @Test
+  void initializationFailureWithoutConfigurationSourceClosesExposureWriter() {
+    ExposureWriter exposureWriter = mock(ExposureWriter.class);
+    doThrow(new IllegalStateException("exposure init failed")).when(exposureWriter).init();
+
+    assertThrows(
+        IllegalStateException.class, () -> FeatureFlaggingSystem.initialize(null, exposureWriter));
+
+    verify(exposureWriter).close();
+  }
+
+  private static SharedCommunicationObjects sharedCommunicationObjects() {
+    DDAgentFeaturesDiscovery discovery = mock(DDAgentFeaturesDiscovery.class);
+    when(discovery.supportsEvpProxy()).thenReturn(true);
+    when(discovery.getEvpProxyEndpoint()).thenReturn("/evp_proxy/");
+    SharedCommunicationObjects sharedCommunicationObjects = mock(SharedCommunicationObjects.class);
+    when(sharedCommunicationObjects.featuresDiscovery(any(Config.class))).thenReturn(discovery);
+    sharedCommunicationObjects.agentUrl = HttpUrl.get("http://localhost");
+    sharedCommunicationObjects.agentHttpClient = new OkHttpClient.Builder().build();
+    return sharedCommunicationObjects;
   }
 }

--- a/products/feature-flagging/feature-flagging-api/README.md
+++ b/products/feature-flagging/feature-flagging-api/README.md
@@ -55,6 +55,24 @@ boolean enabled = client.getBooleanValue("my-feature", false,
     new MutableContext("user-123"));
 ```
 
+### Offline startup configuration
+
+Offline mode accepts a complete UFC JSON payload at provider startup and does not subscribe to a
+network configuration source:
+
+```shell
+DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=offline
+```
+
+```java
+byte[] ufc = Files.readAllBytes(Path.of("flags.json"));
+Provider.Options options = new Provider.Options().offlineConfiguration(ufc);
+OpenFeatureAPI.getInstance().setProviderAndWait(new Provider(options));
+```
+
+The provider copies the payload and applies it once. Invalid or missing bytes fail initialization;
+runtime configuration updates are not supported in offline mode.
+
 ## Evaluation metrics
 
 When `DD_METRICS_OTEL_ENABLED=true` and the OpenTelemetry API is on the classpath, the provider
@@ -90,6 +108,5 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
   different HTTP backend while keeping agentless delivery semantics. A bare
   host uses the standard server-distribution path; a URL with a path is used as
   the exact UFC endpoint. `remote_config` uses the existing Agent Remote
-  Configuration path. `offline` is reserved for startup-provided UFC bytes;
-  until those bytes are implemented, no network source starts and evaluations
-  use defaults.
+  Configuration path. `offline` requires startup-provided UFC bytes and starts
+  neither the agentless poller nor the FFE Remote Configuration subscription.

--- a/products/feature-flagging/feature-flagging-api/README.md
+++ b/products/feature-flagging/feature-flagging-api/README.md
@@ -85,5 +85,11 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ## Requirements
 
 - Java 11+
-- Datadog Agent with Remote Configuration enabled
-- `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`
+- `DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=agentless` uses the Datadog agentless
+  backend. Set `DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL` to a
+  different HTTP backend while keeping agentless delivery semantics. A bare
+  host uses the standard server-distribution path; a URL with a path is used as
+  the exact UFC endpoint. `remote_config` uses the existing Agent Remote
+  Configuration path. `offline` is reserved for startup-provided UFC bytes;
+  until those bytes are implemented, no network source starts and evaluations
+  use defaults.

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/Provider.java
@@ -2,6 +2,7 @@ package datadog.trace.api.openfeature;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
@@ -65,6 +66,12 @@ public class Provider extends EventProvider implements Metadata {
     initializationState.set(InitializationState.INITIALIZING);
     try {
       evaluator = buildEvaluator();
+      final byte[] offlineConfiguration = options.getOfflineConfiguration();
+      if (offlineConfiguration != null
+          && !FeatureFlaggingGateway.dispatchOfflineConfiguration(offlineConfiguration)) {
+        throw new FatalError(
+            "Offline configuration requires DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=offline");
+      }
       if (!evaluator.initialize(options.getTimeout(), options.getUnit(), context)) {
         if (markInitialConfigReceivedReady()) {
           return;
@@ -238,12 +245,30 @@ public class Provider extends EventProvider implements Metadata {
 
   public static class Options {
 
-    private long timeout;
-    private TimeUnit unit;
+    private long timeout = 30;
+    private TimeUnit unit = SECONDS;
+    private byte[] offlineConfiguration;
 
     public Options initTimeout(final long timeout, final TimeUnit unit) {
       this.timeout = timeout;
       this.unit = unit;
+      return this;
+    }
+
+    /**
+     * Supplies the complete UFC JSON payload used for startup-only offline evaluation.
+     *
+     * <p>This option requires {@code DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=offline}. The payload is
+     * copied and does not receive runtime updates.
+     *
+     * @param configuration complete UFC JSON bytes
+     * @return this options instance
+     */
+    public Options offlineConfiguration(final byte[] configuration) {
+      if (configuration == null || configuration.length == 0) {
+        throw new IllegalArgumentException("Offline configuration must not be empty");
+      }
+      this.offlineConfiguration = configuration.clone();
       return this;
     }
 
@@ -253,6 +278,10 @@ public class Provider extends EventProvider implements Metadata {
 
     public TimeUnit getUnit() {
       return unit;
+    }
+
+    byte[] getOfflineConfiguration() {
+      return offlineConfiguration == null ? null : offlineConfiguration.clone();
     }
   }
 }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -7,6 +7,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -92,6 +94,56 @@ public class ProviderTest {
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
     provider.get(1, SECONDS);
+  }
+
+  @Test
+  public void testOfflineConfigurationIsDispatchedBeforeEvaluatorInitialization() throws Exception {
+    final byte[] configuration = {1, 2, 3};
+    final FeatureFlaggingGateway.OfflineConfigListener listener =
+        mock(FeatureFlaggingGateway.OfflineConfigListener.class);
+    final Evaluator evaluator = mock(Evaluator.class);
+    when(evaluator.initialize(eq(30L), eq(SECONDS), any())).thenReturn(true);
+    when(evaluator.hasConfiguration()).thenReturn(true);
+    FeatureFlaggingGateway.addOfflineConfigListener(listener);
+
+    try {
+      final Provider provider =
+          new Provider(new Options().offlineConfiguration(configuration), evaluator);
+
+      provider.initialize(null);
+
+      verify(listener).accept(configuration);
+      verify(evaluator).initialize(30, SECONDS, null);
+    } finally {
+      FeatureFlaggingGateway.removeOfflineConfigListener(listener);
+    }
+  }
+
+  @Test
+  public void testOfflineConfigurationRequiresOfflineSource() {
+    final Provider provider =
+        new Provider(
+            new Options().initTimeout(10, MILLISECONDS).offlineConfiguration(new byte[] {1}),
+            mock(Evaluator.class));
+
+    assertThrows(FatalError.class, () -> provider.initialize(null));
+  }
+
+  @Test
+  public void testOfflineConfigurationIsDefensivelyCopied() {
+    final byte[] configuration = {1, 2, 3};
+    final Options options = new Options().offlineConfiguration(configuration);
+
+    configuration[0] = 9;
+    final byte[] firstCopy = options.getOfflineConfiguration();
+    final byte[] secondCopy = options.getOfflineConfiguration();
+
+    assertArrayEquals(new byte[] {1, 2, 3}, firstCopy);
+    assertArrayEquals(firstCopy, secondCopy);
+    assertNotSame(firstCopy, secondCopy);
+    assertThrows(IllegalArgumentException.class, () -> new Options().offlineConfiguration(null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new Options().offlineConfiguration(new byte[0]));
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
@@ -11,9 +11,13 @@ public abstract class FeatureFlaggingGateway {
 
   public interface ConfigListener extends Consumer<ServerConfiguration> {}
 
+  public interface OfflineConfigListener extends Consumer<byte[]> {}
+
   public interface ExposureListener extends Consumer<ExposureEvent> {}
 
   private static final List<ConfigListener> CONFIG_LISTENERS = new CopyOnWriteArrayList<>();
+  private static final List<OfflineConfigListener> OFFLINE_CONFIG_LISTENERS =
+      new CopyOnWriteArrayList<>();
   private static final List<ExposureListener> EXPOSURE_LISTENERS = new CopyOnWriteArrayList<>();
 
   private static final AtomicReference<ServerConfiguration> CURRENT_CONFIG =
@@ -36,6 +40,23 @@ public abstract class FeatureFlaggingGateway {
   public static void dispatch(final ServerConfiguration config) {
     CURRENT_CONFIG.set(config);
     CONFIG_LISTENERS.forEach(listener -> listener.accept(config));
+  }
+
+  public static void addOfflineConfigListener(final OfflineConfigListener listener) {
+    OFFLINE_CONFIG_LISTENERS.add(listener);
+  }
+
+  public static void removeOfflineConfigListener(final OfflineConfigListener listener) {
+    OFFLINE_CONFIG_LISTENERS.remove(listener);
+  }
+
+  public static boolean dispatchOfflineConfiguration(final byte[] config) {
+    boolean dispatched = false;
+    for (final OfflineConfigListener listener : OFFLINE_CONFIG_LISTENERS) {
+      listener.accept(config.clone());
+      dispatched = true;
+    }
+    return dispatched;
   }
 
   public static void addExposureListener(final ExposureListener listener) {

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/FeatureFlaggingGatewayTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/FeatureFlaggingGatewayTest.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.featureflag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.Test;
 class FeatureFlaggingGatewayTest {
 
   private FeatureFlaggingGateway.ConfigListener configListener;
+  private FeatureFlaggingGateway.OfflineConfigListener offlineConfigListener;
   private FeatureFlaggingGateway.ExposureListener exposureListener;
   private ServerConfiguration firstConfiguration;
   private ServerConfiguration secondConfiguration;
@@ -22,6 +25,7 @@ class FeatureFlaggingGatewayTest {
   @BeforeEach
   void setUp() {
     configListener = mock(FeatureFlaggingGateway.ConfigListener.class);
+    offlineConfigListener = mock(FeatureFlaggingGateway.OfflineConfigListener.class);
     exposureListener = mock(FeatureFlaggingGateway.ExposureListener.class);
     firstConfiguration = mock(ServerConfiguration.class);
     secondConfiguration = mock(ServerConfiguration.class);
@@ -32,7 +36,21 @@ class FeatureFlaggingGatewayTest {
   @AfterEach
   void tearDown() {
     FeatureFlaggingGateway.removeConfigListener(configListener);
+    FeatureFlaggingGateway.removeOfflineConfigListener(offlineConfigListener);
     FeatureFlaggingGateway.removeExposureListener(exposureListener);
+  }
+
+  @Test
+  void testDispatchingOfflineConfiguration() {
+    final byte[] configuration = {1, 2, 3};
+
+    assertFalse(FeatureFlaggingGateway.dispatchOfflineConfiguration(configuration));
+
+    FeatureFlaggingGateway.addOfflineConfigListener(offlineConfigListener);
+
+    assertTrue(FeatureFlaggingGateway.dispatchOfflineConfiguration(configuration));
+    verify(offlineConfigListener).accept(configuration);
+    verifyNoMoreInteractions(offlineConfigListener);
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-lib/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-lib/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   api(project(":communication"))
   implementation(project(":internal-api"))
   api(project(":products:feature-flagging:feature-flagging-bootstrap"))
+  implementation(project(":utils:logging-utils"))
   api(project(":utils:queue-utils"))
 
   compileOnly(project(":dd-trace-core")) // shading does not work with this one

--- a/products/feature-flagging/feature-flagging-lib/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-lib/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   api(libs.moshi)
   api(libs.jctools)
   api(project(":communication"))
+  implementation(project(":internal-api"))
   api(project(":products:feature-flagging:feature-flagging-bootstrap"))
   api(project(":utils:queue-utils"))
 

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
@@ -4,6 +4,7 @@ import static datadog.communication.http.OkHttpUtils.prepareRequest;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.FEATURE_FLAG_CONFIGURATION_POLLER;
 
 import datadog.communication.http.OkHttpUtils;
+import datadog.logging.RatelimitedLogger;
 import datadog.trace.api.Config;
 import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
@@ -38,6 +39,7 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
   private static final String DATADOG_API_SERVER_DISTRIBUTION_PATH =
       "/api/v2/feature-flagging/config/server-distribution";
   private static final int MAX_ATTEMPTS = 3;
+  private static final int MINUTES_BETWEEN_AUTH_WARNINGS = 5;
   private static final long FIRST_RETRY_MIN_MILLIS = 2_000;
   private static final long FIRST_RETRY_MAX_MILLIS = 10_000;
   private static final long SECOND_RETRY_MIN_MILLIS = 5_000;
@@ -51,6 +53,7 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
   private final ScheduledExecutorService executor;
   private final RetrySleeper retrySleeper;
   private final DoubleSupplier jitter;
+  private final RatelimitedLogger ratelimitedLogger;
   private final Object lifecycleLock = new Object();
   private final AtomicBoolean polling = new AtomicBoolean();
   private volatile boolean closed;
@@ -73,7 +76,8 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
         Executors.newSingleThreadScheduledExecutor(
             new AgentThreadFactory(FEATURE_FLAG_CONFIGURATION_POLLER)),
         TimeUnit.MILLISECONDS::sleep,
-        () -> ThreadLocalRandom.current().nextDouble(1 - RETRY_JITTER, 1 + RETRY_JITTER));
+        () -> ThreadLocalRandom.current().nextDouble(1 - RETRY_JITTER, 1 + RETRY_JITTER),
+        new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_AUTH_WARNINGS, TimeUnit.MINUTES));
   }
 
   AgentlessConfigurationSource(
@@ -89,7 +93,8 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
         client,
         executor,
         TimeUnit.MILLISECONDS::sleep,
-        () -> 1.0);
+        () -> 1.0,
+        new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_AUTH_WARNINGS, TimeUnit.MINUTES));
   }
 
   AgentlessConfigurationSource(
@@ -100,6 +105,26 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
       final ScheduledExecutorService executor,
       final RetrySleeper retrySleeper,
       final DoubleSupplier jitter) {
+    this(
+        endpoint,
+        config,
+        pollIntervalMillis,
+        client,
+        executor,
+        retrySleeper,
+        jitter,
+        new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_AUTH_WARNINGS, TimeUnit.MINUTES));
+  }
+
+  AgentlessConfigurationSource(
+      final HttpUrl endpoint,
+      final Config config,
+      final long pollIntervalMillis,
+      final UfcHttpClient client,
+      final ScheduledExecutorService executor,
+      final RetrySleeper retrySleeper,
+      final DoubleSupplier jitter,
+      final RatelimitedLogger ratelimitedLogger) {
     this.endpoint = endpoint;
     this.config = config;
     this.pollIntervalMillis = pollIntervalMillis;
@@ -107,6 +132,7 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
     this.executor = executor;
     this.retrySleeper = retrySleeper;
     this.jitter = jitter;
+    this.ratelimitedLogger = ratelimitedLogger;
   }
 
   @Override
@@ -207,9 +233,13 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
       return true;
     }
     if (response.status == HttpURLConnection.HTTP_UNAUTHORIZED
-        || response.status == HttpURLConnection.HTTP_FORBIDDEN
-        || response.status != HttpURLConnection.HTTP_OK
-        || response.body == null) {
+        || response.status == HttpURLConnection.HTTP_FORBIDDEN) {
+      ratelimitedLogger.warn(
+          "Feature Flagging agentless endpoint returned HTTP {}; verify DD_API_KEY is configured and valid",
+          response.status);
+      return false;
+    }
+    if (response.status != HttpURLConnection.HTTP_OK || response.body == null) {
       return false;
     }
     final ServerConfiguration configuration;

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
@@ -242,13 +242,33 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
   }
 
   static HttpUrl endpoint(final Config config) {
-    final String endpoint = datadogApiServerDistributionEndpoint(config);
+    final String configuredBaseUrl = config.getFeatureFlaggingConfigurationSourceAgentlessBaseUrl();
+    final String endpoint =
+        configuredBaseUrl == null
+            ? datadogApiServerDistributionEndpoint(config)
+            : endpointFromConfiguredBaseUrl(configuredBaseUrl);
     final HttpUrl parsed = HttpUrl.parse(endpoint);
     if (parsed == null) {
       throw new IllegalArgumentException(
           "Invalid Feature Flagging HTTP configuration source URL: " + endpoint);
     }
     return parsed;
+  }
+
+  private static String endpointFromConfiguredBaseUrl(final String configuredBaseUrl) {
+    final HttpUrl parsed = HttpUrl.parse(configuredBaseUrl.trim());
+    if (parsed == null) {
+      throw new IllegalArgumentException(
+          "Invalid Feature Flagging HTTP configuration source URL: " + configuredBaseUrl);
+    }
+    if ("/".equals(parsed.encodedPath()) || parsed.encodedPath().isEmpty()) {
+      return parsed
+          .newBuilder()
+          .addPathSegments(DATADOG_API_SERVER_DISTRIBUTION_PATH.substring(1))
+          .build()
+          .toString();
+    }
+    return parsed.toString();
   }
 
   private static String datadogApiServerDistributionEndpoint(final Config config) {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
@@ -1,0 +1,358 @@
+package com.datadog.featureflag;
+
+import static datadog.communication.http.OkHttpUtils.prepareRequest;
+import static datadog.trace.util.AgentThreadFactory.AgentThread.FEATURE_FLAG_CONFIGURATION_POLLER;
+
+import datadog.communication.http.OkHttpUtils;
+import datadog.trace.api.Config;
+import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.util.AgentThreadFactory;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class AgentlessConfigurationSource implements ConfigurationSourceService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AgentlessConfigurationSource.class);
+
+  // TODO before merge: confirm the final backend route with the server-distribution API owners.
+  private static final String DATADOG_API_SERVER_DISTRIBUTION_PATH =
+      "/api/v2/feature-flagging/config/server-distribution";
+  private static final int MAX_ATTEMPTS = 3;
+  private static final long FIRST_RETRY_MIN_MILLIS = 2_000;
+  private static final long FIRST_RETRY_MAX_MILLIS = 10_000;
+  private static final long SECOND_RETRY_MIN_MILLIS = 5_000;
+  private static final long SECOND_RETRY_MAX_MILLIS = 30_000;
+  private static final double RETRY_JITTER = 0.2;
+
+  private final HttpUrl endpoint;
+  private final Config config;
+  private final long pollIntervalMillis;
+  private final UfcHttpClient client;
+  private final ScheduledExecutorService executor;
+  private final RetrySleeper retrySleeper;
+  private final DoubleSupplier jitter;
+  private final Object lifecycleLock = new Object();
+  private final AtomicBoolean polling = new AtomicBoolean();
+  private volatile boolean closed;
+  private volatile ScheduledFuture<?> scheduledPoll;
+  private volatile String etag;
+
+  AgentlessConfigurationSource(final Config config) {
+    this(config, endpoint(config));
+  }
+
+  private AgentlessConfigurationSource(final Config config, final HttpUrl endpoint) {
+    this(
+        endpoint,
+        config,
+        millis(config.getFeatureFlaggingConfigurationSourcePollIntervalSeconds()),
+        new OkHttpUfcHttpClient(
+            OkHttpUtils.buildHttpClient(
+                endpoint,
+                millis(config.getFeatureFlaggingConfigurationSourceRequestTimeoutSeconds()))),
+        Executors.newSingleThreadScheduledExecutor(
+            new AgentThreadFactory(FEATURE_FLAG_CONFIGURATION_POLLER)),
+        TimeUnit.MILLISECONDS::sleep,
+        () -> ThreadLocalRandom.current().nextDouble(1 - RETRY_JITTER, 1 + RETRY_JITTER));
+  }
+
+  AgentlessConfigurationSource(
+      final HttpUrl endpoint,
+      final Config config,
+      final long pollIntervalMillis,
+      final UfcHttpClient client,
+      final ScheduledExecutorService executor) {
+    this(
+        endpoint,
+        config,
+        pollIntervalMillis,
+        client,
+        executor,
+        TimeUnit.MILLISECONDS::sleep,
+        () -> 1.0);
+  }
+
+  AgentlessConfigurationSource(
+      final HttpUrl endpoint,
+      final Config config,
+      final long pollIntervalMillis,
+      final UfcHttpClient client,
+      final ScheduledExecutorService executor,
+      final RetrySleeper retrySleeper,
+      final DoubleSupplier jitter) {
+    this.endpoint = endpoint;
+    this.config = config;
+    this.pollIntervalMillis = pollIntervalMillis;
+    this.client = client;
+    this.executor = executor;
+    this.retrySleeper = retrySleeper;
+    this.jitter = jitter;
+  }
+
+  @Override
+  public void init() {
+    synchronized (lifecycleLock) {
+      if (closed || scheduledPoll != null) {
+        return;
+      }
+      scheduledPoll =
+          executor.scheduleWithFixedDelay(
+              this::pollOnceSafely, 0, pollIntervalMillis, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  boolean pollOnce() {
+    if (closed || !polling.compareAndSet(false, true)) {
+      return false;
+    }
+    try {
+      return fetchAndApply();
+    } finally {
+      polling.set(false);
+    }
+  }
+
+  @Override
+  public void close() {
+    final ScheduledFuture<?> poll;
+    synchronized (lifecycleLock) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      poll = scheduledPoll;
+      scheduledPoll = null;
+    }
+    if (poll != null) {
+      poll.cancel(true);
+    }
+    client.cancel();
+    executor.shutdownNow();
+  }
+
+  private void pollOnceSafely() {
+    try {
+      pollOnce();
+    } catch (final RuntimeException e) {
+      LOGGER.debug("Unexpected error while polling Feature Flagging HTTP configuration source", e);
+    }
+  }
+
+  private boolean fetchAndApply() {
+    for (int attempt = 1; ; attempt++) {
+      try {
+        final UfcHttpResponse response = client.fetch(endpoint, config, etag);
+        if (closed) {
+          return false;
+        }
+        if (isRetryableStatus(response.status) && attempt < MAX_ATTEMPTS) {
+          if (!waitBeforeRetry(attempt)) {
+            return false;
+          }
+          continue;
+        }
+        synchronized (lifecycleLock) {
+          return !closed && apply(response);
+        }
+      } catch (final IOException e) {
+        if (closed) {
+          return false;
+        }
+        if (attempt == MAX_ATTEMPTS) {
+          LOGGER.debug("Feature Flagging HTTP configuration source request failed", e);
+          return false;
+        }
+        if (!waitBeforeRetry(attempt)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  private boolean waitBeforeRetry(final int attempt) {
+    if (closed) {
+      return false;
+    }
+    try {
+      retrySleeper.sleep(retryDelayMillis(pollIntervalMillis, attempt, jitter.getAsDouble()));
+      return !closed;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  private boolean apply(final UfcHttpResponse response) {
+    if (response.status == HttpURLConnection.HTTP_NOT_MODIFIED) {
+      return true;
+    }
+    if (response.status == HttpURLConnection.HTTP_UNAUTHORIZED
+        || response.status == HttpURLConnection.HTTP_FORBIDDEN
+        || response.status != HttpURLConnection.HTTP_OK
+        || response.body == null) {
+      return false;
+    }
+    final ServerConfiguration configuration;
+    try {
+      configuration =
+          RemoteConfigServiceImpl.UniversalFlagConfigDeserializer.INSTANCE.deserialize(
+              response.body);
+    } catch (final IOException | RuntimeException e) {
+      LOGGER.debug("Feature Flagging HTTP configuration source returned malformed UFC payload", e);
+      return false;
+    }
+    if (configuration == null) {
+      return false;
+    }
+    FeatureFlaggingGateway.dispatch(configuration);
+    updateEtag(response.etag);
+    return true;
+  }
+
+  private static boolean isRetryableStatus(final int status) {
+    return status == HttpURLConnection.HTTP_CLIENT_TIMEOUT
+        || status == 429
+        || (status >= 500 && status <= 599);
+  }
+
+  private void updateEtag(final String nextEtag) {
+    if (nextEtag != null && !nextEtag.trim().isEmpty()) {
+      etag = nextEtag;
+    }
+  }
+
+  static HttpUrl endpoint(final Config config) {
+    final String endpoint = datadogApiServerDistributionEndpoint(config);
+    final HttpUrl parsed = HttpUrl.parse(endpoint);
+    if (parsed == null) {
+      throw new IllegalArgumentException(
+          "Invalid Feature Flagging HTTP configuration source URL: " + endpoint);
+    }
+    return parsed;
+  }
+
+  private static String datadogApiServerDistributionEndpoint(final Config config) {
+    final StringBuilder endpoint =
+        new StringBuilder("https://api.")
+            .append(config.getSite().toLowerCase(Locale.ROOT))
+            .append(DATADOG_API_SERVER_DISTRIBUTION_PATH);
+    final String env = config.getEnv();
+    if (env != null && !env.isEmpty()) {
+      endpoint.append("?dd_env=").append(urlEncode(env));
+    }
+    return endpoint.toString();
+  }
+
+  private static String urlEncode(final String value) {
+    try {
+      return URLEncoder.encode(value, "UTF-8");
+    } catch (final IOException e) {
+      throw new IllegalArgumentException("Unable to encode Feature Flagging environment", e);
+    }
+  }
+
+  static long millis(final int seconds) {
+    return TimeUnit.SECONDS.toMillis(seconds);
+  }
+
+  static long retryDelayMillis(
+      final long pollIntervalMillis, final int attempt, final double jitter) {
+    final long baseDelay;
+    if (attempt == 1) {
+      baseDelay = clamp(pollIntervalMillis / 6, FIRST_RETRY_MIN_MILLIS, FIRST_RETRY_MAX_MILLIS);
+    } else if (attempt == 2) {
+      baseDelay = clamp(pollIntervalMillis / 3, SECOND_RETRY_MIN_MILLIS, SECOND_RETRY_MAX_MILLIS);
+    } else {
+      throw new IllegalArgumentException("Unsupported Feature Flagging retry attempt: " + attempt);
+    }
+    return Math.max(1, Math.round(baseDelay * jitter));
+  }
+
+  private static long clamp(final long value, final long minimum, final long maximum) {
+    return Math.max(minimum, Math.min(maximum, value));
+  }
+
+  interface UfcHttpClient {
+    UfcHttpResponse fetch(HttpUrl endpoint, Config config, String etag) throws IOException;
+
+    void cancel();
+  }
+
+  interface RetrySleeper {
+    void sleep(long delayMillis) throws InterruptedException;
+  }
+
+  static final class UfcHttpResponse {
+    final int status;
+    final String etag;
+    final byte[] body;
+
+    UfcHttpResponse(final int status, final String etag, final byte[] body) {
+      this.status = status;
+      this.etag = etag;
+      this.body = body;
+    }
+  }
+
+  static final class OkHttpUfcHttpClient implements UfcHttpClient {
+    private final OkHttpClient httpClient;
+    private final AtomicReference<Call> activeCall = new AtomicReference<>();
+    private final AtomicBoolean cancelled = new AtomicBoolean();
+
+    OkHttpUfcHttpClient(final OkHttpClient httpClient) {
+      this.httpClient = httpClient;
+    }
+
+    @Override
+    public UfcHttpResponse fetch(final HttpUrl endpoint, final Config config, final String etag)
+        throws IOException {
+      final Map<String, String> headers = new HashMap<>();
+      if (etag != null) {
+        headers.put("If-None-Match", etag);
+      }
+      final Request request = prepareRequest(endpoint, headers, config, true).get().build();
+      final Call call = httpClient.newCall(request);
+      if (!activeCall.compareAndSet(null, call)) {
+        throw new IllegalStateException("Feature Flagging HTTP request already in flight");
+      }
+      if (cancelled.get()) {
+        call.cancel();
+      }
+      try (Response response = call.execute()) {
+        final ResponseBody responseBody = response.body();
+        return new UfcHttpResponse(response.code(), response.header("ETag"), responseBody.bytes());
+      } finally {
+        activeCall.compareAndSet(call, null);
+      }
+    }
+
+    @Override
+    public void cancel() {
+      cancelled.set(true);
+      final Call call = activeCall.get();
+      if (call != null) {
+        call.cancel();
+      }
+    }
+  }
+}

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ConfigurationSourceService.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ConfigurationSourceService.java
@@ -2,7 +2,7 @@ package com.datadog.featureflag;
 
 import java.io.Closeable;
 
-public interface RemoteConfigService extends Closeable {
+public interface ConfigurationSourceService extends Closeable {
 
   void init();
 

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/OfflineConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/OfflineConfigurationSource.java
@@ -1,0 +1,45 @@
+package com.datadog.featureflag;
+
+import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class OfflineConfigurationSource
+    implements ConfigurationSourceService, FeatureFlaggingGateway.OfflineConfigListener {
+
+  private final AtomicBoolean listening = new AtomicBoolean();
+  private final AtomicBoolean configured = new AtomicBoolean();
+
+  @Override
+  public void init() {
+    if (listening.compareAndSet(false, true)) {
+      FeatureFlaggingGateway.addOfflineConfigListener(this);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (listening.compareAndSet(true, false)) {
+      FeatureFlaggingGateway.removeOfflineConfigListener(this);
+    }
+  }
+
+  @Override
+  public void accept(final byte[] content) {
+    final ServerConfiguration configuration;
+    try {
+      configuration =
+          RemoteConfigServiceImpl.UniversalFlagConfigDeserializer.INSTANCE.deserialize(content);
+    } catch (final IOException | RuntimeException error) {
+      throw new IllegalArgumentException("Invalid offline Feature Flagging configuration", error);
+    }
+    if (configuration == null) {
+      throw new IllegalArgumentException("Offline Feature Flagging configuration must not be null");
+    }
+    if (!configured.compareAndSet(false, true)) {
+      throw new IllegalStateException("Offline Feature Flagging configuration is already set");
+    }
+    FeatureFlaggingGateway.dispatch(configuration);
+  }
+}

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/RemoteConfigServiceImpl.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/RemoteConfigServiceImpl.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 import okio.Okio;
 
 public class RemoteConfigServiceImpl
-    implements RemoteConfigService, ConfigurationChangesTypedListener<ServerConfiguration> {
+    implements ConfigurationSourceService, ConfigurationChangesTypedListener<ServerConfiguration> {
 
   private final ConfigurationPoller configurationPoller;
 

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
@@ -75,6 +75,41 @@ class AgentlessConfigurationSourceTest {
   }
 
   @Test
+  void appendsServerDistributionPathToConfiguredAgentlessBaseUrl() {
+    final Config config = config();
+    lenient()
+        .when(config.getFeatureFlaggingConfigurationSourceAgentlessBaseUrl())
+        .thenReturn("http://mock-backend:8080");
+
+    assertEquals(
+        "http://mock-backend:8080/api/v2/feature-flagging/config/server-distribution",
+        AgentlessConfigurationSource.endpoint(config).toString());
+  }
+
+  @Test
+  void usesConfiguredAgentlessEndpointWithPathUnchanged() {
+    final Config config = config();
+    lenient()
+        .when(config.getFeatureFlaggingConfigurationSourceAgentlessBaseUrl())
+        .thenReturn("http://mock-backend:8080/custom/ufc?tenant=test");
+
+    assertEquals(
+        "http://mock-backend:8080/custom/ufc?tenant=test",
+        AgentlessConfigurationSource.endpoint(config).toString());
+  }
+
+  @Test
+  void rejectsInvalidConfiguredAgentlessBaseUrl() {
+    final Config config = config();
+    lenient()
+        .when(config.getFeatureFlaggingConfigurationSourceAgentlessBaseUrl())
+        .thenReturn("not a URL");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> AgentlessConfigurationSource.endpoint(config));
+  }
+
+  @Test
   void rejectsInvalidDatadogApiServerDistributionEndpoint() {
     assertThrows(
         IllegalArgumentException.class,
@@ -702,6 +737,7 @@ class AgentlessConfigurationSourceTest {
     lenient()
         .when(config.getFeatureFlaggingConfigurationSourceRequestTimeoutSeconds())
         .thenReturn(2);
+    lenient().when(config.getFeatureFlaggingConfigurationSourceAgentlessBaseUrl()).thenReturn(null);
     lenient().when(config.getApiKey()).thenReturn("test-api-key");
     lenient().when(config.getSite()).thenReturn(site);
     lenient().when(config.getEnv()).thenReturn(env);

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import datadog.communication.http.OkHttpUtils;
+import datadog.logging.RatelimitedLogger;
 import datadog.trace.agent.test.server.http.JavaTestHttpServer;
 import datadog.trace.api.Config;
 import datadog.trace.api.featureflag.FeatureFlaggingGateway;
@@ -411,6 +412,39 @@ class AgentlessConfigurationSourceTest {
     assertFalse(service.pollOnce());
 
     verifyNoInteractions(listener);
+  }
+
+  @Test
+  void warnsRateLimitedOnUnauthorizedAndForbidden() throws Exception {
+    final RatelimitedLogger ratelimitedLogger = mock(RatelimitedLogger.class);
+    final FakeClient client = new FakeClient(response(401, null, null), response(403, null, null));
+    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    final AgentlessConfigurationSource service =
+        new AgentlessConfigurationSource(
+            HttpUrl.get("http://localhost" + CONFIG_PATH),
+            config(),
+            30_000,
+            client,
+            executor,
+            delay -> {},
+            () -> 1.0,
+            ratelimitedLogger);
+
+    try {
+      assertFalse(service.pollOnce());
+      assertFalse(service.pollOnce());
+
+      verify(ratelimitedLogger)
+          .warn(
+              "Feature Flagging agentless endpoint returned HTTP {}; verify DD_API_KEY is configured and valid",
+              HttpURLConnection.HTTP_UNAUTHORIZED);
+      verify(ratelimitedLogger)
+          .warn(
+              "Feature Flagging agentless endpoint returned HTTP {}; verify DD_API_KEY is configured and valid",
+              HttpURLConnection.HTTP_FORBIDDEN);
+    } finally {
+      service.close();
+    }
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
@@ -1,0 +1,805 @@
+package com.datadog.featureflag;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import datadog.communication.http.OkHttpUtils;
+import datadog.trace.agent.test.server.http.JavaTestHttpServer;
+import datadog.trace.api.Config;
+import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentlessConfigurationSourceTest {
+  private static final String CONFIG_PATH = "/api/v2/feature-flagging/config/server-distribution";
+
+  @Mock private FeatureFlaggingGateway.ConfigListener listener;
+
+  @AfterEach
+  void cleanup() {
+    FeatureFlaggingGateway.removeConfigListener(listener);
+    FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
+  }
+
+  @Test
+  void derivesDatadogApiServerDistributionEndpointFromSiteAndEnv() {
+    final Config config = config("datad0g.com", "staging env");
+
+    assertEquals(
+        "https://api.datad0g.com/api/v2/feature-flagging/config/server-distribution?dd_env=staging+env",
+        AgentlessConfigurationSource.endpoint(config).toString());
+  }
+
+  @Test
+  void derivesDatadogApiServerDistributionEndpointWithoutEnv() {
+    assertEquals(
+        "https://api.datadoghq.com/api/v2/feature-flagging/config/server-distribution",
+        AgentlessConfigurationSource.endpoint(config("datadoghq.com", "")).toString());
+    assertEquals(
+        "https://api.datadoghq.com/api/v2/feature-flagging/config/server-distribution",
+        AgentlessConfigurationSource.endpoint(config("datadoghq.com", null)).toString());
+  }
+
+  @Test
+  void rejectsInvalidDatadogApiServerDistributionEndpoint() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AgentlessConfigurationSource.endpoint(config("datadoghq.com:bad", "")));
+  }
+
+  @Test
+  void defaultConstructorBuildsHttpClientFromConfig() {
+    final AgentlessConfigurationSource service =
+        new AgentlessConfigurationSource(config("datad0g.com", "staging"));
+
+    service.close();
+  }
+
+  @Test
+  void realHttpClientSendsAgentlessHeadersAndReadsResponse() throws Exception {
+    try (JavaTestHttpServer server =
+        JavaTestHttpServer.httpServer(
+            s ->
+                s.handlers(
+                    h ->
+                        h.get(
+                            CONFIG_PATH,
+                            api ->
+                                api.getResponse()
+                                    .addHeader("ETag", "etag-b")
+                                    .send(emptyConfig()))))) {
+      final OkHttpClient httpClient = new OkHttpClient.Builder().build();
+      final AgentlessConfigurationSource.OkHttpUfcHttpClient client =
+          new AgentlessConfigurationSource.OkHttpUfcHttpClient(httpClient);
+
+      try {
+        final AgentlessConfigurationSource.UfcHttpResponse response =
+            client.fetch(HttpUrl.get(server.getAddress().resolve(CONFIG_PATH)), config(), "etag-a");
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.status);
+        assertEquals("etag-b", response.etag);
+        assertEquals(emptyConfig(), new String(response.body, UTF_8));
+        assertEquals("test-api-key", server.getLastRequest().getHeader("DD-API-KEY"));
+        assertEquals("etag-a", server.getLastRequest().getHeader("If-None-Match"));
+        assertEquals("java", server.getLastRequest().getHeader("Datadog-Meta-Lang"));
+      } finally {
+        httpClient.dispatcher().executorService().shutdownNow();
+        httpClient.connectionPool().evictAll();
+      }
+    }
+  }
+
+  @Test
+  void realHttpClientAllowsMissingEtagAndEmptyResponseBody() throws Exception {
+    try (JavaTestHttpServer server =
+        JavaTestHttpServer.httpServer(
+            s ->
+                s.handlers(
+                    h ->
+                        h.get(
+                            CONFIG_PATH,
+                            api ->
+                                api.getResponse()
+                                    .status(HttpURLConnection.HTTP_NO_CONTENT)
+                                    .send())))) {
+      final OkHttpClient httpClient = new OkHttpClient.Builder().build();
+      final AgentlessConfigurationSource.OkHttpUfcHttpClient client =
+          new AgentlessConfigurationSource.OkHttpUfcHttpClient(httpClient);
+
+      try {
+        final AgentlessConfigurationSource.UfcHttpResponse response =
+            client.fetch(HttpUrl.get(server.getAddress().resolve(CONFIG_PATH)), config(), null);
+
+        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.status);
+        assertNull(response.etag);
+        assertEquals(0, response.body.length);
+        assertNull(server.getLastRequest().getHeader("If-None-Match"));
+      } finally {
+        httpClient.dispatcher().executorService().shutdownNow();
+        httpClient.connectionPool().evictAll();
+      }
+    }
+  }
+
+  @Test
+  void realHttpClientCancellationInterruptsInFlightRequest() throws Exception {
+    final CountDownLatch requestStarted = new CountDownLatch(1);
+    final CountDownLatch releaseRequest = new CountDownLatch(1);
+    try (JavaTestHttpServer server =
+        JavaTestHttpServer.httpServer(
+            s ->
+                s.handlers(
+                    h ->
+                        h.get(
+                            CONFIG_PATH,
+                            api -> {
+                              requestStarted.countDown();
+                              assertTrue(releaseRequest.await(1, TimeUnit.SECONDS));
+                              api.getResponse().send(emptyConfig());
+                            })))) {
+      final OkHttpClient httpClient = new OkHttpClient.Builder().build();
+      final AgentlessConfigurationSource.OkHttpUfcHttpClient client =
+          new AgentlessConfigurationSource.OkHttpUfcHttpClient(httpClient);
+      final ExecutorService runner = Executors.newSingleThreadExecutor();
+
+      try {
+        final Future<AgentlessConfigurationSource.UfcHttpResponse> response =
+            runner.submit(
+                () ->
+                    client.fetch(
+                        HttpUrl.get(server.getAddress().resolve(CONFIG_PATH)), config(), null));
+        assertTrue(requestStarted.await(1, TimeUnit.SECONDS));
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                client.fetch(
+                    HttpUrl.get(server.getAddress().resolve(CONFIG_PATH)), config(), null));
+
+        client.cancel();
+
+        final ExecutionException failure =
+            assertThrows(ExecutionException.class, () -> response.get(1, TimeUnit.SECONDS));
+        assertInstanceOf(IOException.class, failure.getCause());
+      } finally {
+        releaseRequest.countDown();
+        runner.shutdownNow();
+        httpClient.dispatcher().executorService().shutdownNow();
+        httpClient.connectionPool().evictAll();
+      }
+    }
+  }
+
+  @Test
+  void realHttpClientCancellationBeforeFetchPreventsRequest() throws Exception {
+    try (JavaTestHttpServer server =
+        JavaTestHttpServer.httpServer(
+            s ->
+                s.handlers(
+                    h -> h.get(CONFIG_PATH, api -> api.getResponse().send(emptyConfig()))))) {
+      final OkHttpClient httpClient = new OkHttpClient.Builder().build();
+      final AgentlessConfigurationSource.OkHttpUfcHttpClient client =
+          new AgentlessConfigurationSource.OkHttpUfcHttpClient(httpClient);
+
+      try {
+        client.cancel();
+
+        assertThrows(
+            IOException.class,
+            () ->
+                client.fetch(
+                    HttpUrl.get(server.getAddress().resolve(CONFIG_PATH)), config(), null));
+      } finally {
+        httpClient.dispatcher().executorService().shutdownNow();
+        httpClient.connectionPool().evictAll();
+      }
+    }
+  }
+
+  @Test
+  void realHttpClientTimesOutDelayedResponse() throws Exception {
+    try (JavaTestHttpServer server =
+        JavaTestHttpServer.httpServer(
+            s ->
+                s.handlers(
+                    h ->
+                        h.get(
+                            CONFIG_PATH,
+                            api -> {
+                              TimeUnit.MILLISECONDS.sleep(500);
+                              api.getResponse().send(emptyConfig());
+                            })))) {
+      final HttpUrl endpoint = HttpUrl.get(server.getAddress().resolve(CONFIG_PATH));
+      final OkHttpClient httpClient = OkHttpUtils.buildHttpClient(endpoint, 50);
+      final AgentlessConfigurationSource.OkHttpUfcHttpClient client =
+          new AgentlessConfigurationSource.OkHttpUfcHttpClient(httpClient);
+
+      try {
+        assertThrows(IOException.class, () -> client.fetch(endpoint, config(), null));
+      } finally {
+        httpClient.dispatcher().executorService().shutdownNow();
+        httpClient.connectionPool().evictAll();
+      }
+    }
+  }
+
+  @Test
+  void appliesAcceptedUfcThroughGatewayAndSendsApiKey() throws Exception {
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+
+    verify(listener).accept(any(ServerConfiguration.class));
+    assertEquals("test-api-key", client.requests.get(0).apiKey);
+    assertNull(client.requests.get(0).etag);
+  }
+
+  @Test
+  void ignoresBlankEtag() throws Exception {
+    final FakeClient client =
+        new FakeClient(response(200, " ", emptyConfig()), response(304, null, null));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+    assertTrue(service.pollOnce());
+
+    assertNull(client.requests.get(1).etag);
+    verify(listener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void usesEtagAndSkipsDispatchOnUnchangedConfig() throws Exception {
+    final FakeClient client =
+        new FakeClient(response(200, "etag-a", emptyConfig()), response(304, null, null));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+    assertTrue(service.pollOnce());
+
+    verify(listener).accept(any(ServerConfiguration.class));
+    assertEquals("etag-a", client.requests.get(1).etag);
+  }
+
+  @Test
+  void coldNotModifiedDoesNotEstablishEtag() throws Exception {
+    final FakeClient client =
+        new FakeClient(response(304, "etag-cold", null), response(200, "etag-warm", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+    assertTrue(service.pollOnce());
+
+    assertNull(client.requests.get(1).etag);
+    verify(listener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void failedGatewayDispatchDoesNotAdvanceEtag() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            response(200, "etag-a", emptyConfig()), response(200, "etag-b", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+    final FeatureFlaggingGateway.ConfigListener failingListener =
+        configuration -> {
+          throw new IllegalStateException("listener rejected configuration");
+        };
+    FeatureFlaggingGateway.addConfigListener(failingListener);
+
+    try {
+      assertThrows(IllegalStateException.class, service::pollOnce);
+      FeatureFlaggingGateway.removeConfigListener(failingListener);
+
+      assertTrue(service.pollOnce());
+
+      assertNull(client.requests.get(1).etag);
+    } finally {
+      FeatureFlaggingGateway.removeConfigListener(failingListener);
+    }
+  }
+
+  @Test
+  void keepsLastKnownGoodOnAuthFailureAndMalformedPayload() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            response(200, "etag-good", emptyConfig()),
+            response(401, null, null),
+            response(200, null, "{not-json}"),
+            response(200, null, "{\"flags\":[]}"));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+
+    verify(listener).accept(any(ServerConfiguration.class));
+    assertEquals("etag-good", client.requests.get(1).etag);
+    assertEquals("etag-good", client.requests.get(2).etag);
+    assertEquals("etag-good", client.requests.get(3).etag);
+  }
+
+  @Test
+  void rejectsForbiddenNonOkMissingBodyAndNullConfiguration() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            response(403, null, null),
+            response(404, null, null),
+            response(600, null, null),
+            response(200, null, null),
+            response(200, null, "null"));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+    assertFalse(service.pollOnce());
+
+    verifyNoInteractions(listener);
+  }
+
+  @Test
+  void retriesTimeoutBeforeApplyingConfig() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            new SocketTimeoutException("slow HTTP configuration source"),
+            new SocketTimeoutException("slow HTTP configuration source"),
+            response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+
+    assertEquals(3, client.calls.get());
+    verify(listener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void retriesClientTimeoutAndRateLimitStatusBeforeApplyingConfig() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            response(408, null, null),
+            response(200, "etag-a", emptyConfig()),
+            response(429, null, null),
+            response(200, "etag-b", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+    assertTrue(service.pollOnce());
+
+    assertEquals(4, client.calls.get());
+    verify(listener, times(2)).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void retriesServerErrorThenKeepsColdStateOnNotModified() throws Exception {
+    final FakeClient client = new FakeClient(response(500, null, null), response(304, null, null));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+
+    assertEquals(2, client.calls.get());
+    verifyNoInteractions(listener);
+  }
+
+  @Test
+  void givesUpAfterRetryableFailuresAreExhausted() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            response(503, null, null), response(503, null, null), response(503, null, null));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertFalse(service.pollOnce());
+
+    assertEquals(3, client.calls.get());
+    verifyNoInteractions(listener);
+  }
+
+  @Test
+  void givesUpAfterIoFailuresAreExhausted() throws Exception {
+    final FakeClient client =
+        new FakeClient(
+            new SocketTimeoutException("slow HTTP configuration source"),
+            new SocketTimeoutException("slow HTTP configuration source"),
+            new SocketTimeoutException("slow HTTP configuration source"));
+    final AgentlessConfigurationSource service = service(client);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertFalse(service.pollOnce());
+
+    assertEquals(3, client.calls.get());
+    verifyNoInteractions(listener);
+  }
+
+  @Test
+  void usesIntervalAwareRetryBackoff() throws Exception {
+    final List<Long> delays = new ArrayList<>();
+    final FakeClient client =
+        new FakeClient(
+            response(503, null, null),
+            new SocketTimeoutException("slow HTTP configuration source"),
+            response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client, delays::add, () -> 1.0);
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    assertTrue(service.pollOnce());
+
+    assertEquals(java.util.Arrays.asList(5_000L, 10_000L), delays);
+    verify(listener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void clampsAndJittersRetryBackoff() {
+    assertEquals(2_000, AgentlessConfigurationSource.retryDelayMillis(1_000, 1, 1.0));
+    assertEquals(5_000, AgentlessConfigurationSource.retryDelayMillis(1_000, 2, 1.0));
+    assertEquals(10_000, AgentlessConfigurationSource.retryDelayMillis(600_000, 1, 1.0));
+    assertEquals(30_000, AgentlessConfigurationSource.retryDelayMillis(600_000, 2, 1.0));
+    assertEquals(6_000, AgentlessConfigurationSource.retryDelayMillis(30_000, 1, 1.2));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AgentlessConfigurationSource.retryDelayMillis(30_000, 3, 1.0));
+  }
+
+  @Test
+  void rejectsOverlappingPolls() throws Exception {
+    final CountDownLatch requestStarted = new CountDownLatch(1);
+    final CountDownLatch releaseRequest = new CountDownLatch(1);
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    client.block(requestStarted, releaseRequest);
+    final AgentlessConfigurationSource service = service(client);
+    final ExecutorService runner = Executors.newFixedThreadPool(2);
+
+    try {
+      final Future<Boolean> first = runner.submit(service::pollOnce);
+      assertTrue(requestStarted.await(1, TimeUnit.SECONDS));
+      final Future<Boolean> second = runner.submit(service::pollOnce);
+
+      assertFalse(second.get(1, TimeUnit.SECONDS));
+      releaseRequest.countDown();
+      assertTrue(first.get(1, TimeUnit.SECONDS));
+      assertEquals(1, client.calls.get());
+    } finally {
+      releaseRequest.countDown();
+      runner.shutdownNow();
+    }
+  }
+
+  @Test
+  void initSchedulesPollAndCloseCancelsFuture() throws Exception {
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service =
+        new AgentlessConfigurationSource(
+            HttpUrl.get("http://localhost" + CONFIG_PATH),
+            config(),
+            60_000,
+            client,
+            Executors.newSingleThreadScheduledExecutor());
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    service.init();
+    awaitCalls(client, 1);
+    service.close();
+
+    verify(listener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void repeatedInitStartsOnlyOnePoller() throws Exception {
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+
+    service.init();
+    service.init();
+    awaitCalls(client, 1);
+    service.close();
+
+    assertEquals(1, client.calls.get());
+  }
+
+  @Test
+  void closeCancelsInFlightRequestAndIgnoresLateSuccess() throws Exception {
+    final CountDownLatch requestStarted = new CountDownLatch(1);
+    final CountDownLatch releaseRequest = new CountDownLatch(1);
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    client.block(requestStarted, releaseRequest);
+    final AgentlessConfigurationSource service = service(client);
+    final ExecutorService runner = Executors.newSingleThreadExecutor();
+    FeatureFlaggingGateway.addConfigListener(listener);
+
+    try {
+      final Future<Boolean> poll = runner.submit(service::pollOnce);
+      assertTrue(requestStarted.await(1, TimeUnit.SECONDS));
+
+      service.close();
+
+      assertFalse(poll.get(1, TimeUnit.SECONDS));
+      assertEquals(1, client.cancelCalls.get());
+      assertEquals(1, client.calls.get());
+      verifyNoInteractions(listener);
+    } finally {
+      releaseRequest.countDown();
+      runner.shutdownNow();
+    }
+  }
+
+  @Test
+  void closeDuringIoFailurePreventsRetry() throws Exception {
+    final CountDownLatch requestStarted = new CountDownLatch(1);
+    final CountDownLatch releaseRequest = new CountDownLatch(1);
+    final FakeClient client =
+        new FakeClient(new SocketTimeoutException("slow HTTP configuration source"));
+    client.block(requestStarted, releaseRequest);
+    final AgentlessConfigurationSource service = service(client);
+    final ExecutorService runner = Executors.newSingleThreadExecutor();
+
+    try {
+      final Future<Boolean> poll = runner.submit(service::pollOnce);
+      assertTrue(requestStarted.await(1, TimeUnit.SECONDS));
+
+      service.close();
+
+      assertFalse(poll.get(1, TimeUnit.SECONDS));
+      assertEquals(1, client.calls.get());
+    } finally {
+      releaseRequest.countDown();
+      runner.shutdownNow();
+    }
+  }
+
+  @Test
+  void closeInterruptsRetryBackoff() throws Exception {
+    final CountDownLatch backoffStarted = new CountDownLatch(1);
+    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    final FakeClient client =
+        new FakeClient(
+            new SocketTimeoutException("slow HTTP configuration source"),
+            response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service =
+        new AgentlessConfigurationSource(
+            HttpUrl.get("http://localhost" + CONFIG_PATH),
+            config(),
+            30_000,
+            client,
+            executor,
+            delay -> {
+              backoffStarted.countDown();
+              TimeUnit.MINUTES.sleep(1);
+            },
+            () -> 1.0);
+
+    service.init();
+    assertTrue(backoffStarted.await(1, TimeUnit.SECONDS));
+
+    service.close();
+
+    assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+    assertEquals(1, client.calls.get());
+  }
+
+  @Test
+  void closePreventsFurtherPolls() throws Exception {
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+
+    service.close();
+
+    assertFalse(service.pollOnce());
+    assertEquals(0, client.calls.get());
+  }
+
+  @Test
+  void initAfterCloseDoesNotSchedulePoll() throws Exception {
+    final FakeClient client = new FakeClient(response(200, "etag-a", emptyConfig()));
+    final AgentlessConfigurationSource service = service(client);
+
+    service.close();
+    service.init();
+
+    assertEquals(0, client.calls.get());
+  }
+
+  @Nested
+  class SystemTestParity {
+    @Test
+    void preservesSystemTestSourceTransitionsAndLastKnownGoodState() throws Exception {
+      final FakeClient client =
+          new FakeClient(
+              response(200, "etag-a", emptyConfig()),
+              response(304, "etag-must-not-replace-a", null),
+              response(509, null, null),
+              response(200, "etag-b", emptyConfig()),
+              response(200, "etag-c", "{not-json}"),
+              response(401, null, null));
+      final AgentlessConfigurationSource service = service(client);
+      FeatureFlaggingGateway.addConfigListener(listener);
+
+      assertTrue(service.pollOnce());
+      assertTrue(service.pollOnce());
+      assertTrue(service.pollOnce());
+      assertFalse(service.pollOnce());
+      assertFalse(service.pollOnce());
+
+      verify(listener, times(2)).accept(any(ServerConfiguration.class));
+      assertEquals("etag-a", client.requests.get(1).etag);
+      assertEquals("etag-a", client.requests.get(2).etag);
+      assertEquals("etag-a", client.requests.get(3).etag);
+      assertEquals("etag-b", client.requests.get(4).etag);
+      assertEquals("etag-b", client.requests.get(5).etag);
+    }
+  }
+
+  private static AgentlessConfigurationSource service(final FakeClient client) {
+    return service(client, delay -> {}, () -> 1.0);
+  }
+
+  private static AgentlessConfigurationSource service(
+      final FakeClient client,
+      final AgentlessConfigurationSource.RetrySleeper retrySleeper,
+      final java.util.function.DoubleSupplier jitter) {
+    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    return new AgentlessConfigurationSource(
+        HttpUrl.get("http://localhost" + CONFIG_PATH),
+        config(),
+        30_000,
+        client,
+        executor,
+        retrySleeper,
+        jitter);
+  }
+
+  private static Config config() {
+    return config("datadoghq.com", "");
+  }
+
+  private static Config config(final String site, final String env) {
+    final Config config = mock(Config.class);
+    lenient()
+        .when(config.getFeatureFlaggingConfigurationSourcePollIntervalSeconds())
+        .thenReturn(30);
+    lenient()
+        .when(config.getFeatureFlaggingConfigurationSourceRequestTimeoutSeconds())
+        .thenReturn(2);
+    lenient().when(config.getApiKey()).thenReturn("test-api-key");
+    lenient().when(config.getSite()).thenReturn(site);
+    lenient().when(config.getEnv()).thenReturn(env);
+    return config;
+  }
+
+  private static AgentlessConfigurationSource.UfcHttpResponse response(
+      final int status, final String etag, final String body) {
+    return new AgentlessConfigurationSource.UfcHttpResponse(
+        status, etag, body == null ? null : body.getBytes(UTF_8));
+  }
+
+  private static String emptyConfig() {
+    return "{"
+        + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+        + "\"format\":\"SERVER\","
+        + "\"environment\":{\"name\":\"Test\"},"
+        + "\"flags\":{}"
+        + "}";
+  }
+
+  private static void awaitCalls(final FakeClient client, final int count) throws Exception {
+    for (int i = 0; i < 100; i++) {
+      if (client.calls.get() >= count) {
+        return;
+      }
+      TimeUnit.MILLISECONDS.sleep(10);
+    }
+    assertEquals(count, client.calls.get());
+  }
+
+  private static final class FakeClient implements AgentlessConfigurationSource.UfcHttpClient {
+    private final AtomicInteger calls = new AtomicInteger();
+    private final AtomicInteger cancelCalls = new AtomicInteger();
+    private final List<Request> requests = new ArrayList<>();
+    private final BlockingQueue<Object> responses = new LinkedBlockingQueue<>();
+    private CountDownLatch requestStarted;
+    private CountDownLatch releaseRequest;
+
+    private FakeClient(final Object... responses) {
+      for (final Object response : responses) {
+        this.responses.add(response);
+      }
+    }
+
+    private void block(final CountDownLatch requestStarted, final CountDownLatch releaseRequest) {
+      this.requestStarted = requestStarted;
+      this.releaseRequest = releaseRequest;
+    }
+
+    @Override
+    public AgentlessConfigurationSource.UfcHttpResponse fetch(
+        final HttpUrl endpoint, final Config config, final String etag) throws IOException {
+      calls.incrementAndGet();
+      requests.add(new Request(config.getApiKey(), etag));
+      if (requestStarted != null) {
+        requestStarted.countDown();
+      }
+      if (releaseRequest != null) {
+        await(releaseRequest);
+      }
+      final Object response = responses.remove();
+      if (response instanceof IOException) {
+        throw (IOException) response;
+      }
+      if (response instanceof RuntimeException) {
+        throw (RuntimeException) response;
+      }
+      return (AgentlessConfigurationSource.UfcHttpResponse) response;
+    }
+
+    @Override
+    public void cancel() {
+      cancelCalls.incrementAndGet();
+      if (releaseRequest != null) {
+        releaseRequest.countDown();
+      }
+    }
+
+    private static void await(final CountDownLatch latch) throws IOException {
+      try {
+        if (!latch.await(1, TimeUnit.SECONDS)) {
+          throw new SocketTimeoutException("test request did not release");
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException(e);
+      }
+    }
+  }
+
+  private static final class Request {
+    private final String apiKey;
+    private final String etag;
+
+    private Request(final String apiKey, final String etag) {
+      this.apiKey = apiKey;
+      this.etag = etag;
+    }
+  }
+}

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/OfflineConfigurationSourceTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/OfflineConfigurationSourceTest.java
@@ -1,0 +1,78 @@
+package com.datadog.featureflag;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OfflineConfigurationSourceTest {
+
+  private final FeatureFlaggingGateway.ConfigListener configListener =
+      mock(FeatureFlaggingGateway.ConfigListener.class);
+  private final OfflineConfigurationSource source = new OfflineConfigurationSource();
+
+  @AfterEach
+  void cleanup() {
+    source.close();
+    FeatureFlaggingGateway.removeConfigListener(configListener);
+    FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
+  }
+
+  @Test
+  void appliesStartupConfigurationExactlyOnce() {
+    source.init();
+    FeatureFlaggingGateway.addConfigListener(configListener);
+
+    assertTrue(FeatureFlaggingGateway.dispatchOfflineConfiguration(emptyConfiguration()));
+    assertThrows(
+        IllegalStateException.class,
+        () -> FeatureFlaggingGateway.dispatchOfflineConfiguration(emptyConfiguration()));
+
+    verify(configListener, times(1)).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void invalidConfigurationDoesNotPreventValidStartupConfiguration() {
+    source.init();
+    FeatureFlaggingGateway.addConfigListener(configListener);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> FeatureFlaggingGateway.dispatchOfflineConfiguration("{".getBytes(UTF_8)));
+    verifyNoInteractions(configListener);
+
+    assertTrue(FeatureFlaggingGateway.dispatchOfflineConfiguration(emptyConfiguration()));
+    verify(configListener).accept(any(ServerConfiguration.class));
+  }
+
+  @Test
+  void repeatedInitRegistersOneListenerAndCloseUnregistersIt() {
+    source.init();
+    source.init();
+
+    assertTrue(FeatureFlaggingGateway.dispatchOfflineConfiguration(emptyConfiguration()));
+
+    source.close();
+    assertFalse(FeatureFlaggingGateway.dispatchOfflineConfiguration(emptyConfiguration()));
+  }
+
+  private static byte[] emptyConfiguration() {
+    return ("{"
+            + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+            + "\"format\":\"SERVER\","
+            + "\"environment\":{\"name\":\"Test\"},"
+            + "\"flags\":{}"
+            + "}")
+        .getBytes(UTF_8);
+  }
+}


### PR DESCRIPTION
## Motivation

Provide a small Java reference implementation for the startup-only offline Feature Flagging mode so the cross-SDK system-test contract can be exercised before the production implementation is reviewed. This draft is stacked on #11892 and intentionally keeps the offline API narrow: the application supplies complete UFC JSON bytes once at provider initialization.

## Changes

- add `Provider.Options.offlineConfiguration(byte[])`
- route startup bytes through the bootstrap gateway to a dedicated offline configuration source
- parse UFC with the existing Java deserializer and publish the existing `ServerConfiguration` model
- reject missing, empty, malformed, or repeated offline configuration
- document Java startup usage and cover listener lifecycle, defensive copying, initialization order, malformed payload recovery, and repeated initialization

## Decisions

- offline is a distinct startup-only source; it starts neither the agentless poller nor the FFE Remote Configuration subscription
- the public API owns the caller-facing bytes, while the agent-owned source performs parsing and dispatch
- the source registers once even if agent initialization is invoked repeatedly
- this is a provisional Java reference used to validate the system-test contract; all system-tests manifests remain disabled

```mermaid
flowchart LR
  A["#11892<br/>agentless + source selection"] --> B["This draft<br/>Java offline reference"]
  C["system-tests main<br/>disabled offline contract"] --> B
  B --> D["Provisional proof<br/>26 offline tests pass"]
  C --> E["Small per-SDK<br/>manifest enablement PRs"]
```

## Validation

- `./gradlew :products:feature-flagging:feature-flagging-bootstrap:spotlessCheck :products:feature-flagging:feature-flagging-lib:spotlessCheck :products:feature-flagging:feature-flagging-api:spotlessCheck :products:feature-flagging:feature-flagging-agent:spotlessCheck`
- `./gradlew :products:feature-flagging:feature-flagging-bootstrap:test :products:feature-flagging:feature-flagging-lib:test :products:feature-flagging:feature-flagging-api:test :products:feature-flagging:feature-flagging-agent:test` — `BUILD SUCCESSFUL`
- `./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :products:feature-flagging:feature-flagging-api:jar` — `BUILD SUCCESSFUL`
- locally built these three artifacts, installed them into `system-tests`, and force-ran the disabled offline contract: `26 passed in 37.82s`

Companion system-tests draft: [DataDog/system-tests#7305](https://github.com/DataDog/system-tests/pull/7305).
