### PR TITLE
Disallow `AgentTracer.forceRegister(null)`

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
@@ -20,7 +20,7 @@ class DebuggerTracerTest {
 
   @AfterEach
   public void after() {
-    AgentTracer.forceRegister(null);
+    AgentTracer.forceRegister(AgentTracer.NOOP_TRACER);
   }
 
   @Test
@@ -60,7 +60,7 @@ class DebuggerTracerTest {
 
   @Test
   public void noApi() {
-    AgentTracer.forceRegister(null);
+    AgentTracer.forceRegister(AgentTracer.NOOP_TRACER);
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     DebuggerTracer debuggerTracer = new DebuggerTracer(probeStatusSink);
     DebuggerSpan span =

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -258,6 +258,9 @@ public class AgentTracer {
   }
 
   public static synchronized void forceRegister(TracerAPI tracer) {
+    if (tracer == null) {
+      throw new IllegalArgumentException("tracer must not be null, use NOOP_TRACER instead");
+    }
     provider = tracer;
   }
 


### PR DESCRIPTION
# What Does This Do

Disallow `AgentTracer.forceRegister(null)`; callers should pass `NOOP_TRACER` explicitly instead of null.

# Motivation

Helps ensure `AgentTracer.get()` is never `null`

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
