### PR TITLE
Mark testDynamicInstrumentationEnablementWithLineProbe as Flaky

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -42,6 +42,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
     waitForReTransformation(appUrl); // wait for retransformation of removed probe
   }
 
+  @Flaky
   @Test
   @DisplayName("testDynamicInstrumentationEnablementWithLineProbe")
   void testDynamicInstrumentationEnablementWithLineProbe() throws Exception {


### PR DESCRIPTION
# What Does This Do

Mark `testDynamicInstrumentationEnablementWithLineProbe()` as Flaky

# Motivation

Green CI

# Additional Notes

For failure examples, see:
* GitLab job: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1857686266
* [CI/CD Optimization list](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.branch%3Amaster%20%40ci.job.name%3A%2Aflaky%2A%20%40test.status%3Afail%20%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-java%22%20%40test.full_name%3Adatadog.smoketest.InProductEnablementIntegrationTest.testExceptionReplayEnablementFailure%20%40test.codeowners%3A%40DataDog%2Fdebugger-java&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&currentTab=overview&eventStack=&fromUser=false&index=citest&refresh_mode=sliding&start=1781453126142&end=1784045126142&paused=false)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
