### PR TITLE
Move akka context swap test to forked

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
@@ -18,12 +18,16 @@ apply from: "$rootDir/gradle/test-with-scala.gradle"
 addTestSuite('akka23Test')
 addTestSuiteExtendingForDir('akka23ForkedTest', 'akka23Test', 'akka23Test')
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'akka23Test')
 
 tasks.named("compileAkka23TestGroovy", GroovyCompile) {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)
 }
 tasks.named("compileAkka23ForkedTestGroovy", GroovyCompile) {
   classpath += files(sourceSets.akka23ForkedTest.scala.classesDirectory)
+}
+tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
+  classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
 }
 
 // Run the akka23Test against the normal and latestDep akka version as well

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
@@ -16,10 +16,14 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
 addTestSuite('akka23Test')
+addTestSuiteExtendingForDir('akka23ForkedTest', 'akka23Test', 'akka23Test')
 addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileAkka23TestGroovy", GroovyCompile) {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)
+}
+tasks.named("compileAkka23ForkedTestGroovy", GroovyCompile) {
+  classpath += files(sourceSets.akka23ForkedTest.scala.classesDirectory)
 }
 
 // Run the akka23Test against the normal and latestDep akka version as well

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/groovy/AkkaActorTest.groovy
@@ -84,7 +84,7 @@ class AkkaActorTest extends InstrumentationSpecification {
   }
 }
 
-class AkkaActorContextSwapTest extends AkkaActorTest {
+class AkkaActorContextSwapForkedTest extends AkkaActorTest {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/groovy/AkkaActorTest.groovy
@@ -1,10 +1,12 @@
 import datadog.trace.agent.test.InstrumentationSpecification
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 class AkkaActorTest extends InstrumentationSpecification {
   @Shared
+  @AutoCleanup
   def akkaTester = new AkkaActors()
 
   def "akka actor send #name #iterations"() {

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
@@ -89,16 +89,17 @@ object AkkaActors {
 
   // The way to terminate an actor system has changed between versions
   val terminate: (ActorSystem) => Unit = { system =>
-    if (isAkka23) {
-      classOf[ActorSystem].getMethod("shutdown").invoke(system)
-      classOf[ActorSystem].getMethod("awaitTermination").invoke(system)
-    } else {
+    try {
       classOf[ActorSystem].getMethod("terminate").invoke(system)
       val whenTerminated = classOf[ActorSystem]
         .getMethod("whenTerminated")
         .invoke(system)
         .asInstanceOf[scala.concurrent.Future[AnyRef]]
       Await.ready(whenTerminated, 30.seconds)
+    } catch {
+      case _: NoSuchMethodException =>
+        classOf[ActorSystem].getMethod("shutdown").invoke(system)
+        classOf[ActorSystem].getMethod("awaitTermination").invoke(system)
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/src/akka23Test/scala/AkkaActors.scala
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.{
   startSpan
 }
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class AkkaActors extends AutoCloseable {
@@ -87,24 +88,17 @@ object AkkaActors {
     }
 
   // The way to terminate an actor system has changed between versions
-  val terminate: (ActorSystem) => Unit = {
-    val t =
-      try {
-        ActorSystem.getClass.getMethod("terminate")
-      } catch {
-        case _: Throwable =>
-          try {
-            ActorSystem.getClass.getMethod("awaitTermination")
-          } catch {
-            case _: Throwable => null
-          }
-      }
-    if (t ne null) {
-      { system: ActorSystem =>
-        t.invoke(system)
-      }
+  val terminate: (ActorSystem) => Unit = { system =>
+    if (isAkka23) {
+      classOf[ActorSystem].getMethod("shutdown").invoke(system)
+      classOf[ActorSystem].getMethod("awaitTermination").invoke(system)
     } else {
-      { _ => ??? }
+      classOf[ActorSystem].getMethod("terminate").invoke(system)
+      val whenTerminated = classOf[ActorSystem]
+        .getMethod("whenTerminated")
+        .invoke(system)
+        .asInstanceOf[scala.concurrent.Future[AnyRef]]
+      Await.ready(whenTerminated, 30.seconds)
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/build.gradle
@@ -22,9 +22,13 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
+}
+tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
+  classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/groovy/PekkoActorTest.groovy
+++ b/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/groovy/PekkoActorTest.groovy
@@ -1,11 +1,13 @@
 import datadog.trace.agent.test.InstrumentationSpecification
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 class PekkoActorTest extends InstrumentationSpecification {
 
   @Shared
+  @AutoCleanup
   def pekkoTester = new PekkoActors()
 
   @Override

--- a/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/groovy/PekkoActorTest.groovy
+++ b/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/groovy/PekkoActorTest.groovy
@@ -122,7 +122,7 @@ class PekkoActorTest extends InstrumentationSpecification {
   }
 }
 
-class PekkoActorContextSwapTest extends PekkoActorTest {
+class PekkoActorContextSwapForkedTest extends PekkoActorTest {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()

--- a/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/scala/PekkoActors.scala
+++ b/dd-java-agent/instrumentation/pekko/pekko-concurrent-1.0/src/test/scala/PekkoActors.scala
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.{
   startSpan
 }
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class PekkoActors extends AutoCloseable {
@@ -90,26 +91,9 @@ class PekkoActors extends AutoCloseable {
 
 object PekkoActors {
 
-  // The way to terminate an actor system has changed between versions
-  val terminate: (ActorSystem) => Unit = {
-    val t =
-      try {
-        ActorSystem.getClass.getMethod("terminate")
-      } catch {
-        case _: Throwable =>
-          try {
-            ActorSystem.getClass.getMethod("awaitTermination")
-          } catch {
-            case _: Throwable => null
-          }
-      }
-    if (t ne null) {
-      { system: ActorSystem =>
-        t.invoke(system)
-      }
-    } else {
-      { _ => ??? }
-    }
+  val terminate: (ActorSystem) => Unit = { system =>
+    system.terminate()
+    Await.ready(system.whenTerminated, 30.seconds)
   }
 }
 


### PR DESCRIPTION
# What Does This Do

This PR fixes the flakiness of akka/pekko context swap. tests. The main issue:

The akka/pekko mailbox was not shutting down properly. It was instantiated with one context mode and then when the configuration switched from one test to another there was:
```
11:43:21.891 [akka-actors-test-akka.actor.default-dispatcher-4] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for akka.dispatch.Mailbox - datadog.trace.instrumentation.akka.concurrent.AkkaMailboxInstrumentation$SuppressMailboxRunAdvice
java.lang.IllegalStateException: rollbackActiveToCheckpoint must not be called when context swap based logic is enabled
	at datadog.trace.core.CoreTracer.rollbackActiveToCheckpoint(CoreTracer.java:1225)
	at datadog.trace.core.CoreTracer$SpockMock$590092662.rollbackActiveToCheckpoint$accessor$y6uFR7JF(Unknown Source)
	at datadog.trace.core.CoreTracer$SpockMock$590092662$auxiliary$snbDkg3H.call(Unknown Source)
	at org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:22)
	at org.spockframework.mock.IResponseGenerator.lambda$getResponseSupplier$0(IResponseGenerator.java:67)
	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:61)
	at org.spockframework.mock.runtime.MockController.handle(MockController.java:60)
	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:83)
	at org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at datadog.trace.core.CoreTracer$SpockMock$590092662.rollbackActiveToCheckpoint(Unknown Source)
	at datadog.trace.bootstrap.instrumentation.api.AgentTracer.rollbackActiveToCheckpoint(AgentTracer.java:128)
	at akka.dispatch.Mailbox.run(Mailbox.scala:228)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:234)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```
The second run passed because was on a fresh JVM.

This PR ensures that the actor system cleans nicely on test completion. Also moves those tests to forked for extra safety

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
