### PR TITLE
Fix TOCTOU race causing NPE in Hibernate closeScope

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/hibernate-common/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -62,14 +62,15 @@ public class SessionMethodUtils {
       final Object entity,
       final boolean closeSpan) {
 
-    if (sessionState == null || sessionState.getMethodScope() == null) {
+    final AgentScope scope = sessionState == null ? null : sessionState.getMethodScope();
+    if (scope == null) {
       // This method call was re-entrant. Do nothing, since it is being traced by the parent/first
       // call.
       return;
     }
 
     CallDepthThreadLocalMap.reset(SessionMethodUtils.class);
-    final AgentScope scope = sessionState.getMethodScope();
+    sessionState.setMethodScope(null);
     final AgentSpan span = scope.span();
     if (span != null && (sessionState.hasChildSpan() || closeSpan)) {
       DECORATOR.onError(span, throwable);
@@ -81,7 +82,6 @@ public class SessionMethodUtils {
     }
 
     scope.close();
-    sessionState.setMethodScope(null);
   }
 
   /**


### PR DESCRIPTION
# What Does This Do

SessionMethodUtils.closeScope read SessionState.methodScope twice (once to check null, once to use) with no lock between the reads. A concurrent call could null it out in between, causing

```
Error : Failed to handle exception in instrumentation for org.hibernate.internal.CriteriaImpl - datadog.trace.instrumentation.hibernate.core.v4_0.CriteriaInstrumentation$CriteriaMethodAdvice
java.lang.NullPointerException
  at datadog.trace.instrumentation.hibernate.SessionMethodUtils.closeScope(SessionMethodUtils.java:73)
  at (redacted: 29 frames)
  at sun.reflect.GeneratedMethodAccessor5142.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at (redacted: 16 frames)
  at sun.reflect.GeneratedMethodAccessor5141.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at (redacted: 11 frames)
  at sun.reflect.GeneratedMethodAccessor5731.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMet
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
