### PR TITLE
InternalTagAdder: defensively guard against null prebuilt tagmap entry

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/InternalTagsAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/InternalTagsAdder.java
@@ -34,8 +34,10 @@ public final class InternalTagsAdder extends TagsPostProcessor {
     }
 
     if (!ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
-      // service name != DD_SERVICE
-      unsafeTags.set(baseServiceEntry);
+      if (baseServiceEntry != null) {
+        // service name != DD_SERVICE
+        unsafeTags.set(baseServiceEntry);
+      }
     } else {
       // as per config consistency, the version tag is added across tracers only if
       // the service name is DD_SERVICE and version  tag is not manually set


### PR DESCRIPTION
# What Does This Do

There is a codepath where, if DD_SERVICE is set empty, the prebuilt tagmap entry for _dd.base_service is null and can break  the advice from the span finish callsite

Having an empty service name is not something we should allow. We prevent only null becoming unnamed-java-service but when it's set to the config it can be empty. 

This PR implements a defensive fix

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
