### PR TITLE
Guard against null logback events

### DIFF
--- a/dd-java-agent/instrumentation/logback-1.0/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1.0/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
@@ -74,6 +74,9 @@ public class LogbackLoggerInstrumentation extends InstrumenterModule.ContextTrac
   public static class CallAppendersAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(@Advice.Argument(0) ILoggingEvent event) {
+      if (event == null) {
+        return;
+      }
       AgentSpan span = activeSpan();
 
       if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
@@ -86,6 +89,9 @@ public class LogbackLoggerInstrumentation extends InstrumenterModule.ContextTrac
   public static class CallAppendersAdvice2 {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(@Advice.Argument(0) ILoggingEvent event) {
+      if (event == null) {
+        return;
+      }
       LogsIntakeHelper.log(event);
     }
   }


### PR DESCRIPTION
# What Does This Do

Even I did not found a codepath on logback source that calls `callAppenders` with a null event, we surface this situation:

```
Error : Failed to handle exception in instrumentation for ch.qos.logback.classic.Logger - datadog.trace.instrumentation.logback.LogbackLoggerInstrumentation$CallAppendersAdvice
java.lang.NullPointerException
  at (redacted: 9 frames)
  at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
  at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
```

It can also be a third party. In any case our store is not supporting null keys hence adding this guard for code hygiene. 



# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
