### PR TITLE
Make the TagMap Entry pathway null-tolerant

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -16,6 +16,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A super simple hash map designed for...
@@ -150,14 +152,14 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
   Object put(String tag, Object value);
 
   /** Sets value without returning prior value - more efficient than {@link Map#put} */
-  void set(String tag, Object value);
+  void set(String tag, @Nonnull Object value);
 
   /**
    * Similar to {@link TagMap#set(String, Object)} but more efficient when working with
    * CharSequences and Strings. Depending on this situation, this methods avoids having to do type
    * resolution later on
    */
-  void set(String tag, CharSequence value);
+  void set(String tag, @Nonnull CharSequence value);
 
   void set(String tag, boolean value);
 
@@ -169,7 +171,8 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
 
   void set(String tag, double value);
 
-  void set(EntryReader newEntry);
+  /** A null reader is a no-op (see the null-tolerance contract on {@link #getAndSet(Entry)}). */
+  void set(@Nullable EntryReader newEntry);
 
   /** sets the value while returning the prior Entry */
   Entry getAndSet(String tag, Object value);
@@ -187,10 +190,12 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
   Entry getAndSet(String tag, double value);
 
   /**
-   * TagMap specific method that places an Entry directly into an optimized TagMap avoiding need to
-   * allocate a new Entry object
+   * Places an Entry directly into the map, avoiding a new Entry allocation. Null-tolerant: a null
+   * {@code newEntry} is a no-op returning null, so an Entry producer (e.g. {@link
+   * Entry#create(String, Object)} for a null/empty value) can emit "no tag" without the caller
+   * filtering. Contrast the strict {@link Nonnull} {@code set(String, value)} setters.
    */
-  Entry getAndSet(Entry newEntry);
+  Entry getAndSet(@Nullable Entry newEntry);
 
   void putAll(Map<? extends String, ? extends Object> map);
 
@@ -368,15 +373,20 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
      */
     static final byte ANY = 0;
 
-    /** If value is non-null, returns a new TagMap.Entry If value is null, returns null */
+    /**
+     * Entry for {@code (tag, value)}, or null when {@code value} is null or an empty {@code
+     * CharSequence} -- checked by runtime type, so an empty String passed as {@code Object} skips
+     * the same as via the {@link #create(String, CharSequence)} overload.
+     */
+    @Nullable
     public static final Entry create(String tag, Object value) {
-      // NOTE: From the static typing, it is possible that value is a primitive box, so need to call
-      // Any variant
-
-      return (value == null) ? null : TagMap.Entry.newAnyEntry(tag, value);
+      if (value == null) return null;
+      if (value instanceof CharSequence && ((CharSequence) value).length() == 0) return null;
+      return TagMap.Entry.newAnyEntry(tag, value);
     }
 
     /** If value is non-null, returns a new TagMap.Entry If value is null or empty, returns null */
+    @Nullable
     public static final Entry create(String tag, CharSequence value) {
       // NOTE: From the static typing, we know that value is not a primitive box
 
@@ -1357,6 +1367,7 @@ final class OptimizedTagMap implements TagMap {
 
   @Override
   public void set(TagMap.EntryReader newEntryReader) {
+    if (newEntryReader == null) return;
     this.getAndSet(newEntryReader.entry());
   }
 
@@ -1397,6 +1408,8 @@ final class OptimizedTagMap implements TagMap {
 
   @Override
   public Entry getAndSet(Entry newEntry) {
+    if (newEntry == null) return null;
+
     this.checkWriteAccess();
 
     Object[] thisBuckets = this.buckets;

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -380,8 +380,12 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
      */
     @Nullable
     public static final Entry create(@Nonnull String tag, Object value) {
-      if (value == null) return null;
-      if (value instanceof CharSequence && ((CharSequence) value).length() == 0) return null;
+      if (value == null) {
+        return null;
+      }
+      if (value instanceof CharSequence && ((CharSequence) value).length() == 0) {
+        return null;
+      }
       return TagMap.Entry.newAnyEntry(tag, value);
     }
 
@@ -1367,7 +1371,9 @@ final class OptimizedTagMap implements TagMap {
 
   @Override
   public void set(TagMap.EntryReader newEntryReader) {
-    if (newEntryReader == null) return;
+    if (newEntryReader == null) {
+      return;
+    }
     this.getAndSet(newEntryReader.entry());
   }
 
@@ -1408,7 +1414,9 @@ final class OptimizedTagMap implements TagMap {
 
   @Override
   public Entry getAndSet(Entry newEntry) {
-    if (newEntry == null) return null;
+    if (newEntry == null) {
+      return null;
+    }
 
     this.checkWriteAccess();
 

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -149,45 +149,45 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
    * are implemented more efficiently.
    */
   @Deprecated
-  Object put(String tag, Object value);
+  Object put(@Nonnull String tag, Object value);
 
   /** Sets value without returning prior value - more efficient than {@link Map#put} */
-  void set(String tag, @Nonnull Object value);
+  void set(@Nonnull String tag, @Nonnull Object value);
 
   /**
    * Similar to {@link TagMap#set(String, Object)} but more efficient when working with
    * CharSequences and Strings. Depending on this situation, this methods avoids having to do type
    * resolution later on
    */
-  void set(String tag, @Nonnull CharSequence value);
+  void set(@Nonnull String tag, @Nonnull CharSequence value);
 
-  void set(String tag, boolean value);
+  void set(@Nonnull String tag, boolean value);
 
-  void set(String tag, int value);
+  void set(@Nonnull String tag, int value);
 
-  void set(String tag, long value);
+  void set(@Nonnull String tag, long value);
 
-  void set(String tag, float value);
+  void set(@Nonnull String tag, float value);
 
-  void set(String tag, double value);
+  void set(@Nonnull String tag, double value);
 
   /** A null reader is a no-op (see the null-tolerance contract on {@link #getAndSet(Entry)}). */
   void set(@Nullable EntryReader newEntry);
 
   /** sets the value while returning the prior Entry */
-  Entry getAndSet(String tag, Object value);
+  Entry getAndSet(@Nonnull String tag, Object value);
 
-  Entry getAndSet(String tag, CharSequence value);
+  Entry getAndSet(@Nonnull String tag, CharSequence value);
 
-  Entry getAndSet(String tag, boolean value);
+  Entry getAndSet(@Nonnull String tag, boolean value);
 
-  Entry getAndSet(String tag, int value);
+  Entry getAndSet(@Nonnull String tag, int value);
 
-  Entry getAndSet(String tag, long value);
+  Entry getAndSet(@Nonnull String tag, long value);
 
-  Entry getAndSet(String tag, float value);
+  Entry getAndSet(@Nonnull String tag, float value);
 
-  Entry getAndSet(String tag, double value);
+  Entry getAndSet(@Nonnull String tag, double value);
 
   /**
    * Places an Entry directly into the map, avoiding a new Entry allocation. Null-tolerant: a null
@@ -379,7 +379,7 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
      * the same as via the {@link #create(String, CharSequence)} overload.
      */
     @Nullable
-    public static final Entry create(String tag, Object value) {
+    public static final Entry create(@Nonnull String tag, Object value) {
       if (value == null) return null;
       if (value instanceof CharSequence && ((CharSequence) value).length() == 0) return null;
       return TagMap.Entry.newAnyEntry(tag, value);
@@ -387,7 +387,7 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
 
     /** If value is non-null, returns a new TagMap.Entry If value is null or empty, returns null */
     @Nullable
-    public static final Entry create(String tag, CharSequence value) {
+    public static final Entry create(@Nonnull String tag, CharSequence value) {
       // NOTE: From the static typing, we know that value is not a primitive box
 
       return (value == null || value.length() == 0)
@@ -395,23 +395,23 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
           : TagMap.Entry.newObjectEntry(tag, value);
     }
 
-    public static final Entry create(String tag, boolean value) {
+    public static final Entry create(@Nonnull String tag, boolean value) {
       return TagMap.Entry.newBooleanEntry(tag, value);
     }
 
-    public static final Entry create(String tag, int value) {
+    public static final Entry create(@Nonnull String tag, int value) {
       return TagMap.Entry.newIntEntry(tag, value);
     }
 
-    public static final Entry create(String tag, long value) {
+    public static final Entry create(@Nonnull String tag, long value) {
       return TagMap.Entry.newLongEntry(tag, value);
     }
 
-    public static final Entry create(String tag, float value) {
+    public static final Entry create(@Nonnull String tag, float value) {
       return TagMap.Entry.newFloatEntry(tag, value);
     }
 
-    public static final Entry create(String tag, double value) {
+    public static final Entry create(@Nonnull String tag, double value) {
       return TagMap.Entry.newDoubleEntry(tag, value);
     }
 

--- a/internal-api/src/test/java/datadog/trace/api/TagMapNullToleranceTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapNullToleranceTest.java
@@ -1,0 +1,66 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the Entry-pathway null-tolerance contract: {@code create(...)} returns null for a null or
+ * empty value, and the {@code Entry} sinks ({@code set(Entry)} / {@code getAndSet(Entry)}) treat
+ * null as a no-op -- so a null/empty value flows through as "no tag" without any caller guarding.
+ */
+class TagMapNullToleranceTest {
+
+  @Test
+  void createReturnsNullForNullOrEmptyValue() {
+    // CharSequence overload: null or empty -> null
+    assertNull(TagMap.Entry.create("k", (CharSequence) null));
+    assertNull(TagMap.Entry.create("k", ""));
+
+    // Object overload: null -> null, and an empty String typed as Object -> null (runtime check,
+    // so the convention holds regardless of the static type at the call site)
+    assertNull(TagMap.Entry.create("k", (Object) null));
+    assertNull(TagMap.Entry.create("k", (Object) ""));
+
+    // Non-empty values still produce an entry, whatever the static type
+    assertNotNull(TagMap.Entry.create("k", "v"));
+    assertNotNull(TagMap.Entry.create("k", (Object) "v"));
+    // Non-CharSequence Object has no notion of "empty" -> always an entry
+    assertNotNull(TagMap.Entry.create("k", (Object) Integer.valueOf(0)));
+  }
+
+  @Test
+  void getAndSetToleratesNullEntry() {
+    TagMap map = TagMap.create();
+    assertNull(map.getAndSet((TagMap.Entry) null), "null entry is a no-op returning null");
+    assertEquals(0, map.size(), "no tag added");
+  }
+
+  @Test
+  void setToleratesNullReader() {
+    TagMap map = TagMap.create();
+    map.set((TagMap.EntryReader) null); // must not throw
+    assertEquals(0, map.size(), "no tag added");
+  }
+
+  @Test
+  void nullOrEmptyFlowsThroughTheEntryPathwayAsNoTag() {
+    TagMap map = TagMap.create();
+
+    // The seamless case: create(...) -> set(Entry) with a null/empty value, no caller guard.
+    map.set(TagMap.Entry.create("empty", ""));
+    map.set(TagMap.Entry.create("emptyObj", (Object) ""));
+    map.set(TagMap.Entry.create("nul", (CharSequence) null));
+    assertEquals(0, map.size(), "null/empty values leave no tags behind");
+    assertFalse(map.containsKey("empty"));
+
+    // A real value still lands.
+    map.set(TagMap.Entry.create("present", "v"));
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey("present"));
+  }
+}


### PR DESCRIPTION
## What Does This Do

Makes the TagMap **Entry pathway** null-tolerant, so a null/empty value flows through as "no tag" without any caller guarding:

- `Entry.create(Object)` / `Entry.create(CharSequence)` return `null` for a null or empty value (`@Nullable`). `create(Object)` now applies the empty-`CharSequence` check **by runtime type**, so an empty String passed as `Object` skips the same as via the `CharSequence` overload — behavior no longer depends on the static type at the call site.
- The Entry **sinks** — `getAndSet(Entry)` and `set(EntryReader)` — treat a null Entry as a no-op (`@Nullable` params). Two guards because `set(EntryReader)` derefs `.entry()` before delegating.
- The strict `(key, value)` setters keep their contract: their **values** (`set(String, Object)` / `set(String, CharSequence)`) are `@Nonnull`.
- **Keys stay strict everywhere they're written:** all `tag` keys on the write/create surface (`put` / `set` / `getAndSet` / `create`) are `@Nonnull` — a null key is a bug, not "no tag". So null-tolerance is scoped to *values and Entries on the Entry pathway*; keys and strict-setter values are non-null. The annotations make the whole split self-describing.

## Motivation

Make handling easier - and avoid NPEs

The Entry pathway is the prebuilt/producer path (`create(...) → set(Entry)`); a null Entry is the designed "nothing to add" value, mirroring `DDSpanContext.setTag`'s null/empty ⇒ absent convention. Centralizing the tolerance in the primitive means callers needn't each remember a guard — which they don't: this **fixes a latent NPE by construction** in `RemoteHostnameAdder`, which sets `create(TRACER_HOST, hostname)` guarding only null (not empty), so an empty hostname previously NPE'd on `set(null)`.

## Notes

- **`getAndSet`'s null check is the first statement**, ahead of `checkWriteAccess()` and any field read, so it dead-code-eliminates when inlined at a provably-non-null call site (e.g. `set(String,value) → getAndSet(newAnyEntry(...))`) and stays only where the arg can actually be null. A null Entry is thus a complete no-op and does not assert write access.
- **Scope:** primitive + test only. Caller-side guard cleanup — dropping the now-redundant guards (incl. #11958) and simplifying `InternalTagsAdder` — is a fast follow-up.
- The `@Nonnull` keys cover the **write/create** surface; read/lookup keys (`getString`, `remove`, `getXxxOrDefault`) are intentionally left unannotated here — same "null key = bug" logic, but a broader, Map-contract-adjacent sweep worth doing on its own.

## Test

`TagMapNullToleranceTest` pins the contract: `create(...)` → null for null/empty (incl. empty-as-`Object`); `set`/`getAndSet` null no-op; end-to-end `create()→set()` with null/empty leaves no tag. Existing `TagMapTest` / `TagMapEntryTest` green (no behavior regression).

tag: ai generated
tag: no release note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
