### PR TITLE
Hoist local vars for exception probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -95,6 +95,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
   private volatile Configuration currentConfiguration;
   private DebuggerTransformer currentTransformer;
   private final ProbeMetadata probeMetadata = new ProbeMetadata();
+  private final Config config;
   private final DebuggerSink sink;
   private final ClassesToRetransformFinder finder;
   private final String serviceName;
@@ -112,6 +113,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     this.instrumentation = instrumentation;
     this.transformerSupplier = transformerSupplier;
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
+    this.config = config;
     this.sink = sink;
     this.finder = finder;
   }
@@ -255,11 +257,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     // install new probe definitions
     DebuggerTransformer newTransformer =
         transformerSupplier.supply(
-            Config.get(),
-            newConfiguration,
-            this::recordInstrumentationProgress,
-            probeMetadata,
-            sink);
+            config, newConfiguration, this::recordInstrumentationProgress, probeMetadata, sink);
     instrumentation.addTransformer(newTransformer, true);
     currentTransformer = newTransformer;
     LOGGER.debug("New transformer installed with probes: {}", newConfiguration.getDefinitions());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
@@ -74,7 +74,7 @@ public class CapturedContextInstrumenter extends Instrumenter {
   private int exitContextVar = -1;
   private int timestampStartVar = -1;
   private int throwableListVar = -1;
-  private Collection<LocalVariableNode> hoistedLocalVars = Collections.emptyList();
+  protected Collection<LocalVariableNode> hoistedLocalVars = Collections.emptyList();
 
   public CapturedContextInstrumenter(
       ProbeDefinition definition,
@@ -470,7 +470,7 @@ public class CapturedContextInstrumenter extends Instrumenter {
 
   // Initialize and hoist local variables to the top of the method
   // if there is name/slot conflict, do nothing for the conflicting local variable
-  private Collection<LocalVariableNode> initAndHoistLocalVars(MethodNode methodNode) {
+  protected Collection<LocalVariableNode> initAndHoistLocalVars(MethodNode methodNode) {
     int hoistingLevel = Config.get().getDynamicInstrumentationLocalVarHoistingLevel();
     if (hoistingLevel == 0 || language != JvmLanguage.JAVA) {
       // for now, only hoist local vars for Java

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
@@ -21,6 +21,10 @@ public class ExceptionInstrumenter extends CapturedContextInstrumenter {
 
   @Override
   public InstrumentationResult.Status instrument() {
+    // hoisting is required because exception instrumentation is wrapping the whole method body in
+    // a try/catch that create a subscobe and even level method local vars are not accessible
+    // in the catch clause for capture
+    hoistedLocalVars = initAndHoistLocalVars(methodNode);
     Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
     processInstructions(frames); // fill returnHandlerLabel
     addFinallyHandler(methodEnterLabel, returnHandlerLabel);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -135,6 +135,9 @@ public class ExceptionProbeInstrumentationTest {
   }
 
   @Test
+  @DisabledIf(
+      value = "datadog.environment.JavaVirtualMachine#isJ9",
+      disabledReason = "Bug in J9: no LocalVariableTable for ClassFileTransformer")
   public void instrumentAndCaptureSnapshots() throws Exception {
     Config config = createConfig();
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
@@ -162,6 +165,8 @@ public class ExceptionProbeInstrumentationTest {
     assertEquals(fingerprint, span.getTags().get(DD_DEBUG_ERROR_EXCEPTION_HASH));
     assertEquals(Boolean.TRUE, span.getTags().get(Tags.ERROR_DEBUG_INFO_CAPTURED));
     assertEquals(snapshot0.getId(), span.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 0)));
+    assertTrue(snapshot0.getCaptures().getReturn().getArguments().containsKey("arg"));
+    assertTrue(snapshot0.getCaptures().getReturn().getLocals().containsKey("intLocal"));
     assertEquals(1, probeSampler.getCallCount());
     assertEquals(1, globalSampler.getCallCount());
   }


### PR DESCRIPTION
# What Does This Do
Exception probe instrumentation was not performing hoisting of local vars which is in fact required if we want to capture those locals because the wrapping with try/catch of the whole method body create sub scope preventing locals to be captured in the catch clause.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [DEBUG-5838]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5838]: https://datadoghq.atlassian.net/browse/DEBUG-5838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ