### PR TITLE
Restore techdebt review

### DIFF
--- a/.agents/skills/techdebt/SKILL.md
+++ b/.agents/skills/techdebt/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: techdebt
-description: Analyze branch changes for technical debt, code duplication, and unnecessary complexity
+description: >-
+  Review a code diff / branch / PR for technical debt — code duplication,
+  unnecessary complexity / over-engineering, and redundant or dead code. Use
+  whenever the user wants a tech-debt, cleanup, or refactor review, asks to check
+  a branch or PR for duplication / complexity / dead code before opening a PR, or
+  mentions "techdebt". Refactor-only: it reports issues and offers
+  behavior-preserving fixes; it never changes behavior.
 user-invocable: true
 context: fork
 allowed-tools:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,6 @@
 
 ## Claude Code workflow
 
-- Before creating a pull request, run `/techdebt` to check for technical debt, code duplication, and unnecessary complexity in the branch changes.
+- Before creating a pull request, run the [Review Guidelines](../AGENTS.md#review-guidelines) checks over the branch changes.
 - After running `/migrate-groovy-to-java`, run `/review-groovy-migration` on the migrated files before opening a PR.
 - Always write new unit tests using JUnit 5 and Java. If the target test file is `.groovy`, run the `/migrate-groovy-to-java` skill on it first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,11 @@ docs/                     Developer documentation (see below)
 
 ## Review Guidelines
 
-Before marking a PR ready, run the applicable reviews below over the branch changes (the diff since the merge-base with `master`). These are **advisory, precision-first** checks — they surface high-severity issues early and are not merge gates. The linked guidelines are the tool-agnostic source of truth.
+Before marking a PR ready, run these reviews over the branch changes.
+Each skill's `SKILL.md` is the source of truth for scope and method.
 
-### Performance Review
-
-Follow the performance-review guidelines in [.agents/skills/perf-review/SKILL.md](.agents/skills/perf-review/SKILL.md) — the do-no-harm / assume-hot posture, the hot-path checks (universal + Java J1–J11 + ByteBuddy-Advice idioms), and the confidence/severity model, with the detailed rubric in its `references/`. Scope: hot-path allocation, unbounded memory, repeated work, escaping objects, native-boundary crossings, and JVM-specific pitfalls.
+- **Technical debt** — run [`/techdebt`](.agents/skills/techdebt/SKILL.md) to catch code duplication, unnecessary complexity, and dead code. Refactor-only: it never changes behavior.
+- **Performance** — run [`/perf-review`](.agents/skills/perf-review/SKILL.md) for hot-path overhead, applying the do-no-harm / assume-hot posture and the tracer perf rubric. There are **advisory, precision-first** passes — they surface high-severity issues early and are not merge gates.
 
 ## Bootstrap constraints (critical)
 


### PR DESCRIPTION
# What Does This Do

This PR restores the `/techdebt` review to avoid pushing bloated code.

# Motivation

The performance review removed the design review.

# Additional Notes

Update the skill description to the new standards.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [APMLP-1609]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1609]: https://datadoghq.atlassian.net/browse/APMLP-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ