### PR TITLE
Memoize per-test class analysis in a module-wide cache

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/ExecutionDataAdapter.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/ExecutionDataAdapter.java
@@ -18,6 +18,14 @@ public class ExecutionDataAdapter {
     return className;
   }
 
+  long getClassId() {
+    return classId;
+  }
+
+  boolean[] getProbeActivations() {
+    return probeActivations;
+  }
+
   void record(int probeId) {
     probeActivations[probeId] = true;
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/ExecutionDataAdapter.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/ExecutionDataAdapter.java
@@ -1,7 +1,5 @@
 package datadog.trace.civisibility.coverage.line;
 
-import org.jacoco.core.data.ExecutionData;
-
 public class ExecutionDataAdapter {
   private final long classId;
   private final String className;
@@ -35,9 +33,5 @@ public class ExecutionDataAdapter {
       probeActivations[i] |= other.probeActivations[i];
     }
     return this;
-  }
-
-  ExecutionData toExecutionData() {
-    return new ExecutionData(classId, className, probeActivations);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
@@ -14,6 +14,7 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.source.Utils;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,16 +38,27 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
 
   private static final Logger log = LoggerFactory.getLogger(LineCoverageStore.class);
 
+  /**
+   * Upper bound on the number of cached class analyses. Coverage stays correct beyond it (analysis
+   * just isn't cached), this only guards memory for pathologically large suites.
+   */
+  private static final int MAX_ANALYSIS_CACHE_ENTRIES = 50_000;
+
   private final CiVisibilityMetricCollector metrics;
   private final SourcePathResolver sourcePathResolver;
+  // Module-wide cache: (class id + probe set) -> covered lines, shared across tests so a class
+  // covered identically by many tests is parsed by Jacoco's Analyzer only once.
+  private final Map<AnalysisCacheKey, BitSet> analysisCache;
 
   private LineCoverageStore(
       Function<Boolean, LineProbes> probesFactory,
       CiVisibilityMetricCollector metrics,
-      SourcePathResolver sourcePathResolver) {
+      SourcePathResolver sourcePathResolver,
+      Map<AnalysisCacheKey, BitSet> analysisCache) {
     super(probesFactory);
     this.metrics = metrics;
     this.sourcePathResolver = sourcePathResolver;
+    this.analysisCache = analysisCache;
   }
 
   @Nullable
@@ -83,24 +95,9 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
       }
       String sourcePath = sourcePaths.iterator().next();
 
-      try (InputStream is = Utils.getClassStream(clazz)) {
-        BitSet coveredLines =
-            coveredLinesBySourcePath.computeIfAbsent(sourcePath, key -> new BitSet());
-        ExecutionDataStore store = new ExecutionDataStore();
-        store.put(executionDataAdapter.toExecutionData());
-
-        // TODO optimize this part to avoid parsing
-        //  the same class multiple times for different test cases
-        Analyzer analyzer = new Analyzer(store, new SourceAnalyzer(coveredLines));
-        analyzer.analyzeClass(is, null);
-
-      } catch (Exception exception) {
-        log.debug(
-            "Skipping coverage reporting for {} ({}) because of error",
-            className,
-            sourcePath,
-            exception);
-        metrics.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 1);
+      BitSet coveredLines = analyzeClass(clazz, executionDataAdapter);
+      if (coveredLines != null) {
+        coveredLinesBySourcePath.computeIfAbsent(sourcePath, key -> new BitSet()).or(coveredLines);
       }
     }
 
@@ -132,9 +129,80 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
     return report;
   }
 
+  /**
+   * Resolves the covered lines for a class given a test's probe activations. Parsing the class with
+   * Jacoco's {@link Analyzer} is the dominant cost of reporting, and the result depends only on the
+   * class bytecode and the probe set, so it is memoized: the same class covered identically by
+   * different tests is parsed once.
+   *
+   * @return the covered lines, or {@code null} if the class could not be analyzed
+   */
+  @Nullable
+  private BitSet analyzeClass(Class<?> clazz, ExecutionDataAdapter executionDataAdapter) {
+    AnalysisCacheKey key =
+        new AnalysisCacheKey(
+            executionDataAdapter.getClassId(), executionDataAdapter.getProbeActivations());
+    BitSet cached = analysisCache.get(key);
+    if (cached != null) {
+      return cached;
+    }
+
+    try (InputStream is = Utils.getClassStream(clazz)) {
+      BitSet coveredLines = new BitSet();
+      ExecutionDataStore store = new ExecutionDataStore();
+      store.put(executionDataAdapter.toExecutionData());
+      Analyzer analyzer = new Analyzer(store, new SourceAnalyzer(coveredLines));
+      analyzer.analyzeClass(is, null);
+
+      if (analysisCache.size() < MAX_ANALYSIS_CACHE_ENTRIES) {
+        analysisCache.putIfAbsent(key, coveredLines);
+      }
+      return coveredLines;
+
+    } catch (Exception exception) {
+      log.debug(
+          "Skipping coverage reporting for {} because of error",
+          executionDataAdapter.getClassName(),
+          exception);
+      metrics.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 1);
+      return null;
+    }
+  }
+
+  /** Cache key identifying a class (by Jacoco class id) covered by a specific set of probes. */
+  static final class AnalysisCacheKey {
+    private final long classId;
+    private final boolean[] probes;
+    private final int hash;
+
+    AnalysisCacheKey(long classId, boolean[] probes) {
+      this.classId = classId;
+      this.probes = probes;
+      this.hash = 31 * Long.hashCode(classId) + Arrays.hashCode(probes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof AnalysisCacheKey)) {
+        return false;
+      }
+      AnalysisCacheKey other = (AnalysisCacheKey) o;
+      return classId == other.classId && hash == other.hash && Arrays.equals(probes, other.probes);
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+  }
+
   public static final class Factory implements CoverageStore.Factory {
 
     private final Map<String, Integer> probeCounts = new ConcurrentHashMap<>();
+    private final Map<AnalysisCacheKey, BitSet> analysisCache = new ConcurrentHashMap<>();
 
     private final CiVisibilityMetricCollector metrics;
     private final SourcePathResolver sourcePathResolver;
@@ -146,7 +214,7 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
 
     @Override
     public CoverageStore create(@Nullable TestIdentifier testIdentifier) {
-      return new LineCoverageStore(this::createProbes, metrics, sourcePathResolver);
+      return new LineCoverageStore(this::createProbes, metrics, sourcePathResolver, analysisCache);
     }
 
     private LineProbes createProbes(boolean isTestThread) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
@@ -14,7 +14,6 @@ import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.source.Utils;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashMap;
@@ -23,9 +22,11 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.data.ExecutionData;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,26 +40,40 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
   private static final Logger log = LoggerFactory.getLogger(LineCoverageStore.class);
 
   /**
-   * Upper bound on the number of cached class analyses. Coverage stays correct beyond it (analysis
-   * just isn't cached), this only guards memory for pathologically large suites.
+   * Upper bound on the approximate memory retained by the analysis cache. Coverage stays correct
+   * beyond it (analysis just isn't cached), this only guards memory for pathologically large
+   * suites. Bounding by bytes (rather than entry count) is what keeps a class with many probes,
+   * covered by many distinct probe sets, from retaining large arrays for the whole module lifetime.
    */
-  private static final int MAX_ANALYSIS_CACHE_ENTRIES = 50_000;
+  private static final long MAX_ANALYSIS_CACHE_BYTES = 64L * 1024 * 1024;
+
+  /**
+   * Approximate fixed cost of one cache entry beyond its variable bit data: the {@link
+   * AnalysisCacheKey} and both {@link BitSet} objects (with their {@code long[]} + array headers)
+   * plus the {@code ConcurrentHashMap} node. Deliberately generous so small entries aren't
+   * undercounted and the byte bound stays a real ceiling.
+   */
+  private static final int APPROX_ENTRY_OVERHEAD_BYTES = 160;
 
   private final CiVisibilityMetricCollector metrics;
   private final SourcePathResolver sourcePathResolver;
   // Module-wide cache: (class id + probe set) -> covered lines, shared across tests so a class
   // covered identically by many tests is parsed by Jacoco's Analyzer only once.
   private final Map<AnalysisCacheKey, BitSet> analysisCache;
+  // Approximate bytes retained by analysisCache, so the cache is bounded by size, not entry count.
+  private final AtomicLong analysisCacheBytes;
 
   private LineCoverageStore(
       Function<Boolean, LineProbes> probesFactory,
       CiVisibilityMetricCollector metrics,
       SourcePathResolver sourcePathResolver,
-      Map<AnalysisCacheKey, BitSet> analysisCache) {
+      Map<AnalysisCacheKey, BitSet> analysisCache,
+      AtomicLong analysisCacheBytes) {
     super(probesFactory);
     this.metrics = metrics;
     this.sourcePathResolver = sourcePathResolver;
     this.analysisCache = analysisCache;
+    this.analysisCacheBytes = analysisCacheBytes;
   }
 
   @Nullable
@@ -139,9 +154,13 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
    */
   @Nullable
   private BitSet analyzeClass(Class<?> clazz, ExecutionDataAdapter executionDataAdapter) {
-    AnalysisCacheKey key =
-        new AnalysisCacheKey(
-            executionDataAdapter.getClassId(), executionDataAdapter.getProbeActivations());
+    long classId = executionDataAdapter.getClassId();
+    // Snapshot the activations once and use the same snapshot for both the cache key and the
+    // analysis. The per-test array is mutable and a propagated/background thread may record a late
+    // probe while report() runs; sharing one snapshot ensures the cached covered lines always match
+    // the key's probe set, so a late activation can't poison the entry for later tests.
+    boolean[] probes = executionDataAdapter.getProbeActivations().clone();
+    AnalysisCacheKey key = new AnalysisCacheKey(classId, probes);
     BitSet cached = analysisCache.get(key);
     if (cached != null) {
       return cached;
@@ -150,12 +169,21 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
     try (InputStream is = Utils.getClassStream(clazz)) {
       BitSet coveredLines = new BitSet();
       ExecutionDataStore store = new ExecutionDataStore();
-      store.put(executionDataAdapter.toExecutionData());
+      store.put(new ExecutionData(classId, executionDataAdapter.getClassName(), probes));
       Analyzer analyzer = new Analyzer(store, new SourceAnalyzer(coveredLines));
       analyzer.analyzeClass(is, null);
 
-      if (analysisCache.size() < MAX_ANALYSIS_CACHE_ENTRIES) {
-        analysisCache.putIfAbsent(key, coveredLines);
+      // Reserve the entry's weight before inserting so concurrent inserts near the limit can't
+      // collectively overshoot the bound; release the reservation if we exceed it or another thread
+      // cached the class first.
+      long entryBytes =
+          APPROX_ENTRY_OVERHEAD_BYTES + key.packedBytes() + (coveredLines.size() >>> 3);
+      if (analysisCacheBytes.addAndGet(entryBytes) <= MAX_ANALYSIS_CACHE_BYTES) {
+        if (analysisCache.putIfAbsent(key, coveredLines) != null) {
+          analysisCacheBytes.addAndGet(-entryBytes);
+        }
+      } else {
+        analysisCacheBytes.addAndGet(-entryBytes);
       }
       return coveredLines;
 
@@ -169,16 +197,32 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
     }
   }
 
-  /** Cache key identifying a class (by Jacoco class id) covered by a specific set of probes. */
+  /**
+   * Cache key identifying a class (by Jacoco class id) covered by a specific set of probes. The
+   * probe activations are bit-packed into a {@link BitSet} rather than retaining the test's full
+   * {@code boolean[]} (1 byte/element), so a cached key uses ~8x less memory. Equality is exact:
+   * two keys match iff the same class was covered by the same set of probe ids.
+   */
   static final class AnalysisCacheKey {
     private final long classId;
-    private final boolean[] probes;
+    private final BitSet probes;
     private final int hash;
 
-    AnalysisCacheKey(long classId, boolean[] probes) {
+    AnalysisCacheKey(long classId, boolean[] probeActivations) {
       this.classId = classId;
-      this.probes = probes;
-      this.hash = 31 * Long.hashCode(classId) + Arrays.hashCode(probes);
+      BitSet bits = new BitSet(probeActivations.length);
+      for (int i = 0; i < probeActivations.length; i++) {
+        if (probeActivations[i]) {
+          bits.set(i);
+        }
+      }
+      this.probes = bits;
+      this.hash = 31 * Long.hashCode(classId) + bits.hashCode();
+    }
+
+    /** Bytes of the packed probe bits (the variable part of the retained key). */
+    int packedBytes() {
+      return probes.size() >>> 3;
     }
 
     @Override
@@ -190,7 +234,7 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
         return false;
       }
       AnalysisCacheKey other = (AnalysisCacheKey) o;
-      return classId == other.classId && hash == other.hash && Arrays.equals(probes, other.probes);
+      return classId == other.classId && hash == other.hash && probes.equals(other.probes);
     }
 
     @Override
@@ -203,6 +247,7 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
 
     private final Map<String, Integer> probeCounts = new ConcurrentHashMap<>();
     private final Map<AnalysisCacheKey, BitSet> analysisCache = new ConcurrentHashMap<>();
+    private final AtomicLong analysisCacheBytes = new AtomicLong();
 
     private final CiVisibilityMetricCollector metrics;
     private final SourcePathResolver sourcePathResolver;
@@ -214,7 +259,8 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
 
     @Override
     public CoverageStore create(@Nullable TestIdentifier testIdentifier) {
-      return new LineCoverageStore(this::createProbes, metrics, sourcePathResolver, analysisCache);
+      return new LineCoverageStore(
+          this::createProbes, metrics, sourcePathResolver, analysisCache, analysisCacheBytes);
     }
 
     private LineProbes createProbes(boolean isTestThread) {

--- a/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/coverage/line/LineCoverageStoreTest.java
+++ b/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/coverage/line/LineCoverageStoreTest.java
@@ -1,0 +1,38 @@
+package datadog.trace.civisibility.coverage.line;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import datadog.trace.civisibility.coverage.line.LineCoverageStore.AnalysisCacheKey;
+import org.junit.jupiter.api.Test;
+
+class LineCoverageStoreTest {
+
+  @Test
+  void cacheKeyReusesAnalysisForSameClassAndProbes() {
+    AnalysisCacheKey key = new AnalysisCacheKey(1L, new boolean[] {true, false, true, false});
+    AnalysisCacheKey same = new AnalysisCacheKey(1L, new boolean[] {true, false, true, false});
+    // identical class id + probe set must collide so the analysis is reused
+    assertEquals(key, same);
+    assertEquals(key.hashCode(), same.hashCode());
+  }
+
+  @Test
+  void cacheKeyDistinguishesClassesAndProbeSets() {
+    AnalysisCacheKey key = new AnalysisCacheKey(1L, new boolean[] {true, false, true});
+    // a different class or a different probe set must NOT hit the same cache entry
+    assertNotEquals(key, new AnalysisCacheKey(2L, new boolean[] {true, false, true}));
+    assertNotEquals(key, new AnalysisCacheKey(1L, new boolean[] {true, true, true}));
+  }
+
+  @Test
+  void cacheKeyIgnoresTrailingUnsetProbes() {
+    // The key bit-packs the activated probe set; trailing probes that never fire don't change
+    // coverage, so padding differences must not create distinct entries.
+    AnalysisCacheKey shortKey = new AnalysisCacheKey(1L, new boolean[] {true, false, true});
+    AnalysisCacheKey padded =
+        new AnalysisCacheKey(1L, new boolean[] {true, false, true, false, false});
+    assertEquals(shortKey, padded);
+    assertEquals(shortKey.hashCode(), padded.hashCode());
+  }
+}


### PR DESCRIPTION
# What Does This Do

Memoizes per-test line-coverage class analysis in a module-wide cache.

When line-level coverage is enabled, JaCoCo's `Analyzer` re-parses and re-analyzes each covered class's bytecode once **per test** that covers it, which dominates the report-time cost. This caches the covered lines per `(class id, probe set)`, shared across tests, so a class covered identically by many tests is analyzed only once.

# Motivation

Reduce the runtime overhead of line-level per-test code coverage (Test Optimization). Report-time re-analysis was the dominant hotspot; in the test-environment, marginal line-coverage overhead drops meaningfully on suites with headroom (e.g. nebula, spring-boot, okhttp).

The probe recording and instrumentation paths are unchanged, so JaCoCo's aggregate coverage (total %/report uploads, used to back-fill coverage for TIA/ITR-skipped tests) is preserved by its native probe writes.

# Additional Notes

Scoped to the report path only: `LineCoverageStore.analyzeClass` plus two getters on `ExecutionDataAdapter`. No changes to instrumentation, probe recording, or the coverage API.

The cache is memory-safe: keys bit-pack the probe activations (exact equality), the cache is bounded by approximate retained bytes (not entry count), and each analysis uses a single probe-array snapshot for both the key and the JaCoCo analysis so concurrent late writes can't poison an entry. Coverage stays correct beyond the size bound — the class is simply analyzed each time.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [SDTEST-3847]


[SDTEST-3847]: https://datadoghq.atlassian.net/browse/SDTEST-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ