### PR TITLE
Increase build_tests job memory to tier l (20 GiB)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -358,6 +358,7 @@ build:
 build_tests:
   extends: .gradle_build
   variables:
+    <<: *tier_l_variables
     BUILD_CACHE_POLICY: push
     DEPENDENCY_CACHE_POLICY: pull
   parallel:


### PR DESCRIPTION
# What Does This Do

Increases the `build_tests` job memory (via the tier L variables, 20GiB). These were sometimes getting OOMKilled. 

# Motivation

# Additional Notes

Example build container:
<img width="2508" height="1684" alt="image" src="https://github.com/user-attachments/assets/39df51d6-0cda-4d3e-9387-53db0d34575f" />
<img width="2502" height="1102" alt="image" src="https://github.com/user-attachments/assets/b6f9b4b6-9305-454f-9878-d1756387ca5f" />

Over the past 15 days most of the OOMKilled errors come from the `build_tests` jobs. And 10% from exploration tests.

<img width="1714" height="942" alt="image" src="https://github.com/user-attachments/assets/b490a3e3-1e43-498e-8d1b-3fb83c6bd037" />



# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
