### PR TITLE
No captures in eval errors snapshots

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -834,6 +834,13 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
     Snapshot snapshot = createSnapshot();
     boolean shouldCommit = false;
     if (status.shouldSend()) {
+      if (isFullSnapshot()) {
+        // freeze context just before commit because line probes have only one context
+        Duration timeout =
+            Duration.ofMillis(Config.get().getDynamicInstrumentationCaptureTimeout());
+        lineContext.freeze(TimeoutChecker.create(Config.get(), timeout));
+        snapshot.addLine(lineContext, line);
+      }
       snapshot.setTraceId(CorrelationIdentifier.getTraceId());
       snapshot.setSpanId(CorrelationIdentifier.getSpanId());
       snapshot.setMessage(status.getMessage());
@@ -846,13 +853,6 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
     if (shouldCommit) {
       incrementBudget();
       if (inBudget()) {
-        if (isFullSnapshot()) {
-          // freeze context just before commit because line probes have only one context
-          Duration timeout =
-              Duration.ofMillis(Config.get().getDynamicInstrumentationCaptureTimeout());
-          lineContext.freeze(TimeoutChecker.create(Config.get(), timeout));
-          snapshot.addLine(lineContext, line);
-        }
         commitSnapshot(snapshot, sink);
         return;
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1250,6 +1250,26 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
+  public void lineProbeConditionFailed() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
+    LogProbe logProbe =
+        createProbeBuilder(LINE_PROBE_ID1, CLASS_NAME, line)
+            .when(
+                new ProbeCondition(DSL.when(DSL.eq(ref("foobar"), nullValue())), "foobar == null"))
+            .build();
+    TestSnapshotListener listener = installProbes(logProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "0").get();
+    assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID1, listener);
+    assertNull(snapshot.getCaptures().getLines());
+    assertEquals(1, snapshot.getEvaluationErrors().size());
+    assertEquals(
+        "Cannot dereference field: foobar", snapshot.getEvaluationErrors().get(0).getMessage());
+  }
+
+  @Test
   public void staticFieldCondition() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot19";
     LogProbe logProbe =


### PR DESCRIPTION
# What Does This Do
for Log line probe captures was included even though there is an evaluation error while for method probe it was not included make sure we are only including captures if no eval errors

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [DEBUG-5770]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5770]: https://datadoghq.atlassian.net/browse/DEBUG-5770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ