### PR TITLE
Deprecate TagMap.create(int) — its size hint is a no-op

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -50,7 +50,7 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
 
   /** Creates a new mutable TagMap that contains the contents of <code>map</code> */
   static TagMap fromMap(Map<String, ?> map) {
-    TagMap tagMap = TagMap.create(map.size());
+    TagMap tagMap = TagMap.create();
     tagMap.putAll(map);
     return tagMap;
   }
@@ -68,6 +68,12 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
     return new OptimizedTagMap();
   }
 
+  /**
+   * @deprecated {@code size} is ignored -- TagMap's storage can't honor a size hint without
+   *     compromising its other optimizations, so this behaves identically to {@link #create()};
+   *     prefer that. A dedicated sizing mechanism may be introduced separately.
+   */
+  @Deprecated
   static TagMap create(int size) {
     return new OptimizedTagMap();
   }
@@ -1114,7 +1120,7 @@ public interface TagMap extends Map<String, Object>, Iterable<TagMap.EntryReader
     }
 
     public TagMap build() {
-      TagMap map = TagMap.create(this.estimateSize());
+      TagMap map = TagMap.create();
       fill(map);
       return map;
     }


### PR DESCRIPTION
## What Does This Do

`TagMap.create(int size)` **ignores its `size`** — the body is just `return new OptimizedTagMap();`. TagMap's storage can't honor a size hint without compromising its other optimizations, so the size arg is vestigial and misleading (callers think they're pre-sizing; they aren't).

- Mark `create(int)` **`@Deprecated`**, pointing at `create()`, with a javadoc explaining the size is ignored.
- Migrate the two **TagMap-internal** callers off it — `fromMap` and `Ledger.build()` — since those components already know `create` does nothing with the size.

## Deliberately left

The three **external** callers keep using it for now: `CoreTracer`, `DDSpanContext`, and `TagContext`. Their deprecation warnings are a useful to-do list — a dedicated sizing mechanism is being developed separately (for the upcoming dense storage), and `DDSpanContext` in particular is its main target, so those sites will be converted there rather than churned here.

## Notes

- Behavior-neutral: `create(int)` and `create()` are identical today, so the migrated calls change nothing at runtime.
- `Ledger.estimateSize()` stays (uncalled internally now, but plausibly a future sizing-hint input).
- Verified: internal-api + dd-trace-core compile (deprecation is a warning, not an error), SpotBugs clean, TagMap suite green, coverage gate green.

tag: ai generated
tag: no release note

🤖 Generated with [Claude Code](https://claude.com/claude-code)