### PR TITLE
Add `Locale.ROOT` to ConfigStrings Environment Variable Normalization

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/InstrumentationSpecification.groovy
@@ -124,7 +124,7 @@ abstract class InstrumentationSpecification extends DDSpecification implements A
     StringBuilder ddEnvVars = new StringBuilder()
     for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
       if (entry.getKey().toString().startsWith("dd.")) {
-        ddEnvVars.append(ConfigStrings.systemPropertyNameToEnvironmentVariableName(entry.getKey().toString()))
+        ddEnvVars.append(ConfigStrings.toEnvVar(entry.getKey().toString()))
         .append("=").append(entry.getValue()).append(",")
       }
     }

--- a/utils/config-utils/src/main/java/datadog/trace/util/ConfigStrings.java
+++ b/utils/config-utils/src/main/java/datadog/trace/util/ConfigStrings.java
@@ -1,5 +1,6 @@
 package datadog.trace.util;
 
+import java.util.Locale;
 import javax.annotation.Nonnull;
 
 public final class ConfigStrings {
@@ -7,11 +8,11 @@ public final class ConfigStrings {
   private ConfigStrings() {}
 
   public static String toEnvVar(String string) {
-    return string.replace('.', '_').replace('-', '_').toUpperCase();
+    return string.replace('.', '_').replace('-', '_').toUpperCase(Locale.ROOT);
   }
 
   public static String toEnvVarLowerCase(String string) {
-    return string.replace('.', '_').replace('-', '_').toLowerCase();
+    return string.replace('.', '_').replace('-', '_').toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -24,18 +25,6 @@ public final class ConfigStrings {
   @Nonnull
   public static String propertyNameToEnvironmentVariableName(final String setting) {
     return "DD_" + toEnvVar(setting);
-  }
-
-  /**
-   * Converts the system property name, e.g. 'dd.service.name' into a public environment variable
-   * name, e.g. `DD_SERVICE_NAME`.
-   *
-   * @param setting The system property name, e.g. `dd.service.name`
-   * @return The public facing environment variable name
-   */
-  @Nonnull
-  public static String systemPropertyNameToEnvironmentVariableName(final String setting) {
-    return setting.replace('.', '_').replace('-', '_').toUpperCase();
   }
 
   /**

--- a/utils/config-utils/src/test/java/datadog/trace/util/ConfigStringsTest.java
+++ b/utils/config-utils/src/test/java/datadog/trace/util/ConfigStringsTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Locale;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConfigStringsTest {
@@ -13,31 +11,23 @@ class ConfigStringsTest {
   /** Dotted capital I (U+0130) that a Turkish-locale {@code toUpperCase()} produces from 'i'. */
   private static final char DOTTED_CAPITAL_I = 'İ';
 
-  private Locale previousDefault;
-
-  @BeforeEach
-  void forceTurkishLocale() {
-    // Turkish is the locale where a locale-sensitive toUpperCase() maps 'i' -> 'İ' (U+0130) and
-    // toLowerCase() maps 'I' -> 'ı' (U+0131, dotless). That is exactly what corrupted the config
-    // telemetry payload. Forcing it as the default locale here proves the conversions are
-    // locale-independent (pinned to Locale.ROOT) rather than relying on the machine's locale.
-    previousDefault = Locale.getDefault();
-    Locale.setDefault(new Locale("tr", "TR"));
-  }
-
-  @AfterEach
-  void restoreLocale() {
-    Locale.setDefault(previousDefault);
-  }
-
   @Test
   void toEnvVarUppercasesLowerIToAsciiIOnTurkishLocale() {
-    String result = ConfigStrings.toEnvVar("dd.profiling.i");
+    // Turkish is the locale where a locale-sensitive toUpperCase() maps 'i' -> 'İ'
+    // Forcing it as the default locale here proves the conversions are
+    // locale-independent (pinned to Locale.ROOT) rather than relying on the machine's locale.
+    Locale previousDefault = Locale.getDefault();
+    Locale.setDefault(new Locale("tr", "TR"));
+    try {
+      String result = ConfigStrings.toEnvVar("dd.profiling.i");
 
-    // Must be the plain ASCII 'I' (U+0049), not the Turkish dotted 'İ' (U+0130).
-    assertEquals("DD_PROFILING_I", result);
-    assertFalse(
-        result.indexOf(DOTTED_CAPITAL_I) >= 0,
-        "env var name must not contain the dotted capital I (U+0130)");
+      // Must be the plain ASCII 'I' (U+0049), not the Turkish dotted 'İ' (U+0130).
+      assertEquals("DD_PROFILING_I", result);
+      assertFalse(
+          result.indexOf(DOTTED_CAPITAL_I) >= 0,
+          "env var name must not contain the dotted capital I (U+0130)");
+    } finally {
+      Locale.setDefault(previousDefault);
+    }
   }
 }

--- a/utils/config-utils/src/test/java/datadog/trace/util/ConfigStringsTest.java
+++ b/utils/config-utils/src/test/java/datadog/trace/util/ConfigStringsTest.java
@@ -1,0 +1,43 @@
+package datadog.trace.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConfigStringsTest {
+
+  /** Dotted capital I (U+0130) that a Turkish-locale {@code toUpperCase()} produces from 'i'. */
+  private static final char DOTTED_CAPITAL_I = 'İ';
+
+  private Locale previousDefault;
+
+  @BeforeEach
+  void forceTurkishLocale() {
+    // Turkish is the locale where a locale-sensitive toUpperCase() maps 'i' -> 'İ' (U+0130) and
+    // toLowerCase() maps 'I' -> 'ı' (U+0131, dotless). That is exactly what corrupted the config
+    // telemetry payload. Forcing it as the default locale here proves the conversions are
+    // locale-independent (pinned to Locale.ROOT) rather than relying on the machine's locale.
+    previousDefault = Locale.getDefault();
+    Locale.setDefault(new Locale("tr", "TR"));
+  }
+
+  @AfterEach
+  void restoreLocale() {
+    Locale.setDefault(previousDefault);
+  }
+
+  @Test
+  void toEnvVarUppercasesLowerIToAsciiIOnTurkishLocale() {
+    String result = ConfigStrings.toEnvVar("dd.profiling.i");
+
+    // Must be the plain ASCII 'I' (U+0049), not the Turkish dotted 'İ' (U+0130).
+    assertEquals("DD_PROFILING_I", result);
+    assertFalse(
+        result.indexOf(DOTTED_CAPITAL_I) >= 0,
+        "env var name must not contain the dotted capital I (U+0130)");
+  }
+}


### PR DESCRIPTION
# What Does This Do
Previously, Turkish Locale would uppercase `i` -> a dotted `I`. This led to issues w/ our telemetry monitors after hitting the backend, sparking false alarms that were were not properly capturing config telemetry.

This PR also replaces a duplicate function `systemPropertyNameToEnvironmentVariableName` to `toEnvVar`.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
