### PR TITLE
Declare instrumentation dependencies directly

### DIFF
--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -90,9 +90,10 @@ subprojects { Project subProj ->
     if (subProj.path != ':dd-java-agent:instrumentation:vertx:vertx-redis-client:vertx-redis-client-stubs'
       && subProj.path != ':dd-java-agent:instrumentation:tibco-businessworks:tibco-businessworks-stubs') {
       // don't include the redis or tibco stubs
-      parent_project.dependencies {
-        addProvider("implementation", providers.provider { project(subProj.path) })
-      }
+      parent_project.dependencies.add(
+        "implementation",
+        parent_project.dependencies.project(path: subProj.path)
+        )
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Replaces provider-wrapped instrumentation project dependencies with direct `ProjectDependency` declarations.

It also collects the full paths of projects excluded from the aggregate instrumentation JAR in an explicit set.

# Motivation

Instrumentation project paths are already known during configuration. Wrapping `project(...)` in `providers.provider` adds unnecessary indirection without providing useful laziness.

Declaring project dependencies directly makes the aggregation logic clearer.

# Additional Notes

This was introduced when work on removing the `afterEvaluate` in this project.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
