### PR TITLE
Disallow benchmarks on commit tag-triggered pipelines

### DIFF
--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -42,9 +42,9 @@ linux-java-spring-petclinic-parallel:
     - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
-      when: always
+      when: on_success
     - if: '$CI_COMMIT_BRANCH == "master"'
-      when: always
+      when: on_success
       interruptible: false
     - when: manual
       allow_failure: true

--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -3,8 +3,7 @@
   - if: '$POPULATE_CACHE'
     when: never
   - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-    when: manual
-    allow_failure: true
+    when: never
   - if: '$CI_COMMIT_BRANCH == "master"'
     when: on_success
     interruptible: false
@@ -23,8 +22,7 @@
   - if: '$POPULATE_CACHE'
     when: never
   - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-    when: manual
-    allow_failure: true
+    when: never
   - if: '$CI_COMMIT_BRANCH == "master"'
     when: on_success
     interruptible: false
@@ -38,9 +36,18 @@
     interruptible: true
     allow_failure: true
 
-# Ensure the tracer artifact publish finishes before the benchmark jobs start.
 linux-java-spring-petclinic-parallel:
   needs: ["publish-artifacts-to-s3"]
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: always
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: always
+      interruptible: false
+    - when: manual
+      allow_failure: true
 
 linux-java-insecure-bank-load-parallel:
   needs: ["publish-artifacts-to-s3"]


### PR DESCRIPTION
# What Does This Do

Disallow benchmarks from running on commit tag-triggered pipelines

# Motivation

Commit tag-triggered pipelines run for releases only off of the latest `master` pipeline commit. This commit already has a `master` GitLab pipeline run with benchmarks, so there's no need to run the same benchmarks for the commit tag-triggered pipelines.

Furthermore, benchmark jobs pull artifacts from a merge-base pipeline to compare benchmarking results against. There is currently no support for finding the merge-base pipeline corresponding to a commit tag-triggered pipeline (see example [failed jobs](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/pipelines/125085778)). We could add support; however, we don't need to run the benchmarks on commit tag-triggered pipelines anyway - hence the changes in this PR.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
