### PR TITLE
Capture Kafka consumer group membership on join

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -622,6 +622,10 @@ tasks.register('verifyAgentJarIntegrations', JavaExec) {
   classpath = objects.fileCollection().from(jarProvider)
   args = ['--list-integrations']
 
+  // Listing integrations only inspects classes and metadata in the assembled agent jar, so it does
+  // not need inherited JAVA_TOOL_OPTIONS.
+  environment.remove('JAVA_TOOL_OPTIONS')
+
   // Capture both stdout and stderr: InstrumenterIndex.buildModule() logs ERROR and returns null when a module
   // fails to load, while the process exits with status 0.
   def capturedOutput = new ByteArrayOutputStream()

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
@@ -10,6 +10,7 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.datastreams.DataStreamsTags;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.kafka_common.KafkaConfigHelper;
 import datadog.trace.instrumentation.kafka_common.MetadataState;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +62,7 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".KafkaConsumerInfo",
+      "datadog.trace.instrumentation.kafka_common.KafkaConfigHelper",
       "datadog.trace.instrumentation.kafka_common.PendingConfig",
       "datadog.trace.instrumentation.kafka_common.MetadataState",
     };
@@ -71,6 +73,9 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
     transformer.applyAdvice(
         isMethod().and(named("sendOffsetCommitRequest")).and(takesArguments(1)),
         ConsumerCoordinatorInstrumentation.class.getName() + "$CommitOffsetAdvice");
+    transformer.applyAdvice(
+        isMethod().and(named("onJoinComplete")).and(takesArguments(4)),
+        ConsumerCoordinatorInstrumentation.class.getName() + "$JoinGroupAdvice");
   }
 
   public static class CommitOffsetAdvice {
@@ -124,6 +129,48 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
     public static void muzzleCheck(ConsumerRecord record) {
       // KafkaConsumerInstrumentation only applies for kafka versions with headers
       // Make an explicit call so ConsumerCoordinatorInstrumentation does the same
+      record.headers();
+    }
+  }
+
+  public static class JoinGroupAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void trackJoinGroup(
+        @Advice.This ConsumerCoordinator coordinator,
+        @Advice.Argument(0) final int generationId,
+        @Advice.Argument(1) final String memberId,
+        @Advice.Argument(2) final String memberProtocol) {
+      if (memberId == null || memberId.isEmpty()) {
+        return;
+      }
+      KafkaConsumerInfo kafkaConsumerInfo =
+          InstrumentationContext.get(ConsumerCoordinator.class, KafkaConsumerInfo.class)
+              .get(coordinator);
+      if (kafkaConsumerInfo == null) {
+        return;
+      }
+      // Only report when the membership changes (new member id or new generation) to avoid
+      // re-reporting an unchanged membership.
+      if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId())
+          && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
+        return;
+      }
+      kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
+
+      String consumerGroup = kafkaConsumerInfo.getConsumerGroup();
+      Metadata consumerMetadata = kafkaConsumerInfo.getClientMetadata();
+      String clusterId = null;
+      if (consumerMetadata != null) {
+        MetadataState metadataState =
+            InstrumentationContext.get(Metadata.class, MetadataState.class).get(consumerMetadata);
+        clusterId = metadataState != null ? metadataState.clusterId : null;
+      }
+      KafkaConfigHelper.reportConsumerGroupMember(
+          clusterId, consumerGroup, memberId, generationId, memberProtocol);
+    }
+
+    public static void muzzleCheck(ConsumerRecord record) {
+      // Match CommitOffsetAdvice: only apply for kafka versions with headers
       record.headers();
     }
   }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
@@ -149,13 +149,10 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
       if (kafkaConsumerInfo == null) {
         return;
       }
-      // Only report when the membership changes (new member id or new generation) to avoid
-      // re-reporting an unchanged membership.
       if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId())
           && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
         return;
       }
-      kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
 
       String consumerGroup = kafkaConsumerInfo.getConsumerGroup();
       Metadata consumerMetadata = kafkaConsumerInfo.getClientMetadata();
@@ -165,12 +162,13 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
             InstrumentationContext.get(Metadata.class, MetadataState.class).get(consumerMetadata);
         clusterId = metadataState != null ? metadataState.clusterId : null;
       }
-      KafkaConfigHelper.reportConsumerGroupMember(
-          clusterId, consumerGroup, memberId, generationId, memberProtocol);
+      if (KafkaConfigHelper.reportConsumerGroupMember(
+          clusterId, consumerGroup, memberId, generationId, memberProtocol)) {
+        kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
+      }
     }
 
     public static void muzzleCheck(ConsumerRecord record) {
-      // Match CommitOffsetAdvice: only apply for kafka versions with headers
       record.headers();
     }
   }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
@@ -149,8 +149,7 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
       if (kafkaConsumerInfo == null) {
         return;
       }
-      if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId())
-          && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
+      if (!kafkaConsumerInfo.hasMembershipChanged(memberId, generationId)) {
         return;
       }
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
@@ -8,8 +8,6 @@ public class KafkaConsumerInfo {
   private final String consumerGroup;
   private final Metadata clientMetadata;
   private final String bootstrapServers;
-  // Last consumer group membership reported to DSM; used to avoid re-reporting when neither the
-  // member id nor the generation changed. Not part of identity (excluded from equals/hashCode).
   private volatile String lastReportedMemberId;
   private volatile int lastReportedGenerationId = Integer.MIN_VALUE;
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
@@ -8,6 +8,10 @@ public class KafkaConsumerInfo {
   private final String consumerGroup;
   private final Metadata clientMetadata;
   private final String bootstrapServers;
+  // Last consumer group membership reported to DSM; used to avoid re-reporting when neither the
+  // member id nor the generation changed. Not part of identity (excluded from equals/hashCode).
+  private volatile String lastReportedMemberId;
+  private volatile int lastReportedGenerationId = Integer.MIN_VALUE;
 
   public KafkaConsumerInfo(String consumerGroup, Metadata clientMetadata, String bootstrapServers) {
     this.consumerGroup = consumerGroup;
@@ -34,6 +38,20 @@ public class KafkaConsumerInfo {
   @Nullable
   public String getBootstrapServers() {
     return bootstrapServers;
+  }
+
+  @Nullable
+  public String getLastReportedMemberId() {
+    return lastReportedMemberId;
+  }
+
+  public int getLastReportedGenerationId() {
+    return lastReportedGenerationId;
+  }
+
+  public void setLastReportedMembership(String memberId, int generationId) {
+    this.lastReportedMemberId = memberId;
+    this.lastReportedGenerationId = generationId;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInfo.java
@@ -38,13 +38,9 @@ public class KafkaConsumerInfo {
     return bootstrapServers;
   }
 
-  @Nullable
-  public String getLastReportedMemberId() {
-    return lastReportedMemberId;
-  }
-
-  public int getLastReportedGenerationId() {
-    return lastReportedGenerationId;
+  public boolean hasMembershipChanged(String memberId, int generationId) {
+    return !Objects.equals(memberId, lastReportedMemberId)
+        || generationId != lastReportedGenerationId;
   }
 
   public void setLastReportedMembership(String memberId, int generationId) {

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java/datadog/trace/instrumentation/kafka_clients38/ConsumerCoordinatorInstrumentation.java
@@ -45,6 +45,7 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".KafkaConsumerInfo",
+      "datadog.trace.instrumentation.kafka_common.KafkaConfigHelper",
       "datadog.trace.instrumentation.kafka_common.PendingConfig",
       "datadog.trace.instrumentation.kafka_common.MetadataState",
     };
@@ -55,5 +56,8 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
     transformer.applyAdvice(
         isMethod().and(named("sendOffsetCommitRequest")).and(takesArguments(1)),
         packageName + ".ConsumerCoordinatorAdvice");
+    transformer.applyAdvice(
+        isMethod().and(named("onJoinComplete")).and(takesArguments(4)),
+        packageName + ".JoinGroupAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
@@ -24,13 +24,10 @@ public class JoinGroupAdvice {
     if (kafkaConsumerInfo == null) {
       return;
     }
-    // Only report when the membership changes (new member id or new generation) to avoid
-    // re-reporting an unchanged membership.
     if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId().orElse(null))
         && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
       return;
     }
-    kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
 
     String consumerGroup = kafkaConsumerInfo.getConsumerGroup().orElse(null);
     Metadata consumerMetadata = kafkaConsumerInfo.getmetadata().orElse(null);
@@ -40,12 +37,13 @@ public class JoinGroupAdvice {
           InstrumentationContext.get(Metadata.class, MetadataState.class).get(consumerMetadata);
       clusterId = metadataState != null ? metadataState.clusterId : null;
     }
-    KafkaConfigHelper.reportConsumerGroupMember(
-        clusterId, consumerGroup, memberId, generationId, memberProtocol);
+    if (KafkaConfigHelper.reportConsumerGroupMember(
+        clusterId, consumerGroup, memberId, generationId, memberProtocol)) {
+      kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
+    }
   }
 
   public static void muzzleCheck(ConsumerRecord record) {
-    // Match ConsumerCoordinatorAdvice: only apply for kafka versions with headers
     record.headers();
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.kafka_clients38;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.kafka_common.KafkaConfigHelper;
+import datadog.trace.instrumentation.kafka_common.MetadataState;
+import net.bytebuddy.asm.Advice;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.internals.ConsumerCoordinator;
+
+public class JoinGroupAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void trackJoinGroup(
+      @Advice.This ConsumerCoordinator coordinator,
+      @Advice.Argument(0) final int generationId,
+      @Advice.Argument(1) final String memberId,
+      @Advice.Argument(2) final String memberProtocol) {
+    if (memberId == null || memberId.isEmpty()) {
+      return;
+    }
+    KafkaConsumerInfo kafkaConsumerInfo =
+        InstrumentationContext.get(ConsumerCoordinator.class, KafkaConsumerInfo.class)
+            .get(coordinator);
+    if (kafkaConsumerInfo == null) {
+      return;
+    }
+    // Only report when the membership changes (new member id or new generation) to avoid
+    // re-reporting an unchanged membership.
+    if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId().orElse(null))
+        && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
+      return;
+    }
+    kafkaConsumerInfo.setLastReportedMembership(memberId, generationId);
+
+    String consumerGroup = kafkaConsumerInfo.getConsumerGroup().orElse(null);
+    Metadata consumerMetadata = kafkaConsumerInfo.getmetadata().orElse(null);
+    String clusterId = null;
+    if (consumerMetadata != null) {
+      MetadataState metadataState =
+          InstrumentationContext.get(Metadata.class, MetadataState.class).get(consumerMetadata);
+      clusterId = metadataState != null ? metadataState.clusterId : null;
+    }
+    KafkaConfigHelper.reportConsumerGroupMember(
+        clusterId, consumerGroup, memberId, generationId, memberProtocol);
+  }
+
+  public static void muzzleCheck(ConsumerRecord record) {
+    // Match ConsumerCoordinatorAdvice: only apply for kafka versions with headers
+    record.headers();
+  }
+}

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/JoinGroupAdvice.java
@@ -24,8 +24,7 @@ public class JoinGroupAdvice {
     if (kafkaConsumerInfo == null) {
       return;
     }
-    if (memberId.equals(kafkaConsumerInfo.getLastReportedMemberId().orElse(null))
-        && generationId == kafkaConsumerInfo.getLastReportedGenerationId()) {
+    if (!kafkaConsumerInfo.hasMembershipChanged(memberId, generationId)) {
       return;
     }
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
@@ -8,8 +8,6 @@ public class KafkaConsumerInfo {
   private final String consumerGroup;
   private final Metadata metadata;
   private final String bootstrapServers;
-  // Last consumer group membership reported to DSM; used to avoid re-reporting when neither the
-  // member id nor the generation changed. Not part of identity (excluded from equals/hashCode).
   private volatile String lastReportedMemberId;
   private volatile int lastReportedGenerationId = Integer.MIN_VALUE;
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
@@ -8,6 +8,10 @@ public class KafkaConsumerInfo {
   private final String consumerGroup;
   private final Metadata metadata;
   private final String bootstrapServers;
+  // Last consumer group membership reported to DSM; used to avoid re-reporting when neither the
+  // member id nor the generation changed. Not part of identity (excluded from equals/hashCode).
+  private volatile String lastReportedMemberId;
+  private volatile int lastReportedGenerationId = Integer.MIN_VALUE;
 
   public KafkaConsumerInfo(String consumerGroup, Metadata metadata, String bootstrapServers) {
     this.consumerGroup = consumerGroup;
@@ -31,6 +35,19 @@ public class KafkaConsumerInfo {
 
   public Optional<String> getBootstrapServers() {
     return Optional.ofNullable(bootstrapServers);
+  }
+
+  public Optional<String> getLastReportedMemberId() {
+    return Optional.ofNullable(lastReportedMemberId);
+  }
+
+  public int getLastReportedGenerationId() {
+    return lastReportedGenerationId;
+  }
+
+  public void setLastReportedMembership(String memberId, int generationId) {
+    this.lastReportedMemberId = memberId;
+    this.lastReportedGenerationId = generationId;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInfo.java
@@ -35,12 +35,9 @@ public class KafkaConsumerInfo {
     return Optional.ofNullable(bootstrapServers);
   }
 
-  public Optional<String> getLastReportedMemberId() {
-    return Optional.ofNullable(lastReportedMemberId);
-  }
-
-  public int getLastReportedGenerationId() {
-    return lastReportedGenerationId;
+  public boolean hasMembershipChanged(String memberId, int generationId) {
+    return !Objects.equals(memberId, lastReportedMemberId)
+        || generationId != lastReportedGenerationId;
   }
 
   public void setLastReportedMembership(String memberId, int generationId) {

--- a/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
@@ -105,22 +105,14 @@ public class KafkaConfigHelper {
     log.debug("Stored pending consumer config (cluster ID not yet known)");
   }
 
-  /**
-   * Reports consumer group membership when a consumer (re)joins a group. The broker-assigned member
-   * id is sent alongside the cluster id and consumer group.
-   */
-  public static void reportConsumerGroupMember(
+  public static boolean reportConsumerGroupMember(
       String clusterId,
       String consumerGroup,
       String memberId,
       int generationId,
       String memberProtocol) {
-    if (memberId == null || memberId.isEmpty()) {
-      return;
-    }
-    // Skip until the cluster id is known: the report can't be attributed downstream without it.
-    if (clusterId == null || clusterId.isEmpty()) {
-      return;
+    if (memberId == null || memberId.isEmpty() || clusterId == null || clusterId.isEmpty()) {
+      return false;
     }
     if (Config.get().isDataStreamsEnabled()) {
       AgentTracer.get()
@@ -132,6 +124,7 @@ public class KafkaConfigHelper {
               generationId,
               memberProtocol != null ? memberProtocol : "");
     }
+    return true;
   }
 
   /** Called from metadata update advice when the cluster ID becomes available. */

--- a/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
@@ -105,6 +105,31 @@ public class KafkaConfigHelper {
     log.debug("Stored pending consumer config (cluster ID not yet known)");
   }
 
+  /**
+   * Reports consumer group membership when a consumer (re)joins a group. The broker-assigned member
+   * id is sent alongside the cluster id and consumer group.
+   */
+  public static void reportConsumerGroupMember(
+      String clusterId,
+      String consumerGroup,
+      String memberId,
+      int generationId,
+      String memberProtocol) {
+    if (memberId == null || memberId.isEmpty()) {
+      return;
+    }
+    if (Config.get().isDataStreamsEnabled()) {
+      AgentTracer.get()
+          .getDataStreamsMonitoring()
+          .reportKafkaConsumerGroupMember(
+              clusterId != null ? clusterId : "",
+              consumerGroup != null ? consumerGroup : "",
+              memberId,
+              generationId,
+              memberProtocol != null ? memberProtocol : "");
+    }
+  }
+
   /** Called from metadata update advice when the cluster ID becomes available. */
   public static void reportPendingConfig(MetadataState state, String clusterId) {
     PendingConfig pending = state.takePendingConfig();

--- a/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/KafkaConfigHelper.java
@@ -118,11 +118,15 @@ public class KafkaConfigHelper {
     if (memberId == null || memberId.isEmpty()) {
       return;
     }
+    // Skip until the cluster id is known: the report can't be attributed downstream without it.
+    if (clusterId == null || clusterId.isEmpty()) {
+      return;
+    }
     if (Config.get().isDataStreamsEnabled()) {
       AgentTracer.get()
           .getDataStreamsMonitoring()
           .reportKafkaConsumerGroupMember(
-              clusterId != null ? clusterId : "",
+              clusterId,
               consumerGroup != null ? consumerGroup : "",
               memberId,
               generationId,

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -306,6 +306,26 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
   }
 
   @Override
+  public void reportKafkaConsumerGroupMember(
+      String kafkaClusterId,
+      String consumerGroup,
+      String memberId,
+      int generationId,
+      String memberProtocol) {
+    inbox.offer(
+        new KafkaConfigReport(
+            "kafka_consumer",
+            kafkaClusterId,
+            consumerGroup,
+            memberId,
+            generationId,
+            memberProtocol,
+            Collections.<String, String>emptyMap(),
+            timeSource.getCurrentTimeNanos(),
+            getThreadServiceName()));
+  }
+
+  @Override
   public void setCheckpoint(AgentSpan span, DataStreamsContext context) {
     PathwayContext pathwayContext = span.spanContext().getPathwayContext();
     if (pathwayContext != null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -293,7 +293,6 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     packer.writeUTF8(CONFIGS);
     packer.startArray(configs.size());
     for (KafkaConfigReport config : configs) {
-      // Type, KafkaClusterId, ConsumerGroup, MemberId, GenerationId, MemberProtocol, Config
       packer.startMap(7);
 
       packer.writeUTF8(CONFIG_TYPE);
@@ -309,7 +308,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
       packer.writeString(config.getMemberId(), null);
 
       packer.writeUTF8(CONFIG_GENERATION_ID);
-      packer.writeLong(config.getGenerationId());
+      packer.writeInt(config.getGenerationId());
 
       packer.writeUTF8(CONFIG_MEMBER_PROTOCOL);
       packer.writeString(config.getMemberProtocol(), null);

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -57,6 +57,9 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
   private static final byte[] CONFIG_TYPE = "Type".getBytes(ISO_8859_1);
   private static final byte[] CONFIG_KAFKA_CLUSTER_ID = "KafkaClusterId".getBytes(ISO_8859_1);
   private static final byte[] CONFIG_CONSUMER_GROUP = "ConsumerGroup".getBytes(ISO_8859_1);
+  private static final byte[] CONFIG_MEMBER_ID = "MemberId".getBytes(ISO_8859_1);
+  private static final byte[] CONFIG_GENERATION_ID = "GenerationId".getBytes(ISO_8859_1);
+  private static final byte[] CONFIG_MEMBER_PROTOCOL = "MemberProtocol".getBytes(ISO_8859_1);
   private static final byte[] CONFIG_ENTRIES = "Config".getBytes(ISO_8859_1);
 
   private static final int INITIAL_CAPACITY = 512 * 1024;
@@ -290,7 +293,8 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     packer.writeUTF8(CONFIGS);
     packer.startArray(configs.size());
     for (KafkaConfigReport config : configs) {
-      packer.startMap(4); // Type, KafkaClusterId, ConsumerGroup, Config
+      // Type, KafkaClusterId, ConsumerGroup, MemberId, GenerationId, MemberProtocol, Config
+      packer.startMap(7);
 
       packer.writeUTF8(CONFIG_TYPE);
       packer.writeString(config.getType(), null);
@@ -300,6 +304,15 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
 
       packer.writeUTF8(CONFIG_CONSUMER_GROUP);
       packer.writeString(config.getConsumerGroup(), null);
+
+      packer.writeUTF8(CONFIG_MEMBER_ID);
+      packer.writeString(config.getMemberId(), null);
+
+      packer.writeUTF8(CONFIG_GENERATION_ID);
+      packer.writeLong(config.getGenerationId());
+
+      packer.writeUTF8(CONFIG_MEMBER_PROTOCOL);
+      packer.writeString(config.getMemberProtocol(), null);
 
       packer.writeUTF8(CONFIG_ENTRIES);
       Map<String, String> entries = config.getConfig();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -293,6 +293,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     packer.writeUTF8(CONFIGS);
     packer.startArray(configs.size());
     for (KafkaConfigReport config : configs) {
+      // Type, KafkaClusterId, ConsumerGroup, MemberId, GenerationId, MemberProtocol, Config
       packer.startMap(7);
 
       packer.writeUTF8(CONFIG_TYPE);

--- a/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsWritingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsWritingTest.java
@@ -325,6 +325,57 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
   }
 
   @Test
+  void writeKafkaConsumerGroupMemberToMockServer() throws InterruptedException, IOException {
+    WellKnownTags wellKnownTags =
+        new WellKnownTags(
+            "runtimeid", "hostname", "test", Config.get().getServiceName(), "version", "java");
+    Config fakeConfig = mock(Config.class);
+    when(fakeConfig.getAgentUrl()).thenReturn(serverAddress.toString());
+    when(fakeConfig.getWellKnownTags()).thenReturn(wellKnownTags);
+    when(fakeConfig.getPrimaryTag()).thenReturn("region-1");
+
+    OkHttpClient testOkhttpClient = OkHttpUtils.buildHttpClient(serverAddress, 5000L);
+    DDAgentFeaturesDiscovery features = mock(DDAgentFeaturesDiscovery.class);
+    when(features.supportsDataStreams()).thenReturn(true);
+    SharedCommunicationObjects sharedCommObjects = new SharedCommunicationObjects();
+    sharedCommObjects.setFeaturesDiscovery(features);
+    sharedCommObjects.agentHttpClient = testOkhttpClient;
+    sharedCommObjects.createRemaining(fakeConfig);
+
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    TraceConfig traceConfig = mock(TraceConfig.class);
+    when(traceConfig.isDataStreamsEnabled()).thenReturn(true);
+
+    DefaultDataStreamsMonitoring dataStreams =
+        new DefaultDataStreamsMonitoring(
+            fakeConfig, sharedCommObjects, timeSource, () -> traceConfig);
+    dataStreams.start();
+
+    // Report consumer group membership (as emitted on join)
+    dataStreams.reportKafkaConsumerGroupMember(
+        "cluster-1", "test-group", "consumer-1-abc123", 7, "range");
+
+    // Also add a stats point so the bucket has content
+    dataStreams.add(
+        new StatsPoint(
+            DataStreamsTags.create(null, null),
+            9,
+            0,
+            10,
+            timeSource.getCurrentTimeNanos(),
+            0,
+            0,
+            0,
+            null));
+
+    timeSource.advance(defaultBucketDurationNanos);
+    dataStreams.close();
+
+    awaitOneRequestBody();
+    validateKafkaConsumerGroupMemberMessage(requestBodies.get(0));
+  }
+
+  @Test
   void duplicateKafkaConfigsAreEachSerializedInPayload() throws InterruptedException, IOException {
     WellKnownTags wellKnownTags =
         new WellKnownTags(
@@ -407,13 +458,19 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
             // Collect configs in a map keyed by type
             Map<String, Map<String, String>> configsByType = new HashMap<>();
             for (int n = 0; n < numConfigs; n++) {
-              assertEquals(4, unpacker.unpackMapHeader());
+              assertEquals(7, unpacker.unpackMapHeader());
               assertEquals("Type", unpacker.unpackString());
               String type = unpacker.unpackString();
               assertEquals("KafkaClusterId", unpacker.unpackString());
               unpacker.unpackString(); // skip cluster id value
               assertEquals("ConsumerGroup", unpacker.unpackString());
               unpacker.unpackString(); // skip consumer group value
+              assertEquals("MemberId", unpacker.unpackString());
+              unpacker.unpackString(); // skip member id value
+              assertEquals("GenerationId", unpacker.unpackString());
+              unpacker.unpackLong(); // skip generation id value
+              assertEquals("MemberProtocol", unpacker.unpackString());
+              unpacker.unpackString(); // skip member protocol value
               assertEquals("Config", unpacker.unpackString());
               int configSize = unpacker.unpackMapHeader();
               Map<String, String> configEntries = new HashMap<>();
@@ -455,6 +512,61 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
     assertTrue(foundStats, "Stats field not found in payload");
   }
 
+  private void validateKafkaConsumerGroupMemberMessage(byte[] message) throws IOException {
+    GzipSource gzipSource = new GzipSource(Okio.source(new ByteArrayInputStream(message)));
+    BufferedSource bufferedSource = Okio.buffer(gzipSource);
+    MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bufferedSource.inputStream());
+
+    int outerMapSize = unpacker.unpackMapHeader();
+    boolean foundStats = false;
+    for (int i = 0; i < outerMapSize; i++) {
+      String key = unpacker.unpackString();
+      if ("Stats".equals(key)) {
+        foundStats = true;
+        int numBuckets = unpacker.unpackArrayHeader();
+        assertTrue(numBuckets >= 1);
+
+        int bucketMapSize = unpacker.unpackMapHeader();
+        boolean foundConfigs = false;
+        for (int j = 0; j < bucketMapSize; j++) {
+          String bucketKey = unpacker.unpackString();
+          if ("Configs".equals(bucketKey)) {
+            foundConfigs = true;
+            int numConfigs = unpacker.unpackArrayHeader();
+            assertEquals(1, numConfigs);
+
+            assertEquals(7, unpacker.unpackMapHeader());
+            assertEquals("Type", unpacker.unpackString());
+            assertEquals("kafka_consumer", unpacker.unpackString());
+            assertEquals("KafkaClusterId", unpacker.unpackString());
+            assertEquals("cluster-1", unpacker.unpackString());
+            assertEquals("ConsumerGroup", unpacker.unpackString());
+            assertEquals("test-group", unpacker.unpackString());
+            assertEquals("MemberId", unpacker.unpackString());
+            assertEquals("consumer-1-abc123", unpacker.unpackString());
+            assertEquals("GenerationId", unpacker.unpackString());
+            assertEquals(7, unpacker.unpackLong());
+            assertEquals("MemberProtocol", unpacker.unpackString());
+            assertEquals("range", unpacker.unpackString());
+            assertEquals("Config", unpacker.unpackString());
+            // Membership reports carry no config entries
+            assertEquals(0, unpacker.unpackMapHeader());
+          } else {
+            unpacker.skipValue();
+          }
+        }
+        assertTrue(foundConfigs, "Configs field not found in bucket");
+
+        for (int b = 1; b < numBuckets; b++) {
+          unpacker.skipValue();
+        }
+      } else {
+        unpacker.skipValue();
+      }
+    }
+    assertTrue(foundStats, "Stats field not found in payload");
+  }
+
   private void validateDuplicateKafkaConfigMessage(byte[] message) throws IOException {
     GzipSource gzipSource = new GzipSource(Okio.source(new ByteArrayInputStream(message)));
     BufferedSource bufferedSource = Okio.buffer(gzipSource);
@@ -481,13 +593,19 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
             assertEquals(2, numConfigs);
 
             for (int n = 0; n < numConfigs; n++) {
-              assertEquals(4, unpacker.unpackMapHeader());
+              assertEquals(7, unpacker.unpackMapHeader());
               assertEquals("Type", unpacker.unpackString());
               assertEquals("kafka_producer", unpacker.unpackString());
               assertEquals("KafkaClusterId", unpacker.unpackString());
               unpacker.unpackString(); // skip cluster id value
               assertEquals("ConsumerGroup", unpacker.unpackString());
               unpacker.unpackString(); // skip consumer group value
+              assertEquals("MemberId", unpacker.unpackString());
+              unpacker.unpackString(); // skip member id value
+              assertEquals("GenerationId", unpacker.unpackString());
+              unpacker.unpackLong(); // skip generation id value
+              assertEquals("MemberProtocol", unpacker.unpackString());
+              unpacker.unpackString(); // skip member protocol value
               assertEquals("Config", unpacker.unpackString());
               int configSize = unpacker.unpackMapHeader();
               Map<String, String> configEntries = new HashMap<>();

--- a/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsWritingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DataStreamsWritingTest.java
@@ -351,11 +351,9 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
             fakeConfig, sharedCommObjects, timeSource, () -> traceConfig);
     dataStreams.start();
 
-    // Report consumer group membership (as emitted on join)
     dataStreams.reportKafkaConsumerGroupMember(
         "cluster-1", "test-group", "consumer-1-abc123", 7, "range");
 
-    // Also add a stats point so the bucket has content
     dataStreams.add(
         new StatsPoint(
             DataStreamsTags.create(null, null),
@@ -466,11 +464,11 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
               assertEquals("ConsumerGroup", unpacker.unpackString());
               unpacker.unpackString(); // skip consumer group value
               assertEquals("MemberId", unpacker.unpackString());
-              unpacker.unpackString(); // skip member id value
+              unpacker.unpackString();
               assertEquals("GenerationId", unpacker.unpackString());
-              unpacker.unpackLong(); // skip generation id value
+              unpacker.unpackInt();
               assertEquals("MemberProtocol", unpacker.unpackString());
-              unpacker.unpackString(); // skip member protocol value
+              unpacker.unpackString();
               assertEquals("Config", unpacker.unpackString());
               int configSize = unpacker.unpackMapHeader();
               Map<String, String> configEntries = new HashMap<>();
@@ -545,11 +543,10 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
             assertEquals("MemberId", unpacker.unpackString());
             assertEquals("consumer-1-abc123", unpacker.unpackString());
             assertEquals("GenerationId", unpacker.unpackString());
-            assertEquals(7, unpacker.unpackLong());
+            assertEquals(7, unpacker.unpackInt());
             assertEquals("MemberProtocol", unpacker.unpackString());
             assertEquals("range", unpacker.unpackString());
             assertEquals("Config", unpacker.unpackString());
-            // Membership reports carry no config entries
             assertEquals(0, unpacker.unpackMapHeader());
           } else {
             unpacker.skipValue();
@@ -601,11 +598,11 @@ public class DataStreamsWritingTest extends DDCoreJavaSpecification {
               assertEquals("ConsumerGroup", unpacker.unpackString());
               unpacker.unpackString(); // skip consumer group value
               assertEquals("MemberId", unpacker.unpackString());
-              unpacker.unpackString(); // skip member id value
+              unpacker.unpackString();
               assertEquals("GenerationId", unpacker.unpackString());
-              unpacker.unpackLong(); // skip generation id value
+              unpacker.unpackInt();
               assertEquals("MemberProtocol", unpacker.unpackString());
-              unpacker.unpackString(); // skip member protocol value
+              unpacker.unpackString();
               assertEquals("Config", unpacker.unpackString());
               int configSize = unpacker.unpackMapHeader();
               Map<String, String> configEntries = new HashMap<>();

--- a/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.java
@@ -1190,7 +1190,6 @@ public class DefaultDataStreamsMonitoringTest extends DDCoreJavaSpecification {
     assertEquals("range", report.getMemberProtocol());
     assertTrue(report.getConfig().isEmpty());
 
-    // cleanup
     payloadWriter.close();
     dataStreams.close();
   }

--- a/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.java
@@ -1155,6 +1155,47 @@ public class DefaultDataStreamsMonitoringTest extends DDCoreJavaSpecification {
   }
 
   @Test
+  void kafkaConsumerGroupMemberIsReportedInBucket() throws InterruptedException {
+    DDAgentFeaturesDiscovery features = stubFeatures(true);
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    Sink sink = mock(Sink.class);
+    CapturingPayloadWriter payloadWriter = new CapturingPayloadWriter();
+    TraceConfig traceConfig = stubTraceConfig(true);
+
+    DefaultDataStreamsMonitoring dataStreams =
+        new DefaultDataStreamsMonitoring(
+            sink,
+            features,
+            timeSource,
+            () -> traceConfig,
+            payloadWriter,
+            DEFAULT_BUCKET_DURATION_NANOS);
+    dataStreams.start();
+    dataStreams.reportKafkaConsumerGroupMember(
+        "cluster-1", "test-group", "consumer-1-abc123", 7, "range");
+    timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS);
+    dataStreams.report();
+
+    awaitBuckets(dataStreams, payloadWriter, 1);
+
+    StatsBucket bucket = payloadWriter.buckets.get(0);
+    List<KafkaConfigReport> kafkaConfigs = bucket.getKafkaConfigs();
+    assertEquals(1, kafkaConfigs.size());
+    KafkaConfigReport report = kafkaConfigs.get(0);
+    assertEquals("kafka_consumer", report.getType());
+    assertEquals("cluster-1", report.getKafkaClusterId());
+    assertEquals("test-group", report.getConsumerGroup());
+    assertEquals("consumer-1-abc123", report.getMemberId());
+    assertEquals(7, report.getGenerationId());
+    assertEquals("range", report.getMemberProtocol());
+    assertTrue(report.getConfig().isEmpty());
+
+    // cleanup
+    payloadWriter.close();
+    dataStreams.close();
+  }
+
+  @Test
   void duplicateKafkaConfigsAreEachReportedInTheBucket() throws InterruptedException {
     DDAgentFeaturesDiscovery features = stubFeatures(true);
     ControllableTimeSource timeSource = new ControllableTimeSource();

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/AgentDataStreamsMonitoring.java
@@ -22,17 +22,6 @@ public interface AgentDataStreamsMonitoring
   void reportKafkaConfig(
       String type, String kafkaClusterId, String consumerGroup, Map<String, String> config);
 
-  /**
-   * Reports Kafka consumer group membership for Data Streams Monitoring. Called every time a
-   * consumer (re)joins a group, carrying the broker-assigned member id alongside the cluster id and
-   * consumer group.
-   *
-   * @param kafkaClusterId the Kafka cluster identifier, or empty string if not yet known
-   * @param consumerGroup the consumer group name
-   * @param memberId the broker-assigned consumer group member id
-   * @param generationId the consumer group generation/epoch at join time
-   * @param memberProtocol the negotiated partition assignment protocol (e.g. "range")
-   */
   void reportKafkaConsumerGroupMember(
       String kafkaClusterId,
       String consumerGroup,

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/AgentDataStreamsMonitoring.java
@@ -23,6 +23,24 @@ public interface AgentDataStreamsMonitoring
       String type, String kafkaClusterId, String consumerGroup, Map<String, String> config);
 
   /**
+   * Reports Kafka consumer group membership for Data Streams Monitoring. Called every time a
+   * consumer (re)joins a group, carrying the broker-assigned member id alongside the cluster id and
+   * consumer group.
+   *
+   * @param kafkaClusterId the Kafka cluster identifier, or empty string if not yet known
+   * @param consumerGroup the consumer group name
+   * @param memberId the broker-assigned consumer group member id
+   * @param generationId the consumer group generation/epoch at join time
+   * @param memberProtocol the negotiated partition assignment protocol (e.g. "range")
+   */
+  void reportKafkaConsumerGroupMember(
+      String kafkaClusterId,
+      String consumerGroup,
+      String memberId,
+      int generationId,
+      String memberProtocol);
+
+  /**
    * Tracks Schema Registry usage for Data Streams Monitoring.
    *
    * @param topic Kafka topic name

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
@@ -7,22 +7,16 @@ import java.util.Objects;
 /**
  * KafkaConfigReport captures Kafka producer or consumer configuration to be sent via the Data
  * Streams payload. Each unique configuration is sent only once.
- *
- * <p>It is also reused to report consumer-group membership: when a consumer (re)joins a group, a
- * report is emitted carrying the broker-assigned {@code memberId} (plus the group {@code
- * generationId} and the negotiated {@code memberProtocol}) alongside the cluster id and consumer
- * group, with an empty {@link #config} map.
  */
 public class KafkaConfigReport implements InboxItem {
-  /** Sentinel generation id for reports that are not membership reports. */
-  public static final int NO_GENERATION = -1;
+  private static final int NO_GENERATION = -1;
 
-  private final String type; // "kafka_producer" or "kafka_consumer"
+  private final String type;
   private final String kafkaClusterId;
   private final String consumerGroup;
-  private final String memberId; // broker-assigned consumer group member id, or "" when unknown
-  private final int generationId; // consumer group generation/epoch, or NO_GENERATION
-  private final String memberProtocol; // negotiated partition assignment protocol, or ""
+  private final String memberId;
+  private final int generationId;
+  private final String memberProtocol;
   private final Map<String, String> config;
   private final long timestampNanos;
   private final String serviceNameOverride;

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public class KafkaConfigReport implements InboxItem {
   private static final int NO_GENERATION = -1;
 
-  private final String type;
+  private final String type; // "kafka_producer" or "kafka_consumer"
   private final String kafkaClusterId;
   private final String consumerGroup;
   private final String memberId;

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/KafkaConfigReport.java
@@ -1,16 +1,28 @@
 package datadog.trace.api.datastreams;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * KafkaConfigReport captures Kafka producer or consumer configuration to be sent via the Data
  * Streams payload. Each unique configuration is sent only once.
+ *
+ * <p>It is also reused to report consumer-group membership: when a consumer (re)joins a group, a
+ * report is emitted carrying the broker-assigned {@code memberId} (plus the group {@code
+ * generationId} and the negotiated {@code memberProtocol}) alongside the cluster id and consumer
+ * group, with an empty {@link #config} map.
  */
 public class KafkaConfigReport implements InboxItem {
+  /** Sentinel generation id for reports that are not membership reports. */
+  public static final int NO_GENERATION = -1;
+
   private final String type; // "kafka_producer" or "kafka_consumer"
   private final String kafkaClusterId;
   private final String consumerGroup;
+  private final String memberId; // broker-assigned consumer group member id, or "" when unknown
+  private final int generationId; // consumer group generation/epoch, or NO_GENERATION
+  private final String memberProtocol; // negotiated partition assignment protocol, or ""
   private final Map<String, String> config;
   private final long timestampNanos;
   private final String serviceNameOverride;
@@ -22,10 +34,35 @@ public class KafkaConfigReport implements InboxItem {
       Map<String, String> config,
       long timestampNanos,
       String serviceNameOverride) {
+    this(
+        type,
+        kafkaClusterId,
+        consumerGroup,
+        "",
+        NO_GENERATION,
+        "",
+        config,
+        timestampNanos,
+        serviceNameOverride);
+  }
+
+  public KafkaConfigReport(
+      String type,
+      String kafkaClusterId,
+      String consumerGroup,
+      String memberId,
+      int generationId,
+      String memberProtocol,
+      Map<String, String> config,
+      long timestampNanos,
+      String serviceNameOverride) {
     this.type = type;
     this.kafkaClusterId = kafkaClusterId != null ? kafkaClusterId : "";
     this.consumerGroup = consumerGroup != null ? consumerGroup : "";
-    this.config = config;
+    this.memberId = memberId != null ? memberId : "";
+    this.generationId = generationId;
+    this.memberProtocol = memberProtocol != null ? memberProtocol : "";
+    this.config = config != null ? config : Collections.<String, String>emptyMap();
     this.timestampNanos = timestampNanos;
     this.serviceNameOverride = serviceNameOverride;
   }
@@ -40,6 +77,18 @@ public class KafkaConfigReport implements InboxItem {
 
   public String getConsumerGroup() {
     return consumerGroup;
+  }
+
+  public String getMemberId() {
+    return memberId;
+  }
+
+  public int getGenerationId() {
+    return generationId;
+  }
+
+  public String getMemberProtocol() {
+    return memberProtocol;
   }
 
   public Map<String, String> getConfig() {
@@ -59,9 +108,12 @@ public class KafkaConfigReport implements InboxItem {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     KafkaConfigReport that = (KafkaConfigReport) o;
-    return Objects.equals(type, that.type)
+    return generationId == that.generationId
+        && Objects.equals(type, that.type)
         && Objects.equals(kafkaClusterId, that.kafkaClusterId)
         && Objects.equals(consumerGroup, that.consumerGroup)
+        && Objects.equals(memberId, that.memberId)
+        && Objects.equals(memberProtocol, that.memberProtocol)
         && Objects.equals(config, that.config);
   }
 
@@ -70,6 +122,9 @@ public class KafkaConfigReport implements InboxItem {
     int result = type != null ? type.hashCode() : 0;
     result = 31 * result + (kafkaClusterId != null ? kafkaClusterId.hashCode() : 0);
     result = 31 * result + (consumerGroup != null ? consumerGroup.hashCode() : 0);
+    result = 31 * result + (memberId != null ? memberId.hashCode() : 0);
+    result = 31 * result + generationId;
+    result = 31 * result + (memberProtocol != null ? memberProtocol.hashCode() : 0);
     result = 31 * result + (config != null ? config.hashCode() : 0);
     return result;
   }

--- a/internal-api/src/main/java/datadog/trace/api/datastreams/NoopDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/api/datastreams/NoopDataStreamsMonitoring.java
@@ -71,6 +71,14 @@ public class NoopDataStreamsMonitoring implements AgentDataStreamsMonitoring {
       String type, String kafkaClusterId, String consumerGroup, Map<String, String> config) {}
 
   @Override
+  public void reportKafkaConsumerGroupMember(
+      String kafkaClusterId,
+      String consumerGroup,
+      String memberId,
+      int generationId,
+      String memberProtocol) {}
+
+  @Override
   public void setConsumeCheckpoint(String type, String source, DataStreamsContextCarrier carrier) {}
 
   @Override


### PR DESCRIPTION
## What
Instruments `ConsumerCoordinator.onJoinComplete` (kafka-clients 0.11 + 3.8) so that every time a consumer (re)joins a group the tracer reports its broker-assigned **member id**, **generation id**, and negotiated **member protocol** through Data Streams Monitoring, alongside the consumer group and Kafka cluster id.

- New `AgentDataStreamsMonitoring.reportKafkaConsumerGroupMember(...)`; carried on the DSM payload as first-class fields (`MemberId`, `GenerationId`, `MemberProtocol`) on the existing kafka config report — no new payload section.
- Change-detection on `(memberId, generationId)` avoids re-reporting unchanged membership.

## Motivation

The agent integration collects member ID --> [(topic, partition), ...] collection

However, users don't know what a member ID is. This PR adds the correlation member ID --> Infra tags (pod, host, etc).

That way, a user will be able to correlate a specific partition with a specific pod. (high lag on a partition & high CPU on the corresponding pod ==> probably a hot partition.