### PR TITLE
Make decorator exception safe 1/3

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.trace.bootstrap.instrumentation.java.net.HostNameResolver.hostName;
 
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.api.Config;
@@ -20,8 +21,25 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for span decorators.
+ *
+ * <p>Decorator lifecycle hooks such as {@link #onError(AgentSpan, Throwable)} and {@link
+ * #beforeFinish(AgentSpan)} are invoked from instrumentation advice, often after the active scope
+ * has been closed and around {@code span.finish()}. To keep that advice free of defensive {@code
+ * try/finally} blocks, these hooks <strong>must not throw</strong>: the public methods are {@code
+ * final} and route through an exception barrier that logs and swallows any {@link Throwable} raised
+ * by the overridable {@code doOnError}/{@code doBeforeFinish} hooks. {@link BlockingException} is
+ * deliberately re-thrown so AppSec/RASP blocking keeps working. Subclasses customize behavior by
+ * overriding the protected {@code doXxx} hooks, which should themselves avoid throwing (other than
+ * {@link BlockingException}).
+ */
 public abstract class BaseDecorator {
+  private static final Logger log = LoggerFactory.getLogger(BaseDecorator.class);
+
   protected static final int UNSET_PORT = 0;
 
   private static final QualifiedClassNameCache CLASS_NAMES =
@@ -106,35 +124,67 @@ public abstract class BaseDecorator {
     span.setMetric(traceAnalyticsEntry);
   }
 
-  public void beforeFinish(final ContextScope scope) {
+  public final void beforeFinish(final ContextScope scope) {
     beforeFinish(scope.context());
   }
 
-  public void beforeFinish(final AgentSpan span) {}
+  public final void beforeFinish(final AgentSpan span) {
+    beforeFinish((Context) span);
+  }
 
-  public void beforeFinish(final Context context) {}
+  public final void beforeFinish(final Context context) {
+    try {
+      doBeforeFinish(context);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span before finish", t);
+    }
+  }
 
-  public void onError(final AgentScope scope, final Throwable throwable) {
+  /**
+   * Hook invoked by {@link #beforeFinish(Context)} behind an exception barrier. Override to add
+   * decoration before the span is finished. Implementations must not throw (other than {@link
+   * BlockingException}).
+   */
+  protected void doBeforeFinish(final Context context) {}
+
+  public final void onError(final AgentScope scope, final Throwable throwable) {
     if (scope != null) {
       onError(scope.span(), throwable);
     }
   }
 
-  public void onError(final AgentSpan span, final Throwable throwable) {
+  public final void onError(final AgentSpan span, final Throwable throwable) {
     onError(span, throwable, ErrorPriorities.DEFAULT);
   }
 
-  public void onError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+  public final void onError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    try {
+      doOnError(span, throwable, errorPriority);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on error", t);
+    }
+  }
+
+  public final void onError(final ContextScope scope, final Throwable throwable) {
+    if (scope != null) {
+      onError(AgentSpan.fromContext(scope.context()), throwable);
+    }
+  }
+
+  /**
+   * Hook invoked by {@link #onError(AgentSpan, Throwable, byte)} behind an exception barrier.
+   * Override to customize error decoration. Implementations must not throw (other than {@link
+   * BlockingException}).
+   */
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
     if (throwable != null && span != null) {
       span.addThrowable(
           throwable instanceof ExecutionException ? throwable.getCause() : throwable,
           errorPriority);
-    }
-  }
-
-  public void onError(final ContextScope scope, final Throwable throwable) {
-    if (scope != null) {
-      onError(AgentSpan.fromContext(scope.context()), throwable);
     }
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -21,22 +21,11 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Base class for span decorators.
- *
- * <p>Decorator lifecycle hooks such as {@link #onError(AgentSpan, Throwable)} and {@link
- * #beforeFinish(AgentSpan)} are invoked from instrumentation advice, often after the active scope
- * has been closed and around {@code span.finish()}. To keep that advice free of defensive {@code
- * try/finally} blocks, these hooks <strong>must not throw</strong>: the public methods are {@code
- * final} and route through an exception barrier that logs and swallows any {@link Throwable} raised
- * by the overridable {@code doOnError}/{@code doBeforeFinish} hooks. {@link BlockingException} is
- * deliberately re-thrown so AppSec/RASP blocking keeps working. Subclasses customize behavior by
- * overriding the protected {@code doXxx} hooks, which should themselves avoid throwing (other than
- * {@link BlockingException}).
- */
 public abstract class BaseDecorator {
   private static final Logger log = LoggerFactory.getLogger(BaseDecorator.class);
 
@@ -124,15 +113,19 @@ public abstract class BaseDecorator {
     span.setMetric(traceAnalyticsEntry);
   }
 
-  public final void beforeFinish(final ContextScope scope) {
-    beforeFinish(scope.context());
+  public final void beforeFinish(@Nullable final ContextScope scope) {
+    if (scope != null) {
+      beforeFinish(scope.context());
+    }
   }
 
-  public final void beforeFinish(final AgentSpan span) {
-    beforeFinish((Context) span);
+  public final void beforeFinish(@Nullable final AgentSpan span) {
+    if (span != null) {
+      beforeFinish((Context) span);
+    }
   }
 
-  public final void beforeFinish(final Context context) {
+  public final void beforeFinish(@Nonnull final Context context) {
     try {
       doBeforeFinish(context);
     } catch (BlockingException e) {
@@ -142,12 +135,7 @@ public abstract class BaseDecorator {
     }
   }
 
-  /**
-   * Hook invoked by {@link #beforeFinish(Context)} behind an exception barrier. Override to add
-   * decoration before the span is finished. Implementations must not throw (other than {@link
-   * BlockingException}).
-   */
-  protected void doBeforeFinish(final Context context) {}
+  protected void doBeforeFinish(@Nonnull final Context context) {}
 
   public final void onError(final AgentScope scope, final Throwable throwable) {
     if (scope != null) {
@@ -175,12 +163,8 @@ public abstract class BaseDecorator {
     }
   }
 
-  /**
-   * Hook invoked by {@link #onError(AgentSpan, Throwable, byte)} behind an exception barrier.
-   * Override to customize error decoration. Implementations must not throw (other than {@link
-   * BlockingException}).
-   */
-  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+  protected void doOnError(
+      @Nullable final AgentSpan span, @Nullable final Throwable throwable, byte errorPriority) {
     if (throwable != null && span != null) {
       span.addThrowable(
           throwable instanceof ExecutionException ? throwable.getCause() : throwable,

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 import static datadog.trace.api.datastreams.DataStreamsContext.forHttpServer;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.ActiveSubsystems.APPSEC_ACTIVE;
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
@@ -431,7 +432,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   protected static AgentSpanContext.Extracted getExtractedSpanContext(Context parentContext) {
-    AgentSpan extractedSpan = AgentSpan.fromContext(parentContext);
+    AgentSpan extractedSpan = fromContext(parentContext);
     if (extractedSpan != null) {
       AgentSpanContext extractedSpanContext = extractedSpan.spanContext();
       if (extractedSpanContext instanceof AgentSpanContext.Extracted) {
@@ -635,8 +636,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   @Override
-  protected void doBeforeFinish(Context context) {
-    AgentSpan span = AgentSpan.fromContext(context);
+  protected void doBeforeFinish(@Nonnull Context context) {
+    AgentSpan span = fromContext(context);
     if (span != null) {
       onRequestEndForInstrumentationGateway(span);
     }
@@ -650,7 +651,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   protected void finishInferredProxySpan(Context context) {
     InferredProxySpan inferredProxySpan;
     if ((inferredProxySpan = InferredProxySpan.fromContext(context)) != null) {
-      inferredProxySpan.finish(AgentSpan.fromContext(context));
+      inferredProxySpan.finish(fromContext(context));
     }
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -533,7 +533,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   @Override
-  public void onError(final AgentSpan span, final Throwable throwable) {
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
     if (throwable != null) {
       span.addThrowable(
           throwable instanceof ExecutionException ? throwable.getCause() : throwable,
@@ -635,7 +635,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   @Override
-  public void beforeFinish(Context context) {
+  protected void doBeforeFinish(Context context) {
     AgentSpan span = AgentSpan.fromContext(context);
     if (span != null) {
       onRequestEndForInstrumentationGateway(span);
@@ -644,7 +644,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     // Close Serverless Gateway Inferred Span if any
     finishInferredProxySpan(context);
 
-    super.beforeFinish(context);
+    super.doBeforeFinish(context);
   }
 
   protected void finishInferredProxySpan(Context context) {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -9,6 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.config.inversion.ConfigHelper
 import datadog.trace.test.util.DDSpecification
+import javax.annotation.Nonnull
 import spock.lang.Shared
 
 class BaseDecoratorTest extends DDSpecification {
@@ -286,7 +287,7 @@ class BaseDecoratorTest extends DDSpecification {
         }
 
         @Override
-        protected void doBeforeFinish(Context context) {
+        protected void doBeforeFinish(@Nonnull Context context) {
           throw toThrow
         }
       }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -93,6 +93,7 @@ class BaseDecoratorTest extends DDSpecification {
 
     then:
     (0..1) * span.localRootSpan
+    _ * span.get(_)
     0 * _
   }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
+import datadog.appsec.api.blocking.BlockingException
+import datadog.context.Context
 import datadog.trace.api.TagMap
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext
@@ -91,6 +93,54 @@ class BaseDecoratorTest extends DDSpecification {
     then:
     (0..1) * span.localRootSpan
     0 * _
+  }
+
+  def "test onError swallows a throwing decorator"() {
+    setup:
+    def throwing = newThrowingDecorator(new RuntimeException("boom"))
+
+    when:
+    throwing.onError(span, new IllegalStateException("original"))
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "test beforeFinish swallows a throwing decorator"() {
+    setup:
+    def throwing = newThrowingDecorator(new RuntimeException("boom"))
+
+    when:
+    throwing.beforeFinish(span)
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "test onError rethrows BlockingException"() {
+    setup:
+    def blocking = new BlockingException("blocked")
+    def throwing = newThrowingDecorator(blocking)
+
+    when:
+    throwing.onError(span, new IllegalStateException("original"))
+
+    then:
+    def caught = thrown(BlockingException)
+    caught.is(blocking)
+  }
+
+  def "test beforeFinish rethrows BlockingException"() {
+    setup:
+    def blocking = new BlockingException("blocked")
+    def throwing = newThrowingDecorator(blocking)
+
+    when:
+    throwing.beforeFinish(span)
+
+    then:
+    def caught = thrown(BlockingException)
+    caught.is(blocking)
   }
 
   def "test analytics rate default disabled"() {
@@ -209,6 +259,35 @@ class BaseDecoratorTest extends DDSpecification {
         @Override
         protected CharSequence component() {
           return "test-component"
+        }
+      }
+  }
+
+  def newThrowingDecorator(Throwable toThrow) {
+    return new BaseDecorator() {
+        @Override
+        protected String[] instrumentationNames() {
+          return ["test1", "test2"]
+        }
+
+        @Override
+        protected CharSequence spanType() {
+          return "test-type"
+        }
+
+        @Override
+        protected CharSequence component() {
+          return "test-component"
+        }
+
+        @Override
+        protected void doOnError(AgentSpan span, Throwable throwable, byte errorPriority) {
+          throw toThrow
+        }
+
+        @Override
+        protected void doBeforeFinish(Context context) {
+          throw toThrow
         }
       }
   }

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
@@ -111,8 +111,8 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void onError(AgentSpan span, Throwable throwable) {
-    super.onError(span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+  protected void doOnError(AgentSpan span, Throwable throwable, byte errorPriority) {
+    super.doOnError(span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
     if (throwable instanceof StatusRuntimeException) {
       onStatus(span, ((StatusRuntimeException) throwable).getStatus());
     } else if (throwable instanceof StatusException) {

--- a/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra/datastax-cassandra-4.0/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
@@ -99,8 +99,8 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   @Override
-  public void onError(final AgentSpan span, final Throwable throwable) {
-    super.onError(span, throwable);
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    super.doOnError(span, throwable, errorPriority);
 
     if (throwable instanceof CoordinatorException) {
       onResponse(span, ((CoordinatorException) throwable).getCoordinator(), null);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -112,8 +112,8 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void onError(AgentSpan span, Throwable throwable) {
-    super.onError(span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+  protected void doOnError(AgentSpan span, Throwable throwable, byte errorPriority) {
+    super.doOnError(span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
     if (throwable instanceof StatusRuntimeException) {
       onStatus(span, ((StatusRuntimeException) throwable).getStatus());
     } else if (throwable instanceof StatusException) {

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -148,7 +148,7 @@ public class OpenAiDecorator extends ClientDecorator {
             .recordSpanFinished(INTEGRATION, spanKind, isRootSpan, true, span.isError(), false);
       }
     }
-    super.doBeforeFinish(span);
+    super.doBeforeFinish(context);
   }
 
   public void withHttpResponse(AgentSpan span, Headers headers) {

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -19,6 +19,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public class OpenAiDecorator extends ClientDecorator {
   public static final OpenAiDecorator DECORATE = new OpenAiDecorator();
@@ -133,7 +134,7 @@ public class OpenAiDecorator extends ClientDecorator {
   }
 
   @Override
-  protected void doBeforeFinish(Context context) {
+  protected void doBeforeFinish(@Nonnull Context context) {
     AgentSpan span = fromContext(context);
     if (llmObsEnabled && span != null) {
       span.setTag(CommonTags.ERROR, span.isError() ? 1 : 0);

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.openai_java;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
+
 import com.openai.core.ClientOptions;
 import com.openai.core.http.Headers;
+import datadog.context.Context;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceApiInfo;
@@ -130,8 +133,9 @@ public class OpenAiDecorator extends ClientDecorator {
   }
 
   @Override
-  public void beforeFinish(AgentSpan span) {
-    if (llmObsEnabled) {
+  protected void doBeforeFinish(Context context) {
+    AgentSpan span = fromContext(context);
+    if (llmObsEnabled && span != null) {
       span.setTag(CommonTags.ERROR, span.isError() ? 1 : 0);
       span.setTag(CommonTags.ERROR_TYPE, span.getTag(DDTags.ERROR_TYPE));
 
@@ -143,7 +147,7 @@ public class OpenAiDecorator extends ClientDecorator {
             .recordSpanFinished(INTEGRATION, spanKind, isRootSpan, true, span.isError(), false);
       }
     }
-    super.beforeFinish(span);
+    super.doBeforeFinish(span);
   }
 
   public void withHttpResponse(AgentSpan span, Headers headers) {

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -162,7 +162,7 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onError(final AgentSpan span, Throwable throwable) {
+  protected void doOnError(final AgentSpan span, Throwable throwable, byte errorPriority) {
     if (REPORT_HTTP_STATUS) {
       span.setHttpStatusCode(500);
     }
@@ -174,6 +174,6 @@ public class PlayHttpServerDecorator
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
-    super.onError(span, throwable);
+    super.doOnError(span, throwable, errorPriority);
   }
 }

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -162,7 +162,7 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onError(final AgentSpan span, Throwable throwable) {
+  protected void doOnError(final AgentSpan span, Throwable throwable, byte errorPriority) {
     if (REPORT_HTTP_STATUS) {
       span.setHttpStatusCode(500);
     }
@@ -174,6 +174,6 @@ public class PlayHttpServerDecorator
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
-    super.onError(span, throwable);
+    super.doOnError(span, throwable, errorPriority);
   }
 }

--- a/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -213,7 +213,7 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onError(final AgentSpan span, Throwable throwable) {
+  protected void doOnError(final AgentSpan span, Throwable throwable, byte errorPriority) {
     if (REPORT_HTTP_STATUS) {
       span.setHttpStatusCode(500);
     }
@@ -225,7 +225,7 @@ public class PlayHttpServerDecorator
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
-    super.onError(span, throwable);
+    super.doOnError(span, throwable, errorPriority);
   }
 
   public void updateOn404Only(final AgentSpan span, final Result result) {

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -90,12 +90,12 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   }
 
   @Override
-  public void onError(final AgentSpan span, Throwable throwable) {
+  protected void doOnError(final AgentSpan span, Throwable throwable, byte errorPriority) {
     // Attempt to unwrap ratpack.handling.internal.HandlerException without direct reference.
     if (throwable instanceof Error && throwable.getCause() != null) {
-      super.onError(span, throwable.getCause());
+      super.doOnError(span, throwable.getCause(), errorPriority);
     } else {
-      super.onError(span, throwable);
+      super.doOnError(span, throwable, errorPriority);
     }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -120,11 +120,11 @@ public class Servlet3Decorator
   }
 
   @Override
-  public void onError(final AgentSpan span, final Throwable throwable) {
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
     if (throwable instanceof ServletException && throwable.getCause() != null) {
-      super.onError(span, throwable.getCause());
+      super.doOnError(span, throwable.getCause(), errorPriority);
     } else {
-      super.onError(span, throwable);
+      super.doOnError(span, throwable, errorPriority);
     }
   }
 

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -34,11 +34,11 @@ public class RequestDispatcherDecorator extends BaseDecorator {
   }
 
   @Override
-  public void onError(final AgentSpan span, final Throwable throwable) {
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
     if (throwable instanceof ServletException && throwable.getCause() != null) {
-      super.onError(span, throwable.getCause());
+      super.doOnError(span, throwable.getCause(), errorPriority);
     } else {
-      super.onError(span, throwable);
+      super.doOnError(span, throwable, errorPriority);
     }
   }
 

--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
@@ -95,16 +95,14 @@ public final class SynapseServerWorkerInstrumentation extends InstrumenterModule
       }
       // server worker is created in request event so be prepared to finish the span here
       // (if there's an ACK response or error we might not get a separate response event)
-      boolean finishSpan =
-          (null != httpResponse || null != error)
-              && null != request.getConnection().getContext().removeAttribute(SYNAPSE_CONTEXT_KEY);
-      if (finishSpan) {
+      if ((null != httpResponse || null != error)
+          && null != request.getConnection().getContext().removeAttribute(SYNAPSE_CONTEXT_KEY)) {
         DECORATE.beforeFinish(scope.context());
-      }
-      // otherwise the span will be finished by a separate server response event
-      scope.close();
-      if (finishSpan) {
+        scope.close();
         span.finish();
+      } else {
+        scope.close();
+        // otherwise will be finished by a separate server response event
       }
     }
   }

--- a/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3.0/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
@@ -95,14 +95,16 @@ public final class SynapseServerWorkerInstrumentation extends InstrumenterModule
       }
       // server worker is created in request event so be prepared to finish the span here
       // (if there's an ACK response or error we might not get a separate response event)
-      if ((null != httpResponse || null != error)
-          && null != request.getConnection().getContext().removeAttribute(SYNAPSE_CONTEXT_KEY)) {
+      boolean finishSpan =
+          (null != httpResponse || null != error)
+              && null != request.getConnection().getContext().removeAttribute(SYNAPSE_CONTEXT_KEY);
+      if (finishSpan) {
         DECORATE.beforeFinish(scope.context());
-        scope.close();
+      }
+      // otherwise the span will be finished by a separate server response event
+      scope.close();
+      if (finishSpan) {
         span.finish();
-      } else {
-        scope.close();
-        // otherwise will be finished by a separate server response event
       }
     }
   }

--- a/docs/add_new_instrumentation.md
+++ b/docs/add_new_instrumentation.md
@@ -307,16 +307,13 @@ public static class GoogleHttpClientAdvice {
             @Advice.Return final HttpResponse response,
             @Advice.Thrown final Throwable throwable) {
         AgentSpan span = scope.span();
-        try {
-            DECORATE.onError(span, throwable);
-            DECORATE.onResponse(span, response);
-            DECORATE.beforeFinish(span);
-        } finally {
-            if (!inheritedScope) {
-                scope.close();
-            }
-            span.finish();
+        DECORATE.onError(span, throwable);
+        DECORATE.onResponse(span, response);
+        DECORATE.beforeFinish(span);
+        if (!inheritedScope) {
+            scope.close();
         }
+        span.finish();
     }
 }
 ```

--- a/docs/how_instrumentations_work.md
+++ b/docs/how_instrumentations_work.md
@@ -388,6 +388,18 @@ instrumentation.
 
 Decorator class names should end in _Decorator._
 
+### Decorators must not throw
+
+Decorator lifecycle hooks (`onError`, `beforeFinish`, …) are called from advice around
+`scope.close()` / `span.finish()`, so a decorator that throws would leak scopes and spans — and
+force every call site into defensive `try/finally` blocks. To prevent this, decorators make
+these public methods `final` and routes them through an exception barrier that logs and swallows any
+`Throwable`. `BlockingException` is deliberately re-thrown so AppSec/RASP blocking keeps working.
+
+Subclasses customize behavior by overriding the protected `doOnError` / `doBeforeFinish` hooks
+(**not** the public `onError` / `beforeFinish` methods). Those hooks should still avoid throwing
+(other than `BlockingException`); the barrier is a safety net, not a license to throw.
+
 ## Advice Classes
 
 Byte Buddy injects compiled bytecode at runtime to wrap existing methods, so they communicate with Datadog at entry or exit.


### PR DESCRIPTION
# What Does This Do

This is a follow up of https://github.com/DataDog/dd-trace-java/pull/11951 and proposes an improvement to instrumentation API decorators to make them "exception safe".

The main ideas are: 
* Simple / easy to use API for instrumentations - they are left untouched to avoid large refactoring but can be deduplicated at some later point
* Smaller SPI to implement - refactored few implementations to only have 1 method per signal (vs the multiple existing overloads) to implement
* A construct that prevent exception to bubble into application code - `beforeFinish` to call / `doBeforeFinish` to implementation, where safety is done on `beforeFinish` that can't be overridden.

Additionally:

* I added nullability information too because I find the default pattern quite confusing (calling `onEvent` with null values when the even did not happen),
* I simplified existing child class to override the single method per signal - the one with all parameters

# Motivation

The goal is to simplify how write instrumentations, and make the dumb way safe.

# Additional Notes

This part is part of stack PRs:
* https://github.com/DataDog/dd-trace-java/pull/11998
* https://github.com/DataDog/dd-trace-java/pull/12016
* https://github.com/DataDog/dd-trace-java/pull/12017


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
