### PR TITLE
Promote hint about avoiding static interface methods in advice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,9 @@ Code running in the agent's `premain` phase must **not** use:
 - `javax.management.*` — causes class loading issues
 
 See [docs/bootstrap_design_guidelines.md](docs/bootstrap_design_guidelines.md) for details and alternatives.
+
+## Advice constraints (critical)
+
+Advice methods (OnMethodEnter/OnMethodExit) are inlined into the instrumented class's bytecode.
+Calling a static interface method there, such as Context.root() or Context.current(), can cause
+a VerifyError at runtime — use Java8BytecodeBridge (rootContext, currentContext, etc.) instead.


### PR DESCRIPTION
# Motivation

Promoting this to `AGENTS.md` should stop agents from having to relearn this in future migrations.

Note that this particular hint is not just specific to authoring instrumentations - general refactoring tasks that touch advice classes must also see this. That's why it's not under the authoring instrumentations skill. (I've had to remind Claude about this several times in recent refactorings, and this is the place it recommended to avoid that happening again.)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
