### PR TITLE
Use full Git hash in generated version files

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFile.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFile.kt
@@ -1,5 +1,6 @@
 package datadog.gradle.plugin.version
 
+import org.checkerframework.checker.units.qual.g
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
@@ -8,6 +9,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
@@ -34,7 +36,11 @@ abstract class WriteVersionFile @Inject constructor(
       }
     )
 
-  @get:Internal
+  @get:Input
+  val gitHashTruncation: Property<Int> = objects.property<Int>()
+    .convention(10)
+
+  @get:Input
   val projectName: Property<String> = objects.property<String>()
     .convention(project.name)
 
@@ -46,6 +52,6 @@ abstract class WriteVersionFile @Inject constructor(
   fun writeVersionFile() {
     val versionFile = outputDirectory.file("${projectName.get()}.version").get().asFile
     versionFile.parentFile.mkdirs()
-    versionFile.writeText("${version.get()}~${gitHash.get()}")
+    versionFile.writeText("${version.get()}~${gitHash.get().take(gitHashTruncation.get())}")
   }
 }

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFile.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/version/WriteVersionFile.kt
@@ -7,6 +7,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
@@ -27,11 +28,15 @@ abstract class WriteVersionFile @Inject constructor(
     .convention(
       providerFactory.of(GitCommandValueSource::class.java) {
         parameters {
-          gitCommand.addAll("git", "rev-parse", "--short", "HEAD")
+          gitCommand.addAll("git", "rev-parse", "HEAD")
           workingDirectory.set(layout.projectDirectory)
         }
       }
     )
+
+  @get:Internal
+  val projectName: Property<String> = objects.property<String>()
+    .convention(project.name)
 
   @get:OutputDirectory
   val outputDirectory: DirectoryProperty = objects.directoryProperty()
@@ -39,7 +44,7 @@ abstract class WriteVersionFile @Inject constructor(
 
   @TaskAction
   fun writeVersionFile() {
-    val versionFile = outputDirectory.file("${project.name}.version").get().asFile
+    val versionFile = outputDirectory.file("${projectName.get()}.version").get().asFile
     versionFile.parentFile.mkdirs()
     versionFile.writeText("${version.get()}~${gitHash.get()}")
   }

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
@@ -8,9 +8,10 @@ import org.junit.jupiter.api.Test
 class WriteVersionFilePluginTest : VersionPluginsFixture() {
 
   @Test
-  fun `writes version file in version~full hash format`() {
+  fun `writes version file in version~hash format`() {
+    // task truncation convention is 10
     assertVersionFile(
-      expectedContentRegex = "1\\.2\\.3~[0-9a-f]{40}",
+      expectedContentRegex = "1\\.2\\.3~[0-9a-f]{10}",
       beforeGradle = {
         initGitRepo()
       },

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/version/WriteVersionFilePluginTest.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test
 class WriteVersionFilePluginTest : VersionPluginsFixture() {
 
   @Test
-  fun `writes version file in version~hash format`() {
+  fun `writes version file in version~full hash format`() {
     assertVersionFile(
-      expectedContentRegex = "1\\.2\\.3~[0-9a-f]+",
+      expectedContentRegex = "1\\.2\\.3~[0-9a-f]{40}",
       beforeGradle = {
         initGitRepo()
       },


### PR DESCRIPTION
# What Does This Do

Uses the full Git commit hash in generated version files instead of an abbreviated hash:

```text
1.65.0-SNAPSHOT~846103dfeb02cb7e162b0404af6d87a4882e2e91
```

# Motivation

Release jar reproducibility.

`git rev-parse --short HEAD` computes the shortest hex prefix (the abbreviation) that's unique among the git objects present *n that specific local clone, at that moment. It depends on local repo state, not on the commit itself. Separate GitLab runners appears to have more or less Git objects and therefore produce abbreviations of different lengths for the same commit. Possibly due to the local clone receiving more or less commits maybe via fetch.

Because the generated version file is packaged into the JAR, this made artifacts built from the same commit differ across jobs.
The validate job build scan reported that `:dd-trace-api:writeVersionNumberFile` was not _up-to-date_ because its `gitHash` input had changed.

<img width="896" height="422" alt="image" src="https://github.com/user-attachments/assets/1191c7a4-d065-407c-994f-3caab8f8ae09" />

I believe the reason for that to happen is that each GitLab job uses a separately prepared runner checkout whose available Git objects can differ because of fetched refs and repository state; and since `--short` determines uniqueness from those local objects, the same commit can have a different "abbreviation" (short hash).

See the [`git rev-parse --short` documentation](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortltlengthgt).

# Additional Notes

It also captures the project name during configuration rather than accessing `project.name` from the task action.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
