### PR TITLE
Remove unused AgentScope.Continuation.span() method

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
@@ -5,7 +5,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTraceCollector;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -127,11 +126,6 @@ final class ScopeContinuation implements AgentScope.Continuation {
   @Override
   public AgentScope activate() {
     return (AgentScope) resume();
-  }
-
-  @Override
-  public AgentSpan span() {
-    return AgentSpan.fromContext(context);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -24,8 +24,5 @@ public interface AgentScope extends ContextScope, TraceScope, Closeable {
 
     @Override
     AgentScope activate();
-
-    /** Provide access to the captured span */
-    AgentSpan span();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopContinuation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopContinuation.java
@@ -33,10 +33,5 @@ final class NoopContinuation implements AgentScope.Continuation {
   }
 
   @Override
-  public AgentSpan span() {
-    return NoopSpan.INSTANCE;
-  }
-
-  @Override
   public void cancel() {}
 }


### PR DESCRIPTION
# Motivation

As the context migration proceeds, this is a good time to remove unused internal methods.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
