### PR TITLE
Fix NoSuchElementException from unchecked Optional.get() in Kafka consumer instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelper.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelper.java
@@ -2,12 +2,13 @@ package datadog.trace.instrumentation.kafka_clients38;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.instrumentation.kafka_common.MetadataState;
+import java.util.Optional;
 import org.apache.kafka.clients.Metadata;
 
 public class KafkaConsumerInstrumentationHelper {
   public static String extractGroup(KafkaConsumerInfo kafkaConsumerInfo) {
     if (kafkaConsumerInfo != null) {
-      return kafkaConsumerInfo.getConsumerGroup().get();
+      return kafkaConsumerInfo.getConsumerGroup().orElse(null);
     }
     return null;
   }
@@ -16,9 +17,9 @@ public class KafkaConsumerInstrumentationHelper {
       KafkaConsumerInfo kafkaConsumerInfo,
       ContextStore<Metadata, MetadataState> metadataContextStore) {
     if (kafkaConsumerInfo != null) {
-      Metadata metadata = kafkaConsumerInfo.getmetadata().get();
-      if (metadata != null) {
-        MetadataState state = metadataContextStore.get(metadata);
+      Optional<Metadata> metadata = kafkaConsumerInfo.getmetadata();
+      if (metadata.isPresent()) {
+        MetadataState state = metadataContextStore.get(metadata.get());
         return state != null ? state.clusterId : null;
       }
     }
@@ -26,6 +27,6 @@ public class KafkaConsumerInstrumentationHelper {
   }
 
   public static String extractBootstrapServers(KafkaConsumerInfo kafkaConsumerInfo) {
-    return kafkaConsumerInfo == null ? null : kafkaConsumerInfo.getBootstrapServers().get();
+    return kafkaConsumerInfo == null ? null : kafkaConsumerInfo.getBootstrapServers().orElse(null);
   }
 }

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/java/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelperTest.java
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/src/test/java/datadog/trace/instrumentation/kafka_clients38/KafkaConsumerInstrumentationHelperTest.java
@@ -1,0 +1,94 @@
+package datadog.trace.instrumentation.kafka_clients38;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.instrumentation.kafka_common.MetadataState;
+import org.apache.kafka.clients.Metadata;
+import org.junit.jupiter.api.Test;
+
+class KafkaConsumerInstrumentationHelperTest {
+
+  @SuppressWarnings("unchecked")
+  private final ContextStore<Metadata, MetadataState> metadataContextStore =
+      mock(ContextStore.class);
+
+  @Test
+  void extractGroupReturnsNullForNullKafkaConsumerInfo() {
+    assertNull(KafkaConsumerInstrumentationHelper.extractGroup(null));
+  }
+
+  @Test
+  void extractGroupReturnsNullWhenConsumerGroupIsNull() {
+    KafkaConsumerInfo kafkaConsumerInfo = new KafkaConsumerInfo(null, null, "localhost:9092");
+    assertNull(KafkaConsumerInstrumentationHelper.extractGroup(kafkaConsumerInfo));
+  }
+
+  @Test
+  void extractGroupReturnsConsumerGroupWhenPresent() {
+    KafkaConsumerInfo kafkaConsumerInfo =
+        new KafkaConsumerInfo("test-group", null, "localhost:9092");
+    assertEquals("test-group", KafkaConsumerInstrumentationHelper.extractGroup(kafkaConsumerInfo));
+  }
+
+  @Test
+  void extractBootstrapServersReturnsNullForNullKafkaConsumerInfo() {
+    assertNull(KafkaConsumerInstrumentationHelper.extractBootstrapServers(null));
+  }
+
+  @Test
+  void extractBootstrapServersReturnsNullWhenBootstrapServersIsNull() {
+    KafkaConsumerInfo kafkaConsumerInfo = new KafkaConsumerInfo("test-group", null, null);
+    assertNull(KafkaConsumerInstrumentationHelper.extractBootstrapServers(kafkaConsumerInfo));
+  }
+
+  @Test
+  void extractBootstrapServersReturnsValueWhenPresent() {
+    KafkaConsumerInfo kafkaConsumerInfo =
+        new KafkaConsumerInfo("test-group", null, "localhost:9092");
+    assertEquals(
+        "localhost:9092",
+        KafkaConsumerInstrumentationHelper.extractBootstrapServers(kafkaConsumerInfo));
+  }
+
+  @Test
+  void extractClusterIdReturnsNullForNullKafkaConsumerInfo() {
+    assertNull(KafkaConsumerInstrumentationHelper.extractClusterId(null, metadataContextStore));
+  }
+
+  @Test
+  void extractClusterIdReturnsNullWhenMetadataIsNull() {
+    KafkaConsumerInfo kafkaConsumerInfo = new KafkaConsumerInfo("test-group", "localhost:9092");
+    assertNull(
+        KafkaConsumerInstrumentationHelper.extractClusterId(
+            kafkaConsumerInfo, metadataContextStore));
+  }
+
+  @Test
+  void extractClusterIdReturnsNullWhenNoStateForMetadata() {
+    Metadata metadata = mock(Metadata.class);
+    KafkaConsumerInfo kafkaConsumerInfo =
+        new KafkaConsumerInfo("test-group", metadata, "localhost:9092");
+    when(metadataContextStore.get(metadata)).thenReturn(null);
+    assertNull(
+        KafkaConsumerInstrumentationHelper.extractClusterId(
+            kafkaConsumerInfo, metadataContextStore));
+  }
+
+  @Test
+  void extractClusterIdReturnsClusterIdWhenStatePresent() {
+    Metadata metadata = mock(Metadata.class);
+    KafkaConsumerInfo kafkaConsumerInfo =
+        new KafkaConsumerInfo("test-group", metadata, "localhost:9092");
+    MetadataState state = new MetadataState();
+    state.clusterId = "cluster-1";
+    when(metadataContextStore.get(metadata)).thenReturn(state);
+    assertEquals(
+        "cluster-1",
+        KafkaConsumerInstrumentationHelper.extractClusterId(
+            kafkaConsumerInfo, metadataContextStore));
+  }
+}


### PR DESCRIPTION
## Summary
- `KafkaConsumerInstrumentationHelper` (kafka-clients-3.8) called `Optional.get()` on the consumer group, metadata, and bootstrap servers without checking `isPresent()`/using `orElse()`, throwing `NoSuchElementException` when those values weren't captured (e.g. `Optional.get` errors seen in production telemetry, introduced in 1.64).
- Fixed all three accessors (`extractGroup`, `extractClusterId`, `extractBootstrapServers`) to safely handle the empty case instead of throwing.
- Added a `KafkaConsumerInstrumentationHelperTest` unit test covering null/empty-Optional cases for all three accessors, to prevent regressions.
- Checked the older `kafka-clients-0.11` module — it never wraps these values in `Optional` (plain nullable getters with `!= null` checks), so it isn't affected.

Reported in https://dd.slack.com/archives/C047YAMGZ7T/p1784318891028629

## Test plan
- [x] `./gradlew :dd-java-agent:instrumentation:kafka:kafka-clients-3.8:compileJava` succeeds
- [x] `./gradlew :dd-java-agent:instrumentation:kafka:kafka-clients-3.8:spotlessApply` clean
- [x] `./gradlew :dd-java-agent:instrumentation:kafka:kafka-clients-3.8:test` passes, including new `KafkaConsumerInstrumentationHelperTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)