### PR TITLE
Drop `noopScope()` wrapper caching from OT/OTel TypeConverters

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/TypeConverter.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.opentelemetry;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext;
 
@@ -16,12 +15,10 @@ import io.opentelemetry.trace.SpanContext;
 public class TypeConverter {
   private final Span noopSpanWrapper;
   private final SpanContext noopContextWrapper;
-  private final OtelScope noopScopeWrapper;
 
   public TypeConverter() {
     noopSpanWrapper = new OtelSpan(noopSpan(), this);
     noopContextWrapper = new OtelSpanContext(noopSpanContext());
-    noopScopeWrapper = new OtelScope(noopScope());
   }
 
   public AgentSpan toAgentSpan(final Span span) {
@@ -54,9 +51,6 @@ public class TypeConverter {
   public Scope toScope(final AgentScope scope) {
     if (scope == null) {
       return null;
-    }
-    if (scope == noopScope()) {
-      return noopScopeWrapper;
     }
     return new OtelScope(scope);
   }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
@@ -9,7 +9,6 @@ import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentelemetry.TypeConverter
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
@@ -37,12 +36,6 @@ class TypeConverterTest extends InstrumentationSpecification {
     def noopContext = noopSpanContext()
     expect:
     typeConverter.toSpanContext(noopContext) is typeConverter.toSpanContext(noopContext)
-  }
-
-  def "should avoid the noop scope wrapper allocation"() {
-    def noopScope = noopScope()
-    expect:
-    typeConverter.toScope(noopScope) is typeConverter.toScope(noopScope)
   }
 
   def createTestSpanContext() {

--- a/dd-java-agent/instrumentation/opentracing/opentracing-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/opentracing-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.opentracing31;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext;
 
@@ -18,13 +17,11 @@ public class TypeConverter {
   private final LogHandler logHandler;
   private final OTSpan noopSpanWrapper;
   private final OTSpanContext noopContextWrapper;
-  private final OTScopeManager.OTScope noopScopeWrapper;
 
   public TypeConverter(final LogHandler logHandler) {
     this.logHandler = logHandler;
     noopSpanWrapper = new OTSpan(noopSpan(), this, logHandler);
     noopContextWrapper = new OTSpanContext(noopSpanContext());
-    noopScopeWrapper = new OTScopeManager.OTScope(noopScope(), false, this);
   }
 
   public AgentSpan toAgentSpan(final Span span) {
@@ -57,9 +54,6 @@ public class TypeConverter {
   public Scope toScope(final AgentScope scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
-    }
-    if (scope == noopScope()) {
-      return noopScopeWrapper;
     }
     return new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
   }

--- a/dd-java-agent/instrumentation/opentracing/opentracing-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/opentracing-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -8,9 +8,9 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
+import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.instrumentation.opentracing31.TypeConverter
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
@@ -40,14 +40,14 @@ class TypeConverterTest extends InstrumentationSpecification {
     typeConverter.toSpanContext(noopContext) is typeConverter.toSpanContext(noopContext)
   }
 
-  def "should avoid the noop scope wrapper allocation"() {
-    def noopScope = noopScope()
+  def "should reuse the noop span wrapper via scope"() {
+    def noopScope = Stub(AgentScope) {
+      span() >> noopSpan()
+    }
+    def noopSpanWrapper = typeConverter.toSpan(noopSpan())
     expect:
-    typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, true)
-    typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, false)
-    // noop scopes expected to be the same despite the finishSpanOnClose flag
-    typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, false)
-    typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, true)
+    typeConverter.toScope(noopScope, true).span() is noopSpanWrapper
+    typeConverter.toScope(noopScope, false).span() is noopSpanWrapper
   }
 
   def createTestSpanContext() {

--- a/dd-java-agent/instrumentation/opentracing/opentracing-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/opentracing-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.opentracing32;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext;
 
@@ -18,13 +17,11 @@ public class TypeConverter {
   private final LogHandler logHandler;
   private final OTSpan noopSpanWrapper;
   private final OTSpanContext noopContextWrapper;
-  private final OTScopeManager.OTScope noopScopeWrapper;
 
   public TypeConverter(final LogHandler logHandler) {
     this.logHandler = logHandler;
     noopSpanWrapper = new OTSpan(noopSpan(), this, logHandler);
     noopContextWrapper = new OTSpanContext(noopSpanContext());
-    noopScopeWrapper = new OTScopeManager.OTScope(noopScope(), false, this);
   }
 
   public AgentSpan toAgentSpan(final Span span) {
@@ -57,9 +54,6 @@ public class TypeConverter {
   public Scope toScope(final AgentScope scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
-    }
-    if (scope == noopScope()) {
-      return noopScopeWrapper;
     }
     return new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
   }

--- a/dd-java-agent/instrumentation/opentracing/opentracing-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/opentracing-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -8,9 +8,9 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
+import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.instrumentation.opentracing32.TypeConverter
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext
 
@@ -40,14 +40,14 @@ class TypeConverterTest extends InstrumentationSpecification {
     typeConverter.toSpanContext(noopContext) is typeConverter.toSpanContext(noopContext)
   }
 
-  def "should avoid the noop scope wrapper allocation"() {
-    def noopScope = noopScope()
+  def "should reuse the noop span wrapper via scope"() {
+    def noopScope = Stub(AgentScope) {
+      span() >> noopSpan()
+    }
+    def noopSpanWrapper = typeConverter.toSpan(noopSpan())
     expect:
-    typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, true)
-    typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, false)
-    // noop scopes expected to be the same despite the finishSpanOnClose flag
-    typeConverter.toScope(noopScope, true) is typeConverter.toScope(noopScope, false)
-    typeConverter.toScope(noopScope, false) is typeConverter.toScope(noopScope, true)
+    typeConverter.toScope(noopScope, true).span() is noopSpanWrapper
+    typeConverter.toScope(noopScope, false).span() is noopSpanWrapper
   }
 
   def createTestSpanContext() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -1,6 +1,5 @@
 package datadog.opentracing;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext;
 
@@ -17,13 +16,11 @@ class TypeConverter {
   private final LogHandler logHandler;
   private final OTSpan noopSpanWrapper;
   private final OTSpanContext noopContextWrapper;
-  private final OTScopeManager.OTScope noopScopeWrapper;
 
   public TypeConverter(final LogHandler logHandler) {
     this.logHandler = logHandler;
     noopSpanWrapper = new OTSpan(noopSpan(), this, logHandler);
     noopContextWrapper = new OTSpanContext(noopSpanContext());
-    noopScopeWrapper = new OTScopeManager.OTScope(noopScope(), false, this);
   }
 
   public AgentSpan toAgentSpan(final Span span) {
@@ -60,9 +57,6 @@ class TypeConverter {
   public Scope toScope(final AgentScope scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
-    }
-    if (scope == noopScope()) {
-      return noopScopeWrapper;
     }
     return new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
   }

--- a/dd-trace-ot/src/test/java/datadog/opentracing/TypeConverterTest.java
+++ b/dd-trace-ot/src/test/java/datadog/opentracing/TypeConverterTest.java
@@ -1,11 +1,13 @@
 package datadog.opentracing;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpanContext;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.core.CoreTracer;
@@ -45,20 +47,11 @@ class TypeConverterTest extends DDJavaSpecification {
   }
 
   @Test
-  void shouldAvoidTheNoopScopeWrapperAllocation() {
-    datadog.trace.bootstrap.instrumentation.api.AgentScope noopScopeInstance = noopScope();
-    assertSame(
-        typeConverter.toScope(noopScopeInstance, true),
-        typeConverter.toScope(noopScopeInstance, true));
-    assertSame(
-        typeConverter.toScope(noopScopeInstance, false),
-        typeConverter.toScope(noopScopeInstance, false));
-    // noop scopes expected to be the same despite the finishSpanOnClose flag
-    assertSame(
-        typeConverter.toScope(noopScopeInstance, true),
-        typeConverter.toScope(noopScopeInstance, false));
-    assertSame(
-        typeConverter.toScope(noopScopeInstance, false),
-        typeConverter.toScope(noopScopeInstance, true));
+  void shouldReuseNoopSpanWrapperViaScope() {
+    AgentScope noopScope = mock(AgentScope.class);
+    when(noopScope.span()).thenReturn(noopSpan());
+    OTSpan noopSpanWrapper = typeConverter.toSpan(noopSpan());
+    assertSame(typeConverter.toScope(noopScope, true).span(), noopSpanWrapper);
+    assertSame(typeConverter.toScope(noopScope, false).span(), noopSpanWrapper);
   }
 }


### PR DESCRIPTION
# What Does This Do

The cached `noopScopeWrapper` only optimized an already-rare path (scope-manager depth-limit overflow); drop the special-casing and the now-unneeded dependency on `AgentTracer.noopScope()` identity.

# Motivation

Further step towards being able to completely remove the noopScope() sentinel

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
