### PR TITLE
Make decorator exception safe 2/3

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
+import static datadog.trace.bootstrap.instrumentation.api.ErrorPriorities.DEFAULT;
 import static datadog.trace.bootstrap.instrumentation.java.net.HostNameResolver.hostName;
 
 import datadog.appsec.api.blocking.BlockingException;
@@ -12,7 +13,6 @@ import datadog.trace.api.TagMap;
 import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.lang.reflect.Method;
 import java.net.Inet4Address;
@@ -97,7 +97,7 @@ public abstract class BaseDecorator {
     return false;
   }
 
-  public final void afterStart(final AgentSpan span) {
+  public final void afterStart(@Nonnull final AgentSpan span) {
     try {
       doAfterStart(span);
     } catch (BlockingException e) {
@@ -147,17 +147,18 @@ public abstract class BaseDecorator {
 
   protected void doBeforeFinish(@Nonnull final Context context) {}
 
-  public final void onError(final AgentScope scope, final Throwable throwable) {
+  public final void onError(@Nullable final AgentScope scope, @Nullable final Throwable throwable) {
     if (scope != null) {
       onError(scope.span(), throwable);
     }
   }
 
-  public final void onError(final AgentSpan span, final Throwable throwable) {
-    onError(span, throwable, ErrorPriorities.DEFAULT);
+  public final void onError(@Nullable final AgentSpan span, @Nullable final Throwable throwable) {
+    onError(span, throwable, DEFAULT);
   }
 
-  public final void onError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+  public final void onError(
+      @Nullable final AgentSpan span, @Nullable final Throwable throwable, byte errorPriority) {
     try {
       doOnError(span, throwable, errorPriority);
     } catch (BlockingException e) {
@@ -167,7 +168,8 @@ public abstract class BaseDecorator {
     }
   }
 
-  public final void onError(final ContextScope scope, final Throwable throwable) {
+  public final void onError(
+      @Nullable final ContextScope scope, @Nullable final Throwable throwable) {
     if (scope != null) {
       onError(AgentSpan.fromContext(scope.context()), throwable);
     }
@@ -183,18 +185,20 @@ public abstract class BaseDecorator {
   }
 
   public final void onPeerConnection(
-      final AgentSpan span, final InetSocketAddress remoteConnection) {
+      @Nonnull final AgentSpan span, @Nullable final InetSocketAddress remoteConnection) {
     if (remoteConnection != null) {
       onPeerConnection(span, remoteConnection.getAddress(), !remoteConnection.isUnresolved());
       setPeerPort(span, remoteConnection.getPort());
     }
   }
 
-  public final void onPeerConnection(final AgentSpan span, final InetAddress remoteAddress) {
+  public final void onPeerConnection(
+      @Nonnull final AgentSpan span, @Nullable final InetAddress remoteAddress) {
     onPeerConnection(span, remoteAddress, true);
   }
 
-  public final void onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
+  public final void onPeerConnection(
+      @Nonnull AgentSpan span, @Nullable InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
       if (resolved && Config.get().isPeerHostNameEnabled()) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -21,7 +21,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.slf4j.Logger;
@@ -186,18 +185,21 @@ public abstract class BaseDecorator {
     }
   }
 
-  public final void onPeerConnection(final AgentSpan span, @Nullable final InetSocketAddress remoteConnection) {
+  public final void onPeerConnection(
+      final AgentSpan span, @Nullable final InetSocketAddress remoteConnection) {
     if (remoteConnection != null) {
       onPeerConnection(span, remoteConnection.getAddress(), !remoteConnection.isUnresolved());
       setPeerPort(span, remoteConnection.getPort());
     }
   }
 
-  public final void onPeerConnection(final AgentSpan span, @Nullable final InetAddress remoteAddress) {
+  public final void onPeerConnection(
+      final AgentSpan span, @Nullable final InetAddress remoteAddress) {
     onPeerConnection(span, remoteAddress, true);
   }
 
-  public final void onPeerConnection(AgentSpan span, @Nullable InetAddress remoteAddress, boolean resolved) {
+  public final void onPeerConnection(
+      AgentSpan span, @Nullable InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
       if (resolved && Config.get().isPeerHostNameEnabled()) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -97,7 +97,17 @@ public abstract class BaseDecorator {
     return false;
   }
 
-  public void afterStart(final AgentSpan span) {
+  public final void afterStart(final AgentSpan span) {
+    try {
+      doAfterStart(span);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span after start", t);
+    }
+  }
+
+  protected void doAfterStart(final AgentSpan span) {
     if (spanType() != null) {
       span.setSpanType(spanType());
     }
@@ -172,18 +182,19 @@ public abstract class BaseDecorator {
     }
   }
 
-  public void onPeerConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+  public final void onPeerConnection(
+      final AgentSpan span, final InetSocketAddress remoteConnection) {
     if (remoteConnection != null) {
       onPeerConnection(span, remoteConnection.getAddress(), !remoteConnection.isUnresolved());
       setPeerPort(span, remoteConnection.getPort());
     }
   }
 
-  public void onPeerConnection(final AgentSpan span, final InetAddress remoteAddress) {
+  public final void onPeerConnection(final AgentSpan span, final InetAddress remoteAddress) {
     onPeerConnection(span, remoteAddress, true);
   }
 
-  public void onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
+  public final void onPeerConnection(AgentSpan span, InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
       if (resolved && Config.get().isPeerHostNameEnabled()) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -137,7 +137,7 @@ public abstract class BaseDecorator {
     }
   }
 
-  public final void beforeFinish(@Nonnull final Context context) {
+  public final void beforeFinish(final Context context) {
     try {
       doBeforeFinish(context);
     } catch (BlockingException e) {
@@ -147,7 +147,7 @@ public abstract class BaseDecorator {
     }
   }
 
-  protected void doBeforeFinish(@Nonnull final Context context) {}
+  protected void doBeforeFinish(final Context context) {}
 
   public final void onError(@Nullable final AgentScope scope, @Nullable final Throwable throwable) {
     if (scope != null) {
@@ -186,21 +186,18 @@ public abstract class BaseDecorator {
     }
   }
 
-  public final void onPeerConnection(
-      @Nonnull final AgentSpan span, @Nullable final InetSocketAddress remoteConnection) {
+  public final void onPeerConnection(final AgentSpan span, @Nullable final InetSocketAddress remoteConnection) {
     if (remoteConnection != null) {
       onPeerConnection(span, remoteConnection.getAddress(), !remoteConnection.isUnresolved());
       setPeerPort(span, remoteConnection.getPort());
     }
   }
 
-  public final void onPeerConnection(
-      @Nonnull final AgentSpan span, @Nullable final InetAddress remoteAddress) {
+  public final void onPeerConnection(final AgentSpan span, @Nullable final InetAddress remoteAddress) {
     onPeerConnection(span, remoteAddress, true);
   }
 
-  public final void onPeerConnection(
-      @Nonnull AgentSpan span, @Nullable InetAddress remoteAddress, boolean resolved) {
+  public final void onPeerConnection(AgentSpan span, @Nullable InetAddress remoteAddress, boolean resolved) {
     if (remoteAddress != null) {
       String ip = remoteAddress.getHostAddress();
       if (resolved && Config.get().isPeerHostNameEnabled()) {
@@ -227,9 +224,6 @@ public abstract class BaseDecorator {
   /**
    * This method is used to generate an acceptable span (operation) name based on a given method
    * reference. Anonymous classes are named based on their parent.
-   *
-   * @param method
-   * @return
    */
   public CharSequence spanNameForMethod(final Method method) {
     return spanNameForMethod(method.getDeclaringClass(), method);
@@ -242,7 +236,7 @@ public abstract class BaseDecorator {
    * @param method the method to get the name from, nullable
    * @return the span name from the class and method
    */
-  public CharSequence spanNameForMethod(final Class<?> clazz, final Method method) {
+  public CharSequence spanNameForMethod(final Class<?> clazz, @Nullable final Method method) {
     if (null == method) {
       return CLASS_NAMES.getClassName(clazz);
     }
@@ -256,16 +250,13 @@ public abstract class BaseDecorator {
    * @param methodName the name of the method to get the name from, nullable
    * @return the span name from the class and method
    */
-  public CharSequence spanNameForMethod(final Class<?> clazz, final String methodName) {
+  public CharSequence spanNameForMethod(final Class<?> clazz, @Nullable final String methodName) {
     return CLASS_NAMES.getQualifiedName(clazz, methodName);
   }
 
   /**
    * This method is used to generate an acceptable span (operation) name based on a given class
    * reference. Anonymous classes are named based on their parent.
-   *
-   * @param clazz
-   * @return
    */
   public CharSequence className(final Class<?> clazz) {
     String simpleName = clazz.getSimpleName();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -23,9 +23,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ParametersAreNonnullByDefault
 public abstract class BaseDecorator {
   private static final Logger log = LoggerFactory.getLogger(BaseDecorator.class);
 
@@ -97,7 +99,7 @@ public abstract class BaseDecorator {
     return false;
   }
 
-  public final void afterStart(@Nonnull final AgentSpan span) {
+  public final void afterStart(final AgentSpan span) {
     try {
       doAfterStart(span);
     } catch (BlockingException e) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -3,7 +3,9 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public abstract class ClientDecorator extends BaseDecorator {
   // Deliberately not volatile, reading a stale null and creating an extra Entry is safe
   private TagMap.Entry cachedSpanKindEntry = null;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -32,7 +32,7 @@ public abstract class ClientDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     final String service = service();
     if (service != null) {
       span.setServiceName(service, component());
@@ -41,6 +41,6 @@ public abstract class ClientDecorator extends BaseDecorator {
 
     // Generate metrics for all client spans.
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public abstract class DBTypeProcessingDatabaseClientDecorator<CONNECTION>
     extends DatabaseClientDecorator<CONNECTION> {
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecorator.java
@@ -6,8 +6,8 @@ public abstract class DBTypeProcessingDatabaseClientDecorator<CONNECTION>
     extends DatabaseClientDecorator<CONNECTION> {
 
   @Override
-  public void afterStart(AgentSpan span) {
+  protected void doAfterStart(AgentSpan span) {
     processDatabaseType(span, dbType());
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -145,7 +145,17 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
     }
   }
 
-  public void onResponse(final AgentSpan span, final RESPONSE response) {
+  public final void onResponse(final AgentSpan span, final RESPONSE response) {
+    try {
+      doOnResponse(span, response);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on response", t);
+    }
+  }
+
+  protected void doOnResponse(final AgentSpan span, final RESPONSE response) {
     if (response != null) {
       final int status = status(response);
       if (status > UNSET_STATUS) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -92,7 +92,17 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
             }
           };
 
-  public void onRequest(final AgentSpan span, final REQUEST request) {
+  public final void onRequest(final AgentSpan span, final REQUEST request) {
+    try {
+      doOnRequest(span, request);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on request", t);
+    }
+  }
+
+  protected void doOnRequest(final AgentSpan span, final REQUEST request) {
     if (request != null) {
       AgentTracer.get()
           .getDataStreamsMonitoring()

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -482,7 +482,17 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     return false;
   }
 
-  public void onResponse(final AgentSpan span, final RESPONSE response) {
+  public final void onResponse(final AgentSpan span, final RESPONSE response) {
+    try {
+      doOnResponse(span, response);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on response", t);
+    }
+  }
+
+  protected void doOnResponse(final AgentSpan span, final RESPONSE response) {
     if (response != null) {
       final int status = status(response);
       onResponseStatus(span, status);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -238,7 +238,21 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
             }
           };
 
-  public void onRequest(
+  public final void onRequest(
+      final AgentSpan span,
+      final CONNECTION connection,
+      final REQUEST request,
+      final Context parentContext) {
+    try {
+      doOnRequest(span, connection, request, parentContext);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on request", t);
+    }
+  }
+
+  protected void doOnRequest(
       final AgentSpan span,
       final CONNECTION connection,
       final REQUEST request,
@@ -449,7 +463,17 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     return null;
   }
 
-  public void onResponseStatus(final AgentSpan span, final int status) {
+  public final void onResponseStatus(final AgentSpan span, final int status) {
+    try {
+      doOnResponseStatus(span, status);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on response status", t);
+    }
+  }
+
+  protected void doOnResponseStatus(final AgentSpan span, final int status) {
     if (status > UNSET_STATUS) {
       span.setHttpStatusCode(status);
       // explicitly set here because some other decorators might already set an error without

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -519,7 +519,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   protected void doOnResponse(final AgentSpan span, final RESPONSE response) {
     if (response != null) {
       final int status = status(response);
-      onResponseStatus(span, status);
+      doOnResponseStatus(span, status);
 
       AgentPropagation.ContextVisitor<RESPONSE> getter = responseGetter();
       if (getter != null) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
@@ -20,10 +20,10 @@ public abstract class MessagingClientDecorator extends ClientDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     if (endToEndDurationsEnabled) {
       span.beginEndToEnd();
     }
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MessagingClientDecorator.java
@@ -2,7 +2,10 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public abstract class MessagingClientDecorator extends ClientDecorator {
 
   protected final boolean endToEndDurationsEnabled;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -4,7 +4,10 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public abstract class ServerDecorator extends BaseDecorator {
   private static final TagMap.Entry SPAN_KIND_ENTRY =
       TagMap.Entry.create(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -4,7 +4,6 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.TagMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -12,10 +12,10 @@ public abstract class ServerDecorator extends BaseDecorator {
       TagMap.Entry.create(DDTags.LANGUAGE_TAG_KEY, DDTags.LANGUAGE_TAG_VALUE);
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setTag(SPAN_KIND_ENTRY);
     span.setTag(LANG_ENTRY);
 
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
@@ -26,6 +26,7 @@ import datadog.trace.bootstrap.instrumentation.api.SpanLink;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.websocket.HandlerContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ public class WebsocketDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NonNull AgentSpan span) {
     super.doAfterStart(span);
     span.setMeasured(true);
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
@@ -15,6 +15,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER;
 
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -26,8 +27,12 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.websocket.HandlerContext;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WebsocketDecorator extends BaseDecorator {
+  private static final Logger log = LoggerFactory.getLogger(WebsocketDecorator.class);
+
   private static final CharSequence WEBSOCKET = UTF8BytesString.create("websocket");
   private static final String[] INSTRUMENTATION_NAMES = {WEBSOCKET.toString()};
   private static final CharSequence WEBSOCKET_RECEIVE = UTF8BytesString.create("websocket.receive");
@@ -96,7 +101,17 @@ public class WebsocketDecorator extends BaseDecorator {
         WEBSOCKET_SEND, SPAN_KIND_PRODUCER, handlerContext, SPAN_ATTRIBUTES_SEND, false);
   }
 
-  public void onFrameEnd(final HandlerContext handlerContext) {
+  public final void onFrameEnd(final HandlerContext handlerContext) {
+    try {
+      doOnFrameEnd(handlerContext);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on frame end", t);
+    }
+  }
+
+  protected void doOnFrameEnd(final HandlerContext handlerContext) {
     if (handlerContext == null) {
       return;
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
@@ -62,8 +62,8 @@ public class WebsocketDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
-    super.afterStart(span);
+  protected void doAfterStart(AgentSpan span) {
+    super.doAfterStart(span);
     span.setMeasured(true);
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
@@ -29,8 +29,8 @@ public class RmiServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
@@ -5,7 +5,10 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class RmiServerDecorator extends ServerDecorator {
   public static final CharSequence RMI_SERVER = UTF8BytesString.create("rmi-server");
   public static final RmiServerDecorator DECORATE = new RmiServerDecorator();

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
@@ -19,6 +19,7 @@ import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import java.util.BitSet;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 
 public class GrpcServerDecorator extends ServerDecorator {
 
@@ -79,7 +80,7 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(@NonNullDecl final AgentSpan span) {
     span.setMeasured(true);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/armeria/armeria-grpc-0.84/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
@@ -79,9 +79,9 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public <RespT, ReqT> void onCall(final AgentSpan span, ServerCall<ReqT, RespT> call) {

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -78,9 +78,9 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public void onRequest(final AgentSpan span, final Request request) {
+  protected void doOnRequest(final AgentSpan span, final Request request) {
     // Call super first because we override the resource name below.
-    super.onRequest(span, request);
+    super.doOnRequest(span, request);
 
     final String awsServiceName = request.getServiceName();
     final String awsSimplifiedServiceName = simplifyServiceName(awsServiceName);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -288,13 +288,13 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public void onResponse(final AgentSpan span, final Response response) {
+  protected void doOnResponse(final AgentSpan span, final Response response) {
     if (response.getAwsResponse() instanceof AmazonWebServiceResponse) {
       final AmazonWebServiceResponse awsResp = (AmazonWebServiceResponse) response.getAwsResponse();
       span.setTag(InstrumentationTags.AWS_REQUEST_ID, awsResp.getRequestId());
     }
 
-    super.onResponse(span, response);
+    super.doOnResponse(span, response);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
@@ -95,8 +95,8 @@ public class AxisMessageDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
-    super.afterStart(span);
+  protected void doAfterStart(AgentSpan span) {
+    super.doAfterStart(span);
     span.setMeasured(true);
   }
 

--- a/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
+++ b/dd-java-agent/instrumentation/axis2-1.3/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
@@ -14,6 +14,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.URI;
 import org.apache.axis2.addressing.EndpointReference;
 import org.apache.axis2.context.MessageContext;
@@ -95,7 +96,7 @@ public class AxisMessageDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NonNull AgentSpan span) {
     super.doAfterStart(span);
     span.setMeasured(true);
   }

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/CicsDecorator.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/CicsDecorator.java
@@ -6,6 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetAddress;
 
 public class CicsDecorator extends ClientDecorator {
@@ -36,7 +37,7 @@ public class CicsDecorator extends ClientDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NonNull AgentSpan span) {
     assert span != null;
     span.setTag("rpc.system", "cics");
     super.doAfterStart(span);

--- a/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/CicsDecorator.java
+++ b/dd-java-agent/instrumentation/cics-9.1/src/main/java/datadog/trace/instrumentation/cics/CicsDecorator.java
@@ -36,10 +36,10 @@ public class CicsDecorator extends ClientDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
+  protected void doAfterStart(AgentSpan span) {
     assert span != null;
     span.setTag("rpc.system", "cics");
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   /**

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
@@ -54,9 +54,9 @@ public class GraphQLDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public void onRequest(final AgentSpan span, final ExecutionContext context) {

--- a/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
+++ b/dd-java-agent/instrumentation/graphql-java/graphql-java-common/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import graphql.execution.ExecutionContext;
 import graphql.language.Argument;
 import graphql.language.Field;
@@ -54,7 +55,7 @@ public class GraphQLDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(@NonNull final AgentSpan span) {
     span.setMeasured(true);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -80,9 +80,9 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public <RespT, ReqT> void onCall(final AgentSpan span, ServerCall<ReqT, RespT> call) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -14,6 +14,7 @@ import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -80,7 +81,7 @@ public class GrpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(@NonNull final AgentSpan span) {
     span.setMeasured(true);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -94,13 +94,13 @@ public class LibertyDecorator
   }
 
   @Override
-  public void onResponseStatus(AgentSpan span, int status) {
+  protected void doOnResponseStatus(AgentSpan span, int status) {
     Integer currentStatus = (Integer) span.getTag(Tags.HTTP_STATUS);
     // do not set status if the tag is already there and it's an error span
     // we may have the status during response blocking, but in that case
     // the status code is not propagated to the servlet layer
     if (currentStatus == null || !span.isError()) {
-      super.onResponseStatus(span, status);
+      super.doOnResponseStatus(span, status);
     }
   }
 

--- a/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -8,6 +8,7 @@ import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.ws.webcontainer.webapp.WebAppErrorReport;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedResponse;
 import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.gateway.BlockResponseFunction;
@@ -32,6 +33,7 @@ public class LibertyDecorator
 
   public static final CharSequence LIBERTY_SERVER = UTF8BytesString.create("liberty-server");
   public static final LibertyDecorator DECORATE = new LibertyDecorator();
+  private static final Logger log = LoggerFactory.getLogger(LibertyDecorator.class);
   public static final CharSequence SERVLET_REQUEST =
       UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_PARENT_CONTEXT_ATTRIBUTE = "datadog.parent-context";
@@ -126,13 +128,23 @@ public class LibertyDecorator
     return true;
   }
 
-  protected void doOnResponse(AgentSpan span, SRTServletResponse response) {
+  public void onResponse(AgentSpan span, SRTServletResponse response) {
+    try {
+      decorateResponse(span, response);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on response", t);
+    }
+  }
+
+  private void decorateResponse(AgentSpan span, SRTServletResponse response) {
     HttpServletRequest req = response.getRequest();
 
     if (Config.get().isServletPrincipalEnabled() && req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
     }
-    super.doOnResponse(span, response);
+    super.onResponse(span, response);
 
     Object ex = req.getAttribute("javax.servlet.error.exception");
     Object report;

--- a/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-20.0/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -126,13 +126,13 @@ public class LibertyDecorator
     return true;
   }
 
-  public void onResponse(AgentSpan span, SRTServletResponse response) {
+  protected void doOnResponse(AgentSpan span, SRTServletResponse response) {
     HttpServletRequest req = response.getRequest();
 
     if (Config.get().isServletPrincipalEnabled() && req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
     }
-    super.onResponse(span, response);
+    super.doOnResponse(span, response);
 
     Object ex = req.getAttribute("javax.servlet.error.exception");
     Object report;

--- a/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
@@ -94,13 +94,13 @@ public class LibertyDecorator
   }
 
   @Override
-  public void onResponseStatus(AgentSpan span, int status) {
+  protected void doOnResponseStatus(AgentSpan span, int status) {
     Integer currentStatus = (Integer) span.getTag(Tags.HTTP_STATUS);
     // do not set status if the tag is already there and it's an error span
     // we may have the status during response blocking, but in that case
     // the status code is not propagated to the servlet layer
     if (currentStatus == null || !span.isError()) {
-      super.onResponseStatus(span, status);
+      super.doOnResponseStatus(span, status);
     }
   }
 

--- a/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
@@ -8,6 +8,7 @@ import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.ws.webcontainer.webapp.WebAppErrorReport;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedResponse;
 import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.gateway.BlockResponseFunction;
@@ -32,6 +33,7 @@ public class LibertyDecorator
 
   public static final CharSequence LIBERTY_SERVER = UTF8BytesString.create("liberty-server");
   public static final LibertyDecorator DECORATE = new LibertyDecorator();
+  private static final Logger log = LoggerFactory.getLogger(LibertyDecorator.class);
   public static final CharSequence SERVLET_REQUEST =
       UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_PARENT_CONTEXT_ATTRIBUTE = "datadog.parent-context";
@@ -126,13 +128,23 @@ public class LibertyDecorator
     return true;
   }
 
-  protected void doOnResponse(AgentSpan span, SRTServletResponse response) {
+  public void onResponse(AgentSpan span, SRTServletResponse response) {
+    try {
+      decorateResponse(span, response);
+    } catch (BlockingException e) {
+      throw e;
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on response", t);
+    }
+  }
+
+  private void decorateResponse(AgentSpan span, SRTServletResponse response) {
     HttpServletRequest req = response.getRequest();
 
     if (Config.get().isServletPrincipalEnabled() && req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
     }
-    super.doOnResponse(span, response);
+    super.onResponse(span, response);
 
     Object ex = req.getAttribute("jakarta.servlet.error.exception");
     Object report;

--- a/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty/liberty-23.0/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
@@ -126,13 +126,13 @@ public class LibertyDecorator
     return true;
   }
 
-  public void onResponse(AgentSpan span, SRTServletResponse response) {
+  protected void doOnResponse(AgentSpan span, SRTServletResponse response) {
     HttpServletRequest req = response.getRequest();
 
     if (Config.get().isServletPrincipalEnabled() && req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
     }
-    super.onResponse(span, response);
+    super.doOnResponse(span, response);
 
     Object ex = req.getAttribute("jakarta.servlet.error.exception");
     Object report;

--- a/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
+++ b/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.tracer.api.span.info.InitialSpanInfo;
@@ -51,7 +52,7 @@ public class MuleDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(final @NonNull AgentSpan span) {
     span.setMeasured(true);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
     super.doAfterStart(span);

--- a/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
+++ b/dd-java-agent/instrumentation/mule-4.5/src/main/java/datadog/trace/instrumentation/mule4/MuleDecorator.java
@@ -51,10 +51,10 @@ public class MuleDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setMeasured(true);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public AgentSpan startMuleSpan(

--- a/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
@@ -85,6 +85,7 @@ public class NettyChannelHandlerContextInstrumentation extends InstrumenterModul
       scope.close();
     }
 
+    @SuppressWarnings("DataFlowIssue")
     private void muzzleCheck() {
       NettyHttpClientDecorator.DECORATE.afterStart(null);
       NettyHttpServerDecorator.DECORATE.afterStart(null);

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
@@ -85,6 +85,7 @@ public class NettyChannelHandlerContextInstrumentation extends InstrumenterModul
       scope.close();
     }
 
+    @SuppressWarnings("DataFlowIssue")
     private void muzzleCheck() {
       NettyHttpClientDecorator.DECORATE.afterStart(null);
       NettyHttpServerDecorator.DECORATE.afterStart(null);

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -96,7 +96,7 @@ public class OpenAiDecorator extends ClientDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
+  protected void doAfterStart(AgentSpan span) {
     if (llmObsEnabled) {
       // set global dd_tags as base layer so UST and span-level tags can override them
       for (Map.Entry<String, String> entry : Config.get().getGlobalTags().entrySet()) {
@@ -130,7 +130,7 @@ public class OpenAiDecorator extends ClientDecorator {
         span.setTag(CommonTags.SESSION_ID, sessionId);
       }
     }
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/main/java/datadog/trace/instrumentation/openai_java/OpenAiDecorator.java
@@ -20,6 +20,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class OpenAiDecorator extends ClientDecorator {
   public static final OpenAiDecorator DECORATE = new OpenAiDecorator();
@@ -96,7 +97,7 @@ public class OpenAiDecorator extends ClientDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NotNull AgentSpan span) {
     if (llmObsEnabled) {
       // set global dd_tags as base layer so UST and span-level tags can override them
       for (Map.Entry<String, String> entry : Config.get().getGlobalTags().entrySet()) {

--- a/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -84,7 +84,7 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final Request<?> connection,
       final Request<?> request,
@@ -96,7 +96,7 @@ public class PlayHttpServerDecorator
     // forwarded one. This way the IG callbacks and tags receive the correct peer.
     // (APPSEC-62562)
     final Request<?> connectionForSuper = withCapturedPeer(span, connection);
-    super.onRequest(span, connectionForSuper, request, parentContext);
+    super.doOnRequest(span, connectionForSuper, request, parentContext);
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes

--- a/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -84,7 +84,7 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final Request<?> connection,
       final Request<?> request,
@@ -96,7 +96,7 @@ public class PlayHttpServerDecorator
     // forwarded one. This way the IG callbacks and tags receive the correct peer.
     // (APPSEC-62562)
     final Request<?> connectionForSuper = withCapturedPeer(span, connection);
-    super.onRequest(span, connectionForSuper, request, parentContext);
+    super.doOnRequest(span, connectionForSuper, request, parentContext);
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes

--- a/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -126,12 +126,12 @@ public class PlayHttpServerDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final Request<?> connection,
       final Request<?> request,
       final Context parentContext) {
-    super.onRequest(span, connection, request, parentContext);
+    super.doOnRequest(span, connection, request, parentContext);
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jSpanDecorator.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jSpanDecorator.java
@@ -27,8 +27,8 @@ public class Resilience4jSpanDecorator<T> extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
-    super.afterStart(span);
+  protected void doAfterStart(AgentSpan span) {
+    super.doAfterStart(span);
     span.setSpanName(RESILIENCE4J);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
     if (Config.get().isResilience4jMeasuredEnabled()) {

--- a/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jSpanDecorator.java
+++ b/dd-java-agent/instrumentation/resilience4j/resilience4j-2.0/src/main/java/datadog/trace/instrumentation/resilience4j/Resilience4jSpanDecorator.java
@@ -5,6 +5,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class Resilience4jSpanDecorator<T> extends BaseDecorator {
   public static final Resilience4jSpanDecorator<Void> DECORATE = new Resilience4jSpanDecorator<>();
@@ -27,7 +28,7 @@ public class Resilience4jSpanDecorator<T> extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NonNull AgentSpan span) {
     super.doAfterStart(span);
     span.setSpanName(RESILIENCE4J);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-2.2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -80,7 +80,7 @@ public class Servlet2Decorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final HttpServletRequest connection,
       final HttpServletRequest request,
@@ -90,6 +90,6 @@ public class Servlet2Decorator
       span.setTag("servlet.context", request.getContextPath());
       span.setTag("servlet.path", request.getServletPath());
     }
-    super.onRequest(span, connection, request, parentContext);
+    super.doOnRequest(span, connection, request, parentContext);
   }
 }

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-3.0/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -97,7 +97,7 @@ public class Servlet3Decorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final HttpServletRequest connection,
       final HttpServletRequest request,
@@ -116,7 +116,7 @@ public class Servlet3Decorator
       request.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, contextPath);
       request.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, servletPath);
     }
-    super.onRequest(span, connection, request, parentContext);
+    super.doOnRequest(span, connection, request, parentContext);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/SofaRpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/SofaRpcServerDecorator.java
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class SofaRpcServerDecorator extends ServerDecorator {
 
@@ -35,7 +36,7 @@ public class SofaRpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  protected void doAfterStart(AgentSpan span) {
+  protected void doAfterStart(@NonNull AgentSpan span) {
     span.setMeasured(true);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/SofaRpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/src/main/java/datadog/trace/instrumentation/sofarpc/SofaRpcServerDecorator.java
@@ -35,9 +35,9 @@ public class SofaRpcServerDecorator extends ServerDecorator {
   }
 
   @Override
-  public void afterStart(AgentSpan span) {
+  protected void doAfterStart(AgentSpan span) {
     span.setMeasured(true);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public void onRequest(AgentSpan span, SofaRequest request) {

--- a/dd-java-agent/instrumentation/spark/spark-executor-common/src/main/java/datadog/trace/instrumentation/spark/SparkExecutorDecorator.java
+++ b/dd-java-agent/instrumentation/spark/spark-executor-common/src/main/java/datadog/trace/instrumentation/spark/SparkExecutorDecorator.java
@@ -5,8 +5,12 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import org.apache.spark.executor.Executor;
 import org.apache.spark.executor.TaskMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SparkExecutorDecorator extends BaseDecorator {
+  private static final Logger log = LoggerFactory.getLogger(SparkExecutorDecorator.class);
+
   public static final CharSequence SPARK_TASK = UTF8BytesString.create("spark.task");
   public static final CharSequence SPARK = UTF8BytesString.create("spark");
   public static SparkExecutorDecorator DECORATE = new SparkExecutorDecorator();
@@ -31,7 +35,15 @@ public class SparkExecutorDecorator extends BaseDecorator {
     span.setTag("task_thread_name", taskRunner.threadName());
   }
 
-  public void onTaskEnd(AgentSpan span, Executor.TaskRunner taskRunner) {
+  public final void onTaskEnd(AgentSpan span, Executor.TaskRunner taskRunner) {
+    try {
+      doOnTaskEnd(span, taskRunner);
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on task end", t);
+    }
+  }
+
+  protected void doOnTaskEnd(AgentSpan span, Executor.TaskRunner taskRunner) {
     // task is set by spark in run() by deserializing the task binary coming from the driver
     if (taskRunner.task() == null) {
       return;

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -98,7 +98,7 @@ public class SpringWebHttpServerDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final HttpServletRequest connection,
       final HttpServletRequest request,

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -102,7 +102,7 @@ public class SpringWebHttpServerDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final HttpServletRequest connection,
       final HttpServletRequest request,

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TibcoDecorator.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TibcoDecorator.java
@@ -57,9 +57,9 @@ public class TibcoDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public void onProcessStart(AgentSpan span, String processName) {

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TibcoDecorator.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/TibcoDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class TibcoDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(@NonNull final AgentSpan span) {
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/TibcoDecorator.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/TibcoDecorator.java
@@ -9,6 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class TibcoDecorator extends BaseDecorator {
   }
 
   @Override
-  protected void doAfterStart(final AgentSpan span) {
+  protected void doAfterStart(@NonNull final AgentSpan span) {
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
     super.doAfterStart(span);
   }

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/TibcoDecorator.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-6.5/src/main/java/datadog/trace/instrumentation/tibcobw6/TibcoDecorator.java
@@ -59,9 +59,9 @@ public class TibcoDecorator extends BaseDecorator {
   }
 
   @Override
-  public void afterStart(final AgentSpan span) {
+  protected void doAfterStart(final AgentSpan span) {
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
-    super.afterStart(span);
+    super.doAfterStart(span);
   }
 
   public void onProcessStart(AgentSpan span, String processName) {

--- a/dd-java-agent/instrumentation/tomcat/tomcat-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -95,7 +95,7 @@ public class TomcatDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final Request connection,
       final Request request,
@@ -117,7 +117,7 @@ public class TomcatDecorator
       request.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, contextPath);
       request.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, servletPath);
     }
-    super.onRequest(span, connection, request, parentContext);
+    super.doOnRequest(span, connection, request, parentContext);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/tomcat/tomcat-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -126,7 +126,7 @@ public class TomcatDecorator
   }
 
   @Override
-  public void onResponse(AgentSpan span, Response response) {
+  protected void doOnResponse(AgentSpan span, Response response) {
     Request req = response.getRequest();
     if (Config.get().isServletPrincipalEnabled() && req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
@@ -139,7 +139,7 @@ public class TomcatDecorator
     if (throwable instanceof Throwable) {
       onError(span, (Throwable) throwable);
     }
-    super.onResponse(span, response);
+    super.doOnResponse(span, response);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
+++ b/dd-java-agent/instrumentation/twilio-0.0.1/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
@@ -70,7 +70,15 @@ public class TwilioClientDecorator extends ClientDecorator {
   }
 
   /** Annotate the span with the results of the operation. */
-  public void onResult(final AgentSpan span, Object result) {
+  public final void onResult(final AgentSpan span, Object result) {
+    try {
+      doOnResult(span, result);
+    } catch (Throwable t) {
+      log.debug("Failed to decorate span on result", t);
+    }
+  }
+
+  protected void doOnResult(final AgentSpan span, Object result) {
 
     // Unwrap ListenableFuture (if present)
     if (result instanceof ListenableFuture) {

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/VertxDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/VertxDecorator.java
@@ -54,7 +54,7 @@ public class VertxDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final RoutingContext connection,
       final RoutingContext routingContext,

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
@@ -55,7 +55,7 @@ public class VertxDecorator
   }
 
   @Override
-  public void onRequest(
+  protected void doOnRequest(
       final AgentSpan span,
       final RoutingContext connection,
       final RoutingContext routingContext,


### PR DESCRIPTION
# What Does This Do

This PR is a follow up of #11998 that applies to more signals:
* `BaseDecorator`
  * `afterStart()`
  * `onPeerConnection()` - no delegation, only locked as no override
* `HttpClientDecorator`
  * `onRequest()`
  * `onResponse()`
* `HttpServerDecorator`
  * `onRequest()`
  * `onResponseStatus()`
  * `onResponse()`

Additionally, document null type and safety for the base decorators.

# Motivation

The goal is to simplify how write instrumentations, and make the dumb way safe.

# Additional Notes

This part is part of stack PRs:
* https://github.com/DataDog/dd-trace-java/pull/11998
* https://github.com/DataDog/dd-trace-java/pull/12016
* https://github.com/DataDog/dd-trace-java/pull/12017

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
