### PR TITLE
Support OTLP export over "http/json" for traces, metrics, and logs

### DIFF
--- a/components/json/src/main/java/datadog/json/JsonWriter.java
+++ b/components/json/src/main/java/datadog/json/JsonWriter.java
@@ -1,7 +1,6 @@
 package datadog.json;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Locale.ROOT;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Flushable;
@@ -14,6 +13,7 @@ import java.io.OutputStreamWriter;
  */
 public final class JsonWriter implements Flushable, AutoCloseable {
   private static final int INITIAL_CAPACITY = 256;
+  private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
   private final ByteArrayOutputStream outputStream;
   private final OutputStreamWriter writer;
   private final JsonStructure structure;
@@ -282,14 +282,10 @@ public final class JsonWriter implements Flushable, AutoCloseable {
         if (c > 127) {
           this.writer.write('\\');
           this.writer.write('u');
-          String hexCharacter = Integer.toHexString(c).toUpperCase(ROOT);
-          if (c < 4096) {
-            this.writer.write('0');
-            if (c < 256) {
-              this.writer.write('0');
-            }
-          }
-          this.writer.append(hexCharacter);
+          this.writer.write(HEX_DIGITS[(c >>> 12) & 0xF]);
+          this.writer.write(HEX_DIGITS[(c >>> 8) & 0xF]);
+          this.writer.write(HEX_DIGITS[(c >>> 4) & 0xF]);
+          this.writer.write(HEX_DIGITS[c & 0xF]);
         } else {
           switch (c) {
             case '"': // Quotation mark
@@ -319,7 +315,16 @@ public final class JsonWriter implements Flushable, AutoCloseable {
               this.writer.write('t');
               break;
             default:
-              this.writer.write(c);
+              if (c < 0x20) {
+                this.writer.write('\\');
+                this.writer.write('u');
+                this.writer.write('0');
+                this.writer.write('0');
+                this.writer.write(HEX_DIGITS[(c >>> 4) & 0xF]);
+                this.writer.write(HEX_DIGITS[c & 0xF]);
+              } else {
+                this.writer.write(c);
+              }
               break;
           }
         }

--- a/components/json/src/test/java/datadog/json/JsonWriterTest.java
+++ b/components/json/src/test/java/datadog/json/JsonWriterTest.java
@@ -101,6 +101,16 @@ class JsonWriterTest {
   }
 
   @Test
+  void testControlCharacterEscaping() {
+    try (JsonWriter writer = new JsonWriter()) {
+      writer.beginArray().value("\u0001").value("\u001F").endArray();
+
+      assertEquals(
+          "[\"\\u0001\",\"\\u001F\"]", writer.toString(), "Check control character escaping");
+    }
+  }
+
+  @Test
   void testArrayObjectNesting() {
     try (JsonWriter writer = new JsonWriter()) {
       writer

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
@@ -4,7 +4,6 @@ import datadog.trace.core.CoreSpan;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.core.otlp.trace.OtlpTraceCollector;
-import datadog.trace.core.otlp.trace.OtlpTraceProtoCollector;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -12,10 +11,6 @@ import java.util.List;
 final class OtlpPayloadDispatcher implements PayloadDispatcher {
   private final OtlpTraceCollector collector;
   private final OtlpSender sender;
-
-  OtlpPayloadDispatcher(OtlpSender sender) {
-    this(sender, new OtlpTraceProtoCollector());
-  }
 
   OtlpPayloadDispatcher(OtlpSender sender, OtlpTraceCollector collector) {
     this.sender = sender;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
@@ -13,6 +13,9 @@ import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.otlp.common.OtlpGrpcSender;
 import datadog.trace.core.otlp.common.OtlpHttpSender;
 import datadog.trace.core.otlp.common.OtlpSender;
+import datadog.trace.core.otlp.trace.OtlpTraceCollector;
+import datadog.trace.core.otlp.trace.OtlpTraceJsonCollector;
+import datadog.trace.core.otlp.trace.OtlpTraceProtoCollector;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -140,7 +143,11 @@ public class OtlpWriter extends RemoteWriter {
                     endpoint, HTTP_TRACES_SIGNAL_PATH, headers, timeoutMillis, compression);
       }
 
-      final OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender);
+      final OtlpTraceCollector collector =
+          protocol == OtlpConfig.Protocol.HTTP_JSON
+              ? new OtlpTraceJsonCollector()
+              : new OtlpTraceProtoCollector();
+      final OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
       final TraceProcessingWorker worker =
           new TraceProcessingWorker(
               traceBufferSize,

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/LazyJsonArray.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/LazyJsonArray.java
@@ -1,0 +1,29 @@
+package datadog.trace.core.otlp.common;
+
+import datadog.json.JsonWriter;
+
+/** Tracks a JSON array that's opened lazily, on its first element, and closed once done. */
+public final class LazyJsonArray {
+  private boolean open;
+
+  /** Opens the named array if it isn't already open. */
+  public void ensureOpen(JsonWriter writer, String name) {
+    if (!open) {
+      writer.name(name).beginArray();
+      open = true;
+    }
+  }
+
+  /** Closes the array if it's currently open. */
+  public void closeIfOpen(JsonWriter writer) {
+    if (open) {
+      writer.endArray();
+      open = false;
+    }
+  }
+
+  /** Resets the tracked state without touching the writer. */
+  public void reset() {
+    open = false;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpCommonJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpCommonJson.java
@@ -1,0 +1,162 @@
+package datadog.trace.core.otlp.common;
+
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+
+import datadog.json.JsonWriter;
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import java.util.List;
+
+/** Provides writers for OpenTelemetry's "common.proto" JSON encoding. */
+public final class OtlpCommonJson {
+  private OtlpCommonJson() {}
+
+  /** Hex-encodes a 128-bit trace id, per the OTLP JSON encoding spec. */
+  public static String hexTraceId(DDTraceId traceId) {
+    return traceId.toHexString();
+  }
+
+  /** Hex-encodes a 64-bit span/parent id, per the OTLP JSON encoding spec. */
+  public static String hexSpanId(long spanId) {
+    return DDSpanId.toHexStringPadded(spanId);
+  }
+
+  public static void writeInstrumentationScope(JsonWriter writer, OtelInstrumentationScope scope) {
+    writer.beginObject();
+    writer.name("name").value(scope.getName().toString());
+    if (scope.getVersion() != null) {
+      writer.name("version").value(scope.getVersion().toString());
+    }
+    writer.endObject();
+  }
+
+  /** Writes a scope's {@code "scope"} and optional sibling {@code "schemaUrl"} fields. */
+  public static void writeScopeAndSchema(JsonWriter writer, OtelInstrumentationScope scope) {
+    writer.name("scope");
+    writeInstrumentationScope(writer, scope);
+    if (scope.getSchemaUrl() != null) {
+      writer.name("schemaUrl").value(scope.getSchemaUrl().toString());
+    }
+  }
+
+  /** Writes one {@code KeyValue} JSON object: {@code {"key":...,"value":{...}}}. */
+  @SuppressWarnings("unchecked")
+  public static void writeAttribute(JsonWriter writer, int type, CharSequence key, Object value) {
+    writeAttributeKey(writer, key);
+    switch (type) {
+      case STRING_ATTRIBUTE:
+        writeStringValue(writer, (String) value);
+        break;
+      case BOOLEAN_ATTRIBUTE:
+        writeBooleanValue(writer, (boolean) value);
+        break;
+      case LONG_ATTRIBUTE:
+        writeIntValue(writer, ((Number) value).longValue());
+        break;
+      case DOUBLE_ATTRIBUTE:
+        writeDoubleValue(writer, ((Number) value).doubleValue());
+        break;
+      case STRING_ARRAY_ATTRIBUTE:
+        writeArrayValue(writer, STRING_ATTRIBUTE, (List<String>) value);
+        break;
+      case BOOLEAN_ARRAY_ATTRIBUTE:
+        writeArrayValue(writer, BOOLEAN_ATTRIBUTE, (List<Boolean>) value);
+        break;
+      case LONG_ARRAY_ATTRIBUTE:
+        writeArrayValue(writer, LONG_ATTRIBUTE, (List<? extends Number>) value);
+        break;
+      case DOUBLE_ARRAY_ATTRIBUTE:
+        writeArrayValue(writer, DOUBLE_ATTRIBUTE, (List<? extends Number>) value);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown attribute type: " + type);
+    }
+    writer.endObject();
+  }
+
+  public static void writeAttribute(JsonWriter writer, UTF8BytesString key, String value) {
+    writeAttribute(writer, STRING_ATTRIBUTE, key.toString(), value);
+  }
+
+  public static void writeAttribute(JsonWriter writer, UTF8BytesString key, long value) {
+    writeAttributeKey(writer, key);
+    writeIntValue(writer, value);
+    writer.endObject();
+  }
+
+  private static void writeAttributeKey(JsonWriter writer, CharSequence key) {
+    writer.beginObject();
+    writer.name("key").value(key.toString());
+    writer.name("value");
+  }
+
+  private static void writeArrayValue(JsonWriter writer, int elementType, List<?> values) {
+    writer.beginObject();
+    writer.name("arrayValue").beginObject();
+    writer.name("values").beginArray();
+    for (Object value : values) {
+      writeAnyValue(writer, elementType, value);
+    }
+    writer.endArray();
+    writer.endObject();
+    writer.endObject();
+  }
+
+  private static void writeAnyValue(JsonWriter writer, int type, Object value) {
+    switch (type) {
+      case STRING_ATTRIBUTE:
+        writeStringValue(writer, (String) value);
+        break;
+      case BOOLEAN_ATTRIBUTE:
+        writeBooleanValue(writer, (boolean) value);
+        break;
+      case LONG_ATTRIBUTE:
+        writeIntValue(writer, ((Number) value).longValue());
+        break;
+      case DOUBLE_ATTRIBUTE:
+        writeDoubleValue(writer, ((Number) value).doubleValue());
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown attribute type: " + type);
+    }
+  }
+
+  private static void writeStringValue(JsonWriter writer, String value) {
+    writer.beginObject().name("stringValue").value(value).endObject();
+  }
+
+  private static void writeBooleanValue(JsonWriter writer, boolean value) {
+    writer.beginObject().name("boolValue").value(value).endObject();
+  }
+
+  private static void writeIntValue(JsonWriter writer, long value) {
+    // int64 fields are encoded as decimal strings, per the OTLP JSON encoding spec
+    writer.beginObject().name("intValue").value(Long.toString(value)).endObject();
+  }
+
+  private static void writeDoubleValue(JsonWriter writer, double value) {
+    writer.beginObject().name("doubleValue");
+    writeDouble(writer, value);
+    writer.endObject();
+  }
+
+  /** Writes a double per the OTLP/ProtoJSON encoding spec: NaN/Infinity as JSON strings. */
+  public static void writeDouble(JsonWriter writer, double value) {
+    if (Double.isNaN(value)) {
+      writer.value("NaN");
+    } else if (Double.isInfinite(value)) {
+      writer.value(value > 0 ? "Infinity" : "-Infinity");
+    } else {
+      writer.value(value);
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpHttpSender.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpHttpSender.java
@@ -54,6 +54,10 @@ public final class OtlpHttpSender implements OtlpSender {
     this.client = buildHttpClient(isPlainHttp(url), unixDomainSocketPath, null, timeoutMillis);
   }
 
+  public HttpUrl url() {
+    return url;
+  }
+
   @Override
   public void send(OtlpPayload payload) {
     Request request = makeRequest(payload);

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpPayload.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpPayload.java
@@ -3,6 +3,9 @@ package datadog.trace.core.otlp.common;
 import java.nio.ByteBuffer;
 
 public final class OtlpPayload {
+  public static final String PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
+  public static final String JSON_CONTENT_TYPE = "application/json";
+
   public static final OtlpPayload EMPTY = new OtlpPayload(ByteBuffer.allocate(0), "");
 
   private final ByteBuffer content;

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpProtoBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpProtoBuffer.java
@@ -3,6 +3,7 @@ package datadog.trace.core.otlp.common;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.LEN_WIRE_TYPE;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.sizeVarInt;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeVarInt;
+import static datadog.trace.core.otlp.common.OtlpPayload.PROTOBUF_CONTENT_TYPE;
 import static datadog.trace.util.BitUtils.nextPowerOfTwo;
 
 import datadog.communication.serialization.GrowableBuffer;
@@ -17,8 +18,6 @@ import java.nio.ByteBuffer;
  * @see GrowableBuffer
  */
 public final class OtlpProtoBuffer {
-  private static final String PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
-
   private final int initialCapacity;
   private ByteBuffer buffer;
   private int remaining;

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceAttributes.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceAttributes.java
@@ -1,0 +1,107 @@
+package datadog.trace.core.otlp.common;
+
+import static datadog.communication.ddagent.TracerVersion.TRACER_VERSION;
+import static java.util.Arrays.asList;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.ProcessTags;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/** Enumerates the resource attributes shared by the proto and JSON "resource.proto" encoders. */
+final class OtlpResourceAttributes {
+  private OtlpResourceAttributes() {}
+
+  /** Prefix applied to {@code datadog.runtime_id} and process-tag resource attributes. */
+  private static final String DATADOG_PREFIX = "datadog.";
+
+  /** Marks that the Agent should not recompute trace metrics from the exported spans. */
+  private static final String STATS_COMPUTED_KEY = "_dd.stats_computed";
+
+  private static final Set<String> IGNORED_GLOBAL_TAGS =
+      new HashSet<>(
+          asList(
+              "service",
+              "env",
+              "version",
+              "service.name",
+              "deployment.environment.name",
+              "service.version",
+              "telemetry.sdk.name",
+              "telemetry.sdk.version",
+              "telemetry.sdk.language"));
+
+  /** Visits each resource attribute key/value pair with {@code visitor}. */
+  static void visitResourceAttributes(
+      Config config, Map<String, String> extraAttributes, BiConsumer<String, String> visitor) {
+    String serviceName = config.getServiceName();
+    String env = config.getEnv();
+    String version = config.getVersion();
+
+    visitor.accept("service.name", serviceName);
+    if (!env.isEmpty()) {
+      visitor.accept("deployment.environment.name", env);
+    }
+    if (!version.isEmpty()) {
+      visitor.accept("service.version", version);
+    }
+    if (config.isReportHostName()) {
+      String hostName = config.getHostName();
+      if (hostName != null && !hostName.isEmpty()) {
+        visitor.accept("host.name", hostName);
+      }
+    }
+    visitor.accept("telemetry.sdk.name", "datadog");
+    visitor.accept("telemetry.sdk.version", TRACER_VERSION);
+    visitor.accept("telemetry.sdk.language", "java");
+
+    config
+        .getGlobalTags()
+        .forEach(
+            (key, value) -> {
+              // ignore datadog tags and their otel equivalents that we map above
+              if (!IGNORED_GLOBAL_TAGS.contains(key.toLowerCase(Locale.ROOT))) {
+                visitor.accept(key, value);
+              }
+            });
+
+    extraAttributes.forEach(visitor);
+  }
+
+  /**
+   * Builds the extra resource attributes for the OTLP trace export: the {@code _dd.stats_computed}
+   * marker when the SDK is computing OTLP span metrics, so a downstream Agent does not recompute
+   * them from the exported spans.
+   */
+  static Map<String, String> traceResourceAttributes(Config config) {
+    Map<String, String> attributes = new LinkedHashMap<>();
+    if (config.isOtelTracesSpanMetricsEnabled()) {
+      attributes.put(STATS_COMPUTED_KEY, "true");
+    }
+    return attributes;
+  }
+
+  static Map<String, String> datadogResourceAttributes(Config config) {
+    Map<String, String> attributes = new LinkedHashMap<>();
+    String runtimeId = config.getRuntimeId();
+    if (runtimeId != null && !runtimeId.isEmpty()) {
+      attributes.put(DATADOG_PREFIX + "runtime_id", runtimeId);
+    }
+    // Process tags arrive as "key:value" pairs; emit each as datadog.<key> = value.
+    List<String> processTags = ProcessTags.getTagsAsStringList();
+    if (processTags != null) {
+      for (String tag : processTags) {
+        int colon = tag.indexOf(':');
+        if (colon > 0) {
+          attributes.put(DATADOG_PREFIX + tag.substring(0, colon), tag.substring(colon + 1));
+        }
+      }
+    }
+    return attributes;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceJson.java
@@ -1,0 +1,55 @@
+package datadog.trace.core.otlp.common;
+
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeAttribute;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.datadogResourceAttributes;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.traceResourceAttributes;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.visitResourceAttributes;
+
+import datadog.json.JsonWriter;
+import datadog.trace.api.Config;
+import java.util.Collections;
+import java.util.Map;
+
+/** Provides a canned JSON fragment for OpenTelemetry's "resource.proto" JSON encoding. */
+public final class OtlpResourceJson {
+  private OtlpResourceJson() {}
+
+  /** Vendor-neutral resource (no {@code datadog.*}). Used by the OTLP metric export. */
+  public static final String RESOURCE_FRAGMENT =
+      buildResourceFragment(Config.get(), Collections.emptyMap());
+
+  /**
+   * Resource that additionally carries {@code datadog.runtime_id} and process tags (each prefixed
+   * {@code datadog.}). Used by the default-mode SDK trace-metrics export; omitted in OTel-semantics
+   * mode.
+   */
+  public static final String RESOURCE_FRAGMENT_WITH_DATADOG_ATTRS =
+      buildResourceFragment(Config.get(), datadogResourceAttributes(Config.get()));
+
+  /**
+   * Resource used by the OTLP trace export. Identical to {@link #RESOURCE_FRAGMENT} but adds the
+   * {@code _dd.stats_computed} marker when the SDK is computing OTLP span metrics, so a downstream
+   * Agent does not recompute them from the exported spans.
+   */
+  public static final String TRACE_RESOURCE_FRAGMENT =
+      buildResourceFragment(Config.get(), traceResourceAttributes(Config.get()));
+
+  static String buildResourceFragment(Config config, Map<String, String> extraAttributes) {
+    try (JsonWriter writer = new JsonWriter()) {
+      writer.beginObject();
+      writer.name("attributes").beginArray();
+
+      visitResourceAttributes(
+          config, extraAttributes, (key, value) -> writeResourceAttribute(writer, key, value));
+
+      writer.endArray();
+      writer.endObject();
+      return writer.toString();
+    }
+  }
+
+  private static void writeResourceAttribute(JsonWriter writer, String key, String value) {
+    writeAttribute(writer, STRING_ATTRIBUTE, key, value);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpResourceProto.java
@@ -1,49 +1,22 @@
 package datadog.trace.core.otlp.common;
 
-import static datadog.communication.ddagent.TracerVersion.TRACER_VERSION;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.LEN_WIRE_TYPE;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeAttribute;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeTag;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.datadogResourceAttributes;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.traceResourceAttributes;
+import static datadog.trace.core.otlp.common.OtlpResourceAttributes.visitResourceAttributes;
 
 import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.StreamingBuffer;
 import datadog.trace.api.Config;
-import datadog.trace.api.ProcessTags;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /** Provides a canned message for OpenTelemetry's "resource.proto" wire protocol. */
 public final class OtlpResourceProto {
   private OtlpResourceProto() {}
-
-  private static final Set<String> IGNORED_GLOBAL_TAGS =
-      new HashSet<>(
-          Arrays.asList(
-              "service",
-              "env",
-              "version",
-              "service.name",
-              "deployment.environment.name",
-              "service.version",
-              "telemetry.sdk.name",
-              "telemetry.sdk.version",
-              "telemetry.sdk.language"));
-
-  /** Prefix applied to {@code datadog.runtime_id} and process-tag resource attributes. */
-  private static final String DATADOG_PREFIX = "datadog.";
-
-  /**
-   * Resource attribute added to OTLP trace metrics to ensure calculations are not re-computed in
-   * the Agent
-   */
-  private static final String STATS_COMPUTED_KEY = "_dd.stats_computed";
 
   /** Vendor-neutral resource (no {@code datadog.*}). Used by the OTLP metric export. */
   public static final byte[] RESOURCE_MESSAGE =
@@ -68,40 +41,8 @@ public final class OtlpResourceProto {
   static byte[] buildResourceMessage(Config config, Map<String, String> extraAttributes) {
     GrowableBuffer buf = new GrowableBuffer(512);
 
-    String serviceName = config.getServiceName();
-    String env = config.getEnv();
-    String version = config.getVersion();
-
-    writeResourceAttribute(buf, "service.name", serviceName);
-    if (!env.isEmpty()) {
-      writeResourceAttribute(buf, "deployment.environment.name", env);
-    }
-    if (!version.isEmpty()) {
-      writeResourceAttribute(buf, "service.version", version);
-    }
-    if (config.isReportHostName()) {
-      String hostName = config.getHostName();
-      if (hostName != null && !hostName.isEmpty()) {
-        writeResourceAttribute(buf, "host.name", hostName);
-      }
-    }
-    writeResourceAttribute(buf, "telemetry.sdk.name", "datadog");
-    writeResourceAttribute(buf, "telemetry.sdk.version", TRACER_VERSION);
-    writeResourceAttribute(buf, "telemetry.sdk.language", "java");
-
-    config
-        .getGlobalTags()
-        .forEach(
-            (key, value) -> {
-              // ignore datadog tags and their otel equivalents that we map above
-              if (!IGNORED_GLOBAL_TAGS.contains(key.toLowerCase(Locale.ROOT))) {
-                writeResourceAttribute(buf, key, value);
-              }
-            });
-
-    for (Map.Entry<String, String> attribute : extraAttributes.entrySet()) {
-      writeResourceAttribute(buf, attribute.getKey(), attribute.getValue());
-    }
+    visitResourceAttributes(
+        config, extraAttributes, (key, value) -> writeResourceAttribute(buf, key, value));
 
     OtlpProtoBuffer protobuf = new OtlpProtoBuffer(buf.capacity());
     int numBytes = protobuf.recordMessage(buf, 1);
@@ -109,38 +50,6 @@ public final class OtlpResourceProto {
     protobuf.flip().get(resourceMessage);
 
     return resourceMessage;
-  }
-
-  /**
-   * Builds the extra resource attributes for the OTLP trace export: the {@code _dd.stats_computed}
-   * marker when the SDK is computing OTLP span metrics, so a downstream Agent does not recompute
-   * them from the exported spans.
-   */
-  static Map<String, String> traceResourceAttributes(Config config) {
-    Map<String, String> attributes = new LinkedHashMap<>();
-    if (config.isOtelTracesSpanMetricsEnabled()) {
-      attributes.put(STATS_COMPUTED_KEY, "true");
-    }
-    return attributes;
-  }
-
-  static Map<String, String> datadogResourceAttributes(Config config) {
-    Map<String, String> attributes = new LinkedHashMap<>();
-    String runtimeId = config.getRuntimeId();
-    if (runtimeId != null && !runtimeId.isEmpty()) {
-      attributes.put(DATADOG_PREFIX + "runtime_id", runtimeId);
-    }
-    // Process tags arrive as "key:value" pairs; emit each as datadog.<key> = value.
-    List<String> processTags = ProcessTags.getTagsAsStringList();
-    if (processTags != null) {
-      for (String tag : processTags) {
-        int colon = tag.indexOf(':');
-        if (colon > 0) {
-          attributes.put(DATADOG_PREFIX + tag.substring(0, colon), tag.substring(colon + 1));
-        }
-      }
-    }
-    return attributes;
   }
 
   private static void writeResourceAttribute(StreamingBuffer buf, String key, String value) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpTraceFlags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpTraceFlags.java
@@ -1,0 +1,10 @@
+package datadog.trace.core.otlp.common;
+
+/** OTLP's {@code Span.flags} bit values, shared by the trace and logs proto/JSON encoders. */
+public final class OtlpTraceFlags {
+  private OtlpTraceFlags() {}
+
+  public static final int NO_TRACE_FLAGS = 0x00000000;
+  public static final int SAMPLED_TRACE_FLAG = 0x00000001;
+  public static final int REMOTE_TRACE_FLAG = 0x00000300;
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJson.java
@@ -1,0 +1,42 @@
+package datadog.trace.core.otlp.logs;
+
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexSpanId;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexTraceId;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
+
+import datadog.json.JsonWriter;
+import datadog.trace.bootstrap.otlp.logs.OtlpLogRecord;
+
+/** Provides writers for OpenTelemetry's "logs.proto" JSON encoding. */
+public final class OtlpLogsJson {
+  private OtlpLogsJson() {}
+
+  /**
+   * Writes a log record's non-attribute fields into the currently open {@code LogRecord} object.
+   */
+  public static void writeLogRecordFields(JsonWriter writer, OtlpLogRecord logRecord) {
+    writer.name("timeUnixNano").value(Long.toString(logRecord.timestampNanos));
+    writer.name("observedTimeUnixNano").value(Long.toString(logRecord.observedNanos));
+    writer.name("severityNumber").value(logRecord.severityNumber);
+
+    if (logRecord.severityText != null) {
+      writer.name("severityText").value(logRecord.severityText);
+    }
+
+    if (logRecord.body != null) {
+      writer.name("body").beginObject().name("stringValue").value(logRecord.body).endObject();
+    }
+
+    if (logRecord.spanContext != null) {
+      writer.name("traceId").value(hexTraceId(logRecord.spanContext.getTraceId()));
+      writer.name("spanId").value(hexSpanId(logRecord.spanContext.getSpanId()));
+      if (logRecord.spanContext.getSamplingPriority() > 0) {
+        writer.name("flags").value(SAMPLED_TRACE_FLAG);
+      }
+    }
+
+    if (logRecord.eventName != null) {
+      writer.name("eventName").value(logRecord.eventName);
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollector.java
@@ -1,0 +1,159 @@
+package datadog.trace.core.otlp.logs;
+
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeAttribute;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeScopeAndSchema;
+import static datadog.trace.core.otlp.common.OtlpPayload.JSON_CONTENT_TYPE;
+import static datadog.trace.core.otlp.common.OtlpResourceJson.RESOURCE_FRAGMENT;
+import static datadog.trace.core.otlp.logs.OtlpLogsJson.writeLogRecordFields;
+
+import datadog.json.JsonWriter;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import datadog.trace.bootstrap.otel.logs.data.OtelLogRecordProcessor;
+import datadog.trace.bootstrap.otlp.logs.OtlpLogRecord;
+import datadog.trace.bootstrap.otlp.logs.OtlpLogsVisitor;
+import datadog.trace.bootstrap.otlp.logs.OtlpScopedLogsVisitor;
+import datadog.trace.core.otlp.common.LazyJsonArray;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import java.nio.ByteBuffer;
+import java.util.function.ObjIntConsumer;
+
+/**
+ * Collects OpenTelemetry logs and marshals them into a 'logs.proto' JSON payload.
+ *
+ * <p>This collector is designed to be called by a single thread. To minimize allocations each
+ * collection returns a payload only to be used by the calling thread until the next collection.
+ * (The payload should be copied before passing it onto another thread.)
+ *
+ * <p>Attributes for a log record are written directly into the currently open log record object as
+ * {@code visitAttribute} is called, then {@code visitLogRecord} writes the rest of its fields and
+ * closes it.
+ */
+public final class OtlpLogsJsonCollector extends OtlpLogsCollector
+    implements OtlpLogsVisitor, OtlpScopedLogsVisitor {
+
+  public static final OtlpLogsJsonCollector INSTANCE = new OtlpLogsJsonCollector();
+
+  private JsonWriter writer;
+  private boolean anyLogRecordWritten;
+  private boolean logRecordStarted;
+
+  private final LazyJsonArray attributesArray = new LazyJsonArray();
+
+  private OtelInstrumentationScope currentScope;
+
+  private OtlpLogsJsonCollector() {}
+
+  /**
+   * Collects OpenTelemetry logs and marshals them into a JSON payload.
+   *
+   * <p>This payload is only valid for the calling thread until the next collection.
+   */
+  @Override
+  public OtlpPayload waitForLogs(int intervalMillis) {
+    return collectLogs(OtelLogRecordProcessor.INSTANCE::waitForLogs, intervalMillis);
+  }
+
+  OtlpPayload collectLogs(ObjIntConsumer<OtlpLogsVisitor> processor, int intervalMillis) {
+    start();
+    try {
+      processor.accept(this, intervalMillis);
+      return completePayload();
+    } finally {
+      stop();
+    }
+  }
+
+  /** Prepare temporary elements to collect logs data. */
+  private void start() {
+    writer = new JsonWriter();
+    writer.beginObject();
+    writer.name("resourceLogs").beginArray();
+    writer.beginObject();
+    writer.name("resource").jsonValue(RESOURCE_FRAGMENT);
+    writer.name("scopeLogs").beginArray();
+  }
+
+  /** Cleanup elements used to collect logs data. */
+  private void stop() {
+    attributesArray.reset();
+
+    anyLogRecordWritten = false;
+
+    writer = null;
+
+    logRecordStarted = false;
+
+    currentScope = null;
+  }
+
+  @Override
+  public OtlpScopedLogsVisitor visitScopedLogs(OtelInstrumentationScope scope) {
+    if (currentScope != null) {
+      completeScope();
+    }
+    currentScope = scope;
+
+    writer.beginObject();
+    writeScopeAndSchema(writer, scope);
+    writer.name("logRecords").beginArray();
+
+    return this;
+  }
+
+  @Override
+  public void visitAttribute(int type, String key, Object value) {
+    // add attribute to the log record currently being collected
+    ensureLogRecordStarted();
+    attributesArray.ensureOpen(writer, "attributes");
+    writeAttribute(writer, type, key, value);
+  }
+
+  @Override
+  public void visitLogRecord(OtlpLogRecord logRecord) {
+    ensureLogRecordStarted();
+    attributesArray.closeIfOpen(writer);
+
+    writeLogRecordFields(writer, logRecord);
+
+    writer.endObject(); // log record
+
+    logRecordStarted = false;
+    anyLogRecordWritten = true;
+  }
+
+  // opens the log record object on first attribute or value written for it
+  private void ensureLogRecordStarted() {
+    if (!logRecordStarted) {
+      writer.beginObject();
+      logRecordStarted = true;
+    }
+  }
+
+  // called once we've processed all scopes and log record messages
+  private OtlpPayload completePayload() {
+    if (currentScope != null) {
+      completeScope();
+    }
+
+    writer.endArray(); // scopeLogs
+    writer.endObject(); // resourceLogs[0]
+    writer.endArray(); // resourceLogs
+    writer.endObject(); // root
+
+    if (!anyLogRecordWritten) {
+      return OtlpPayload.EMPTY;
+    }
+
+    byte[] bytes = writer.toByteArray();
+    return new OtlpPayload(ByteBuffer.wrap(bytes), JSON_CONTENT_TYPE);
+  }
+
+  // called once we've processed all log records in a specific scope
+  private void completeScope() {
+    writer.endArray(); // logRecords
+    writer.endObject(); // scopeLogs[0]
+
+    // reset temporary elements for next scope
+    currentScope = null;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProto.java
@@ -12,7 +12,7 @@ import static datadog.trace.core.otlp.common.OtlpCommonProto.writeString;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeStringCached;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeTag;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeVarInt;
-import static datadog.trace.core.otlp.trace.OtlpTraceProto.SAMPLED_TRACE_FLAG;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
 import static datadog.trace.core.otlp.trace.OtlpTraceProto.writeSpanId;
 import static datadog.trace.core.otlp.trace.OtlpTraceProto.writeTraceId;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProtoCollector.java
@@ -35,8 +35,6 @@ public final class OtlpLogsProtoCollector extends OtlpLogsCollector
 
   public static final OtlpLogsProtoCollector INSTANCE = new OtlpLogsProtoCollector();
 
-  private static final String PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
-
   private final GrowableBuffer buf = new GrowableBuffer(512);
   private final OtlpProtoBuffer protobuf = new OtlpProtoBuffer(8192);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsService.java
@@ -23,7 +23,7 @@ public final class OtlpLogsService {
 
   private volatile Thread exporterThread;
 
-  private OtlpLogsService(Config config) {
+  OtlpLogsService(Config config) {
     intervalMillis = config.getLogsOtelInterval();
     switch (config.getOtlpLogsProtocol()) {
       case GRPC:
@@ -46,11 +46,29 @@ public final class OtlpLogsService {
                 config.getOtlpLogsTimeout(),
                 config.getOtlpLogsCompression());
         break;
+      case HTTP_JSON:
+        this.collector = OtlpLogsJsonCollector.INSTANCE;
+        this.sender =
+            new OtlpHttpSender(
+                config.getOtlpLogsEndpoint(),
+                "/v1/logs",
+                config.getOtlpLogsHeaders(),
+                config.getOtlpLogsTimeout(),
+                config.getOtlpLogsCompression());
+        break;
       default:
         LOGGER.debug("Unsupported OTLP logs protocol: {}", config.getOtlpLogsProtocol());
         this.collector = null;
         this.sender = null;
     }
+  }
+
+  OtlpSender getSender() {
+    return sender;
+  }
+
+  OtlpLogsCollector getCollector() {
+    return collector;
   }
 
   public void start() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsCollector.java
@@ -1,10 +1,16 @@
 package datadog.trace.core.otlp.metrics;
 
+import datadog.trace.bootstrap.otlp.metrics.OtlpMetricsVisitor;
 import datadog.trace.core.otlp.common.OtlpPayload;
+import java.util.function.Consumer;
 
 /** Collects metrics ready for export. */
 public abstract class OtlpMetricsCollector {
 
   /** Collects all metrics recorded since the last collection. */
   public abstract OtlpPayload collectMetrics();
+
+  /** Collects metrics from {@code registry} over an explicit time window. */
+  abstract OtlpPayload collectMetrics(
+      Consumer<OtlpMetricsVisitor> registry, long startNanos, long endNanos);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsJson.java
@@ -1,0 +1,128 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.GAUGE;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.OBSERVABLE_GAUGE;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeDouble;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.COUNTER_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.HISTOGRAM_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.OBSERVABLE_COUNTER_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_CUMULATIVE;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_DELTA;
+
+import datadog.json.JsonWriter;
+import datadog.trace.bootstrap.otel.metrics.OtelInstrumentDescriptor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpDataPoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpDoublePoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpHistogramPoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpLongPoint;
+
+/** Provides writers for OpenTelemetry's "metrics.proto" JSON encoding. */
+public final class OtlpMetricsJson {
+  private OtlpMetricsJson() {}
+
+  /** Opens a {@code Metric} JSON object, up to and including its {@code dataPoints} array. */
+  public static void openMetric(JsonWriter writer, OtelInstrumentDescriptor descriptor) {
+    openMetric(writer, descriptor, false);
+  }
+
+  /**
+   * Opens a {@code Metric} JSON object, up to and including its {@code dataPoints} array. When
+   * {@code forceDelta} is {@code true}, a histogram is encoded as DELTA regardless of the
+   * configured temporality preference (for sources whose data points are inherently per-interval
+   * deltas).
+   */
+  public static void openMetric(
+      JsonWriter writer, OtelInstrumentDescriptor descriptor, boolean forceDelta) {
+    writer.beginObject();
+    writer.name("name").value(descriptor.getName().toString());
+    if (descriptor.getDescription() != null) {
+      writer.name("description").value(descriptor.getDescription().toString());
+    }
+    if (descriptor.getUnit() != null) {
+      writer.name("unit").value(descriptor.getUnit().toString());
+    }
+
+    switch (descriptor.getType()) {
+      case GAUGE:
+      case OBSERVABLE_GAUGE:
+        writer.name("gauge").beginObject();
+        // gauges have no aggregation temporality
+        break;
+      case COUNTER:
+        writer.name("sum").beginObject();
+        writer.name("aggregationTemporality").value(COUNTER_TEMPORALITY);
+        writer.name("isMonotonic").value(true);
+        break;
+      case OBSERVABLE_COUNTER:
+        writer.name("sum").beginObject();
+        writer.name("aggregationTemporality").value(OBSERVABLE_COUNTER_TEMPORALITY);
+        writer.name("isMonotonic").value(true);
+        break;
+      case UP_DOWN_COUNTER:
+      case OBSERVABLE_UP_DOWN_COUNTER:
+        writer.name("sum").beginObject();
+        // up/down counters are always cumulative
+        writer.name("aggregationTemporality").value(TEMPORALITY_CUMULATIVE);
+        writer.name("isMonotonic").value(false);
+        break;
+      case HISTOGRAM:
+        writer.name("histogram").beginObject();
+        writer
+            .name("aggregationTemporality")
+            .value(forceDelta ? TEMPORALITY_DELTA : HISTOGRAM_TEMPORALITY);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown instrument type: " + descriptor.getType());
+    }
+
+    writer.name("dataPoints").beginArray();
+  }
+
+  /** Closes a {@code Metric} JSON object previously opened by {@link #openMetric}. */
+  public static void closeMetric(JsonWriter writer) {
+    writer.endArray(); // dataPoints
+    writer.endObject(); // gauge|sum|histogram
+    writer.endObject(); // metric
+  }
+
+  /** Writes a data point's value fields into the currently open data point object. */
+  public static void writeDataPointValue(JsonWriter writer, OtlpDataPoint point) {
+    if (point instanceof OtlpDoublePoint) {
+      writer.name("asDouble");
+      writeDouble(writer, ((OtlpDoublePoint) point).value);
+    } else if (point instanceof OtlpLongPoint) {
+      // int64 fields are encoded as decimal strings, per the OTLP JSON encoding spec
+      writer.name("asInt").value(Long.toString(((OtlpLongPoint) point).value));
+    } else { // must be a histogram point
+      OtlpHistogramPoint histogram = (OtlpHistogramPoint) point;
+      writer.name("count").value(Long.toString((long) histogram.count));
+      writer.name("sum");
+      writeDouble(writer, histogram.sum);
+      writer.name("min");
+      writeDouble(writer, histogram.min);
+      writer.name("max");
+      writeDouble(writer, histogram.max);
+      if (!histogram.bucketCounts.isEmpty()) {
+        boolean hasOverflow = false;
+        writer.name("explicitBounds").beginArray();
+        for (double bucketBoundary : histogram.bucketBoundaries) {
+          if (!Double.isInfinite(bucketBoundary)) {
+            writer.value(bucketBoundary);
+          } else {
+            hasOverflow = true; // don't write the overflow boundary
+          }
+        }
+        writer.endArray();
+
+        writer.name("bucketCounts").beginArray();
+        for (double bucketCount : histogram.bucketCounts) {
+          writer.value(Long.toString((long) bucketCount));
+        }
+        if (!hasOverflow) { // write one more count than boundaries
+          writer.value("0");
+        }
+        writer.endArray();
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsJsonCollector.java
@@ -1,0 +1,277 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.GAUGE;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.OBSERVABLE_GAUGE;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeAttribute;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeScopeAndSchema;
+import static datadog.trace.core.otlp.common.OtlpPayload.JSON_CONTENT_TYPE;
+import static datadog.trace.core.otlp.common.OtlpResourceJson.RESOURCE_FRAGMENT;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsJson.closeMetric;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsJson.openMetric;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsJson.writeDataPointValue;
+
+import datadog.json.JsonWriter;
+import datadog.trace.api.time.TimeSource;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import datadog.trace.bootstrap.otel.metrics.OtelInstrumentDescriptor;
+import datadog.trace.bootstrap.otel.metrics.OtelInstrumentType;
+import datadog.trace.bootstrap.otel.metrics.data.OtelMetricRegistry;
+import datadog.trace.bootstrap.otlp.metrics.OtlpDataPoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpMetricVisitor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpMetricsVisitor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpScopedMetricsVisitor;
+import datadog.trace.core.otlp.common.LazyJsonArray;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+
+/**
+ * Collects OpenTelemetry metrics and marshals them into a 'metrics.proto' JSON payload.
+ *
+ * <p>This collector is designed to be called by a single thread. To minimize allocations each
+ * collection returns a payload only to be used by the calling thread until the next collection.
+ * (The payload should be copied before passing it onto another thread.)
+ *
+ * <p>Unlike the protobuf collector, attributes for a data point are written directly into the
+ * currently open data point object as {@code visitAttribute} is called. A scope's header (and its
+ * {@code metrics} array) and a metric's header (and its {@code gauge}/{@code sum}/{@code histogram}
+ * wrapper) are only opened lazily, on the first attribute or data point visited for them, so scopes
+ * and metrics with no data points contribute nothing to the payload — matching the protobuf
+ * collector's behavior.
+ */
+public final class OtlpMetricsJsonCollector extends OtlpMetricsCollector
+    implements OtlpMetricsVisitor, OtlpScopedMetricsVisitor, OtlpMetricVisitor {
+
+  private final TimeSource timeSource;
+
+  private final boolean forceHistogramDelta;
+
+  // resource fragment prepended to every payload; lets callers pick the plain vendor-neutral
+  // resource or the datadog-attrs variant (datadog.runtime_id / process tags)
+  private final String resourceFragment;
+
+  private long startNanos;
+  private long endNanos;
+  private String startNanosStr;
+  private String endNanosStr;
+
+  private JsonWriter writer;
+  private boolean anyDataPointWritten;
+  private boolean scopeStarted;
+  private boolean metricStarted;
+  private boolean dataPointStarted;
+
+  private final LazyJsonArray attributesArray = new LazyJsonArray();
+
+  private OtelInstrumentationScope currentScope;
+  private OtelInstrumentDescriptor currentMetric;
+
+  public OtlpMetricsJsonCollector(TimeSource timeSource) {
+    this(timeSource, false);
+  }
+
+  OtlpMetricsJsonCollector(TimeSource timeSource, boolean forceHistogramDelta) {
+    this(timeSource, forceHistogramDelta, RESOURCE_FRAGMENT);
+  }
+
+  OtlpMetricsJsonCollector(
+      TimeSource timeSource, boolean forceHistogramDelta, String resourceFragment) {
+    this.timeSource = timeSource;
+    this.endNanos = timeSource.getCurrentTimeNanos();
+    this.forceHistogramDelta = forceHistogramDelta;
+    this.resourceFragment = resourceFragment;
+  }
+
+  /**
+   * Collects OpenTelemetry metrics and marshals them into a JSON payload.
+   *
+   * <p>This payload is only valid for the calling thread until the next collection.
+   */
+  @Override
+  public OtlpPayload collectMetrics() {
+    return collectMetrics(OtelMetricRegistry.INSTANCE::collectMetrics);
+  }
+
+  OtlpPayload collectMetrics(Consumer<OtlpMetricsVisitor> registry) {
+    start();
+    return run(registry);
+  }
+
+  @Override
+  OtlpPayload collectMetrics(
+      Consumer<OtlpMetricsVisitor> registry, long startNanos, long endNanos) {
+    startWithWindow(startNanos, endNanos);
+    return run(registry);
+  }
+
+  private OtlpPayload run(Consumer<OtlpMetricsVisitor> registry) {
+    try {
+      registry.accept(this);
+      return completePayload();
+    } finally {
+      stop();
+    }
+  }
+
+  /** Prepare temporary elements to collect metrics data. */
+  private void start() {
+    // shift interval to cover last collection to now
+    startNanos = endNanos;
+    endNanos = timeSource.getCurrentTimeNanos();
+    beginPayload();
+  }
+
+  private void startWithWindow(long startNanos, long endNanos) {
+    this.startNanos = startNanos;
+    this.endNanos = endNanos;
+    beginPayload();
+  }
+
+  private void beginPayload() {
+    startNanosStr = Long.toString(startNanos);
+    endNanosStr = Long.toString(endNanos);
+
+    writer = new JsonWriter();
+    writer.beginObject();
+    writer.name("resourceMetrics").beginArray();
+    writer.beginObject();
+    writer.name("resource").jsonValue(resourceFragment);
+    writer.name("scopeMetrics").beginArray();
+  }
+
+  /** Cleanup elements used to collect metrics data. */
+  private void stop() {
+    attributesArray.reset();
+
+    anyDataPointWritten = false;
+
+    writer = null;
+
+    scopeStarted = false;
+    metricStarted = false;
+    dataPointStarted = false;
+
+    currentScope = null;
+    currentMetric = null;
+  }
+
+  @Override
+  public OtlpScopedMetricsVisitor visitScopedMetrics(OtelInstrumentationScope scope) {
+    if (currentScope != null) {
+      completeScope();
+    }
+    currentScope = scope;
+    return this;
+  }
+
+  @Override
+  public OtlpMetricVisitor visitMetric(OtelInstrumentDescriptor metric) {
+    if (currentMetric != null) {
+      completeMetric();
+    }
+    currentMetric = metric;
+    return this;
+  }
+
+  @Override
+  public void visitAttribute(int type, String key, Object value) {
+    ensureMetricStarted();
+    ensureDataPointStarted();
+    attributesArray.ensureOpen(writer, "attributes");
+    writeAttribute(writer, type, key, value);
+  }
+
+  @Override
+  public void visitDataPoint(OtlpDataPoint point) {
+    ensureMetricStarted();
+    ensureDataPointStarted();
+    attributesArray.closeIfOpen(writer);
+
+    OtelInstrumentType metricType = currentMetric.getType();
+
+    // gauges don't have a start time (no aggregation temporality)
+    if (metricType != GAUGE && metricType != OBSERVABLE_GAUGE) {
+      writer.name("startTimeUnixNano").value(startNanosStr);
+    }
+    writer.name("timeUnixNano").value(endNanosStr);
+    writeDataPointValue(writer, point);
+
+    writer.endObject(); // data point
+
+    dataPointStarted = false;
+    anyDataPointWritten = true;
+  }
+
+  // opens the scope header (and its metrics array) on first use
+  private void ensureScopeStarted() {
+    if (!scopeStarted) {
+      writer.beginObject();
+      writeScopeAndSchema(writer, currentScope);
+      writer.name("metrics").beginArray();
+      scopeStarted = true;
+    }
+  }
+
+  // opens the metric header (and its gauge/sum/histogram wrapper) on first use
+  private void ensureMetricStarted() {
+    if (!metricStarted) {
+      ensureScopeStarted();
+      openMetric(writer, currentMetric, forceHistogramDelta);
+      metricStarted = true;
+    }
+  }
+
+  // opens the data point object on first attribute or value written for it
+  private void ensureDataPointStarted() {
+    if (!dataPointStarted) {
+      writer.beginObject();
+      dataPointStarted = true;
+    }
+  }
+
+  // called once we've processed all scopes and metric messages
+  private OtlpPayload completePayload() {
+    if (currentScope != null) {
+      completeScope();
+    }
+
+    writer.endArray(); // scopeMetrics
+    writer.endObject(); // resourceMetrics[0]
+    writer.endArray(); // resourceMetrics
+    writer.endObject(); // root
+
+    if (!anyDataPointWritten) {
+      return OtlpPayload.EMPTY;
+    }
+
+    byte[] bytes = writer.toByteArray();
+    return new OtlpPayload(ByteBuffer.wrap(bytes), JSON_CONTENT_TYPE);
+  }
+
+  // called once we've processed all metrics in a specific scope
+  private void completeScope() {
+    if (currentMetric != null) {
+      completeMetric();
+    }
+
+    if (scopeStarted) {
+      writer.endArray(); // metrics
+      writer.endObject(); // scopeMetrics[0]
+      scopeStarted = false;
+    }
+
+    // reset temporary elements for next scope
+    currentScope = null;
+  }
+
+  // called once we've processed all data points in a specific metric
+  private void completeMetric() {
+    if (metricStarted) {
+      closeMetric(writer);
+      metricStarted = false;
+    }
+
+    // reset temporary elements for next metric
+    currentMetric = null;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProto.java
@@ -1,10 +1,5 @@
 package datadog.trace.core.otlp.metrics;
 
-import static datadog.trace.api.config.OtlpConfig.Temporality.DELTA;
-import static datadog.trace.api.config.OtlpConfig.Temporality.LOWMEMORY;
-import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.COUNTER;
-import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.HISTOGRAM;
-import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.OBSERVABLE_COUNTER;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.I64_WIRE_TYPE;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.LEN_WIRE_TYPE;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.VARINT_WIRE_TYPE;
@@ -13,13 +8,15 @@ import static datadog.trace.core.otlp.common.OtlpCommonProto.writeInstrumentatio
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeString;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeTag;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeVarInt;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.COUNTER_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.HISTOGRAM_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.OBSERVABLE_COUNTER_TEMPORALITY;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_CUMULATIVE;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_DELTA;
 
 import datadog.communication.serialization.GrowableBuffer;
-import datadog.trace.api.Config;
-import datadog.trace.api.config.OtlpConfig;
 import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
 import datadog.trace.bootstrap.otel.metrics.OtelInstrumentDescriptor;
-import datadog.trace.bootstrap.otel.metrics.OtelInstrumentType;
 import datadog.trace.bootstrap.otlp.metrics.OtlpDataPoint;
 import datadog.trace.bootstrap.otlp.metrics.OtlpDoublePoint;
 import datadog.trace.bootstrap.otlp.metrics.OtlpHistogramPoint;
@@ -29,13 +26,6 @@ import datadog.trace.core.otlp.common.OtlpProtoBuffer;
 /** Provides optimized writers for OpenTelemetry's "metrics.proto" wire protocol. */
 public final class OtlpMetricsProto {
   private OtlpMetricsProto() {}
-
-  private static final int TEMPORALITY_DELTA = 1;
-  private static final int TEMPORALITY_CUMULATIVE = 2;
-
-  private static final int COUNTER_TEMPORALITY = temporality(COUNTER);
-  private static final int OBSERVABLE_COUNTER_TEMPORALITY = temporality(OBSERVABLE_COUNTER);
-  private static final int HISTOGRAM_TEMPORALITY = temporality(HISTOGRAM);
 
   /** Records a scoped metrics message after its nested metric messages have been recorded. */
   public static int recordScopedMetricsMessage(
@@ -171,21 +161,5 @@ public final class OtlpMetricsProto {
     }
 
     return protobuf.recordMessage(buf, 1);
-  }
-
-  private static int temporality(OtelInstrumentType type) {
-    OtlpConfig.Temporality preference = Config.get().getOtlpMetricsTemporalityPreference();
-    if (preference == DELTA) {
-      // gauges and up/down counters stay as cumulative
-      if (type == HISTOGRAM || type == COUNTER || type == OBSERVABLE_COUNTER) {
-        return TEMPORALITY_DELTA;
-      }
-    } else if (preference == LOWMEMORY) {
-      // observable counters, gauges, and up/down counters stay as cumulative
-      if (type == HISTOGRAM || type == COUNTER) {
-        return TEMPORALITY_DELTA;
-      }
-    }
-    return TEMPORALITY_CUMULATIVE;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsProtoCollector.java
@@ -98,6 +98,7 @@ public final class OtlpMetricsProtoCollector extends OtlpMetricsCollector
     return run(registry);
   }
 
+  @Override
   OtlpPayload collectMetrics(
       Consumer<OtlpMetricsVisitor> registry, long startNanos, long endNanos) {
     startWithWindow(startNanos, endNanos);
@@ -116,10 +117,11 @@ public final class OtlpMetricsProtoCollector extends OtlpMetricsCollector
   /** Prepare temporary elements to collect metrics data. */
   private void start() {
     // shift interval to cover last collection to now
-    startNanos = endNanos;
-    endNanos = timeSource.getCurrentTimeNanos();
+    this.startNanos = endNanos;
+    this.endNanos = timeSource.getCurrentTimeNanos();
 
-    recalibrate();
+    // remove stale entries from caches
+    OtlpCommonProto.recalibrateCaches();
   }
 
   /** Prepare temporary elements to collect metrics over an explicit window. */
@@ -127,10 +129,6 @@ public final class OtlpMetricsProtoCollector extends OtlpMetricsCollector
     this.startNanos = startNanos;
     this.endNanos = endNanos;
 
-    recalibrate();
-  }
-
-  private void recalibrate() {
     // remove stale entries from caches
     OtlpCommonProto.recalibrateCaches();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsSenderFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsSenderFactory.java
@@ -17,7 +17,7 @@ final class OtlpMetricsSenderFactory {
 
   /**
    * Builds the sender for {@code config}'s OTLP metrics protocol, or {@code null} if the protocol
-   * has no protobuf encoder yet (e.g. HTTP_JSON).
+   * is unsupported.
    */
   @Nullable
   static OtlpSender create(Config config) {
@@ -30,6 +30,7 @@ final class OtlpMetricsSenderFactory {
             config.getOtlpMetricsTimeout(),
             config.getOtlpMetricsCompression());
       case HTTP_PROTOBUF:
+      case HTTP_JSON:
         return new OtlpHttpSender(
             config.getOtlpMetricsEndpoint(),
             "/v1/metrics",

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
@@ -3,6 +3,7 @@ package datadog.trace.core.otlp.metrics;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.OTLP_METRICS_EXPORTER;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.config.OtlpConfig;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
@@ -26,7 +27,7 @@ public final class OtlpMetricsService {
 
   private AgentTaskScheduler.Scheduled<?> scheduledTask = null;
 
-  private OtlpMetricsService(Config config) {
+  OtlpMetricsService(Config config) {
     this.scheduler = new AgentTaskScheduler(OTLP_METRICS_EXPORTER);
 
     this.sender = OtlpMetricsSenderFactory.create(config);
@@ -34,10 +35,21 @@ public final class OtlpMetricsService {
       LOGGER.debug("Unsupported OTLP metrics protocol: {}", config.getOtlpMetricsProtocol());
       this.collector = null;
     } else {
-      this.collector = new OtlpMetricsProtoCollector(SystemTimeSource.INSTANCE);
+      this.collector =
+          config.getOtlpMetricsProtocol() == OtlpConfig.Protocol.HTTP_JSON
+              ? new OtlpMetricsJsonCollector(SystemTimeSource.INSTANCE)
+              : new OtlpMetricsProtoCollector(SystemTimeSource.INSTANCE);
     }
 
     this.intervalMillis = config.getMetricsOtelInterval();
+  }
+
+  OtlpSender getSender() {
+    return sender;
+  }
+
+  OtlpMetricsCollector getCollector() {
+    return collector;
   }
 
   public void start() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsTemporality.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsTemporality.java
@@ -1,0 +1,41 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.api.config.OtlpConfig.Temporality.DELTA;
+import static datadog.trace.api.config.OtlpConfig.Temporality.LOWMEMORY;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.COUNTER;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.HISTOGRAM;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.OBSERVABLE_COUNTER;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.config.OtlpConfig;
+import datadog.trace.bootstrap.otel.metrics.OtelInstrumentType;
+
+/** Maps instrument types to OTLP's {@code AggregationTemporality} enum values. */
+final class OtlpMetricsTemporality {
+  private OtlpMetricsTemporality() {}
+
+  static final int TEMPORALITY_DELTA = 1;
+  static final int TEMPORALITY_CUMULATIVE = 2;
+
+  private static final OtlpConfig.Temporality PREFERENCE =
+      Config.get().getOtlpMetricsTemporalityPreference();
+
+  static final int COUNTER_TEMPORALITY = temporality(PREFERENCE, COUNTER);
+  static final int OBSERVABLE_COUNTER_TEMPORALITY = temporality(PREFERENCE, OBSERVABLE_COUNTER);
+  static final int HISTOGRAM_TEMPORALITY = temporality(PREFERENCE, HISTOGRAM);
+
+  static int temporality(OtlpConfig.Temporality preference, OtelInstrumentType type) {
+    if (preference == DELTA) {
+      // gauges and up/down counters stay as cumulative
+      if (type == HISTOGRAM || type == COUNTER || type == OBSERVABLE_COUNTER) {
+        return TEMPORALITY_DELTA;
+      }
+    } else if (preference == LOWMEMORY) {
+      // observable counters, gauges, and up/down counters stay as cumulative
+      if (type == HISTOGRAM || type == COUNTER) {
+        return TEMPORALITY_DELTA;
+      }
+    }
+    return TEMPORALITY_CUMULATIVE;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_AT
 
 import datadog.metrics.api.Histogram;
 import datadog.trace.api.Config;
+import datadog.trace.api.config.OtlpConfig;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
@@ -16,13 +17,12 @@ import datadog.trace.bootstrap.otlp.metrics.OtlpMetricsVisitor;
 import datadog.trace.common.metrics.AggregateEntry;
 import datadog.trace.common.metrics.MetricWriter;
 import datadog.trace.core.otlp.common.OtlpPayload;
+import datadog.trace.core.otlp.common.OtlpResourceJson;
 import datadog.trace.core.otlp.common.OtlpResourceProto;
 import datadog.trace.core.otlp.common.OtlpSender;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link MetricWriter} that exports the client-side trace metrics as a delta-temporality OTLP
@@ -31,8 +31,6 @@ import org.slf4j.LoggerFactory;
  * OTLP histogram data point and pushes it through the shared {@link OtlpMetricsProtoCollector}.
  */
 public final class OtlpStatsMetricWriter implements MetricWriter {
-  private static final Logger log = LoggerFactory.getLogger(OtlpStatsMetricWriter.class);
-
   static final String METRIC_NAME = "traces.span.sdk.metrics.duration";
   static final String METRIC_UNIT = "s";
 
@@ -62,7 +60,7 @@ public final class OtlpStatsMetricWriter implements MetricWriter {
   @Nullable private final String defaultService;
 
   // own single-thread collector; forced to DELTA since trace-stats buckets are per-interval deltas.
-  private final OtlpMetricsProtoCollector collector;
+  private final OtlpMetricsCollector collector;
 
   // data points snapshotted during add(), replayed through the visitor in finishBucket()
   private final List<PendingPoint> pending = new ArrayList<>();
@@ -89,32 +87,42 @@ public final class OtlpStatsMetricWriter implements MetricWriter {
     // shared protocol-based sender selection so both OTLP metrics export paths agree
     this(
         OtlpMetricsSenderFactory.create(config),
+        config.getOtlpMetricsProtocol(),
         config.isTraceOtelSemanticsEnabled(),
         config.getServiceName());
-    if (this.sender == null) {
-      // HTTP_JSON has no protobuf-free encoder yet; JSON transport is deferred per the plan.
-      log.warn(
-          "OTLP trace metrics export disabled: unsupported metrics protocol {}. "
-              + "Set OTEL_EXPORTER_OTLP_METRICS_PROTOCOL to grpc or http/protobuf.",
-          config.getOtlpMetricsProtocol());
-    }
   }
 
-  // visible for testing: lets tests inject a capturing sender to decode the emitted protobuf and
+  // visible for testing: lets tests inject a capturing sender to decode the emitted payload and
   // control the semantics mode and default service
   OtlpStatsMetricWriter(
       @Nullable OtlpSender sender, boolean otelSemanticsMode, @Nullable String defaultService) {
+    this(sender, OtlpConfig.Protocol.HTTP_PROTOBUF, otelSemanticsMode, defaultService);
+  }
+
+  private OtlpStatsMetricWriter(
+      @Nullable OtlpSender sender,
+      OtlpConfig.Protocol protocol,
+      boolean otelSemanticsMode,
+      @Nullable String defaultService) {
     this.sender = sender;
     this.otelSemanticsMode = otelSemanticsMode;
     this.defaultService = defaultService;
     // Default mode carries datadog.runtime_id / process tags on the Resource; OTel-semantics mode
     // uses the plain vendor-neutral resource (no datadog.*).
-    byte[] resourceMessage =
-        otelSemanticsMode
-            ? OtlpResourceProto.RESOURCE_MESSAGE
-            : OtlpResourceProto.RESOURCE_MESSAGE_WITH_DATADOG_ATTRS;
     this.collector =
-        new OtlpMetricsProtoCollector(SystemTimeSource.INSTANCE, true, resourceMessage);
+        protocol == OtlpConfig.Protocol.HTTP_JSON
+            ? new OtlpMetricsJsonCollector(
+                SystemTimeSource.INSTANCE,
+                true,
+                otelSemanticsMode
+                    ? OtlpResourceJson.RESOURCE_FRAGMENT
+                    : OtlpResourceJson.RESOURCE_FRAGMENT_WITH_DATADOG_ATTRS)
+            : new OtlpMetricsProtoCollector(
+                SystemTimeSource.INSTANCE,
+                true,
+                otelSemanticsMode
+                    ? OtlpResourceProto.RESOURCE_MESSAGE
+                    : OtlpResourceProto.RESOURCE_MESSAGE_WITH_DATADOG_ATTRS);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpSpanKind.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpSpanKind.java
@@ -1,0 +1,27 @@
+package datadog.trace.core.otlp.trace;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+
+/** Maps Datadog span-kind tags to OTLP's {@code Span.SpanKind} enum values. */
+final class OtlpSpanKind {
+  private OtlpSpanKind() {}
+
+  static int spanKind(CharSequence spanKind) {
+    if (spanKind == null) {
+      return 0; // UNSPECIFIED
+    } else if (SPAN_KIND_SERVER.contentEquals(spanKind)) {
+      return 2; // SERVER
+    } else if (SPAN_KIND_CLIENT.contentEquals(spanKind)) {
+      return 3; // CLIENT
+    } else if (SPAN_KIND_PRODUCER.contentEquals(spanKind)) {
+      return 4; // PRODUCER
+    } else if (SPAN_KIND_CONSUMER.contentEquals(spanKind)) {
+      return 5; // CONSUMER
+    } else {
+      return 1; // INTERNAL
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
@@ -1,0 +1,227 @@
+package datadog.trace.core.otlp.trace;
+
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_MEASURED;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_PARTIAL_VERSION;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_TOP_LEVEL;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_WAS_LONG_RUNNING;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+import static datadog.trace.common.writer.RemoteMapper.HTTP_STATUS;
+import static datadog.trace.common.writer.ddagent.TraceMapper.ORIGIN_KEY;
+import static datadog.trace.common.writer.ddagent.TraceMapper.PROCESS_TAGS_KEY;
+import static datadog.trace.common.writer.ddagent.TraceMapper.SAMPLING_PRIORITY_KEY;
+import static datadog.trace.common.writer.ddagent.TraceMapper.THREAD_ID;
+import static datadog.trace.common.writer.ddagent.TraceMapper.THREAD_NAME;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexSpanId;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexTraceId;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeAttribute;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.NO_TRACE_FLAGS;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.REMOTE_TRACE_FLAG;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
+import static datadog.trace.core.otlp.trace.OtlpSpanKind.spanKind;
+
+import datadog.json.JsonWriter;
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.TagMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.Metadata;
+import datadog.trace.core.MetadataConsumer;
+import datadog.trace.core.PendingTrace;
+import datadog.trace.core.propagation.PropagationTags;
+import java.util.List;
+import java.util.Map;
+
+/** Provides writers for OpenTelemetry's "trace.proto" JSON encoding. */
+public final class OtlpTraceJson {
+
+  private static final UTF8BytesString SERVICE_NAME = UTF8BytesString.create("service.name");
+  private static final UTF8BytesString RESOURCE_NAME = UTF8BytesString.create("resource.name");
+  private static final UTF8BytesString OPERATION_NAME = UTF8BytesString.create("operation.name");
+  private static final UTF8BytesString SPAN_TYPE = UTF8BytesString.create("span.type");
+
+  private OtlpTraceJson() {}
+
+  /** Writes one complete {@code Span} JSON object. */
+  public static void writeSpan(
+      JsonWriter writer, DDSpan span, MetaWriter metaWriter, List<? extends AgentSpanLink> links) {
+    PropagationTags propagationTags = span.spanContext().getPropagationTags();
+
+    writer.beginObject();
+
+    writer.name("traceId").value(hexTraceId(span.getTraceId()));
+    writer.name("spanId").value(hexSpanId(span.getSpanId()));
+
+    String tracestate = propagationTags.getW3CTracestate();
+    if (tracestate != null) {
+      writer.name("traceState").value(tracestate);
+    }
+
+    if (span.getParentId() != 0) {
+      writer.name("parentSpanId").value(hexSpanId(span.getParentId()));
+    }
+
+    int traceFlags = NO_TRACE_FLAGS;
+    if (span.samplingPriority() > 0) {
+      traceFlags |= SAMPLED_TRACE_FLAG;
+    }
+    if (span.spanContext().isRemote()) {
+      traceFlags |= REMOTE_TRACE_FLAG;
+    }
+    if (traceFlags != NO_TRACE_FLAGS) {
+      writer.name("flags").value(traceFlags);
+    }
+
+    writer.name("name").value(span.getResourceName().toString());
+    writer.name("kind").value(spanKind(span.spanContext().getSpanKindString()));
+    writer.name("startTimeUnixNano").value(Long.toString(span.getStartTime()));
+    writer
+        .name("endTimeUnixNano")
+        .value(Long.toString(span.getStartTime() + PendingTrace.getDurationNano(span)));
+
+    writer.name("attributes").beginArray();
+    if (!Config.get().getServiceName().equals(span.getServiceName())) {
+      writeSpanTag(writer, SERVICE_NAME, span.getServiceName());
+    }
+    writeSpanTag(writer, RESOURCE_NAME, span.getResourceName());
+    writeSpanTag(writer, OPERATION_NAME, span.getOperationName());
+    if (span.getSpanType() != null) {
+      writeSpanTag(writer, SPAN_TYPE, span.getSpanType());
+    }
+    span.processTagsAndBaggage(metaWriter);
+    writer.endArray();
+
+    if (!links.isEmpty()) {
+      writer.name("links").beginArray();
+      for (AgentSpanLink link : links) {
+        writeSpanLink(writer, link);
+      }
+      writer.endArray();
+    }
+
+    if (span.isError()) {
+      writer.name("status").beginObject();
+      Object errorMessage = span.getTag(DDTags.ERROR_MSG);
+      if (errorMessage instanceof String) {
+        writer.name("message").value((String) errorMessage);
+      }
+      writer.name("code").value(2); // STATUS_CODE_ERROR
+      writer.endObject();
+    }
+
+    writer.endObject();
+  }
+
+  /** Writes one complete {@code SpanLink} JSON object. */
+  public static void writeSpanLink(JsonWriter writer, AgentSpanLink spanLink) {
+    writer.beginObject();
+
+    writer.name("traceId").value(hexTraceId(spanLink.traceId()));
+    writer.name("spanId").value(hexSpanId(spanLink.spanId()));
+    if (!spanLink.traceState().isEmpty()) {
+      writer.name("traceState").value(spanLink.traceState());
+    }
+
+    Map<?, ?> attributes = spanLink.attributes().asMap();
+    if (!attributes.isEmpty()) {
+      writer.name("attributes").beginArray();
+      attributes.forEach(
+          (key, value) -> writeAttribute(writer, STRING_ATTRIBUTE, key.toString(), value));
+      writer.endArray();
+    }
+
+    writer.name("flags").value(spanLink.traceFlags() & 0xff);
+
+    writer.endObject();
+  }
+
+  private static void writeSpanTag(JsonWriter writer, TagMap.EntryReader tagEntry) {
+    switch (tagEntry.type()) {
+      case TagMap.EntryReader.BOOLEAN:
+        writeAttribute(writer, BOOLEAN_ATTRIBUTE, tagEntry.tag(), tagEntry.objectValue());
+        break;
+      case TagMap.EntryReader.INT:
+      case TagMap.EntryReader.LONG:
+        writeAttribute(writer, LONG_ATTRIBUTE, tagEntry.tag(), tagEntry.objectValue());
+        break;
+      case TagMap.EntryReader.FLOAT:
+      case TagMap.EntryReader.DOUBLE:
+        writeAttribute(writer, DOUBLE_ATTRIBUTE, tagEntry.tag(), tagEntry.objectValue());
+        break;
+      default:
+        writeAttribute(writer, STRING_ATTRIBUTE, tagEntry.tag(), tagEntry.stringValue());
+    }
+  }
+
+  private static void writeSpanTag(JsonWriter writer, UTF8BytesString key, CharSequence value) {
+    writeAttribute(writer, key, value.toString());
+  }
+
+  private static void writeSpanTag(JsonWriter writer, UTF8BytesString key, long value) {
+    writeAttribute(writer, key, value);
+  }
+
+  public static class MetaWriter implements MetadataConsumer {
+    private final JsonWriter writer;
+
+    private boolean includeProcessTags;
+    private boolean includeSamplingTags;
+
+    public MetaWriter(JsonWriter writer) {
+      this.writer = writer;
+    }
+
+    /** Call this to ensure process tags are written out for the next span. */
+    public void includeProcessTags() {
+      includeProcessTags = true;
+    }
+
+    /** Call this to ensure sampling tags are written out for the next span. */
+    public void includeSamplingTags() {
+      includeSamplingTags = true;
+    }
+
+    @Override
+    public void accept(Metadata metadata) {
+      if ((includeSamplingTags || metadata.topLevel()) && metadata.hasSamplingPriority()) {
+        writeSpanTag(writer, SAMPLING_PRIORITY_KEY, metadata.samplingPriority());
+      }
+      if (metadata.measured()) {
+        writeSpanTag(writer, DD_MEASURED, 1);
+      }
+      if (metadata.topLevel()) {
+        writeSpanTag(writer, DD_TOP_LEVEL, 1);
+      }
+
+      if (metadata.longRunningVersion() != 0) {
+        if (metadata.longRunningVersion() > 0) {
+          writeSpanTag(writer, DD_PARTIAL_VERSION, metadata.longRunningVersion());
+        } else {
+          writeSpanTag(writer, DD_WAS_LONG_RUNNING, 1);
+        }
+      }
+
+      writeSpanTag(writer, THREAD_ID, metadata.getThreadId());
+      writeSpanTag(writer, THREAD_NAME, metadata.getThreadName());
+      if (metadata.getHttpStatusCode() != null) {
+        writeSpanTag(writer, HTTP_STATUS, metadata.getHttpStatusCode());
+      }
+      if (metadata.getOrigin() != null) {
+        writeSpanTag(writer, ORIGIN_KEY, metadata.getOrigin());
+      }
+      if (includeProcessTags && metadata.processTags() != null) {
+        writeSpanTag(writer, PROCESS_TAGS_KEY, metadata.processTags());
+      }
+
+      metadata.getTags().forEach(writer, OtlpTraceJson::writeSpanTag);
+
+      // reset for next span
+      includeProcessTags = false;
+      includeSamplingTags = false;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
@@ -1,0 +1,182 @@
+package datadog.trace.core.otlp.trace;
+
+import static datadog.trace.core.otlp.common.OtlpCommonJson.writeScopeAndSchema;
+import static datadog.trace.core.otlp.common.OtlpPayload.JSON_CONTENT_TYPE;
+import static datadog.trace.core.otlp.common.OtlpResourceJson.TRACE_RESOURCE_FRAGMENT;
+import static datadog.trace.core.otlp.trace.OtlpTraceJson.writeSpan;
+
+import datadog.json.JsonWriter;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import datadog.trace.core.CoreSpan;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Collects Datadog traces and marshals them into a 'trace.proto' JSON payload.
+ *
+ * <p>This collector is designed to be called by a single thread. To minimize allocations each
+ * collection returns a payload only to be used by the calling thread until the next collection.
+ * (The payload should be copied before passing it onto another thread.)
+ *
+ * <p>Unlike the protobuf collector, JSON doesn't need message lengths computed ahead of time, so
+ * spans are written directly and in order into the currently open JSON arrays as they're completed.
+ * Process tags are attached to the first span written in a scope, matching the {@code
+ * firstSpanInPayload} convention used by the other trace mappers. Sampling tags still need a
+ * one-span lookahead: that decision (and the corresponding {@code MetadataConsumer.accept} call)
+ * can only be made once we see the next span (or reach a scope/payload boundary), since it depends
+ * on whether the held-back span is the last one in its trace.
+ */
+public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
+
+  private static final OtelInstrumentationScope DEFAULT_TRACE_SCOPE =
+      new OtelInstrumentationScope("", null, null);
+
+  private JsonWriter writer;
+  private OtlpTraceJson.MetaWriter metaWriter;
+
+  private boolean payloadStarted;
+  private boolean anySpanWritten;
+  private boolean firstSpanInScope;
+
+  private OtelInstrumentationScope currentScope;
+  private DDSpan currentSpan;
+  private List<? extends AgentSpanLink> currentSpanLinks = Collections.emptyList();
+
+  /** Adds the given trace spans to the collector. */
+  @Override
+  public void addTrace(List<? extends CoreSpan<?>> spans) {
+    if (!payloadStarted) {
+      start();
+      payloadStarted = true;
+    }
+
+    for (CoreSpan<?> span : spans) {
+      visitSpan(span);
+    }
+  }
+
+  /**
+   * Marshals the traces collected so far into a JSON payload.
+   *
+   * <p>This payload is only valid for the calling thread until the next collection.
+   */
+  @Override
+  public OtlpPayload collectTraces() {
+    if (!payloadStarted) {
+      return OtlpPayload.EMPTY;
+    }
+    try {
+      return completePayload();
+    } finally {
+      stop();
+    }
+  }
+
+  /** Prepare temporary elements to collect trace data. */
+  private void start() {
+    writer = new JsonWriter();
+    metaWriter = new OtlpTraceJson.MetaWriter(writer);
+
+    writer.beginObject();
+    writer.name("resourceSpans").beginArray();
+    writer.beginObject();
+    writer.name("resource").jsonValue(TRACE_RESOURCE_FRAGMENT);
+    writer.name("scopeSpans").beginArray();
+
+    // for now put all spans under the default scope
+    visitScopedSpans(DEFAULT_TRACE_SCOPE);
+  }
+
+  /** Cleanup elements used to collect trace data. */
+  private void stop() {
+    payloadStarted = false;
+    anySpanWritten = false;
+
+    writer = null;
+    metaWriter = null;
+
+    currentScope = null;
+    currentSpan = null;
+    currentSpanLinks = Collections.emptyList();
+  }
+
+  private void visitScopedSpans(OtelInstrumentationScope scope) {
+    if (currentScope != null) {
+      completeScope();
+    }
+    currentScope = scope;
+    firstSpanInScope = true;
+
+    writer.beginObject();
+    writeScopeAndSchema(writer, scope);
+    writer.name("spans").beginArray();
+  }
+
+  private void visitSpan(CoreSpan<?> span) {
+    if (shouldExport(span)) {
+      if (currentSpan != null) {
+        // ensure last span written at trace boundary includes sampling tags
+        if (!span.getTraceId().equals(currentSpan.getTraceId())) {
+          metaWriter.includeSamplingTags();
+        }
+        completeSpan();
+      }
+      currentSpan = (DDSpan) span;
+      currentSpanLinks = currentSpan.getLinks();
+    }
+  }
+
+  // called once we've processed all scopes and span messages
+  private OtlpPayload completePayload() {
+    if (currentScope != null) {
+      completeScope();
+    }
+
+    writer.endArray(); // scopeSpans
+    writer.endObject(); // resourceSpans[0]
+    writer.endArray(); // resourceSpans
+    writer.endObject(); // root
+
+    if (!anySpanWritten) {
+      return OtlpPayload.EMPTY;
+    }
+
+    byte[] bytes = writer.toByteArray();
+    return new OtlpPayload(ByteBuffer.wrap(bytes), JSON_CONTENT_TYPE);
+  }
+
+  // called once we've processed all spans in a specific scope
+  private void completeScope() {
+    if (currentSpan != null) {
+      // ensure last span written at scope boundary includes sampling tags
+      metaWriter.includeSamplingTags();
+      completeSpan();
+    }
+
+    writer.endArray(); // spans
+    writer.endObject(); // scopeSpans[0]
+
+    // reset temporary elements for next scope
+    currentScope = null;
+  }
+
+  // called once we've processed all span-links in a specific span
+  private void completeSpan() {
+    if (firstSpanInScope) {
+      // ensure first span written in the scope includes process tags,
+      // matching the firstSpanInPayload convention used by the other trace mappers
+      metaWriter.includeProcessTags();
+      firstSpanInScope = false;
+    }
+    writeSpan(writer, currentSpan, metaWriter, currentSpanLinks);
+    anySpanWritten = true;
+
+    // reset temporary elements for next span
+    currentSpan = null;
+    currentSpanLinks = Collections.emptyList();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
@@ -4,10 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_PARTIAL_VERSION;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_TOP_LEVEL;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_WAS_LONG_RUNNING;
-import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT;
-import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER;
-import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER;
-import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ATTRIBUTE;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ATTRIBUTE;
@@ -30,6 +26,10 @@ import static datadog.trace.core.otlp.common.OtlpCommonProto.writeInstrumentatio
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeString;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeTag;
 import static datadog.trace.core.otlp.common.OtlpCommonProto.writeVarInt;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.NO_TRACE_FLAGS;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.REMOTE_TRACE_FLAG;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
+import static datadog.trace.core.otlp.trace.OtlpSpanKind.spanKind;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.communication.serialization.GrowableBuffer;
@@ -55,10 +55,6 @@ public final class OtlpTraceProto {
   private static final UTF8BytesString RESOURCE_NAME = UTF8BytesString.create("resource.name");
   private static final UTF8BytesString OPERATION_NAME = UTF8BytesString.create("operation.name");
   private static final UTF8BytesString SPAN_TYPE = UTF8BytesString.create("span.type");
-
-  public static final int NO_TRACE_FLAGS = 0x00000000;
-  public static final int SAMPLED_TRACE_FLAG = 0x00000001;
-  public static final int REMOTE_TRACE_FLAG = 0x00000300;
 
   private OtlpTraceProto() {}
 
@@ -176,8 +172,10 @@ public final class OtlpTraceProto {
     writeTag(buf, 2, LEN_WIRE_TYPE);
     writeSpanId(buf, spanLink.spanId());
 
-    writeTag(buf, 3, LEN_WIRE_TYPE);
-    writeString(buf, spanLink.traceState());
+    if (!spanLink.traceState().isEmpty()) {
+      writeTag(buf, 3, LEN_WIRE_TYPE);
+      writeString(buf, spanLink.traceState());
+    }
 
     spanLink
         .attributes()
@@ -189,7 +187,7 @@ public final class OtlpTraceProto {
             });
 
     writeTag(buf, 6, I32_WIRE_TYPE);
-    writeI32(buf, spanLink.traceFlags());
+    writeI32(buf, spanLink.traceFlags() & 0xff);
 
     return protobuf.recordMessage(buf, 13);
   }
@@ -242,22 +240,6 @@ public final class OtlpTraceProto {
   private static void writeSpanTag(StreamingBuffer buf, UTF8BytesString key, long value) {
     writeTag(buf, 9, LEN_WIRE_TYPE);
     writeAttribute(buf, key, value);
-  }
-
-  private static int spanKind(CharSequence spanKind) {
-    if (spanKind == null) {
-      return 0; // UNSPECIFIED
-    } else if (SPAN_KIND_SERVER.contentEquals(spanKind)) {
-      return 2; // SERVER
-    } else if (SPAN_KIND_CLIENT.contentEquals(spanKind)) {
-      return 3; // CLIENT
-    } else if (SPAN_KIND_PRODUCER.contentEquals(spanKind)) {
-      return 4; // PRODUCER
-    } else if (SPAN_KIND_CONSUMER.contentEquals(spanKind)) {
-      return 5; // CONSUMER
-    } else {
-      return 1; // INTERNAL
-    }
   }
 
   public static class MetaWriter implements MetadataConsumer {

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpCommonJsonTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpCommonJsonTest.java
@@ -1,0 +1,108 @@
+package datadog.trace.core.otlp.common;
+
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ARRAY_ATTRIBUTE;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import datadog.json.JsonMapper;
+import datadog.json.JsonWriter;
+import datadog.trace.api.DD128bTraceId;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OtlpCommonJsonTest {
+
+  @Test
+  void hexTraceIdEncodesHighAndLowOrderBytes() {
+    DD128bTraceId traceId = DD128bTraceId.from(0x0123456789abcdefL, 0xfedcba9876543210L);
+    assertEquals("0123456789abcdeffedcba9876543210", OtlpCommonJson.hexTraceId(traceId));
+  }
+
+  @Test
+  void hexSpanIdEncodes64Bits() {
+    assertEquals("0000000000000001", OtlpCommonJson.hexSpanId(1L));
+    assertEquals("00000000000004d2", OtlpCommonJson.hexSpanId(1234L));
+  }
+
+  @Test
+  void stringAttribute() throws IOException {
+    Map<String, Object> keyValue = writeAndParseAttribute(STRING_ATTRIBUTE, "k", "v");
+    assertEquals("k", keyValue.get("key"));
+    assertEquals("v", valueOf(keyValue).get("stringValue"));
+  }
+
+  @Test
+  void booleanAttribute() throws IOException {
+    Map<String, Object> keyValue = writeAndParseAttribute(BOOLEAN_ATTRIBUTE, "flag", true);
+    assertEquals(Boolean.TRUE, valueOf(keyValue).get("boolValue"));
+  }
+
+  @Test
+  void longAttributeIsEncodedAsDecimalString() throws IOException {
+    Map<String, Object> keyValue = writeAndParseAttribute(LONG_ATTRIBUTE, "n", 42L);
+    assertEquals("42", valueOf(keyValue).get("intValue"));
+  }
+
+  @Test
+  void doubleAttributeIsEncodedAsNumber() throws IOException {
+    Map<String, Object> keyValue = writeAndParseAttribute(DOUBLE_ATTRIBUTE, "d", 3.14);
+    assertEquals(3.14, ((Number) valueOf(keyValue).get("doubleValue")).doubleValue());
+  }
+
+  @Test
+  void stringArrayAttributeWrapsValuesInArrayValue() throws IOException {
+    Map<String, Object> keyValue =
+        writeAndParseAttribute(STRING_ARRAY_ATTRIBUTE, "tags", Arrays.asList("a", "b"));
+
+    Map<String, Object> value = valueOf(keyValue);
+    Map<String, Object> arrayValue = (Map<String, Object>) value.get("arrayValue");
+    List<Object> values = (List<Object>) arrayValue.get("values");
+    assertEquals(2, values.size());
+    assertEquals("a", ((Map<String, Object>) values.get(0)).get("stringValue"));
+    assertEquals("b", ((Map<String, Object>) values.get(1)).get("stringValue"));
+  }
+
+  @Test
+  void longArrayAttributeEncodesEachElementAsDecimalString() throws IOException {
+    Map<String, Object> keyValue =
+        writeAndParseAttribute(LONG_ARRAY_ATTRIBUTE, "ns", Arrays.asList(1L, 2L, 3L));
+
+    Map<String, Object> arrayValue = (Map<String, Object>) valueOf(keyValue).get("arrayValue");
+    List<Object> values = (List<Object>) arrayValue.get("values");
+    assertEquals("1", ((Map<String, Object>) values.get(0)).get("intValue"));
+    assertEquals("2", ((Map<String, Object>) values.get(1)).get("intValue"));
+    assertEquals("3", ((Map<String, Object>) values.get(2)).get("intValue"));
+  }
+
+  @Test
+  void booleanArrayAttribute() throws IOException {
+    Map<String, Object> keyValue =
+        writeAndParseAttribute(BOOLEAN_ARRAY_ATTRIBUTE, "flags", Arrays.asList(true, false));
+
+    Map<String, Object> arrayValue = (Map<String, Object>) valueOf(keyValue).get("arrayValue");
+    List<Object> values = (List<Object>) arrayValue.get("values");
+    assertEquals(Boolean.TRUE, ((Map<String, Object>) values.get(0)).get("boolValue"));
+    assertEquals(Boolean.FALSE, ((Map<String, Object>) values.get(1)).get("boolValue"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> valueOf(Map<String, Object> keyValue) {
+    return (Map<String, Object>) keyValue.get("value");
+  }
+
+  private static Map<String, Object> writeAndParseAttribute(int type, String key, Object value)
+      throws IOException {
+    try (JsonWriter writer = new JsonWriter()) {
+      OtlpCommonJson.writeAttribute(writer, type, key, value);
+      return JsonMapper.fromJsonToMap(writer.toString());
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpResourceJsonTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpResourceJsonTest.java
@@ -13,12 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.WireFormat;
+import datadog.json.JsonMapper;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -28,22 +28,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for {@link OtlpResourceProto#buildResourceMessage}.
- *
- * <p>Each test creates a {@link Config} from a {@link Properties} instance, calls {@link
- * OtlpResourceProto#buildResourceMessage}, then extracts the byte array and verifies its content
- * against the OpenTelemetry protobuf encoding defined in {@code
- * opentelemetry/proto/resource/v1/resource.proto}.
- *
- * <p>Relevant proto field numbers:
- *
- * <pre>
- *   Resource { repeated KeyValue attributes = 1; }
- *   KeyValue { string key = 1; AnyValue value = 2; }
- *   AnyValue { string string_value = 1; }
- * </pre>
+ * Tests for {@link OtlpResourceJson#buildResourceFragment}, mirroring {@link OtlpResourceProtoTest}
+ * to keep the proto and JSON encoders in parity.
  */
-class OtlpResourceProtoTest {
+class OtlpResourceJsonTest {
 
   // ── test data ─────────────────────────────────────────────────────────────
 
@@ -66,39 +54,32 @@ class OtlpResourceProtoTest {
     return map;
   }
 
-  static Stream<Arguments> resourceMessageCases() {
+  static Stream<Arguments> resourceFragmentCases() {
     return Stream.of(
-        // service not set: should use the auto-detected name
         Arguments.of(
             "service not set, no env, no version, no tags",
             props(),
             attrs("service.name", Config.get().getServiceName())),
-        // custom service name
         Arguments.of(
             "custom service name, no env, no version, no tags",
             props(SERVICE_NAME, "my-service"),
             attrs("service.name", "my-service")),
-        // env set to empty string: no deployment.environment.name written;
         Arguments.of(
             "env set to empty string",
             props(SERVICE_NAME, "my-service", ENV, ""),
             attrs("service.name", "my-service")),
-        // env set to non-empty value: deployment.environment.name written;
         Arguments.of(
             "env set to non-empty value",
             props(SERVICE_NAME, "my-service", ENV, "prod"),
             attrs("service.name", "my-service", "deployment.environment.name", "prod")),
-        // version set to empty string: no service.version written;
         Arguments.of(
             "version set to empty string",
             props(SERVICE_NAME, "my-service", VERSION, ""),
             attrs("service.name", "my-service")),
-        // version set to non-empty value: service.version written;
         Arguments.of(
             "version set to non-empty value",
             props(SERVICE_NAME, "my-service", VERSION, "1.0.0"),
             attrs("service.name", "my-service", "service.version", "1.0.0")),
-        // tags as comma-separated key:value pairs (no env or version)
         Arguments.of(
             "tags as comma-separated key:value pairs",
             props(SERVICE_NAME, "my-service", TAGS, "region:us-east,team:platform"),
@@ -106,12 +87,10 @@ class OtlpResourceProtoTest {
                 "service.name", "my-service",
                 "region", "us-east",
                 "team", "platform")),
-        // report-hostname enabled: host.name written with the detected hostname
         Arguments.of(
             "report-hostname enabled",
             props(SERVICE_NAME, "my-service", TRACE_REPORT_HOSTNAME, "true"),
             attrs("service.name", "my-service", "host.name", Config.get().getHostName())),
-        // all config values set together; telemetry.sdk.* keys in tags must be ignored
         Arguments.of(
             "service, env, version, and tags all set",
             props(
@@ -145,24 +124,24 @@ class OtlpResourceProtoTest {
                 "region", "eu-west")));
   }
 
-  // ── test ─────────────────────────────────────────────────────────────────
+  // ── tests ─────────────────────────────────────────────────────────────────
 
   @ParameterizedTest(name = "{0}")
-  @MethodSource("resourceMessageCases")
-  void testBuildResourceMessage(
+  @MethodSource("resourceFragmentCases")
+  void testBuildResourceFragment(
       String caseName, Properties properties, Map<String, String> expectedAttributes)
       throws IOException {
     Config config = Config.get(properties);
-    byte[] bytes = OtlpResourceProto.buildResourceMessage(config, Collections.emptyMap());
+    String fragment = OtlpResourceJson.buildResourceFragment(config, Collections.emptyMap());
 
-    Map<String, String> actualAttributes = parseResourceAttributes(bytes);
+    Map<String, String> actualAttributes = parseResourceAttributes(fragment);
     assertEquals(expectedAttributes, actualAttributes, "For case: " + caseName);
   }
 
   /**
-   * The datadog-attrs variant ({@code buildResourceMessage(config, datadogResourceAttributes)})
-   * carries {@code datadog.runtime_id}; the plain variant omits it. (Process tags are emitted only
-   * when the experimental process-tag propagation is enabled, so they aren't asserted here.)
+   * The datadog-attrs variant carries {@code datadog.runtime_id}; the plain variant omits it.
+   * (Process tags are emitted only when the experimental process-tag propagation is enabled, so
+   * they aren't asserted here.)
    */
   @Test
   void datadogResourceAttributesVariantCarriesRuntimeId() throws IOException {
@@ -170,10 +149,10 @@ class OtlpResourceProtoTest {
 
     Map<String, String> withDatadog =
         parseResourceAttributes(
-            OtlpResourceProto.buildResourceMessage(config, datadogResourceAttributes(config)));
+            OtlpResourceJson.buildResourceFragment(config, datadogResourceAttributes(config)));
     Map<String, String> plain =
         parseResourceAttributes(
-            OtlpResourceProto.buildResourceMessage(config, Collections.emptyMap()));
+            OtlpResourceJson.buildResourceFragment(config, Collections.emptyMap()));
 
     assertTrue(
         withDatadog.containsKey("datadog.runtime_id"),
@@ -193,11 +172,11 @@ class OtlpResourceProtoTest {
 
     Map<String, String> withMarker =
         parseResourceAttributes(
-            OtlpResourceProto.buildResourceMessage(
+            OtlpResourceJson.buildResourceFragment(
                 withMetrics, traceResourceAttributes(withMetrics)));
     Map<String, String> without =
         parseResourceAttributes(
-            OtlpResourceProto.buildResourceMessage(
+            OtlpResourceJson.buildResourceFragment(
                 withoutMetrics, traceResourceAttributes(withoutMetrics)));
 
     assertEquals(
@@ -205,67 +184,54 @@ class OtlpResourceProtoTest {
     assertFalse(without.containsKey("_dd.stats_computed"), "marker absent when stats not computed");
   }
 
+  @Test
+  void cannedFragmentsMatchTheirProtoCounterparts() throws IOException {
+    assertEquals(
+        parseResourceAttributesFromProto(OtlpResourceProto.RESOURCE_MESSAGE),
+        parseResourceAttributes(OtlpResourceJson.RESOURCE_FRAGMENT));
+    assertEquals(
+        parseResourceAttributesFromProto(OtlpResourceProto.RESOURCE_MESSAGE_WITH_DATADOG_ATTRS),
+        parseResourceAttributes(OtlpResourceJson.RESOURCE_FRAGMENT_WITH_DATADOG_ATTRS));
+    assertEquals(
+        parseResourceAttributesFromProto(OtlpResourceProto.TRACE_RESOURCE_MESSAGE),
+        parseResourceAttributes(OtlpResourceJson.TRACE_RESOURCE_FRAGMENT));
+  }
+
   // ── parsing helpers ───────────────────────────────────────────────────────
 
-  /**
-   * Parses the resource message bytes into an attribute map while validating the protobuf wire
-   * format (field numbers and wire types) of every field read.
-   *
-   * <p>{@code buildResourceMessage} returns a length-prefixed message with an outer tag (field 1,
-   * LEN wire type) followed by the Resource body size and body. Read the outer tag, then iterate
-   * over all {@code Resource.attributes} (field 1, LEN wire type). Each attribute is a {@code
-   * KeyValue} whose {@code value} is an {@code AnyValue} containing a {@code string_value}.
-   */
-  private static Map<String, String> parseResourceAttributes(byte[] bytes) throws IOException {
-    // Read the outer tag (field 1, LEN wire type) that wraps the Resource body
-    CodedInputStream outer = CodedInputStream.newInstance(bytes);
-    int outerTag = outer.readTag();
-    assertEquals(1, WireFormat.getTagFieldNumber(outerTag), "outer field is Resource (field 1)");
-    assertEquals(WireFormat.WIRETYPE_LENGTH_DELIMITED, WireFormat.getTagWireType(outerTag));
-    CodedInputStream resource = outer.readBytes().newCodedInput();
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> parseResourceAttributes(String fragment) throws IOException {
+    Map<String, Object> resource = JsonMapper.fromJsonToMap(fragment);
+    List<Object> attributes = (List<Object>) resource.get("attributes");
+
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Object attribute : attributes) {
+      Map<String, Object> keyValue = (Map<String, Object>) attribute;
+      Map<String, Object> value = (Map<String, Object>) keyValue.get("value");
+      result.put((String) keyValue.get("key"), (String) value.get("stringValue"));
+    }
+    return result;
+  }
+
+  private static Map<String, String> parseResourceAttributesFromProto(byte[] bytes)
+      throws IOException {
+    com.google.protobuf.CodedInputStream outer =
+        com.google.protobuf.CodedInputStream.newInstance(bytes);
+    outer.readTag();
+    com.google.protobuf.CodedInputStream resource = outer.readBytes().newCodedInput();
 
     Map<String, String> attributes = new LinkedHashMap<>();
     while (!resource.isAtEnd()) {
-      // Each attribute is Resource.attributes (field 1, LEN wire type)
-      int tag = resource.readTag();
-      assertEquals(1, WireFormat.getTagFieldNumber(tag), "Resource.attributes is field 1");
-      assertEquals(WireFormat.WIRETYPE_LENGTH_DELIMITED, WireFormat.getTagWireType(tag));
-
-      // Read the full KeyValue body
-      CodedInputStream kv = resource.readBytes().newCodedInput();
-
-      String key = readKeyField(kv);
-      CodedInputStream av = readAnyValueField(kv);
-
-      // Read AnyValue.string_value (field 1, LEN)
-      int avTag = av.readTag();
-      assertEquals(1, WireFormat.getTagFieldNumber(avTag), "AnyValue.string_value is field 1");
-      assertEquals(WireFormat.WIRETYPE_LENGTH_DELIMITED, WireFormat.getTagWireType(avTag));
+      resource.readTag();
+      com.google.protobuf.CodedInputStream kv = resource.readBytes().newCodedInput();
+      kv.readTag();
+      String key = kv.readString();
+      kv.readTag();
+      com.google.protobuf.CodedInputStream av = kv.readBytes().newCodedInput();
+      av.readTag();
       String value = av.readString();
-      assertTrue(av.isAtEnd(), "no extra fields in AnyValue");
-      assertTrue(kv.isAtEnd(), "no extra fields in KeyValue");
-
       attributes.put(key, value);
     }
     return attributes;
-  }
-
-  /** Reads the {@code KeyValue.key} field (field 1, LEN) and returns the string value. */
-  private static String readKeyField(CodedInputStream kv) throws IOException {
-    int tag = kv.readTag();
-    assertEquals(1, WireFormat.getTagFieldNumber(tag), "KeyValue.key is field 1");
-    assertEquals(WireFormat.WIRETYPE_LENGTH_DELIMITED, WireFormat.getTagWireType(tag));
-    return kv.readString();
-  }
-
-  /**
-   * Reads the {@code KeyValue.value} field (field 2, LEN) and returns a stream over the {@code
-   * AnyValue} body.
-   */
-  private static CodedInputStream readAnyValueField(CodedInputStream kv) throws IOException {
-    int tag = kv.readTag();
-    assertEquals(2, WireFormat.getTagFieldNumber(tag), "KeyValue.value is field 2");
-    assertEquals(WireFormat.WIRETYPE_LENGTH_DELIMITED, WireFormat.getTagWireType(tag));
-    return kv.readBytes().newCodedInput();
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollectorTest.java
@@ -1,0 +1,170 @@
+package datadog.trace.core.otlp.logs;
+
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexSpanId;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexTraceId;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.json.JsonMapper;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import datadog.trace.bootstrap.otlp.logs.OtlpLogRecord;
+import datadog.trace.bootstrap.otlp.logs.OtlpScopedLogsVisitor;
+import datadog.trace.common.writer.LoggingWriter;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OtlpLogsJsonCollector}, parsing the produced JSON back with {@link JsonMapper}
+ * to verify the OTLP JSON encoding: lowerCamelCase keys, hex trace/span ids, decimal-string
+ * timestamps, and integer severity/flags.
+ */
+class OtlpLogsJsonCollectorTest {
+
+  private static final CoreTracer TRACER = CoreTracer.builder().writer(new LoggingWriter()).build();
+  private static final OtelInstrumentationScope SCOPE =
+      new OtelInstrumentationScope("test.logger", null, null);
+
+  @Test
+  void emptyBatchProducesEmptyPayload() {
+    OtlpLogsJsonCollector collector = OtlpLogsJsonCollector.INSTANCE;
+    OtlpPayload payload = collector.collectLogs((visitor, interval) -> {}, 0);
+    assertEquals(OtlpPayload.EMPTY, payload);
+  }
+
+  @Test
+  void logRecordWithoutSpanContextHasNoTraceOrSpanId() throws IOException {
+    OtlpLogRecord record = logRecord("hello", null, null);
+
+    Map<String, Object> parsed = onlyLogRecord(collect(record, emptyMap()));
+
+    assertEquals("hello", ((Map<String, Object>) parsed.get("body")).get("stringValue"));
+    assertEquals("9", String.valueOf(parsed.get("severityNumber")));
+    assertEquals("INFO", parsed.get("severityText"));
+    assertTrue(parsed.get("timeUnixNano") instanceof String);
+    assertTrue(parsed.get("observedTimeUnixNano") instanceof String);
+    assertFalse(parsed.containsKey("traceId"));
+    assertFalse(parsed.containsKey("spanId"));
+    assertFalse(parsed.containsKey("flags"));
+  }
+
+  @Test
+  void logRecordWithSpanContextHasHexTraceAndSpanIdAndSampledFlag() throws IOException {
+    AgentSpan span = TRACER.startSpan("test", "test.op");
+    span.setSamplingPriority(PrioritySampling.USER_KEEP, SamplingMechanism.DEFAULT);
+    span.finish();
+    DDSpan ddSpan = (DDSpan) span;
+
+    OtlpLogRecord record = logRecord("with context", ddSpan.spanContext(), null);
+    Map<String, Object> parsed = onlyLogRecord(collect(record, emptyMap()));
+
+    assertEquals(hexTraceId(ddSpan.getTraceId()), parsed.get("traceId"));
+    assertEquals(hexSpanId(ddSpan.getSpanId()), parsed.get("spanId"));
+    assertEquals(1, ((Number) parsed.get("flags")).intValue(), "SAMPLED_TRACE_FLAG = 1");
+  }
+
+  @Test
+  void logRecordWithEventNameHasEventNameField() throws IOException {
+    OtlpLogRecord record = logRecord("clicked", null, "user.interaction");
+    Map<String, Object> parsed = onlyLogRecord(collect(record, emptyMap()));
+
+    assertEquals("user.interaction", parsed.get("eventName"));
+  }
+
+  @Test
+  void logRecordWithAttributesWritesAttributesArray() throws IOException {
+    OtlpLogRecord record = logRecord("tagged", null, null);
+    Map<String, Object> parsed =
+        onlyLogRecord(collect(record, Collections.singletonMap("service.name", "svc")));
+
+    List<Object> attributes = (List<Object>) parsed.get("attributes");
+    assertEquals(1, attributes.size());
+    Map<String, Object> attr = (Map<String, Object>) attributes.get(0);
+    assertEquals("service.name", attr.get("key"));
+  }
+
+  @Test
+  void collectionAfterFailedAttributeWriteIsStillWellFormed() throws IOException {
+    OtlpLogsJsonCollector collector = OtlpLogsJsonCollector.INSTANCE;
+
+    // open the attributes array on the shared/reused collector, then blow up before it's closed
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            collector.collectLogs(
+                (visitor, interval) -> {
+                  OtlpScopedLogsVisitor scoped = visitor.visitScopedLogs(SCOPE);
+                  scoped.visitAttribute(STRING_ATTRIBUTE, "service.name", "svc");
+                  throw new RuntimeException("boom");
+                },
+                0));
+
+    // a subsequent, successful collection must still emit a well-formed attributes array
+    OtlpLogRecord record = logRecord("tagged", null, null);
+    Map<String, Object> parsed =
+        onlyLogRecord(collect(record, Collections.singletonMap("service.name", "svc")));
+
+    List<Object> attributes = (List<Object>) parsed.get("attributes");
+    assertEquals(1, attributes.size());
+    Map<String, Object> attr = (Map<String, Object>) attributes.get(0);
+    assertEquals("service.name", attr.get("key"));
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private static OtlpLogRecord logRecord(String body, AgentSpanContext ctx, String eventName) {
+    return new OtlpLogRecord(
+        SCOPE,
+        1_700_000_000_000_000_000L,
+        1_700_000_000_001_000_000L,
+        9,
+        "INFO",
+        body,
+        emptyMap(),
+        ctx,
+        eventName);
+  }
+
+  private static OtlpPayload collect(OtlpLogRecord record, Map<String, Object> attrs) {
+    OtlpLogsJsonCollector collector = OtlpLogsJsonCollector.INSTANCE;
+    return collector.collectLogs(
+        (visitor, interval) -> {
+          OtlpScopedLogsVisitor scoped = visitor.visitScopedLogs(SCOPE);
+          for (Map.Entry<String, Object> attr : attrs.entrySet()) {
+            scoped.visitAttribute(STRING_ATTRIBUTE, attr.getKey(), attr.getValue());
+          }
+          scoped.visitLogRecord(record);
+        },
+        0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> onlyLogRecord(OtlpPayload payload) throws IOException {
+    byte[] bytes = new byte[payload.getContentLength()];
+    payload.getContent().get(bytes);
+    String json = new String(bytes, StandardCharsets.UTF_8);
+    Map<String, Object> root = JsonMapper.fromJsonToMap(json);
+
+    List<Object> resourceLogs = (List<Object>) root.get("resourceLogs");
+    Map<String, Object> resourceLog = (Map<String, Object>) resourceLogs.get(0);
+    List<Object> scopeLogs = (List<Object>) resourceLog.get("scopeLogs");
+    Map<String, Object> scopeLog = (Map<String, Object>) scopeLogs.get(0);
+    List<Object> logRecords = (List<Object>) scopeLog.get("logRecords");
+    assertEquals(1, logRecords.size());
+    return (Map<String, Object>) logRecords.get(0);
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsProtoTest.java
@@ -4,7 +4,7 @@ import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.BOOLEAN_A
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.DOUBLE_ATTRIBUTE;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.LONG_ATTRIBUTE;
 import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
-import static datadog.trace.core.otlp.trace.OtlpTraceProto.SAMPLED_TRACE_FLAG;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsServiceTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/logs/OtlpLogsServiceTest.java
@@ -1,0 +1,27 @@
+package datadog.trace.core.otlp.logs;
+
+import static datadog.trace.api.config.OtlpConfig.OTLP_LOGS_ENDPOINT;
+import static datadog.trace.api.config.OtlpConfig.OTLP_LOGS_PROTOCOL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import datadog.trace.api.Config;
+import datadog.trace.core.otlp.common.OtlpHttpSender;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class OtlpLogsServiceTest {
+
+  @Test
+  void httpJsonProtocolUsesJsonCollectorAndConfiguredEndpoint() {
+    Properties properties = new Properties();
+    properties.setProperty(OTLP_LOGS_PROTOCOL, "http/json");
+    properties.setProperty(OTLP_LOGS_ENDPOINT, "http://localhost:4318/v1/logs");
+
+    OtlpLogsService service = new OtlpLogsService(Config.get(properties));
+
+    assertInstanceOf(OtlpLogsJsonCollector.class, service.getCollector());
+    OtlpHttpSender sender = assertInstanceOf(OtlpHttpSender.class, service.getSender());
+    assertEquals("http://localhost:4318/v1/logs", sender.url().toString());
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsJsonCollectorTest.java
@@ -1,0 +1,250 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.COUNTER;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.GAUGE;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.HISTOGRAM;
+import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_ATTRIBUTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.json.JsonMapper;
+import datadog.trace.api.time.ControllableTimeSource;
+import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
+import datadog.trace.bootstrap.otel.metrics.OtelInstrumentDescriptor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpDoublePoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpHistogramPoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpLongPoint;
+import datadog.trace.bootstrap.otlp.metrics.OtlpMetricVisitor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpMetricsVisitor;
+import datadog.trace.bootstrap.otlp.metrics.OtlpScopedMetricsVisitor;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OtlpMetricsJsonCollector}, parsing the produced JSON back with {@link
+ * JsonMapper} to verify the OTLP JSON encoding: lowerCamelCase keys, integer aggregation
+ * temporality, decimal-string timestamps/counts, and the overflow-bucket handling for histograms.
+ */
+class OtlpMetricsJsonCollectorTest {
+
+  private static final long START_EPOCH_NS = TimeUnit.SECONDS.toNanos(1330837567);
+  private static final long END_EPOCH_NS = START_EPOCH_NS + TimeUnit.MINUTES.toNanos(30);
+
+  @Test
+  void emptyRegistryProducesEmptyPayload() {
+    OtlpMetricsJsonCollector collector = new OtlpMetricsJsonCollector(new ControllableTimeSource());
+    OtlpPayload payload = collector.collectMetrics(visitor -> {});
+    assertEquals(OtlpPayload.EMPTY, payload);
+  }
+
+  @Test
+  void metricWithNoDataPointsContributesNothing() throws IOException {
+    OtelInstrumentDescriptor descriptor =
+        new OtelInstrumentDescriptor("unused", COUNTER, true, null, null);
+
+    OtlpPayload payload =
+        collect(
+            visitor -> {
+              OtlpScopedMetricsVisitor scoped =
+                  visitor.visitScopedMetrics(new OtelInstrumentationScope("io.test", null, null));
+              scoped.visitMetric(descriptor); // never visited with an attribute or data point
+            });
+
+    assertEquals(OtlpPayload.EMPTY, payload);
+  }
+
+  @Test
+  void scopeWithNoDataPointsContributesNothingWhenAnotherScopeHasData() throws IOException {
+    OtelInstrumentDescriptor emptyDescriptor =
+        new OtelInstrumentDescriptor("unused", COUNTER, true, null, null);
+
+    OtlpPayload payload =
+        collect(
+            visitor -> {
+              OtlpScopedMetricsVisitor emptyScope =
+                  visitor.visitScopedMetrics(new OtelInstrumentationScope("io.empty", null, null));
+              emptyScope.visitMetric(emptyDescriptor); // never visited with a data point
+
+              OtlpScopedMetricsVisitor dataScope =
+                  visitor.visitScopedMetrics(new OtelInstrumentationScope("io.data", null, null));
+              OtlpMetricVisitor mv =
+                  dataScope.visitMetric(
+                      new OtelInstrumentDescriptor("requests", COUNTER, true, null, null));
+              mv.visitDataPoint(new OtlpLongPoint(1L));
+            });
+
+    List<Object> scopeMetrics = onlyScopeMetrics(payload);
+    assertEquals(1, scopeMetrics.size(), "the empty scope must not appear in the payload");
+
+    Map<String, Object> scopeMetric = (Map<String, Object>) scopeMetrics.get(0);
+    Map<String, Object> scope = (Map<String, Object>) scopeMetric.get("scope");
+    assertEquals("io.data", scope.get("name"));
+  }
+
+  @Test
+  void gaugeHasNoStartTimeOrTemporality() throws IOException {
+    Map<String, Object> metric =
+        onlyMetric(
+            collect(
+                visitor -> {
+                  OtlpScopedMetricsVisitor scoped =
+                      visitor.visitScopedMetrics(
+                          new OtelInstrumentationScope("io.gauge", null, null));
+                  OtlpMetricVisitor mv =
+                      scoped.visitMetric(
+                          new OtelInstrumentDescriptor("connections", GAUGE, false, null, null));
+                  mv.visitDataPoint(new OtlpDoublePoint(5.0));
+                }));
+
+    assertEquals("connections", metric.get("name"));
+    Map<String, Object> gauge = (Map<String, Object>) metric.get("gauge");
+    List<Object> dataPoints = (List<Object>) gauge.get("dataPoints");
+    assertEquals(1, dataPoints.size());
+    Map<String, Object> point = (Map<String, Object>) dataPoints.get(0);
+    assertFalse(point.containsKey("startTimeUnixNano"), "gauges have no start time");
+    assertEquals(Long.toString(END_EPOCH_NS), point.get("timeUnixNano"));
+    assertEquals(5.0, ((Number) point.get("asDouble")).doubleValue());
+  }
+
+  @Test
+  void counterIsMonotonicSumWithIntegerTemporalityAndDecimalStringValue() throws IOException {
+    Map<String, Object> metric =
+        onlyMetric(
+            collect(
+                visitor -> {
+                  OtlpScopedMetricsVisitor scoped =
+                      visitor.visitScopedMetrics(
+                          new OtelInstrumentationScope("io.test", null, null));
+                  OtlpMetricVisitor mv =
+                      scoped.visitMetric(
+                          new OtelInstrumentDescriptor("requests", COUNTER, true, null, null));
+                  mv.visitAttribute(STRING_ATTRIBUTE, "method", "GET");
+                  mv.visitDataPoint(new OtlpLongPoint(42L));
+                }));
+
+    Map<String, Object> sum = (Map<String, Object>) metric.get("sum");
+    assertTrue(((Number) sum.get("aggregationTemporality")).intValue() >= 1);
+    assertEquals(Boolean.TRUE, sum.get("isMonotonic"));
+
+    List<Object> dataPoints = (List<Object>) sum.get("dataPoints");
+    Map<String, Object> point = (Map<String, Object>) dataPoints.get(0);
+    assertEquals(Long.toString(START_EPOCH_NS), point.get("startTimeUnixNano"));
+    assertEquals(Long.toString(END_EPOCH_NS), point.get("timeUnixNano"));
+    assertEquals("42", point.get("asInt"));
+
+    List<Object> attributes = (List<Object>) point.get("attributes");
+    Map<String, Object> attr = (Map<String, Object>) attributes.get(0);
+    assertEquals("method", attr.get("key"));
+  }
+
+  @Test
+  void histogramWithOverflowBoundaryOmitsInfinityAndAppendsNoExtraZero() throws IOException {
+    Map<String, Object> metric =
+        onlyMetric(
+            collect(
+                visitor -> {
+                  OtlpScopedMetricsVisitor scoped =
+                      visitor.visitScopedMetrics(
+                          new OtelInstrumentationScope("io.hist", null, null));
+                  OtlpMetricVisitor mv =
+                      scoped.visitMetric(
+                          new OtelInstrumentDescriptor(
+                              "request.size", HISTOGRAM, false, null, null));
+                  mv.visitDataPoint(
+                      new OtlpHistogramPoint(
+                          5.0,
+                          Arrays.asList(100.0, Double.POSITIVE_INFINITY),
+                          Arrays.asList(4.0, 1.0),
+                          280.0,
+                          20.0,
+                          200.0));
+                }));
+
+    Map<String, Object> histogram = (Map<String, Object>) metric.get("histogram");
+    List<Object> dataPoints = (List<Object>) histogram.get("dataPoints");
+    Map<String, Object> point = (Map<String, Object>) dataPoints.get(0);
+
+    assertEquals("5", point.get("count"));
+    assertEquals(280.0, ((Number) point.get("sum")).doubleValue());
+    assertEquals(20.0, ((Number) point.get("min")).doubleValue());
+    assertEquals(200.0, ((Number) point.get("max")).doubleValue());
+
+    List<Object> bounds = (List<Object>) point.get("explicitBounds");
+    assertEquals(Arrays.asList(100.0), bounds);
+
+    List<Object> counts = (List<Object>) point.get("bucketCounts");
+    assertEquals(Arrays.asList("4", "1"), counts);
+  }
+
+  @Test
+  void histogramWithoutOverflowBoundaryAppendsExtraZeroCount() throws IOException {
+    Map<String, Object> metric =
+        onlyMetric(
+            collect(
+                visitor -> {
+                  OtlpScopedMetricsVisitor scoped =
+                      visitor.visitScopedMetrics(
+                          new OtelInstrumentationScope("io.hist", null, null));
+                  OtlpMetricVisitor mv =
+                      scoped.visitMetric(
+                          new OtelInstrumentDescriptor("queue.size", HISTOGRAM, false, null, null));
+                  mv.visitDataPoint(
+                      new OtlpHistogramPoint(
+                          8.0,
+                          Arrays.asList(50.0, 100.0),
+                          Arrays.asList(3.0, 5.0),
+                          750.0,
+                          10.0,
+                          95.0));
+                }));
+
+    Map<String, Object> histogram = (Map<String, Object>) metric.get("histogram");
+    Map<String, Object> point =
+        (Map<String, Object>) ((List<Object>) histogram.get("dataPoints")).get(0);
+
+    List<Object> bounds = (List<Object>) point.get("explicitBounds");
+    assertEquals(Arrays.asList(50.0, 100.0), bounds);
+
+    List<Object> counts = (List<Object>) point.get("bucketCounts");
+    assertEquals(Arrays.asList("3", "5", "0"), counts, "extra zero count appended, no overflow");
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private static OtlpPayload collect(Consumer<OtlpMetricsVisitor> body) {
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    timeSource.set(START_EPOCH_NS); // captured in constructor
+    OtlpMetricsJsonCollector collector = new OtlpMetricsJsonCollector(timeSource);
+    timeSource.set(END_EPOCH_NS); // captured during collection
+    return collector.collectMetrics(body::accept);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> onlyMetric(OtlpPayload payload) throws IOException {
+    List<Object> scopeMetrics = onlyScopeMetrics(payload);
+    Map<String, Object> scopeMetric = (Map<String, Object>) scopeMetrics.get(0);
+    List<Object> metrics = (List<Object>) scopeMetric.get("metrics");
+    assertEquals(1, metrics.size());
+    return (Map<String, Object>) metrics.get(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Object> onlyScopeMetrics(OtlpPayload payload) throws IOException {
+    byte[] bytes = new byte[payload.getContentLength()];
+    payload.getContent().get(bytes);
+    String json = new String(bytes, StandardCharsets.UTF_8);
+    Map<String, Object> root = JsonMapper.fromJsonToMap(json);
+
+    List<Object> resourceMetrics = (List<Object>) root.get("resourceMetrics");
+    Map<String, Object> resourceMetric = (Map<String, Object>) resourceMetrics.get(0);
+    return (List<Object>) resourceMetric.get("scopeMetrics");
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsServiceTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsServiceTest.java
@@ -1,0 +1,27 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.api.config.OtlpConfig.OTLP_METRICS_ENDPOINT;
+import static datadog.trace.api.config.OtlpConfig.OTLP_METRICS_PROTOCOL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import datadog.trace.api.Config;
+import datadog.trace.core.otlp.common.OtlpHttpSender;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class OtlpMetricsServiceTest {
+
+  @Test
+  void httpJsonProtocolUsesJsonCollectorAndConfiguredEndpoint() {
+    Properties properties = new Properties();
+    properties.setProperty(OTLP_METRICS_PROTOCOL, "http/json");
+    properties.setProperty(OTLP_METRICS_ENDPOINT, "http://localhost:4318/v1/metrics");
+
+    OtlpMetricsService service = new OtlpMetricsService(Config.get(properties));
+
+    assertInstanceOf(OtlpMetricsJsonCollector.class, service.getCollector());
+    OtlpHttpSender sender = assertInstanceOf(OtlpHttpSender.class, service.getSender());
+    assertEquals("http://localhost:4318/v1/metrics", sender.url().toString());
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsTemporalityTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpMetricsTemporalityTest.java
@@ -1,0 +1,46 @@
+package datadog.trace.core.otlp.metrics;
+
+import static datadog.trace.api.config.OtlpConfig.Temporality.CUMULATIVE;
+import static datadog.trace.api.config.OtlpConfig.Temporality.DELTA;
+import static datadog.trace.api.config.OtlpConfig.Temporality.LOWMEMORY;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.COUNTER;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.GAUGE;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.HISTOGRAM;
+import static datadog.trace.bootstrap.otel.metrics.OtelInstrumentType.OBSERVABLE_COUNTER;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_CUMULATIVE;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.TEMPORALITY_DELTA;
+import static datadog.trace.core.otlp.metrics.OtlpMetricsTemporality.temporality;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class OtlpMetricsTemporalityTest {
+
+  @Test
+  void deltaPreferenceMakesEligibleTypesDelta() {
+    assertEquals(TEMPORALITY_DELTA, temporality(DELTA, HISTOGRAM));
+    assertEquals(TEMPORALITY_DELTA, temporality(DELTA, COUNTER));
+    assertEquals(TEMPORALITY_DELTA, temporality(DELTA, OBSERVABLE_COUNTER));
+  }
+
+  @Test
+  void deltaPreferenceKeepsIneligibleTypesCumulative() {
+    assertEquals(TEMPORALITY_CUMULATIVE, temporality(DELTA, GAUGE));
+  }
+
+  @Test
+  void lowMemoryPreferenceMakesEligibleTypesDelta() {
+    assertEquals(TEMPORALITY_DELTA, temporality(LOWMEMORY, HISTOGRAM));
+    assertEquals(TEMPORALITY_DELTA, temporality(LOWMEMORY, COUNTER));
+  }
+
+  @Test
+  void lowMemoryPreferenceKeepsObservableCounterCumulative() {
+    assertEquals(TEMPORALITY_CUMULATIVE, temporality(LOWMEMORY, OBSERVABLE_COUNTER));
+  }
+
+  @Test
+  void cumulativePreferenceIsAlwaysCumulative() {
+    assertEquals(TEMPORALITY_CUMULATIVE, temporality(CUMULATIVE, COUNTER));
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
@@ -1,0 +1,302 @@
+package datadog.trace.core.otlp.trace;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MECHANISM_TAG;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexSpanId;
+import static datadog.trace.core.otlp.common.OtlpCommonJson.hexTraceId;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.json.JsonMapper;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TracePropagationStyle;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
+import datadog.trace.bootstrap.instrumentation.api.SpanLink;
+import datadog.trace.common.writer.LoggingWriter;
+import datadog.trace.core.CoreSpan;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.otlp.common.OtlpPayload;
+import datadog.trace.core.propagation.ExtractedContext;
+import datadog.trace.core.propagation.PropagationTags;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OtlpTraceJsonCollector}, parsing the produced JSON back with {@link JsonMapper}
+ * and asserting against the OTLP JSON encoding (hex ids, camelCase keys, integer {@code kind},
+ * decimal-string timestamps).
+ */
+class OtlpTraceJsonCollectorTest {
+
+  private static final CoreTracer TRACER = CoreTracer.builder().writer(new LoggingWriter()).build();
+
+  @Test
+  void emptyTraceProducesEmptyPayload() {
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    OtlpPayload payload = collector.collectTraces();
+    assertEquals(OtlpPayload.EMPTY, payload);
+  }
+
+  @Test
+  void singleSpanIsEncodedWithHexIdsAndCamelCaseKeys() throws IOException {
+    DDSpan span = startAndFinish("op.first", "GET /api/users", null);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) span));
+    OtlpPayload payload = collector.collectTraces();
+
+    Map<String, Object> parsedSpan = onlySpan(payload);
+
+    assertEquals(hexTraceId(span.getTraceId()), parsedSpan.get("traceId"));
+    assertEquals(hexSpanId(span.getSpanId()), parsedSpan.get("spanId"));
+    assertEquals("GET /api/users", parsedSpan.get("name"));
+    assertTrue(parsedSpan.get("startTimeUnixNano") instanceof String, "timestamps are strings");
+    assertTrue(parsedSpan.get("endTimeUnixNano") instanceof String, "timestamps are strings");
+    assertNull(parsedSpan.get("parentSpanId"), "root span has no parentSpanId");
+
+    Set<String> attrKeys = attributeKeys(parsedSpan);
+    assertTrue(attrKeys.contains("resource.name"));
+    assertTrue(attrKeys.contains("operation.name"));
+  }
+
+  @Test
+  void spanKindIsEncodedAsInteger() throws IOException {
+    DDSpan span = startAndFinish("op.server", "GET /api", SPAN_KIND_SERVER);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) span));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertEquals(2, ((Number) parsedSpan.get("kind")).intValue(), "SPAN_KIND_SERVER = 2");
+  }
+
+  @Test
+  void errorSpanHasStatusObject() throws IOException {
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.error");
+    agentSpan.setResourceName("POST /api/data");
+    agentSpan.setError(true);
+    agentSpan.setErrorMessage("boom");
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> status = (Map<String, Object>) parsedSpan.get("status");
+    assertEquals("boom", status.get("message"));
+    assertEquals(2, ((Number) status.get("code")).intValue(), "STATUS_CODE_ERROR = 2");
+  }
+
+  @Test
+  void nonErrorSpanHasNoStatusObject() throws IOException {
+    DDSpan span = startAndFinish("op.ok", "GET /health", null);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) span));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertFalse(parsedSpan.containsKey("status"));
+  }
+
+  @Test
+  void spanTraceStateOmittedWhenNotPropagated() throws IOException {
+    DDSpan span = startAndFinish("op.notracestate", "GET /no-tracestate", null);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) span));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertFalse(
+        parsedSpan.containsKey("traceState"), "no W3C tracestate propagated should be omitted");
+  }
+
+  @Test
+  void spanTraceStateIncludedWhenPropagated() throws IOException {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateW3CTracestate("vendor=state");
+    ExtractedContext parent =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            0L,
+            PrioritySampling.UNSET,
+            null,
+            propagationTags,
+            TracePropagationStyle.DATADOG);
+
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.tracestate", parent);
+    agentSpan.setResourceName("op.tracestate");
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertEquals("vendor=state", parsedSpan.get("traceState"));
+  }
+
+  @Test
+  void spanFlagsOmittedWhenNotSampled() throws IOException {
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.noflags");
+    agentSpan.setResourceName("op.noflags");
+    agentSpan.setSamplingPriority(PrioritySampling.USER_DROP, SamplingMechanism.MANUAL);
+    // Force export despite the dropped trace-level priority, via span-level sampling -
+    // otherwise OtlpTraceCollector#shouldExport would exclude this span entirely.
+    agentSpan.setTag(SPAN_SAMPLING_MECHANISM_TAG, SamplingMechanism.SPAN_SAMPLING_RATE);
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertFalse(parsedSpan.containsKey("flags"), "unsampled span should omit flags");
+  }
+
+  @Test
+  void spanFlagsIncludeSampledBitWhenSampled() throws IOException {
+    DDSpan span = startAndFinish("op.sampled", "GET /sampled", null);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) span));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertEquals(SAMPLED_TRACE_FLAG, ((Number) parsedSpan.get("flags")).intValue());
+  }
+
+  @Test
+  void multipleSpansInATraceAreAllWritten() throws IOException {
+    AgentSpan parent = TRACER.startSpan("test", "op.parent");
+    parent.setResourceName("parent.op");
+    AgentSpan child = TRACER.startSpan("test", "op.child", parent.spanContext());
+    child.setResourceName("child.op");
+    child.finish();
+    parent.finish();
+
+    List<CoreSpan<?>> spans = new ArrayList<>();
+    spans.add((CoreSpan<?>) parent);
+    spans.add((CoreSpan<?>) child);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(spans);
+    OtlpPayload payload = collector.collectTraces();
+
+    List<Map<String, Object>> parsedSpans = allSpans(payload);
+    assertEquals(2, parsedSpans.size());
+
+    Map<String, Object> parsedChild =
+        parsedSpans.stream()
+            .filter(s -> "child.op".equals(s.get("name")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("child span not found"));
+    assertEquals(hexSpanId(((DDSpan) parent).getSpanId()), parsedChild.get("parentSpanId"));
+  }
+
+  @Test
+  void spanLinkOmitsTraceStateWhenEmpty() throws IOException {
+    AgentSpan linked = TRACER.startSpan("test", "op.linked");
+    linked.finish();
+
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.link");
+    agentSpan.setResourceName("op.link");
+    agentSpan.addLink(SpanLink.from(linked.spanContext()));
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    Map<String, Object> parsedLink = onlyLink(parsedSpan);
+    assertFalse(parsedLink.containsKey("traceState"), "empty traceState should be omitted");
+  }
+
+  @Test
+  void spanLinkIncludesTraceStateWhenPresent() throws IOException {
+    AgentSpan linked = TRACER.startSpan("test", "op.linked");
+    linked.finish();
+
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.link");
+    agentSpan.setResourceName("op.link");
+    agentSpan.addLink(
+        SpanLink.from(linked.spanContext(), (byte) 0, "vendor=state", SpanAttributes.EMPTY));
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    Map<String, Object> parsedLink = onlyLink(parsedSpan);
+    assertEquals("vendor=state", parsedLink.get("traceState"));
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private static DDSpan startAndFinish(String operationName, String resourceName, String spanKind) {
+    AgentSpan agentSpan = TRACER.startSpan("test", operationName);
+    agentSpan.setResourceName(resourceName);
+    if (spanKind != null) {
+      agentSpan.setTag(SPAN_KIND, spanKind);
+    }
+    agentSpan.setSamplingPriority(PrioritySampling.USER_KEEP, SamplingMechanism.DEFAULT);
+    agentSpan.finish();
+    return (DDSpan) agentSpan;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> onlySpan(OtlpPayload payload) throws IOException {
+    List<Map<String, Object>> spans = allSpans(payload);
+    assertEquals(1, spans.size());
+    return spans.get(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> allSpans(OtlpPayload payload) throws IOException {
+    byte[] bytes = new byte[payload.getContentLength()];
+    payload.getContent().get(bytes);
+    String json = new String(bytes, StandardCharsets.UTF_8);
+    Map<String, Object> root = JsonMapper.fromJsonToMap(json);
+
+    List<Object> resourceSpans = (List<Object>) root.get("resourceSpans");
+    Map<String, Object> resourceSpan = (Map<String, Object>) resourceSpans.get(0);
+    List<Object> scopeSpans = (List<Object>) resourceSpan.get("scopeSpans");
+    Map<String, Object> scopeSpan = (Map<String, Object>) scopeSpans.get(0);
+    List<Object> spans = (List<Object>) scopeSpan.get("spans");
+
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (Object span : spans) {
+      result.add((Map<String, Object>) span);
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> onlyLink(Map<String, Object> span) {
+    List<Object> links = (List<Object>) span.get("links");
+    assertEquals(1, links.size());
+    return (Map<String, Object>) links.get(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Set<String> attributeKeys(Map<String, Object> span) {
+    List<Object> attributes = (List<Object>) span.get("attributes");
+    Set<String> keys = new HashSet<>();
+    for (Object attribute : attributes) {
+      keys.add((String) ((Map<String, Object>) attribute).get("key"));
+    }
+    return keys;
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUME
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_INTERNAL;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
 import static java.util.Collections.emptyList;
@@ -422,6 +423,11 @@ class OtlpTraceProtoTest {
             asList(
                 span("anchor.op", "anchor.op", "web"),
                 linkedSpanWithFlags("flags.linked", 0, (byte) 0x02))),
+        Arguments.of(
+            "span link with high-bit flags — flags written as unsigned byte, not sign-extended",
+            asList(
+                span("anchor.op", "anchor.op", "web"),
+                linkedSpanWithFlags("flags.highbit.linked", 0, (byte) 0x82))),
 
         // ── metadata paths ────────────────────────────────────────────────────
         Arguments.of(
@@ -966,7 +972,7 @@ class OtlpTraceProtoTest {
     // absent otherwise because the default sampler may still set a positive priority.
     if (spec.samplingPriority > 0) {
       assertTrue(
-          (parsedFlags & OtlpTraceProto.SAMPLED_TRACE_FLAG) != 0,
+          (parsedFlags & SAMPLED_TRACE_FLAG) != 0,
           "SAMPLED flag must be set in flags [" + caseName + "]");
     }
 
@@ -1082,6 +1088,8 @@ class OtlpTraceProtoTest {
     if (!linkSpec.traceState.isEmpty()) {
       assertEquals(
           linkSpec.traceState, parsedTraceState, "Link.trace_state mismatch [" + caseName + "]");
+    } else {
+      assertNull(parsedTraceState, "empty Link.trace_state should be omitted [" + caseName + "]");
     }
     // SpanLink.from() ORs in the SAMPLED_FLAG (0x01) when the target context has positive
     // sampling priority, which all test anchor spans have via the default tracer sampler.


### PR DESCRIPTION
# What Does This Do

Support OTLP export over "http/json" for traces, metrics, and logs.

Adds JSON siblings of existing hand-rolled protobuf OTLP encoders (OtlpCommonJson, OtlpResourceJson, OtlpTraceJson/Collector, OtlpMetricsJson/Collector, OtlpLogsJson/Collector) and wires the previously unused/silently-disabled HTTP_JSON protocol into OtlpWriter, OtlpMetricsService, and OtlpLogsService.

# Motivation

Adds support for OTLP over `http/json` to the existing `http/protobuf ` and `grpc` support.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
