### PR TITLE
Fix FFE config module packaging

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,6 +24,7 @@ final class CachedData {
         filter.exclude(filter.project(':components:environment'))
         filter.exclude(filter.project(':components:json'))
         filter.exclude(filter.project(':products:feature-flagging:feature-flagging-bootstrap'))
+        filter.exclude(filter.project(':products:feature-flagging:feature-flagging-config'))
         filter.exclude(filter.project(':products:metrics:metrics-agent'))
         filter.exclude(filter.project(':products:metrics:metrics-api'))
         filter.exclude(filter.project(':products:metrics:metrics-lib'))


### PR DESCRIPTION
# What Does This Do

This PR fixes duplicate FFE config module:

```
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content 'datadog.trace.api.featureflag.config.*' under 'inst/', already seen in profiling/. Ensure your content is under a distinct directory.
[main] WARN datadog.trace.bootstrap.AgentJarIndex - Detected duplicate content 'datadog.trace.api.featureflag.config.*' under 'jmxfetch/', already seen in profiling/. Ensure your content is under a distinct directory.
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
