### PR TITLE
Update MethodParameters detection for fixed JDK

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -56,6 +56,8 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationUpdater.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
   private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
+  private static final boolean JAVA_AT_LEAST_17_0_20 =
+      JavaVirtualMachine.isJavaVersionAtLeast(17, 0, 20);
   private static final boolean JAVA_AT_LEAST_16 = JavaVirtualMachine.isJavaVersionAtLeast(16);
   private static final boolean JAVA_AT_LEAST_25_0_4 =
       JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4);
@@ -423,8 +425,8 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
         Consumer<String> reportError,
         Instrumentation instrumentation,
         List<Class<?>> changedClasses) {
-      if (JAVA_AT_LEAST_19) {
-        // bug is fixed since JDK19, no need to perform detection
+      if (JAVA_AT_LEAST_19 || JAVA_AT_LEAST_17_0_20) {
+        // bug is fixed since JDK 19 and 17.0.20, no need to perform detection
         return changedClasses;
       }
       List<Class<?>> result = new ArrayList<>();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -55,7 +55,6 @@ import org.slf4j.LoggerFactory;
 public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, ConfigurationAcceptor {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationUpdater.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
-  private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
   private static final boolean JAVA_AT_LEAST_17_0_20 =
       JavaVirtualMachine.isJavaVersionAtLeast(17, 0, 20);
   private static final boolean JAVA_AT_LEAST_16 = JavaVirtualMachine.isJavaVersionAtLeast(16);
@@ -425,7 +424,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
         Consumer<String> reportError,
         Instrumentation instrumentation,
         List<Class<?>> changedClasses) {
-      if (JAVA_AT_LEAST_19 || JAVA_AT_LEAST_17_0_20) {
+      if (JAVA_AT_LEAST_17_0_20) {
         // bug is fixed since JDK 19 and 17.0.20, no need to perform detection
         return changedClasses;
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -94,7 +94,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
           SpanDecorationProbe.class,
           SpanProbe.class);
   private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
-  private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
   private static final boolean JAVA_AT_LEAST_25_0_4 =
       JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4);
   private static final boolean JAVA_AT_LEAST_17_0_20 =
@@ -313,7 +312,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
    */
   private boolean checkMethodParameters(
       ClassNode classNode, List<ProbeDefinition> definitions, String fullyQualifiedClassName) {
-    if (JAVA_AT_LEAST_19 || JAVA_AT_LEAST_17_0_20) {
+    if (JAVA_AT_LEAST_17_0_20) {
       // bug is fixed since JDK 19 and 17.0.20, no need to perform check
       return true;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -97,6 +97,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
   private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
   private static final boolean JAVA_AT_LEAST_25_0_4 =
       JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4);
+  private static final boolean JAVA_AT_LEAST_17_0_20 =
+      JavaVirtualMachine.isJavaVersionAtLeast(17, 0, 20);
   public static Path DUMP_PATH = Paths.get(SystemProperties.get(JAVA_IO_TMPDIR), "debugger");
   private static final String[] SKIPPED_PACKAGES =
       new String[] {
@@ -311,8 +313,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
    */
   private boolean checkMethodParameters(
       ClassNode classNode, List<ProbeDefinition> definitions, String fullyQualifiedClassName) {
-    if (JAVA_AT_LEAST_19) {
-      // bug is fixed since JDK19, no need to perform check
+    if (JAVA_AT_LEAST_19 || JAVA_AT_LEAST_17_0_20) {
+      // bug is fixed since JDK 19 and 17.0.20, no need to perform check
       return true;
     }
     boolean isRecord = ASMHelper.isRecord(classNode);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -3191,7 +3191,7 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     Class<?> testClass = loadClass(CLASS_NAME, buffers);
     int result = Reflect.onClass(testClass).call("main", "1").get();
     assertEquals(3, result);
-    if (JavaVirtualMachine.isJavaVersion(17)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
       // on JDK 17 with Spring6 class, transformation cannot happen
       assertEquals(0, listener.snapshots.size());
       ArgumentCaptor<ProbeId> probeIdCaptor = ArgumentCaptor.forClass(ProbeId.class);
@@ -3226,7 +3226,8 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     Class<?> testClass = loadClass(CLASS_NAME, buffers);
     int result = Reflect.onClass(testClass).call("main", "1").get();
     assertEquals(42, result);
-    if (JavaVirtualMachine.isJavaVersionAtLeast(19)) {
+    if (JavaVirtualMachine.isJavaVersionAtLeast(19)
+        || JavaVirtualMachine.isJavaVersionAtLeast(17, 0, 20)) {
       Snapshot snapshot = assertOneSnapshot(listener);
       assertCaptureArgs(
           snapshot.getCaptures().getReturn(), "firstName", String.class.getTypeName(), "john");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -3191,7 +3191,7 @@ public class CapturedSnapshotTest extends CapturingTestBase {
     Class<?> testClass = loadClass(CLASS_NAME, buffers);
     int result = Reflect.onClass(testClass).call("main", "1").get();
     assertEquals(3, result);
-    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 20)) {
       // on JDK 17 with Spring6 class, transformation cannot happen
       assertEquals(0, listener.snapshots.size());
       ArgumentCaptor<ProbeId> probeIdCaptor = ArgumentCaptor.forClass(ProbeId.class);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -658,7 +658,7 @@ public class ConfigurationUpdaterTest {
     Map<String, byte[]> buffers =
         compile(CLASS_NAME, SourceCompiler.DebugInfo.ALL, "8", Arrays.asList("-parameters"));
     Class<?> testClass = loadClass(CLASS_NAME, buffers);
-    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 20)) {
       // on JDK 17 introduced Spring6 class
       Class<?> springClass = Class.forName("org.springframework.core.SpringVersion");
       when(inst.getAllLoadedClasses()).thenReturn(new Class[] {testClass, springClass});
@@ -669,7 +669,7 @@ public class ConfigurationUpdaterTest {
     configurationUpdater.accept(
         REMOTE_CONFIG,
         singletonList(LogProbe.builder().probeId(PROBE_ID).where(CLASS_NAME, "main").build()));
-    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 20)) {
       // on JDK 17 with Spring6 class, transformation cannot happen
       verify(inst, times(2)).getAllLoadedClasses();
       verify(inst, times(0)).retransformClasses(any());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -658,7 +658,7 @@ public class ConfigurationUpdaterTest {
     Map<String, byte[]> buffers =
         compile(CLASS_NAME, SourceCompiler.DebugInfo.ALL, "8", Arrays.asList("-parameters"));
     Class<?> testClass = loadClass(CLASS_NAME, buffers);
-    if (JavaVirtualMachine.isJavaVersion(17)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
       // on JDK 17 introduced Spring6 class
       Class<?> springClass = Class.forName("org.springframework.core.SpringVersion");
       when(inst.getAllLoadedClasses()).thenReturn(new Class[] {testClass, springClass});
@@ -669,7 +669,7 @@ public class ConfigurationUpdaterTest {
     configurationUpdater.accept(
         REMOTE_CONFIG,
         singletonList(LogProbe.builder().probeId(PROBE_ID).where(CLASS_NAME, "main").build()));
-    if (JavaVirtualMachine.isJavaVersion(17)) {
+    if (JavaVirtualMachine.isJavaVersionBetween(17, 0, 0, 17, 0, 19)) {
       // on JDK 17 with Spring6 class, transformation cannot happen
       verify(inst, times(2)).getAllLoadedClasses();
       verify(inst, times(0)).retransformClasses(any());


### PR DESCRIPTION
# What Does This Do
JDK 17.0.20 fixes the Method Parameters bug ([JDK-8240908](https://bugs.openjdk.org/browse/JDK-8240908)) so we are updating the detection to filter out for this JDK version and onward

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
