### PR TITLE
Update record detection for fixed JDK

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -57,6 +57,8 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
   private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
   private static final boolean JAVA_AT_LEAST_16 = JavaVirtualMachine.isJavaVersionAtLeast(16);
+  private static final boolean JAVA_AT_LEAST_25_0_4 =
+      JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4);
   private static final Method GET_RECORD_COMPONENTS_METHOD;
   private static final Method GET_ANNOTATED_TYPES_METHOD;
 
@@ -353,8 +355,9 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
 
     public static List<Class<?>> detectRecordWithTypeAnnotation(
         Consumer<String> reportError, List<Class<?>> changedClasses) {
-      if (!JAVA_AT_LEAST_16) {
+      if (!JAVA_AT_LEAST_16 || JAVA_AT_LEAST_25_0_4) {
         // records introduced in JDK 16 (final version)
+        // JDK-8376185 fixed since JDK 25.0.4
         return changedClasses;
       }
       List<Class<?>> result = new ArrayList<>();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -95,6 +95,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
           SpanProbe.class);
   private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
   private static final boolean JAVA_AT_LEAST_19 = JavaVirtualMachine.isJavaVersionAtLeast(19);
+  private static final boolean JAVA_AT_LEAST_25_0_4 =
+      JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4);
   public static Path DUMP_PATH = Paths.get(SystemProperties.get(JAVA_IO_TMPDIR), "debugger");
   private static final String[] SKIPPED_PACKAGES =
       new String[] {
@@ -353,6 +355,9 @@ public class DebuggerTransformer implements ClassFileTransformer {
    */
   private boolean checkRecordTypeAnnotation(
       ClassNode classNode, List<ProbeDefinition> definitions, String fullyQualifiedClassName) {
+    if (JAVA_AT_LEAST_25_0_4) {
+      return true;
+    }
     if (!ASMHelper.isRecord(classNode)) {
       return true;
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -3283,6 +3283,10 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   @Test
   @EnabledForJreRange(min = JRE.JAVA_17)
   public void recordWithTypeAnnotation() throws IOException, URISyntaxException {
+    if (JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4)) {
+      // Fixed since JDK 25.0.4
+      return;
+    }
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot33";
     LogProbe probe1 = createMethodProbeAtExit(PROBE_ID1, CLASS_NAME, "parse", null);
     TestSnapshotListener listener = installProbes(probe1);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -715,9 +715,10 @@ public class ConfigurationUpdaterTest {
   @EnabledForJreRange(min = JRE.JAVA_17)
   public void recordWithTypeAnnotation()
       throws IOException, URISyntaxException, UnmodifiableClassException {
-    // make sure record method are not detected as having methodParameters attribute.
-    // /!\ record canonical constructor has the MethodParameters attribute,
-    // but not returned by Class::getDeclaredMethods()
+    if (JavaVirtualMachine.isJavaVersionAtLeast(25, 0, 4)) {
+      // Fixed since JDK 25.0.4
+      return;
+    }
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot33";
     Map<String, byte[]> buffers = compile(CLASS_NAME, SourceCompiler.DebugInfo.ALL, "17");
     Class<?> testClass = loadClass(CLASS_NAME, buffers);


### PR DESCRIPTION
# What Does This Do
JDK 25.0.4 fixes the Record with type annotation bug (JDK-8376185) so we are updating the detection to filter out for this JDK version and onward

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
