### PR TITLE
Experiment with detecting overlapping-output-failure

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -78,6 +78,11 @@ gradlePlugin {
       id = "dd-trace-java.jardiff"
       implementationClass = "datadog.gradle.plugin.jardiff.JardiffPlugin"
     }
+
+    create("check-overlapping-outputs") {
+      id = "dd-trace-java.check-overlapping-outputs"
+      implementationClass = "datadog.gradle.plugin.overlapping.CheckOverlappingOutputsPlugin"
+    }
   }
 }
 

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/overlapping/CheckOverlappingOutputsPlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/overlapping/CheckOverlappingOutputsPlugin.kt
@@ -1,0 +1,52 @@
+package datadog.gradle.plugin.overlapping
+
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
+/**
+ * Detects tasks with overlapping output paths and fails the build immediately.
+ *
+ * When Gradle runs a task, it removes stale outputs — files previously in the task's output
+ * directory that are no longer part of the current execution. If two tasks share an output
+ * directory, one task's stale-output cleanup silently deletes the other task's outputs.
+ * The build cache makes this worse: restoring a cached task only restores that task's files,
+ * leaving the shared directory in a partial state.
+ *
+ * This plugin registers a [org.gradle.api.execution.TaskExecutionGraph] listener that runs
+ * just before task execution and fails the build if any two tasks declare the same output path.
+ *
+ * Applied as a settings plugin so it covers the entire build without a root-project guard.
+ */
+class CheckOverlappingOutputsPlugin : Plugin<Settings> {
+  override fun apply(settings: Settings) {
+    settings.gradle.taskGraph.whenReady {
+      val outputToTasks = mutableMapOf<String, MutableList<String>>()
+
+      allTasks.forEach { task ->
+        task.outputs.files.files.forEach { output ->
+          outputToTasks
+            .getOrPut(output.canonicalPath) { mutableListOf() }
+            .add(task.path)
+        }
+      }
+
+      val overlaps = outputToTasks.filterValues { it.size > 1 }
+      if (overlaps.isNotEmpty()) {
+        throw GradleException(buildString {
+          appendLine("Overlapping task outputs detected.")
+          appendLine(
+            "When a task is rerun, Gradle removes stale outputs from the shared directory, " +
+              "which deletes outputs produced by other tasks sharing that path."
+          )
+          appendLine("Affected paths:")
+          overlaps.forEach { (path, tasks) ->
+            appendLine("  $path")
+            tasks.forEach { appendLine("    - $it") }
+          }
+          append("Fix: ensure each task writes to its own unique output directory.")
+        })
+      }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,8 @@ plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+apply<datadog.gradle.plugin.overlapping.CheckOverlappingOutputsPlugin>()
+
 val isCI = providers.environmentVariable("CI")
 val skipBuildscan = providers.environmentVariable("SKIP_BUILDSCAN").map { it.toBoolean() }.orElse(false)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,28 @@ plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-apply<datadog.gradle.plugin.overlapping.CheckOverlappingOutputsPlugin>()
+// TODO doesn't work:
+// apply<datadog.gradle.plugin.overlapping.CheckOverlappingOutputsPlugin>()
+//
+// buildSrc is NOT an included build, it is built during **after settings is evaluated**, and its output is
+// placed directly on the classpath before the **main** project script is processed. Here's the timeline
+// (https://docs.gradle.org/8.14.4/userguide/configuration_cache.html)
+//
+// 1. run init scripts
+// 2. runs the settings script
+// 3. Configure and build the buildSrc project, if present.
+// 4. Run build scripts, applying any requested project plugins. If plugins come from included builds, Gradle builds them first.
+//
+// Do not mistake `buildSrc` for an _includedBuild_ they are different. An included build has a separate lifecycle
+// which is not the case for buildSrc.
+//
+// https://docs.gradle.org/current/userguide/best_practices_structuring_builds.html
+// https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources
+//
+// TODO
+//  migrate `buildSrc/` → `build-logic/`,
+//  in settings.gradle.kts : `pluginManagement { includeBuild("build-logic") }`, then declare `plugins { id("dd-trace-java.check-overlapping-outputs") }`
+
 
 val isCI = providers.environmentVariable("CI")
 val skipBuildscan = providers.environmentVariable("SKIP_BUILDSCAN").map { it.toBoolean() }.orElse(false)


### PR DESCRIPTION
⚠️Not ready for review, it's an experiment. I'm just creating a PR draft to trac work better. I just reased over the latest master.

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
