### PR TITLE
Identify remaining final field mutations

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
@@ -74,7 +74,7 @@ class RedactionTest {
     try {
       Field field = config.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);
-      field.set(config, value);
+      field.set(config, value); // TODO: JEP 500 - avoid mutating final fields
     } catch (Throwable e) {
       e.printStackTrace();
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/TestHelper.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/TestHelper.java
@@ -8,7 +8,7 @@ public class TestHelper {
     try {
       Field field = config.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);
-      field.set(config, value);
+      field.set(config, value); // TODO: JEP 500 - avoid mutating final fields
     } catch (Throwable e) {
       e.printStackTrace();
     }

--- a/dd-java-agent/agent-debugger/src/test/java/utils/TestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/utils/TestHelper.java
@@ -28,7 +28,7 @@ public class TestHelper {
     try {
       Field field = target.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);
-      field.set(target, value);
+      field.set(target, value); // TODO: JEP 500 - avoid mutating final fields
     } catch (Throwable e) {
       e.printStackTrace();
     }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -644,7 +644,7 @@ public class ProfileUploaderTest {
     // will always fail first on socket timeouts.
     Field fld = ProfileUploader.class.getDeclaredField("uploadTimeout");
     fld.setAccessible(true);
-    fld.set(uploader, Duration.ofSeconds(1));
+    fld.set(uploader, Duration.ofSeconds(1)); // TODO: JEP 500 - avoid mutating final fields
     // ---
 
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.STALL_SOCKET_AT_START));

--- a/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/test/groovy/OpenAiTest.groovy
+++ b/dd-java-agent/instrumentation/openai-java/openai-java-3.0/src/test/groovy/OpenAiTest.groovy
@@ -477,7 +477,7 @@ Alice Johnson majors in mathematics at UCLA.""")
 
     def toolsField = params._body().class.getDeclaredField("tools")
     toolsField.accessible = true
-    toolsField.set(params._body(), rawTools)
+    toolsField.set(params._body(), rawTools) // TODO: JEP 500 - avoid mutating final fields
 
     params
   }


### PR DESCRIPTION
# What Does This Do

Identify remaining final field mutations in library

# Motivation

Prepare for [JEP 500](https://openjdk.org/jeps/500) which will disallow these mutations in a future JDK release

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
